### PR TITLE
[Cherry-pick][Data] Fail execution if no operator makes progress within a timeout

### DIFF
--- a/python/ray/data/BUILD.bazel
+++ b/python/ray/data/BUILD.bazel
@@ -1771,6 +1771,20 @@ py_test(
 )
 
 py_test(
+    name = "test_no_progress_guard",
+    size = "medium",
+    srcs = ["tests/test_no_progress_guard.py"],
+    tags = [
+        "exclusive",
+        "team:data",
+    ],
+    deps = [
+        ":conftest",
+        "//:ray_lib",
+    ],
+)
+
+py_test(
     name = "test_ref_bundle",
     size = "small",
     srcs = ["tests/test_ref_bundle.py"],

--- a/python/ray/data/_internal/execution/no_progress_guard.py
+++ b/python/ray/data/_internal/execution/no_progress_guard.py
@@ -1,0 +1,138 @@
+import time
+from dataclasses import dataclass
+from functools import cached_property
+from typing import Callable, List
+
+from ray.data._internal.execution.operators.base_physical_operator import (
+    AllToAllOperator,
+)
+from ray.data._internal.execution.operators.hash_shuffle import (
+    HashShufflingOperatorBase,
+)
+from ray.data._internal.execution.streaming_executor_state import (
+    Topology,
+)
+from ray.data.exceptions import ExecutionTimeoutError
+
+
+@dataclass(frozen=True)
+class OperatorState:
+    """The state the guard checks against to identify hangs.
+
+    Attributes:
+        num_outputs_taken: The cumulative number of outputs taken.
+        total_enqueued_input_blocks: The current number of inputs queued.
+        total_enqueued_output_blocks: The current number of outputs queued.
+    """
+
+    num_outputs_taken: int
+    total_enqueued_input_blocks: int
+    total_enqueued_output_blocks: int
+
+
+class NoProgressGuard:
+    """
+    Raises an ExecutionTimeoutError when no operator makes progress for
+    DataContext.execution_no_progress_timeout_s.
+
+    Progress is defined as either an output was taken from an operator, or
+    blocks entered or left an operator's queues.
+
+    The clock measures time since the last progress, and
+    progress is checked at the end of each scheduling loop step.
+
+    A value of -1 disables the guard.
+    """
+
+    def __init__(
+        self,
+        topology: Topology,
+        timeout_s: float,
+        *,
+        clock: Callable[[], float] = time.monotonic,
+    ):
+        if timeout_s == 0:
+            raise ValueError(
+                "execution_no_progress_timeout_s must be positive, or -1 to "
+                "disable the timeout. Zero would fail every execution as "
+                f"soon as it started. Got: {timeout_s}"
+            )
+
+        self._topology = topology
+        self._timeout_s = timeout_s
+        self._clock = clock
+
+        self._last_progress_time = clock()
+        self._last_progress_states = self._current_progress_states()
+
+    @cached_property
+    def enabled(self) -> bool:
+        # AllToAllOperator and HashShufflingOperatorBase require special-cased logic to
+        # implement a no-progress check. Since we're deprecating both of them in favor
+        # of the V2 hash shuffle implementation around Ray 2.60, we don't bother
+        # supporting them.
+        if any(
+            isinstance(op, (AllToAllOperator, HashShufflingOperatorBase))
+            for op in self._topology
+        ):
+            return False
+
+        return self._timeout_s > 0
+
+    def check(self) -> None:
+        if not self.enabled:
+            return
+
+        current_time = self._clock()
+        current_progress_states = self._current_progress_states()
+
+        execution_made_progress = current_progress_states != self._last_progress_states
+        if execution_made_progress:
+            self._last_progress_states = current_progress_states
+            self._last_progress_time = current_time
+            return
+
+        if current_time - self._last_progress_time >= self._timeout_s:
+            raise ExecutionTimeoutError(self._error_message())
+
+    def _current_progress_states(self) -> List[OperatorState]:
+        """Return the state of each operator."""
+        return [
+            OperatorState(
+                num_outputs_taken=op.metrics.num_outputs_taken,
+                total_enqueued_input_blocks=state.total_enqueued_input_blocks(),
+                total_enqueued_output_blocks=state.total_enqueued_output_blocks(),
+            )
+            for op, state in self._topology.items()
+        ]
+
+    def _error_message(self) -> str:
+        stalled_s = self._clock() - self._last_progress_time
+        lines = [
+            f"Dataset execution made no progress for at least "
+            f"{stalled_s:.0f}s of scheduling time (timeout: "
+            f"{self._timeout_s:.0f}s). No output was taken and no blocks moved "
+            f"through any operator's queues in that window."
+        ]
+
+        stalled = [op for op in self._topology if not op.has_completed()]
+        if stalled:
+            lines.append("Operators still running:")
+            for op in stalled:
+                metrics = op.metrics
+                lines.append(
+                    f"  - {op.name}: {op.num_active_tasks()} active task(s), "
+                    f"{metrics.num_tasks_finished} finished, "
+                    f"{metrics.num_outputs_taken} outputs taken"
+                )
+
+        lines.append(
+            "If this is expected, for example a UDF that is legitimately this "
+            "slow or a long wait for cluster capacity, raise the timeout for this "
+            "Dataset with `ds.context.execution_no_progress_timeout_s = <seconds>`, "
+            "or set it to -1 to disable. To change the default, set "
+            "`DataContext.get_current().execution_no_progress_timeout_s` before "
+            "creating a Dataset, or set "
+            "RAY_DATA_EXECUTION_NO_PROGRESS_TIMEOUT_S before starting the process."
+        )
+        return "\n".join(lines)

--- a/python/ray/data/_internal/execution/streaming_executor.py
+++ b/python/ray/data/_internal/execution/streaming_executor.py
@@ -24,6 +24,7 @@ from ray.data._internal.execution.interfaces import (
     RefBundle,
 )
 from ray.data._internal.execution.metadata_fetcher import make_metadata_fetcher
+from ray.data._internal.execution.no_progress_guard import NoProgressGuard
 from ray.data._internal.execution.operators.base_physical_operator import (
     InternalQueueOperatorMixin,
 )
@@ -246,7 +247,6 @@ class StreamingExecutor(Executor, threading.Thread):
         self._output_backpressure_guard = OutputBackpressureGuard(
             self._topology, self._resource_manager
         )
-
         # Setup progress manager
         self._progress_manager = get_progress_manager(
             self._data_context,
@@ -269,6 +269,10 @@ class StreamingExecutor(Executor, threading.Thread):
             self._topology,
             self._resource_manager,
             config=self._data_context.autoscaling_config,
+        )
+        self._no_progress_guard = NoProgressGuard(
+            self._topology,
+            self._data_context.execution_no_progress_timeout_s,
         )
 
         self._has_op_completed = dict.fromkeys(self._topology, False)
@@ -580,8 +584,10 @@ class StreamingExecutor(Executor, threading.Thread):
                 self._has_op_completed[op] = True
                 self._validate_operator_queues_empty(op, state)
 
-        # Keep going until all operators run to completion.
-        return not all(op.has_completed() for op in topology)
+        # Check until all oprators have completed.
+        should_continue = not all(op.has_completed() for op in topology)
+        self._no_progress_guard.check()
+        return should_continue
 
     def _refresh_progress_manager(self, topology: Topology):
         # Update the progress manager to reflect scheduling decisions.

--- a/python/ray/data/context.py
+++ b/python/ray/data/context.py
@@ -165,6 +165,10 @@ DEFAULT_RAY_DATA_RAISE_ORIGINAL_MAP_EXCEPTION = env_bool(
     "RAY_DATA_RAISE_ORIGINAL_MAP_EXCEPTION", False
 )
 
+DEFAULT_EXECUTION_NO_PROGRESS_TIMEOUT_S = env_float(
+    "RAY_DATA_EXECUTION_NO_PROGRESS_TIMEOUT_S", 30 * 60
+)
+
 DEFAULT_USE_RAY_TQDM = bool(int(os.environ.get("RAY_TQDM", "1")))
 
 # Globally enable or disable all progress bars.
@@ -675,6 +679,12 @@ class DataContext:
             operators to prevent resource contention.
         op_resource_reservation_ratio: The ratio of the total resources to reserve for
             each operator.
+        execution_no_progress_timeout_s: Maximum time in seconds that an execution may
+            go without any operator producing or consuming an output before it fails
+            with `ExecutionTimeoutError`. Doesn't apply to Datasets with an
+            all-to-all operation.
+            Raise this if your workload can wait a long time for cluster capacity.
+            Set to -1 to disable.
         max_errored_blocks: Max number of blocks that are allowed to have errors,
             unlimited if negative. This option allows application-level exceptions in
             block processing tasks. These exceptions may be caused by UDFs (e.g., due to
@@ -944,6 +954,7 @@ class DataContext:
     op_resource_reservation_enabled: bool = DEFAULT_ENABLE_OP_RESOURCE_RESERVATION
     op_resource_reservation_ratio: float = DEFAULT_OP_RESOURCE_RESERVATION_RATIO
     max_errored_blocks: int = DEFAULT_MAX_ERRORED_BLOCKS
+    execution_no_progress_timeout_s: float = DEFAULT_EXECUTION_NO_PROGRESS_TIMEOUT_S
     log_internal_stack_trace: bool = DEFAULT_LOG_INTERNAL_STACK_TRACE
     raise_original_map_exception: bool = DEFAULT_RAY_DATA_RAISE_ORIGINAL_MAP_EXCEPTION
     print_on_execution_start: bool = True

--- a/python/ray/data/exceptions.py
+++ b/python/ray/data/exceptions.py
@@ -35,6 +35,14 @@ class SystemException(Exception):
 
 
 @DeveloperAPI
+class ExecutionTimeoutError(Exception):
+    """Represents an Exception raised when a Dataset execution stops making
+    progress for `DataContext.execution_no_progress_timeout_s`.
+    This usually means a UDF is blocked, a task is stuck, or the cluster can
+    no longer schedule work."""
+
+
+@DeveloperAPI
 def omit_traceback_stdout(fn: Callable) -> Callable:
     """Decorator which runs the function, and if there is an exception raised,
     drops the stack trace before re-raising the exception. The original exception,
@@ -60,6 +68,9 @@ def omit_traceback_stdout(fn: Callable) -> Callable:
                 raise e
 
             is_user_code_exception = isinstance(e, UserCodeException)
+            is_actionable_exception = is_user_code_exception or isinstance(
+                e, ExecutionTimeoutError
+            )
             if is_user_code_exception:
                 # Exception has occurred in user code.
                 if not log_internal_stack_trace and log_once(
@@ -72,7 +83,7 @@ def omit_traceback_stdout(fn: Callable) -> Callable:
                         f"Data log file at `{get_log_directory()}`, set "
                         "`DataContext.log_internal_stack_trace` to True."
                     )
-            else:
+            elif not is_actionable_exception:
                 # Exception has occurred in internal Ray Data / Ray Core code.
                 logger.error(
                     "Exception occurred in Ray Data or Ray Core internal code. "
@@ -81,9 +92,10 @@ def omit_traceback_stdout(fn: Callable) -> Callable:
                     "https://github.com/ray-project/ray/issues/new/choose"
                 )
 
-            if is_user_code_exception:
-                # The driver-side propagation frames add nothing for a user-code
-                # error — the real failure is the worker traceback in ``str(e)``.
+            if is_actionable_exception:
+                # The driver-side propagation frames add nothing here: for a
+                # user-code error the real failure is the worker traceback in
+                # ``str(e)``, and for a timeout the message is self-contained.
                 # Keep them off stdout always (``hide=True`` filters the console
                 # handler only; the file handler still writes the record). The
                 # flag controls only what reaches the log file.
@@ -97,7 +109,7 @@ def omit_traceback_stdout(fn: Callable) -> Callable:
                 # System exception (likely a Ray bug): surface the full trace on
                 # stdout (and the log file) so the user can report it.
                 logger.exception("Full stack trace:", exc_info=True)
-            if is_user_code_exception:
+            if is_actionable_exception:
                 raise e.with_traceback(None)
             else:
                 raise e.with_traceback(None) from SystemException()

--- a/python/ray/data/tests/test_no_progress_guard.py
+++ b/python/ray/data/tests/test_no_progress_guard.py
@@ -1,0 +1,69 @@
+import time
+
+import pytest
+
+import ray
+from ray.data._internal.execution.interfaces import ExecutionOptions
+from ray.data._internal.execution.no_progress_guard import NoProgressGuard
+from ray.data._internal.execution.streaming_executor_state import (
+    build_streaming_topology,
+)
+from ray.data._internal.logical.optimizers import get_execution_plan
+from ray.data.context import DataContext, ShuffleStrategy
+from ray.data.exceptions import ExecutionTimeoutError
+from ray.data.tests.conftest import *  # noqa
+from ray.data.tests.conftest import noop_counter
+from ray.tests.conftest import *  # noqa
+
+# Deterministic coverage of the guard's timing logic lives in
+# `tests/unit/test_no_progress_guard.py`, which drives it with an injected
+# clock. This file covers the wiring into `StreamingExecutor` against a real
+# cluster.
+#
+# These use `ray_start_regular` rather than the shared cluster: a UDF blocked
+# forever keeps holding its CPU after the execution fails, which would starve
+# whichever test ran next.
+
+
+def test_hanging_udf_fails_execution(
+    ray_start_regular, restore_data_context  # noqa: F811
+):
+    DataContext.get_current().execution_no_progress_timeout_s = 2
+
+    def hang(row):
+        time.sleep(10**6)
+        return row
+
+    ds = ray.data.range(1).map(hang)
+    with pytest.raises(ExecutionTimeoutError, match="made no progress"):
+        ds.take(1)
+
+
+# GPU_SHUFFLE is excluded because building its plan needs GPUs in the cluster.
+@pytest.mark.parametrize(
+    "shuffle_strategy",
+    [s for s in ShuffleStrategy if s is not ShuffleStrategy.GPU_SHUFFLE],
+)
+def test_legacy_shuffle_operators_disable_the_guard(
+    shuffle_strategy,
+    restore_data_context,  # noqa: F811
+):
+    # Only the V2 hash shuffle implementation is supported by the guard.
+    expected_enabled = shuffle_strategy is ShuffleStrategy.HASH_SHUFFLE_V2
+    DataContext.get_current().shuffle_strategy = shuffle_strategy
+
+    ds = ray.data.range(1).groupby("id").count()
+    physical_plan, _ = get_execution_plan(ds._logical_plan)
+    topology = build_streaming_topology(
+        physical_plan.dag, ExecutionOptions(), noop_counter()
+    )
+
+    guard = NoProgressGuard(topology, timeout_s=1)
+
+    assert guard.enabled is expected_enabled
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main(["-v", __file__]))

--- a/python/ray/data/tests/unit/test_no_progress_guard.py
+++ b/python/ray/data/tests/unit/test_no_progress_guard.py
@@ -1,0 +1,182 @@
+from types import SimpleNamespace
+from typing import Optional, cast
+
+import pytest
+
+from ray.data._internal.execution.no_progress_guard import NoProgressGuard
+from ray.data._internal.execution.streaming_executor_state import Topology
+from ray.data.exceptions import ExecutionTimeoutError
+
+
+class _FakeOperator:
+    """Minimal stand-in for the operator surface the guard reads."""
+
+    def __init__(
+        self,
+        name: str,
+        num_outputs_taken: int = 0,
+        num_tasks_finished: int = 0,
+        num_active_tasks: int = 0,
+        completed: bool = False,
+        extra_metrics: Optional[dict] = None,
+    ):
+        self.name = name
+        self.metrics = SimpleNamespace(
+            num_outputs_taken=num_outputs_taken,
+            num_tasks_finished=num_tasks_finished,
+            extra_metrics=extra_metrics or {},
+        )
+        self._num_active_tasks = num_active_tasks
+        self._completed = completed
+
+    def has_completed(self) -> bool:
+        return self._completed
+
+    def num_active_tasks(self) -> int:
+        return self._num_active_tasks
+
+
+class _FakeOpState:
+    """Minimal stand-in for the `OpState` surface the guard reads."""
+
+    def __init__(self, input_blocks: int = 0, output_blocks: int = 0):
+        self.input_blocks = input_blocks
+        self.output_blocks = output_blocks
+
+    def total_enqueued_input_blocks(self) -> int:
+        return self.input_blocks
+
+    def total_enqueued_output_blocks(self) -> int:
+        return self.output_blocks
+
+
+class _FakeClock:
+    def __init__(self):
+        self.now = 0.0
+
+    def __call__(self) -> float:
+        return self.now
+
+    def advance(self, seconds: float) -> None:
+        self.now += seconds
+
+
+def _make_guard(ops, timeout_s=3.0):
+    clock = _FakeClock()
+    topology = {op: _FakeOpState() for op in ops}
+    guard = NoProgressGuard(cast(Topology, topology), timeout_s, clock=clock)
+    return guard, clock
+
+
+def test_raises_once_timeout_elapses_without_progress():
+    op = _FakeOperator("MapBatches(embed)")
+    guard, clock = _make_guard([op], timeout_s=3.0)
+
+    clock.advance(2.0)
+    guard.check()
+
+    clock.advance(1.0)
+    with pytest.raises(ExecutionTimeoutError):
+        guard.check()
+
+
+def test_progress_resets_the_clock():
+    op = _FakeOperator("MapBatches(embed)")
+    guard, clock = _make_guard([op], timeout_s=3.0)
+
+    for _ in range(3):
+        clock.advance(2.0)
+        op.metrics.num_outputs_taken += 1
+        guard.check()
+
+    # 6s elapsed overall without ever tripping the 3s timeout, because each
+    # output restarted the stall clock. The clock restarted at the last check,
+    # so a full `timeout_s` has to pass from there to trip it.
+    clock.advance(2.0)
+    guard.check()
+
+    clock.advance(1.0)
+    with pytest.raises(ExecutionTimeoutError):
+        guard.check()
+
+
+def test_progress_by_any_operator_counts():
+    stalled = _FakeOperator("Sort")
+    moving = _FakeOperator("MapBatches(embed)")
+    guard, clock = _make_guard([stalled, moving], timeout_s=3.0)
+
+    for _ in range(3):
+        clock.advance(2.0)
+        moving.metrics.num_outputs_taken += 1
+        guard.check()
+
+
+def test_queue_movement_counts_as_progress():
+    op = _FakeOperator("MapBatches(embed)")
+    state = _FakeOpState()
+    clock = _FakeClock()
+    guard = NoProgressGuard(cast(Topology, {op: state}), 3.0, clock=clock)
+
+    for _ in range(3):
+        clock.advance(2.0)
+        state.input_blocks += 1
+        guard.check()
+
+    for _ in range(3):
+        clock.advance(2.0)
+        state.output_blocks += 1
+        guard.check()
+
+    clock.advance(3.0)
+    with pytest.raises(ExecutionTimeoutError):
+        guard.check()
+
+
+def test_zero_timeout_is_rejected():
+    """Zero would fail every execution on its first check, so reject it."""
+    with pytest.raises(ValueError, match="must be positive"):
+        NoProgressGuard({}, 0)
+
+
+@pytest.mark.parametrize("timeout_s", [-1, -3])
+def test_disabled(timeout_s):
+    op = _FakeOperator("MapBatches(embed)")
+    guard, clock = _make_guard([op], timeout_s=timeout_s)
+
+    assert not guard.enabled
+    clock.advance(1000.0)
+    guard.check()
+
+
+def test_error_message_names_stalled_operators():
+    stalled = _FakeOperator(
+        "MapBatches(embed)",
+        num_outputs_taken=2,
+        num_tasks_finished=3,
+        num_active_tasks=1,
+    )
+    completed = _FakeOperator("Sort", completed=True)
+    guard, clock = _make_guard([stalled, completed], timeout_s=3.0)
+
+    clock.advance(2.0)
+    guard.check()
+
+    clock.advance(1.0)
+    with pytest.raises(ExecutionTimeoutError) as exc_info:
+        guard.check()
+
+    message = str(exc_info.value)
+    assert (
+        "made no progress for at least 3s of scheduling time "
+        "(timeout: 3s)" in message
+    )
+    assert "MapBatches(embed): 1 active task(s), 3 finished, 2 outputs taken" in message
+    # Completed operators aren't stalled, so they aren't reported.
+    assert "Sort" not in message
+    assert "execution_no_progress_timeout_s" in message
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main(["-v", __file__]))


### PR DESCRIPTION
…(#65152)

## Description

A stalled Ray Data execution today does nothing visible. The scheduling loop keeps spinning, no output comes out, no error is raised, and the job holds cluster resources until someone notices. A blocked UDF, a lost task, and a cluster that can't schedule after preemption all look identical.

This adds a no-progress timeout. If no operator makes progress for 30 minutes, the execution fails with `ExecutionTimeoutError` naming the stalled operators.

## Related issues

Closes #65060

## Additional information

**Design.** A `NoProgressGuard` owned by the executor, checked once per scheduling-loop step. It watches `num_outputs_taken` summed across the topology, plus the same counter from `extra_metrics` so hash-based operators' finalize phase is included. `run()` already forwards loop exceptions through `mark_finished(exc)`, so no new error plumbing was needed.

**The 30 minutes is accumulated stall time, not elapsed time.** It resets on any progress, so a job that runs for hours never approaches it as long as data keeps moving. Three things stop it from advancing at all, and each came out of a case that would otherwise have failed a healthy job:

*Slow consumers.* A slow caller freezes the progress counter through backpressure, so the clock only advances while a consumer is actually blocked on an empty output queue. An empty queue alone isn't enough: a prefetcher can drain it while the caller is still the bottleneck.

*Operators that block the loop.* An all-to-all `bulk_fn` runs a whole sort inside one scheduling step, and its outputs only register on the step after. A single interval therefore contributes at most `10 × WAIT_FOR_TASK_COMPLETION_TIMEOUT_S`, so the clock measures time the loop spent spinning rather than wall-clock time. The flip side is that the configured value is a floor: where a step outlasts the cap, the timeout fires late by roughly `step_duration / cap`.

*Barrier phases.* A hash shuffle, join or aggregate only reports once a whole partition finalizes, and that gap grows with the data, so a large one would eventually look stalled. The clock pauses while one of those phases has a task in flight.

30 minutes is a judgment call, not a derived number. A slow UDF and a hang look identical to any progress counter. It's 30x `WARN_ON_IDLE_TIME_S`, and cheap to revisit since it's configurable.

**Error message.**

```
Dataset execution made no progress for at least 1832s of scheduling time
(timeout: 1800s). No operator produced or consumed an output in that window.
Operators still running:
  - MapBatches(embed): 4 active task(s), 118 finished, 118 outputs taken
If your UDF is legitimately this slow, raise the timeout ...
```

**`omit_traceback_stdout` change.** It previously treated every non-`UserCodeException` as an internal bug ( "please open an issue" banner, internal frames on stdout, chained `from SystemException()`). A timeout is a diagnosable condition, not a Ray bug, so it's carved out. Behavior for all other exception types is unchanged.

**Measurements.** On `groupby(...).count()`, the peak stall the guard actually accumulates is 1% of the run and holds at that ratio from 5M to 20M rows, so a healthy job would have to run around 50 hours before the 30-minute default became a risk. Counting only
`metrics.num_outputs_taken`, without the `extra_metrics` handling or the barrier pause, put that at 75%.

**Not covered.** A hang in the executor thread itself: the check runs from the scheduling loop, so a loop wedged inside a blocking call never reaches it. A hang inside a barrier operator's finalize phase, where the only observable state is that a task is running — task-duration outlier detection is the right tool for that, and
`HangingExecutionIssueDetector` already implements it. And a blocked worker keeps its CPU after the execution fails, until the driver exits; Ray Data's cancellation never reaches `ray.cancel(force=True)`, which I've reported separately.

---------

> Thank you for contributing to Ray! 🚀
> Please review the [Ray Contribution Guide](https://docs.ray.io/en/master/ray-contribute/getting-involved.html) before opening a pull request.

> ⚠️ Remove these instructions before submitting your PR.

> 💡 Tip: Mark as draft if you want early feedback, or ready for review when it's complete.

## Description
> Briefly describe what this PR accomplishes and why it's needed.

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
