### PR TITLE
[cherry-pick][2.58.0][core][taskEvents out of GCS][4/n] Notify task events head on worker death and job finished (#65057)

### DIFF
--- a/python/ray/_private/gcs_pubsub.py
+++ b/python/ray/_private/gcs_pubsub.py
@@ -291,3 +291,79 @@ class GcsAioNodeInfoSubscriber(_AioSubscriber):
             msgs.append((msg.key_id, msg.node_info_message))
             popped += 1
         return msgs
+
+
+class GcsAioWorkerDeltaSubscriber(_AioSubscriber):
+    def __init__(
+        self,
+        worker_id: bytes = None,
+        address: str = None,
+        channel: grpc.Channel = None,
+    ):
+        super().__init__(
+            pubsub_pb2.GCS_WORKER_DELTA_CHANNEL, worker_id, address, channel
+        )
+
+    async def poll(
+        self, batch_size: int, timeout: Optional[float] = None
+    ) -> List[Tuple[bytes, gcs_pb2.WorkerDeltaData]]:
+        """Polls for new worker failure messages.
+
+        Args:
+            batch_size: Maximum number of messages to return.
+            timeout: Optional timeout in seconds for the poll request.
+
+        Returns:
+            A list of tuples of (worker_id, WorkerDeltaData).
+        """
+        await self._poll(timeout=timeout)
+        return self._pop_worker_deltas(self._queue, batch_size=batch_size)
+
+    @staticmethod
+    def _pop_worker_deltas(queue, batch_size):
+        if len(queue) == 0:
+            return []
+        popped = 0
+        msgs = []
+        while len(queue) > 0 and popped < batch_size:
+            msg = queue.popleft()
+            msgs.append((msg.key_id, msg.worker_delta_message))
+            popped += 1
+        return msgs
+
+
+class GcsAioJobSubscriber(_AioSubscriber):
+    def __init__(
+        self,
+        worker_id: bytes = None,
+        address: str = None,
+        channel: grpc.Channel = None,
+    ):
+        super().__init__(pubsub_pb2.GCS_JOB_CHANNEL, worker_id, address, channel)
+
+    async def poll(
+        self, batch_size: int, timeout: Optional[float] = None
+    ) -> List[Tuple[bytes, gcs_pb2.JobTableData]]:
+        """Polls for new job messages.
+
+        Args:
+            batch_size: Maximum number of messages to return.
+            timeout: Optional timeout in seconds for the poll request.
+
+        Returns:
+            A list of tuples of (job_id, JobTableData).
+        """
+        await self._poll(timeout=timeout)
+        return self._pop_job_messages(self._queue, batch_size=batch_size)
+
+    @staticmethod
+    def _pop_job_messages(queue, batch_size):
+        if len(queue) == 0:
+            return []
+        popped = 0
+        msgs = []
+        while len(queue) > 0 and popped < batch_size:
+            msg = queue.popleft()
+            msgs.append((msg.key_id, msg.job_message))
+            popped += 1
+        return msgs

--- a/python/ray/dashboard/consts.py
+++ b/python/ray/dashboard/consts.py
@@ -15,6 +15,7 @@ DASHBOARD_AGENT_CHECK_PARENT_INTERVAL_S = env_integer(
 # The maximum time that parent can be considered
 # as dead before agent kills itself.
 _PARENT_DEATH_THREASHOLD = 5
+
 RAY_STATE_SERVER_MAX_HTTP_REQUEST_ENV_NAME = "RAY_STATE_SERVER_MAX_HTTP_REQUEST"
 # Default number of in-progress requests to the state api server.
 RAY_STATE_SERVER_MAX_HTTP_REQUEST = env_integer(

--- a/python/ray/dashboard/head.py
+++ b/python/ray/dashboard/head.py
@@ -192,9 +192,10 @@ class DashboardHead:
             dashboard_head_modules,
             skipped_head_modules,
         ) = self._load_dashboard_head_modules(modules_to_load)
-        subprocess_module_handles = self._load_subprocess_module_handles(
-            modules_to_load
-        )
+        (
+            subprocess_module_handles,
+            skipped_subprocess_modules,
+        ) = self._load_subprocess_module_handles(modules_to_load)
 
         all_names = {type(m).__name__ for m in dashboard_head_modules} | {
             h.module_cls.__name__ for h in subprocess_module_handles
@@ -203,9 +204,12 @@ class DashboardHead:
             subprocess_module_handles
         ), "Duplicate module names. A module name can't be a DashboardHeadModule and a SubprocessModule at the same time."
 
-        # Verify modules are loaded as expected.
+        # Verify modules are loaded as expected. Subtract both kinds of disabled modules;
+        # a requested-but-disabled module (head or subprocess) is legitimately skipped.
         if modules_to_load is not None:
-            expected_names = modules_to_load - skipped_head_modules
+            expected_names = (
+                modules_to_load - skipped_head_modules - skipped_subprocess_modules
+            )
             if all_names != expected_names:
                 assert False, (
                     f"Actual loaded modules {all_names}, doesn't match the requested modules "
@@ -265,10 +269,10 @@ class DashboardHead:
 
     def _load_subprocess_module_handles(
         self, modules_to_load: Optional[Set[str]] = None
-    ) -> List["SubprocessModuleHandle"]:
+    ) -> Tuple[List["SubprocessModuleHandle"], Set[str]]:
         """Load ``SubprocessModule`` handles.
 
-        If minimal, return an empty list.
+        If minimal, load no subprocess modules.
         If non-minimal, load `SubprocessModule`s by creating Handles to them.
 
         Args:
@@ -276,12 +280,13 @@ class DashboardHead:
                 it loads all modules.
 
         Returns:
-            A list of ``SubprocessModuleHandle`` instances, or an empty list in
-            minimal mode.
+            A tuple of ``(handles, skipped_module_names)``: the loaded
+            ``SubprocessModuleHandle`` instances, and the names of modules skipped
+            because they are disabled. Both are empty in minimal mode.
         """
         if self.minimal:
             logger.info("Subprocess modules not loaded in minimal mode.")
-            return []
+            return [], set()
 
         from ray.dashboard.subprocesses.handle import SubprocessModuleHandle
         from ray.dashboard.subprocesses.module import (
@@ -290,6 +295,7 @@ class DashboardHead:
         )
 
         handles = []
+        skipped_modules = set()
         subprocess_cls_list = dashboard_utils.get_all_modules(SubprocessModule)
 
         loop = ray._common.utils.get_or_create_event_loop()
@@ -315,12 +321,16 @@ class DashboardHead:
             ]
 
         for cls in subprocess_cls_list:
+            if not cls.is_enabled():
+                logger.info(f"Skipping {SubprocessModule.__name__}: {cls} (disabled).")
+                skipped_modules.add(cls.__name__)
+                continue
             logger.info(f"Loading {SubprocessModule.__name__}: {cls}.")
             handle = SubprocessModuleHandle(loop, cls, config)
             handles.append(handle)
 
         logger.info(f"Loaded {len(handles)} subprocess modules: {handles}.")
-        return handles
+        return handles, skipped_modules
 
     async def _setup_metrics(self, gcs_client):
         metrics = DashboardPrometheusMetrics()

--- a/python/ray/dashboard/modules/aggregator/aggregator_agent.py
+++ b/python/ray/dashboard/modules/aggregator/aggregator_agent.py
@@ -121,10 +121,12 @@ class AggregatorAgent(
         # (TaskEventsMetadataBuffer.get() pops), so a shared buffer would split the
         # dropped attempts across publishers instead of delivering them to both.
         self._task_metadata_buffer = TaskEventsMetadataBuffer(
-            common_metric_tags=self._common_tags
+            common_metric_tags=self._common_tags,
+            publisher_name="ray_gcs",
         )
         self._dashboard_head_task_metadata_buffer = TaskEventsMetadataBuffer(
-            common_metric_tags=self._common_tags
+            common_metric_tags=self._common_tags,
+            publisher_name="dashboard_head",
         )
 
         self._events_export_addr = (

--- a/python/ray/dashboard/modules/aggregator/publisher/async_publisher_client.py
+++ b/python/ray/dashboard/modules/aggregator/publisher/async_publisher_client.py
@@ -11,9 +11,6 @@ import aiohttp
 import ray.dashboard.utils as dashboard_utils
 from ray._common.utils import get_or_create_event_loop
 from ray._private import ray_constants
-from ray._private.authentication.http_token_authentication import (
-    get_auth_headers_if_auth_enabled,
-)
 from ray._private.protobuf_compat import message_to_json
 from ray._raylet import GcsClient
 from ray.core.generated import (
@@ -21,6 +18,9 @@ from ray.core.generated import (
     events_event_aggregator_service_pb2,
 )
 from ray.dashboard.consts import GCS_RPC_TIMEOUT_SECONDS
+from ray.dashboard.modules.aggregator.publisher.authenticated_http_client import (
+    AuthenticatedHttpClient,
+)
 from ray.dashboard.modules.aggregator.publisher.configs import (
     HTTP_EXPOSABLE_EVENT_TYPES,
     PUBLISHER_TIMEOUT_SECONDS,
@@ -316,8 +316,7 @@ class AsyncDashboardHeadPublisherClient(PublisherClientInterface):
         self._gcs_client = gcs_client
         self._executor = executor
         self._endpoint_path = endpoint_path
-        self._timeout = aiohttp.ClientTimeout(total=timeout_s)
-        self._session = None
+        self._http_client = AuthenticatedHttpClient(timeout_s=timeout_s)
         # Resolved lazily from InternalKV on first publish and cached.
         self._endpoint = None
 
@@ -393,17 +392,8 @@ class AsyncDashboardHeadPublisherClient(PublisherClientInterface):
                 lambda: request.SerializeToString(),
             )
 
-            # Create session on first use (lazy initialization)
-            if not self._session:
-                self._session = aiohttp.ClientSession(timeout=self._timeout)
-            # Propagate the auth token so the POST passes the dashboard's auth middleware.
-            headers = get_auth_headers_if_auth_enabled({})
             try:
-                async with self._session.post(
-                    endpoint,
-                    data=serialized_request,
-                    headers=headers,
-                ) as resp:
+                async with self._http_client.post(endpoint, serialized_request) as resp:
                     resp.raise_for_status()
             except (aiohttp.ClientConnectionError, asyncio.TimeoutError):
                 # Couldn't reach the endpoint; the dashboard head may have restarted at a
@@ -443,6 +433,4 @@ class AsyncDashboardHeadPublisherClient(PublisherClientInterface):
         return events_data
 
     async def close(self) -> None:
-        if self._session:
-            await self._session.close()
-            self._session = None
+        await self._http_client.close()

--- a/python/ray/dashboard/modules/aggregator/publisher/authenticated_http_client.py
+++ b/python/ray/dashboard/modules/aggregator/publisher/authenticated_http_client.py
@@ -1,0 +1,42 @@
+import logging
+from typing import Optional
+
+import aiohttp
+
+from ray._private.authentication.http_token_authentication import (
+    get_auth_headers_if_auth_enabled,
+)
+from ray.dashboard.modules.aggregator.publisher.configs import (
+    PUBLISHER_TIMEOUT_SECONDS,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class AuthenticatedHttpClient:
+    """Reusable aiohttp client that attaches Ray's cluster auth token on every request.
+
+    Wraps a single lazily-created ``aiohttp.ClientSession`` and injects the auth headers
+    in one place, so callers POSTing to authenticated dashboard endpoints can't
+    accidentally send an unauthenticated request.
+    """
+
+    def __init__(self, timeout_s: float = PUBLISHER_TIMEOUT_SECONDS) -> None:
+        self._timeout = aiohttp.ClientTimeout(total=timeout_s)
+        self._session: Optional[aiohttp.ClientSession] = None
+
+    def post(self, url: str, data: bytes):
+        """POST ``data`` to ``url`` with auth headers attached.
+
+        Mirrors ``aiohttp.ClientSession.post`` and returns its request context manager,
+        so callers use ``async with client.post(...) as resp``.
+        """
+        if self._session is None:
+            self._session = aiohttp.ClientSession(timeout=self._timeout)
+        headers = get_auth_headers_if_auth_enabled({})
+        return self._session.post(url, data=data, headers=headers)
+
+    async def close(self) -> None:
+        if self._session is not None:
+            await self._session.close()
+            self._session = None

--- a/python/ray/dashboard/modules/aggregator/task_events_metadata_buffer.py
+++ b/python/ray/dashboard/modules/aggregator/task_events_metadata_buffer.py
@@ -19,6 +19,7 @@ class TaskEventsMetadataBuffer:
         max_buffer_size: int = 1000,
         max_dropped_attempts_per_metadata_entry: int = 100,
         common_metric_tags: Optional[Dict[str, str]] = None,
+        publisher_name: str = "",
     ):
         self._buffer_maxlen = max(
             max_buffer_size - 1, 1
@@ -31,7 +32,13 @@ class TaskEventsMetadataBuffer:
 
         self._common_metric_tags = common_metric_tags or {}
         self._metric_recorder = OpenTelemetryMetricRecorder()
-        self._dropped_metadata_count_metric_name = f"{AGGREGATOR_AGENT_METRIC_PREFIX}_task_metadata_buffer_dropped_attempts_total"
+        # Namespace the counter per publisher so buffers feeding different publishers
+        # register distinct instruments on the process-global meter instead of colliding
+        # on a single name.
+        self._dropped_metadata_count_metric_name = (
+            f"{AGGREGATOR_AGENT_METRIC_PREFIX}_{publisher_name}"
+            "_task_metadata_buffer_dropped_attempts_total"
+        )
         self._metric_recorder.register_counter_metric(
             self._dropped_metadata_count_metric_name,
             "Total number of dropped task attempt metadata entries which were dropped due to buffer being full",

--- a/python/ray/dashboard/modules/task_events/task_events_head.py
+++ b/python/ray/dashboard/modules/task_events/task_events_head.py
@@ -1,35 +1,65 @@
+import asyncio
 import collections
 import logging
+from typing import Set
 
 import aiohttp.web
 
+import ray
 import ray.dashboard.optional_utils as dashboard_optional_utils
 import ray.dashboard.utils as dashboard_utils
-from ray.core.generated import events_event_aggregator_service_pb2
+from ray._private.gcs_pubsub import GcsAioJobSubscriber, GcsAioWorkerDeltaSubscriber
+from ray.core.generated import events_event_aggregator_service_pb2, gcs_pb2
 from ray.dashboard.subprocesses.module import SubprocessModule
 from ray.dashboard.subprocesses.routes import SubprocessRouteTable as routes
 
 logger = logging.getLogger(__name__)
 
+# Max notifications drained from a GCS pubsub subscriber per poll.
+_SUBSCRIBER_POLL_BATCH_SIZE = 100
+
 
 class TaskEventsHead(SubprocessModule):
-    """Dashboard-head endpoint that receives task events from per-node aggregators.
+    """Dashboard-head sink for task events and their GCS reconciliation signals.
 
-    The per-node aggregator agent POSTs an ``AddEventsRequest`` payload
-     to this module, which holds the received``RayEvent``s in memory.
+    Receives task events over HTTP from the per-node aggregator agents (which POST an
+    ``AddEventsRequest`` payload), and subscribes to GCS pubsub for the worker-death and
+    job-finished notifications needed to reconcile task state (the signals
+    ``GcsTaskManager`` consumes in-process today). Everything is held in memory for now.
     """
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        # TODO(karticam): Replace this with an in-memory store of task events.
-        #   This will mimic current GcsTaskManager and will power state API.
-        #   Will be done in future PRs.
+        # TODO(karticam): Replace these in-memory buffers with a task-event store +
+        #   reconciliation logic (mirroring GcsTaskManager) that powers the state API.
+        #   Consuming the worker-death / job-finished notifications below to actually
+        #   fail tasks (MarkTasksFailedOnWorkerDead / MarkTasksFailedOnJobEnds) is a
+        #   follow-up PR.
         self._events = collections.deque()
+        self._dead_workers = collections.deque()
+        self._finished_jobs = collections.deque()
+        self._background_tasks: Set[asyncio.Task] = set()
+
+    @classmethod
+    def is_enabled(cls) -> bool:
+        """Only load while the "task events out of GCS" migration is enabled; otherwise
+        the module (and its GCS pubsub subscriptions) shouldn't run at all."""
+        return ray._config.enable_task_events_to_dashboard_head()
 
     @property
     def num_events_received(self) -> int:
         """Number of task events currently held in the in-memory buffer (for tests)."""
         return len(self._events)
+
+    @property
+    def num_dead_workers_received(self) -> int:
+        """Number of worker-death notifications received (for tests)."""
+        return len(self._dead_workers)
+
+    @property
+    def num_finished_jobs_received(self) -> int:
+        """Number of job-finished notifications received (for tests)."""
+        return len(self._finished_jobs)
 
     def _deserialize_request(
         self, body: bytes
@@ -47,7 +77,7 @@ class TaskEventsHead(SubprocessModule):
         except Exception as e:
             logger.warning(f"Failed to deserialize task events request: {e}")
             return dashboard_optional_utils.rest_response(
-                status_code=dashboard_utils.HTTPStatusCode.INTERNAL_ERROR,
+                status_code=dashboard_utils.HTTPStatusCode.BAD_REQUEST,
                 message=f"Failed to deserialize task events request: {e}",
             )
 
@@ -63,5 +93,47 @@ class TaskEventsHead(SubprocessModule):
             message="",
         )
 
+    def _handle_worker_delta(self, worker_delta: gcs_pb2.WorkerDeltaData) -> None:
+        """Record a worker-death notification. GCS_WORKER_DELTA_CHANNEL only carries
+        failures, so every message is a death."""
+        self._dead_workers.append(worker_delta)
+
+    def _handle_job_update(self, job_data: gcs_pb2.JobTableData) -> None:
+        """Record a job-finished notification. GCS_JOB_CHANNEL fires on both job start and
+        finish; keep only finished jobs (``is_dead``) to mirror ``OnJobFinished``."""
+        if job_data.is_dead:
+            self._finished_jobs.append(job_data)
+
+    async def _subscribe_for_worker_deaths(self) -> None:
+        subscriber = GcsAioWorkerDeltaSubscriber(address=self.gcs_address)
+        await subscriber.subscribe()
+        while True:
+            try:
+                for _, worker_delta in await subscriber.poll(
+                    batch_size=_SUBSCRIBER_POLL_BATCH_SIZE
+                ):
+                    self._handle_worker_delta(worker_delta)
+            except Exception:
+                logger.exception("Failed handling worker-death notifications.")
+
+    async def _subscribe_for_finished_jobs(self) -> None:
+        subscriber = GcsAioJobSubscriber(address=self.gcs_address)
+        await subscriber.subscribe()
+        while True:
+            try:
+                for _, job_data in await subscriber.poll(
+                    batch_size=_SUBSCRIBER_POLL_BATCH_SIZE
+                ):
+                    self._handle_job_update(job_data)
+            except Exception:
+                logger.exception("Failed handling job-finished notifications.")
+
     async def run(self):
         await super().run()
+        for coro in (
+            self._subscribe_for_worker_deaths(),
+            self._subscribe_for_finished_jobs(),
+        ):
+            task = asyncio.create_task(coro)
+            self._background_tasks.add(task)
+            task.add_done_callback(self._background_tasks.discard)

--- a/python/ray/dashboard/modules/task_events/tests/test_task_events_head.py
+++ b/python/ray/dashboard/modules/task_events/tests/test_task_events_head.py
@@ -9,7 +9,7 @@ from ray._common.ray_constants import (
     LOGGING_ROTATE_BACKUP_COUNT,
     LOGGING_ROTATE_BYTES,
 )
-from ray.core.generated import events_event_aggregator_service_pb2
+from ray.core.generated import events_event_aggregator_service_pb2, gcs_pb2
 from ray.core.generated.events_base_event_pb2 import RayEvent
 from ray.dashboard.modules.task_events.task_events_head import TaskEventsHead
 from ray.dashboard.subprocesses.module import SubprocessModuleConfig
@@ -106,6 +106,35 @@ def test_deserialize_request_roundtrip():
     request = head._deserialize_request(body)
 
     assert len(request.events_data.events) == 1
+
+
+def test_handle_worker_delta_buffers():
+    head = _make_head()
+    assert head.num_dead_workers_received == 0
+
+    head._handle_worker_delta(
+        gcs_pb2.WorkerDeltaData(worker_id=b"worker_1", node_id=b"node_1")
+    )
+
+    assert head.num_dead_workers_received == 1
+
+
+def test_handle_job_update_buffers_finished_job():
+    head = _make_head()
+
+    head._handle_job_update(
+        gcs_pb2.JobTableData(job_id=b"job_1", is_dead=True, end_time=123)
+    )
+
+    assert head.num_finished_jobs_received == 1
+
+
+def test_handle_job_update_ignores_running_job():
+    head = _make_head()
+
+    head._handle_job_update(gcs_pb2.JobTableData(job_id=b"job_1", is_dead=False))
+
+    assert head.num_finished_jobs_received == 0
 
 
 if __name__ == "__main__":

--- a/python/ray/dashboard/modules/task_events/tests/test_task_events_head_integration.py
+++ b/python/ray/dashboard/modules/task_events/tests/test_task_events_head_integration.py
@@ -1,0 +1,103 @@
+import asyncio
+import sys
+
+import pytest
+
+import ray
+import ray._private.ray_constants as ray_constants
+import ray.dashboard.consts as dashboard_consts
+from ray._common.ray_constants import (
+    LOGGING_ROTATE_BACKUP_COUNT,
+    LOGGING_ROTATE_BYTES,
+)
+from ray._common.test_utils import async_wait_for_condition, run_string_as_driver
+from ray.dashboard.modules.task_events.task_events_head import TaskEventsHead
+from ray.dashboard.subprocesses.module import SubprocessModuleConfig
+from ray.tests.conftest import *  # noqa
+
+
+def _make_head(gcs_address: str) -> TaskEventsHead:
+    """Build a TaskEventsHead directly in the test's driver process (not as its usual
+    separate SubprocessModule) so the test can drive its subscription loops and read its
+    in-memory buffers in-process. Test-only."""
+    config = SubprocessModuleConfig(
+        cluster_id_hex="deadbeef",
+        gcs_address=gcs_address,
+        session_name="test_session",
+        temp_dir="/tmp",
+        session_dir="/tmp",
+        logging_level=ray_constants.LOGGER_LEVEL,
+        logging_format=ray_constants.LOGGER_FORMAT,
+        log_dir="/tmp",
+        logging_filename=dashboard_consts.DASHBOARD_LOG_FILENAME,
+        logging_rotate_bytes=LOGGING_ROTATE_BYTES,
+        logging_rotate_backup_count=LOGGING_ROTATE_BACKUP_COUNT,
+        socket_dir="/tmp",
+    )
+    return TaskEventsHead(config)
+
+
+async def _stop(subscription: asyncio.Task) -> None:
+    subscription.cancel()
+    try:
+        await subscription
+    except asyncio.CancelledError:
+        pass
+
+
+@pytest.mark.asyncio
+async def test_worker_death_lands_in_buffer(ray_start_regular):
+    """A killed worker's failure is delivered over GCS pubsub and buffered by the head."""
+    gcs_address = ray_start_regular["gcs_address"]
+    head = _make_head(gcs_address)
+
+    subscription = asyncio.create_task(head._subscribe_for_worker_deaths())
+    try:
+        # Let the subscription register before triggering the death: GCS only queues
+        # messages for a subscriber once its subscription is established.
+        await asyncio.sleep(2)
+
+        @ray.remote
+        class Actor:
+            def get_worker_id(self):
+                return ray.get_runtime_context().get_worker_id()
+
+        actor = Actor.remote()
+        worker_id = bytes.fromhex(await actor.get_worker_id.remote())
+        ray.kill(actor, no_restart=True)
+
+        await async_wait_for_condition(
+            lambda: worker_id in {wd.worker_id for wd in head._dead_workers},
+            timeout=30,
+        )
+    finally:
+        await _stop(subscription)
+
+
+@pytest.mark.asyncio
+async def test_job_finished_lands_in_buffer(ray_start_regular):
+    """A finished job is delivered over GCS pubsub and buffered by the head."""
+    gcs_address = ray_start_regular["gcs_address"]
+    head = _make_head(gcs_address)
+
+    subscription = asyncio.create_task(head._subscribe_for_finished_jobs())
+    try:
+        await asyncio.sleep(2)
+
+        # A driver that connects and immediately exits, finishing its job. Run it off the
+        # event loop so the subscription keeps polling while the subprocess runs.
+        driver = f'import ray\nray.init(address="{gcs_address}")\n'
+        await asyncio.get_running_loop().run_in_executor(
+            None, run_string_as_driver, driver
+        )
+
+        await async_wait_for_condition(
+            lambda: any(job.is_dead for job in head._finished_jobs),
+            timeout=30,
+        )
+    finally:
+        await _stop(subscription)
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/dashboard/subprocesses/module.py
+++ b/python/ray/dashboard/subprocesses/module.py
@@ -99,6 +99,12 @@ class SubprocessModule(abc.ABC):
         """
         return False
 
+    @classmethod
+    def is_enabled(cls) -> bool:
+        """Return True if the module should be loaded. Subclasses can override to gate
+        loading behind a feature flag."""
+        return True
+
     async def run(self):
         """
         Start running the module.

--- a/python/ray/dashboard/tests/test_dashboard.py
+++ b/python/ray/dashboard/tests/test_dashboard.py
@@ -1476,15 +1476,34 @@ async def test_dashboard_module_load(tmpdir):
     with pytest.raises(AssertionError):
         head._load_modules(modules_to_load=loaded_modules_expected)
 
+    # A requested-but-disabled subprocess module (is_enabled() is False, e.g. the
+    # flag-gated TaskEventsHead) is skipped, not treated as a load failure.
+    disabled_subprocess_modules = {
+        m.__name__
+        for m in dashboard_utils.get_all_modules(SubprocessModule)
+        if not m.is_enabled()
+    }
+    if disabled_subprocess_modules:
+        _, subprocess_module_handles = head._load_modules(
+            modules_to_load=disabled_subprocess_modules
+        )
+        assert len(subprocess_module_handles) == 0
+
     # Test the base case.
     # It is needed to pass assertion check from one of modules.
     gcs_client = MagicMock()
     _initialize_internal_kv(gcs_client)
+    # Mirror the loader, which skips modules whose is_enabled() is False (e.g. modules
+    # gated behind a feature flag such as TaskEventsHead / PlatformEventsHead).
     loaded_dashboard_head_modules_expected = {
-        m.__name__ for m in dashboard_utils.get_all_modules(DashboardHeadModule)
+        m.__name__
+        for m in dashboard_utils.get_all_modules(DashboardHeadModule)
+        if m.is_enabled()
     }
     loaded_subprocess_module_handles_expected = {
-        m.__name__ for m in dashboard_utils.get_all_modules(SubprocessModule)
+        m.__name__
+        for m in dashboard_utils.get_all_modules(SubprocessModule)
+        if m.is_enabled()
     }
     dashboard_head_modules, subprocess_module_handles = head._load_modules()
     assert {

--- a/python/ray/tests/resource_isolation/test_resource_isolation_integration.py
+++ b/python/ray/tests/resource_isolation/test_resource_isolation_integration.py
@@ -84,9 +84,10 @@ _EXPECTED_DASHBOARD_MODULES = [
     "ray.dashboard.modules.reporter.reporter_head.ReportHead",
     "ray.dashboard.modules.serve.serve_head.ServeHead",
     "ray.dashboard.modules.state.state_head.StateHead",
-    "ray.dashboard.modules.task_events.task_events_head.TaskEventsHead",
     "ray.dashboard.modules.train.train_head.TrainHead",
 ]
+# TaskEventsHead is intentionally omitted: it is gated off by default
+# (RAY_enable_task_events_to_dashboard_head) and so does not run as a subprocess here.
 
 # The list of processes expected to be started in the system cgroup
 # with default params for 'ray start' and 'ray.init(...)'


### PR DESCRIPTION
Cherry-pick of #65057 (master commit dc13372872a6705d7ff773d7590f80657db77adc) onto `releases/2.58.0`.

Fresh single-commit pick against the current release head (2/n #65274 and 3/n #65275 already merged), created for a clean reviewable diff. Intentionally parallels #65291 — the earlier cherry-pick of the same commit whose branch carries update history; one of the two should be closed in favor of the other.

Clean cherry-pick, no conflicts (`git cherry-pick -x -s`). AI-assisted (Claude Code); submitted and reviewed by @elliot-barn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)