### PR TITLE
[cherry-pick][2.58.0][core][taskEvents out of GCS][5/n] In-memory task event store implementation on task events head (#65123)

### DIFF
--- a/python/ray/dashboard/modules/task_events/gc_policy.py
+++ b/python/ray/dashboard/modules/task_events/gc_policy.py
@@ -1,0 +1,44 @@
+"""Garbage-collection priority policy for the task-event store.
+
+Each task event is assigned a priority tier. When the store is over capacity, events in
+lower-priority tiers are evicted first: finished tasks first, then actor tasks, then
+everything else.
+"""
+from ray.core.generated import gcs_pb2
+from ray.core.generated.common_pb2 import TaskStatus, TaskType
+
+
+class FinishedTaskActorTaskGcPolicy:
+    """Buckets task events into priority tiers; a higher tier is evicted later."""
+
+    # Number of priority tiers, i.e. valid tiers are 0 .. max_priority - 1.
+    _MAX_PRIORITY = 3
+
+    @property
+    def max_priority(self) -> int:
+        """Number of priority tiers; valid tiers are 0 .. max_priority - 1."""
+        return self._MAX_PRIORITY
+
+    def get_task_list_priority(self, task_event: gcs_pb2.TaskEvents) -> int:
+        if self._is_task_finished(task_event):
+            return 0
+        if self._is_actor_task(task_event):
+            return 1
+        return 2
+
+    @staticmethod
+    def _is_task_finished(task_event: gcs_pb2.TaskEvents) -> bool:
+        """Whether the task attempt has reported a FINISHED state."""
+        if not task_event.HasField("state_updates"):
+            return False
+        return TaskStatus.FINISHED in task_event.state_updates.state_ts_ns
+
+    @staticmethod
+    def _is_actor_task(task_event: gcs_pb2.TaskEvents) -> bool:
+        """Whether the task attempt is an actor task or an actor creation task."""
+        if not task_event.HasField("task_info"):
+            return False
+        return task_event.task_info.type in (
+            TaskType.ACTOR_TASK,
+            TaskType.ACTOR_CREATION_TASK,
+        )

--- a/python/ray/dashboard/modules/task_events/ray_event_converter.py
+++ b/python/ray/dashboard/modules/task_events/ray_event_converter.py
@@ -1,0 +1,213 @@
+"""Convert aggregator ``RayEvent``s into the ``TaskEvents`` storage model.
+"""
+from typing import List, Tuple
+
+from ray._raylet import TaskID
+from ray.core.generated import gcs_pb2
+from ray.core.generated.common_pb2 import FunctionDescriptor, TaskInfoEntry, TaskType
+from ray.core.generated.events_base_event_pb2 import RayEvent
+from ray.core.generated.events_event_aggregator_service_pb2 import AddEventsRequest
+
+
+def _short_name(name: str) -> str:
+    """Return the component after the last '.' (e.g. ``module.foo`` -> ``foo``)."""
+    return name[name.rfind(".") + 1 :]
+
+
+def _call_string(function_descriptor: FunctionDescriptor) -> str:
+    """Return the short function/class name (for ``TaskInfoEntry.func_or_class_name``)
+    encoded in a ``FunctionDescriptor`` proto."""
+    which = function_descriptor.WhichOneof("function_descriptor")
+    if which == "python_function_descriptor":
+        p = function_descriptor.python_function_descriptor
+        if not p.class_name:
+            return _short_name(p.function_name)
+        return f"{_short_name(p.class_name)}.{_short_name(p.function_name)}"
+    if which == "java_function_descriptor":
+        j = function_descriptor.java_function_descriptor
+        if not j.class_name:
+            return j.function_name
+        return f"{j.class_name}.{j.function_name}"
+    if which == "cpp_function_descriptor":
+        return function_descriptor.cpp_function_descriptor.function_name
+    return ""
+
+
+def _populate_task_runtime_and_function_info(
+    task_info: TaskInfoEntry,
+    serialized_runtime_env: str,
+    function_descriptor: FunctionDescriptor,
+    required_resources,
+    language,
+) -> None:
+    task_info.language = language
+    task_info.runtime_env_info.serialized_runtime_env = serialized_runtime_env
+    task_info.func_or_class_name = _call_string(function_descriptor)
+    task_info.required_resources.update(required_resources)
+
+
+def _convert_task_definition_event(event) -> gcs_pb2.TaskEvents:
+    task_event = gcs_pb2.TaskEvents()
+    task_event.task_id = event.task_id
+    task_event.attempt_number = event.task_attempt
+    task_event.job_id = event.job_id
+
+    task_info = task_event.task_info
+    task_info.type = event.task_type
+    task_info.name = event.task_name
+    task_info.task_id = event.task_id
+    task_info.job_id = event.job_id
+    task_info.parent_task_id = event.parent_task_id
+    if event.task_type == TaskType.ACTOR_CREATION_TASK:
+        task_info.actor_id = TaskID(event.task_id).actor_id().binary()
+        if event.is_detached_actor:
+            task_info.is_detached_actor = True
+    if event.placement_group_id:
+        task_info.placement_group_id = event.placement_group_id
+    if event.HasField("call_site"):
+        task_info.call_site = event.call_site
+    if event.label_selector:
+        task_info.label_selector.update(event.label_selector)
+    if event.HasField("fallback_strategy"):
+        task_info.fallback_strategy.CopyFrom(event.fallback_strategy)
+
+    _populate_task_runtime_and_function_info(
+        task_info,
+        event.serialized_runtime_env,
+        event.task_func,
+        event.required_resources,
+        event.language,
+    )
+    return task_event
+
+
+_TASK_LOG_INFO_FIELDS = (
+    "stdout_file",
+    "stderr_file",
+    "stdout_start",
+    "stdout_end",
+    "stderr_start",
+    "stderr_end",
+)
+
+
+def _convert_task_log_info(src, dst) -> None:
+    """Copy only the fields the event actually set.
+
+    The log paths and start offsets arrive when the task starts and the end offsets in a
+    later event, so copying an unset field would overwrite what the earlier event
+    reported once the two are merged.
+    """
+    for field in _TASK_LOG_INFO_FIELDS:
+        if src.HasField(field):
+            setattr(dst, field, getattr(src, field))
+
+
+def _convert_task_lifecycle_event(event) -> gcs_pb2.TaskEvents:
+    task_event = gcs_pb2.TaskEvents()
+    task_event.task_id = event.task_id
+    task_event.attempt_number = event.task_attempt
+    task_event.job_id = event.job_id
+
+    state_update = task_event.state_updates
+    if event.node_id:
+        state_update.node_id = event.node_id
+    if event.worker_id:
+        state_update.worker_id = event.worker_id
+    # worker pid can never be 0.
+    if event.worker_pid != 0:
+        state_update.worker_pid = event.worker_pid
+    if event.HasField("ray_error_info"):
+        state_update.error_info.CopyFrom(event.ray_error_info)
+    if event.HasField("is_debugger_paused"):
+        state_update.is_debugger_paused = event.is_debugger_paused
+    if event.HasField("actor_repr_name"):
+        state_update.actor_repr_name = event.actor_repr_name
+    if event.HasField("task_log_info"):
+        _convert_task_log_info(event.task_log_info, state_update.task_log_info)
+
+    for transition in event.state_transitions:
+        ts = transition.timestamp
+        state_update.state_ts_ns[transition.state] = ts.seconds * 10**9 + ts.nanos
+    return task_event
+
+
+def _convert_actor_task_definition_event(event) -> gcs_pb2.TaskEvents:
+    task_event = gcs_pb2.TaskEvents()
+    task_event.task_id = event.task_id
+    task_event.attempt_number = event.task_attempt
+    task_event.job_id = event.job_id
+
+    task_info = task_event.task_info
+    task_info.type = TaskType.ACTOR_TASK
+    task_info.name = event.actor_task_name
+    task_info.task_id = event.task_id
+    task_info.job_id = event.job_id
+    task_info.parent_task_id = event.parent_task_id
+    if event.placement_group_id:
+        task_info.placement_group_id = event.placement_group_id
+    if event.actor_id:
+        task_info.actor_id = event.actor_id
+    if event.is_detached_actor:
+        task_info.is_detached_actor = True
+    if event.HasField("call_site"):
+        task_info.call_site = event.call_site
+    if event.label_selector:
+        task_info.label_selector.update(event.label_selector)
+    if event.HasField("fallback_strategy"):
+        task_info.fallback_strategy.CopyFrom(event.fallback_strategy)
+
+    _populate_task_runtime_and_function_info(
+        task_info,
+        event.serialized_runtime_env,
+        event.actor_func,
+        event.required_resources,
+        event.language,
+    )
+    return task_event
+
+
+def _convert_task_profile_events(event) -> gcs_pb2.TaskEvents:
+    task_event = gcs_pb2.TaskEvents()
+    task_event.task_id = event.task_id
+    task_event.attempt_number = event.attempt_number
+    task_event.job_id = event.job_id
+
+    if event.HasField("profile_events"):
+        task_event.profile_events.CopyFrom(event.profile_events)
+    return task_event
+
+
+def convert_to_task_events(
+    request: AddEventsRequest,
+) -> Tuple[List[gcs_pb2.TaskEvents], list]:
+    """Convert an ``AddEventsRequest`` into ``TaskEvents`` for the store, plus the
+    upstream dropped-task-attempt metadata.
+    Returns ``(task_events, dropped_task_attempts)``.
+    """
+    events_data = request.events_data
+    task_events: List[gcs_pb2.TaskEvents] = []
+    for event in events_data.events:
+        event_type = event.event_type
+        if event_type == RayEvent.EventType.TASK_DEFINITION_EVENT:
+            task_events.append(
+                _convert_task_definition_event(event.task_definition_event)
+            )
+        elif event_type == RayEvent.EventType.TASK_LIFECYCLE_EVENT:
+            task_events.append(
+                _convert_task_lifecycle_event(event.task_lifecycle_event)
+            )
+        elif event_type == RayEvent.EventType.TASK_PROFILE_EVENT:
+            task_events.append(_convert_task_profile_events(event.task_profile_events))
+        elif event_type == RayEvent.EventType.ACTOR_TASK_DEFINITION_EVENT:
+            task_events.append(
+                _convert_actor_task_definition_event(event.actor_task_definition_event)
+            )
+        else:
+            # the aggregator only forwards the four exposable task event types,
+            # so any other type is a bug.
+            raise AssertionError(
+                f"Unsupported event type for task events: {event_type}"
+            )
+    dropped_task_attempts = list(events_data.task_events_metadata.dropped_task_attempts)
+    return task_events, dropped_task_attempts

--- a/python/ray/dashboard/modules/task_events/task_event_storage.py
+++ b/python/ray/dashboard/modules/task_events/task_event_storage.py
@@ -1,0 +1,343 @@
+"""In-memory store for task events on the dashboard head.
+
+Events from the same task attempt (same task id + attempt number) are merged into a single
+``TaskEvents`` entry. The store is bounded by ``MAX_NUM_TASK_EVENTS``; when full, entries
+in lower-priority tiers are evicted first (see ``gc_policy``). Per-job bookkeeping tracks
+which task attempts have been dropped so that late events for a dropped attempt are not
+partially re-stored.
+"""
+import collections
+import logging
+import time
+from typing import Dict, List, Optional, Set, Tuple
+
+import ray
+from ray._raylet import JobID, TaskID
+from ray.core.generated import gcs_pb2
+from ray.core.generated.common_pb2 import TaskType
+from ray.dashboard.modules.task_events.gc_policy import FinishedTaskActorTaskGcPolicy
+
+logger = logging.getLogger(__name__)
+
+# Max number of task events kept before eviction kicks in.
+MAX_NUM_TASK_EVENTS = ray._config.task_events_max_num_task_in_gcs()
+# Max profile events kept per task attempt; older ones are dropped past this.
+MAX_NUM_PROFILE_EVENTS_PER_TASK = (
+    ray._config.task_events_max_num_profile_events_per_task()
+)
+# Max dropped task attempts tracked per job before the tracking set is trimmed.
+MAX_DROPPED_TASK_ATTEMPTS_PER_JOB = (
+    ray._config.task_events_max_dropped_task_attempts_tracked_per_job_in_gcs()
+)
+# How often the per-job dropped-attempt tracking is trimmed. The RayConfig value is in ms.
+GC_JOB_SUMMARY_INTERVAL_S = ray._config.task_events_gc_job_summary_interval_ms() / 1000
+# Minimum seconds between "at capacity" warnings, to avoid log spam on every eviction.
+_CAPACITY_WARNING_INTERVAL_S = 10.0
+
+# Stat counter keys.
+STAT_NUM_STORED = "num_task_events_stored"
+STAT_TOTAL_REPORTED = "total_num_task_events_reported"
+STAT_TOTAL_ATTEMPTS_DROPPED = "total_num_task_attempts_dropped"
+STAT_TOTAL_PROFILE_DROPPED = "total_num_profile_task_events_dropped"
+_TASK_TYPE_STAT = {
+    TaskType.NORMAL_TASK: "total_num_normal_task",
+    TaskType.ACTOR_CREATION_TASK: "total_num_actor_creation_task",
+    TaskType.ACTOR_TASK: "total_num_actor_task",
+    TaskType.DRIVER_TASK: "total_num_driver_task",
+}
+
+# A task attempt is identified by (task_id bytes, attempt number).
+TaskAttempt = Tuple[bytes, int]
+
+_NIL_TASK_ID = TaskID.nil().binary()
+_NIL_JOB_ID = JobID.nil().binary()
+
+
+def _is_nil_id(id_bytes: bytes, nil_bytes: bytes) -> bool:
+    return not id_bytes or id_bytes == nil_bytes
+
+
+def _task_attempt(task_event: gcs_pb2.TaskEvents) -> TaskAttempt:
+    return (task_event.task_id, task_event.attempt_number)
+
+
+def _worker_id(task_event: gcs_pb2.TaskEvents) -> bytes:
+    return task_event.state_updates.worker_id
+
+
+def _num_profile_events(task_event: gcs_pb2.TaskEvents) -> int:
+    return len(task_event.profile_events.events)
+
+
+class JobTaskSummary:
+    """Per-job tracking of dropped task attempts and dropped profile events."""
+
+    def __init__(self):
+        self._num_profile_events_dropped = 0
+        self._num_task_attempts_dropped_tracked = 0
+        self._num_dropped_task_attempts_evicted = 0
+        self._dropped_task_attempts: Set[TaskAttempt] = set()
+
+    def record_task_attempt_dropped(self, task_attempt: TaskAttempt) -> None:
+        self._dropped_task_attempts.add(task_attempt)
+        self._num_task_attempts_dropped_tracked = len(self._dropped_task_attempts)
+
+    def record_profile_events_dropped(self, count: int) -> None:
+        self._num_profile_events_dropped += count
+
+    def should_drop_task_attempt(self, task_attempt: TaskAttempt) -> bool:
+        """A task attempt is dropped once any of its events have been dropped."""
+        return task_attempt in self._dropped_task_attempts
+
+    @property
+    def num_profile_events_dropped(self) -> int:
+        return self._num_profile_events_dropped
+
+    @property
+    def num_task_attempts_dropped(self) -> int:
+        return (
+            self._num_task_attempts_dropped_tracked
+            + self._num_dropped_task_attempts_evicted
+        )
+
+    def on_job_ends(self) -> None:
+        """No more events arrive for a finished job, so stop tracking its drops."""
+        self._dropped_task_attempts.clear()
+
+    def gc_old_dropped_task_attempts(self, job_id: bytes) -> None:
+        """Trim the dropped-attempt set when it grows past the per-job cap."""
+        max_tracked = MAX_DROPPED_TASK_ATTEMPTS_PER_JOB
+        if len(self._dropped_task_attempts) <= max_tracked:
+            return
+        logger.info(
+            "Evicting extra tracked dropped task attempts (%d > %d) for job %s. Set "
+            "RAY_task_events_max_dropped_task_attempts_tracked_per_job_in_gcs to a higher "
+            "value to track more.",
+            len(self._dropped_task_attempts),
+            max_tracked,
+            job_id.hex(),
+        )
+        num_to_evict = len(self._dropped_task_attempts) - max_tracked
+        # Evict an extra 10% to avoid trimming on every pass.
+        num_to_evict = min(
+            len(self._dropped_task_attempts), num_to_evict + int(0.1 * num_to_evict)
+        )
+        self._num_task_attempts_dropped_tracked = len(self._dropped_task_attempts)
+        if num_to_evict == 0:
+            return
+        self._num_dropped_task_attempts_evicted += num_to_evict
+        to_evict = list(self._dropped_task_attempts)[:num_to_evict]
+        self._dropped_task_attempts.difference_update(to_evict)
+        self._num_task_attempts_dropped_tracked = len(self._dropped_task_attempts)
+
+
+class TaskEventStorage:
+    """Bounded, deduplicated in-memory store of ``TaskEvents`` keyed by task attempt.
+
+    - ``_tiers``: one insertion-ordered dict per GC priority tier (task attempt ->
+      ``TaskEvents``); the first key is the oldest, so eviction drops the oldest entry in
+      the lowest-priority non-empty tier.
+    - ``_primary_index``: task attempt -> the tier holding it, so an entry is found (and
+      moved between tiers when its priority changes) via
+      ``_tiers[_primary_index[attempt]][attempt]``.
+    - ``_task_index`` / ``_job_index`` / ``_worker_index``: id -> set of task attempts,
+      for lookups by task / job / worker.
+    """
+
+    def __init__(
+        self,
+        max_num_task_events: int = MAX_NUM_TASK_EVENTS,
+        gc_policy: Optional[FinishedTaskActorTaskGcPolicy] = None,
+    ):
+        self._max_num_task_events = max_num_task_events
+        self._gc_policy = gc_policy or FinishedTaskActorTaskGcPolicy()
+        # One insertion-ordered map per priority tier; oldest key first.
+        self._tiers: List[Dict[TaskAttempt, gcs_pb2.TaskEvents]] = [
+            {} for _ in range(self._gc_policy.max_priority)
+        ]
+        # Primary index: task attempt -> which tier holds it.
+        self._primary_index: Dict[TaskAttempt, int] = {}
+        # Secondary indices: id -> set of task attempts.
+        self._task_index: Dict[bytes, Set[TaskAttempt]] = {}
+        self._job_index: Dict[bytes, Set[TaskAttempt]] = {}
+        self._worker_index: Dict[bytes, Set[TaskAttempt]] = {}
+        self._job_task_summary: Dict[bytes, JobTaskSummary] = {}
+        self._stats: collections.Counter = collections.Counter()
+        self._last_capacity_warning_time = float("-inf")
+
+    def add_or_replace_task_event(self, task_event: gcs_pb2.TaskEvents) -> None:
+        """Add a new task attempt or merge into an existing one, evicting if over capacity."""
+        self._stats[STAT_TOTAL_REPORTED] += 1
+        job_id = task_event.job_id
+        task_id = task_event.task_id
+        if _is_nil_id(job_id, _NIL_JOB_ID) or _is_nil_id(task_id, _NIL_TASK_ID):
+            # Missing task/job id, e.g. profile events created without a task id.
+            logger.debug(
+                "Skipping invalid task event with missing job or task id: %s",
+                task_event,
+            )
+            return
+
+        attempt = _task_attempt(task_event)
+        if self._summary(job_id).should_drop_task_attempt(attempt):
+            logger.debug(
+                "Already dropping task %s attempt %d of job %s",
+                task_id.hex(),
+                task_event.attempt_number,
+                job_id.hex(),
+            )
+            return
+
+        if attempt in self._primary_index:
+            self._update_existing(attempt, task_event)
+        else:
+            self._add_new(attempt, task_event)
+
+        if (
+            self._max_num_task_events > 0
+            and self._stats[STAT_NUM_STORED] > self._max_num_task_events
+        ):
+            self._warn_capacity_reached()
+            self._evict_task_event()
+
+    def _warn_capacity_reached(self) -> None:
+        now = time.monotonic()
+        if now - self._last_capacity_warning_time < _CAPACITY_WARNING_INTERVAL_S:
+            return
+        self._last_capacity_warning_time = now
+        logger.warning(
+            "Max number of task events (%d) reached; old task events will be "
+            "overwritten. Set RAY_task_events_max_num_task_in_gcs to a higher "
+            "value to store more.",
+            self._max_num_task_events,
+        )
+
+    def record_data_loss_from_worker(self, dropped_task_attempts) -> None:
+        """Honor drops reported upstream: mark the attempts dropped and evict any partial
+        copy already stored, so data loss is at task-attempt granularity."""
+        for dropped in dropped_task_attempts:
+            task_id = dropped.task_id
+            attempt = (task_id, dropped.attempt_number)
+            job_id = TaskID(task_id).job_id().binary()
+            self._summary(job_id).record_task_attempt_dropped(attempt)
+            self._stats[STAT_TOTAL_ATTEMPTS_DROPPED] += 1
+            if attempt in self._primary_index:
+                self._remove_task_attempt(attempt)
+
+    def gc_job_summary(self) -> None:
+        for job_id, summary in self._job_task_summary.items():
+            summary.gc_old_dropped_task_attempts(job_id)
+
+    @property
+    def stats(self) -> collections.Counter:
+        return self._stats
+
+    @property
+    def num_task_events_stored(self) -> int:
+        return self._stats[STAT_NUM_STORED]
+
+    def get_task_event(self, task_attempt: TaskAttempt) -> Optional[gcs_pb2.TaskEvents]:
+        tier = self._primary_index.get(task_attempt)
+        return None if tier is None else self._tiers[tier][task_attempt]
+
+    def job_summary(self, job_id: bytes) -> Optional[JobTaskSummary]:
+        return self._job_task_summary.get(job_id)
+
+    def _summary(self, job_id: bytes) -> JobTaskSummary:
+        summary = self._job_task_summary.get(job_id)
+        if summary is None:
+            summary = JobTaskSummary()
+            self._job_task_summary[job_id] = summary
+        return summary
+
+    def _add_new(self, attempt: TaskAttempt, task_event: gcs_pb2.TaskEvents) -> None:
+        tier = self._gc_policy.get_task_list_priority(task_event)
+        self._tiers[tier][attempt] = task_event
+        self._primary_index[attempt] = tier
+        self._stats[STAT_NUM_STORED] += 1
+        if task_event.HasField("task_info") and task_event.attempt_number == 0:
+            self._increment_task_type(task_event.task_info.type)
+        self._update_index(attempt, task_event)
+
+    def _update_existing(
+        self, attempt: TaskAttempt, task_event: gcs_pb2.TaskEvents
+    ) -> None:
+        tier = self._primary_index[attempt]
+        existing = self._tiers[tier][attempt]
+        if task_event.HasField("task_info") and not existing.HasField("task_info"):
+            self._increment_task_type(task_event.task_info.type)
+
+        existing.MergeFrom(task_event)
+
+        num_profile = len(existing.profile_events.events)
+        if num_profile > MAX_NUM_PROFILE_EVENTS_PER_TASK:
+            to_drop = num_profile - MAX_NUM_PROFILE_EVENTS_PER_TASK
+            del existing.profile_events.events[:to_drop]
+            self._summary(existing.job_id).record_profile_events_dropped(to_drop)
+            self._stats[STAT_TOTAL_PROFILE_DROPPED] += to_drop
+
+        new_tier = self._gc_policy.get_task_list_priority(existing)
+        if new_tier != tier:
+            del self._tiers[tier][attempt]
+            self._tiers[new_tier][attempt] = existing
+            self._primary_index[attempt] = new_tier
+
+        self._update_index(attempt, existing)
+
+    def _increment_task_type(self, task_type) -> None:
+        stat = _TASK_TYPE_STAT.get(task_type)
+        if stat is not None:
+            self._stats[stat] += 1
+
+    def _update_index(
+        self, attempt: TaskAttempt, task_event: gcs_pb2.TaskEvents
+    ) -> None:
+        self._task_index.setdefault(task_event.task_id, set()).add(attempt)
+        self._job_index.setdefault(task_event.job_id, set()).add(attempt)
+        worker_id = _worker_id(task_event)
+        if worker_id:
+            self._worker_index.setdefault(worker_id, set()).add(attempt)
+
+    def _remove_from_index(
+        self, attempt: TaskAttempt, task_event: gcs_pb2.TaskEvents
+    ) -> None:
+        self._discard(self._job_index, task_event.job_id, attempt)
+        self._discard(self._task_index, task_event.task_id, attempt)
+        worker_id = _worker_id(task_event)
+        if worker_id:
+            self._discard(self._worker_index, worker_id, attempt)
+        del self._primary_index[attempt]
+
+    @staticmethod
+    def _discard(
+        index: Dict[bytes, Set[TaskAttempt]], key: bytes, attempt: TaskAttempt
+    ) -> None:
+        attempts = index.get(key)
+        if attempts is None:
+            return
+        attempts.discard(attempt)
+        if not attempts:
+            del index[key]
+
+    def _remove_task_attempt(self, attempt: TaskAttempt) -> None:
+        tier = self._primary_index[attempt]
+        task_event = self._tiers[tier][attempt]
+        num_profile = _num_profile_events(task_event)
+
+        summary = self._summary(task_event.job_id)
+        summary.record_profile_events_dropped(num_profile)
+        summary.record_task_attempt_dropped(attempt)
+        self._stats[STAT_NUM_STORED] -= 1
+        self._stats[STAT_TOTAL_ATTEMPTS_DROPPED] += 1
+        self._stats[STAT_TOTAL_PROFILE_DROPPED] += num_profile
+
+        self._remove_from_index(attempt, task_event)
+        del self._tiers[tier][attempt]
+
+    def _evict_task_event(self) -> None:
+        for tier in range(self._gc_policy.max_priority):
+            if self._tiers[tier]:
+                # The first key is the oldest (least recently inserted) in this tier.
+                oldest = next(iter(self._tiers[tier]))
+                self._remove_task_attempt(oldest)
+                return

--- a/python/ray/dashboard/modules/task_events/task_events_head.py
+++ b/python/ray/dashboard/modules/task_events/task_events_head.py
@@ -10,6 +10,11 @@ import ray.dashboard.optional_utils as dashboard_optional_utils
 import ray.dashboard.utils as dashboard_utils
 from ray._private.gcs_pubsub import GcsAioJobSubscriber, GcsAioWorkerDeltaSubscriber
 from ray.core.generated import events_event_aggregator_service_pb2, gcs_pb2
+from ray.dashboard.modules.task_events.ray_event_converter import convert_to_task_events
+from ray.dashboard.modules.task_events.task_event_storage import (
+    GC_JOB_SUMMARY_INTERVAL_S,
+    TaskEventStorage,
+)
 from ray.dashboard.subprocesses.module import SubprocessModule
 from ray.dashboard.subprocesses.routes import SubprocessRouteTable as routes
 
@@ -20,22 +25,19 @@ _SUBSCRIBER_POLL_BATCH_SIZE = 100
 
 
 class TaskEventsHead(SubprocessModule):
-    """Dashboard-head sink for task events and their GCS reconciliation signals.
+    """Dashboard-head sink for task events and their reconciliation signals.
 
     Receives task events over HTTP from the per-node aggregator agents (which POST an
-    ``AddEventsRequest`` payload), and subscribes to GCS pubsub for the worker-death and
-    job-finished notifications needed to reconcile task state (the signals
-    ``GcsTaskManager`` consumes in-process today). Everything is held in memory for now.
+    ``AddEventsRequest`` payload) and stores them, and subscribes to GCS pubsub for the
+    worker-death and job-finished notifications needed to reconcile task state. Everything
+    is held in memory.
     """
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        # TODO(karticam): Replace these in-memory buffers with a task-event store +
-        #   reconciliation logic (mirroring GcsTaskManager) that powers the state API.
-        #   Consuming the worker-death / job-finished notifications below to actually
-        #   fail tasks (MarkTasksFailedOnWorkerDead / MarkTasksFailedOnJobEnds) is a
-        #   follow-up PR.
-        self._events = collections.deque()
+        self._store = TaskEventStorage()
+        # TODO(karticam): consume these worker-death / job-finished notifications to fail
+        #   the affected tasks in the store. Will be done in the next PR.
         self._dead_workers = collections.deque()
         self._finished_jobs = collections.deque()
         self._background_tasks: Set[asyncio.Task] = set()
@@ -47,9 +49,9 @@ class TaskEventsHead(SubprocessModule):
         return ray._config.enable_task_events_to_dashboard_head()
 
     @property
-    def num_events_received(self) -> int:
-        """Number of task events currently held in the in-memory buffer (for tests)."""
-        return len(self._events)
+    def num_task_events_stored(self) -> int:
+        """Number of task attempts currently held in the store (for tests)."""
+        return self._store.num_task_events_stored
 
     @property
     def num_dead_workers_received(self) -> int:
@@ -81,12 +83,14 @@ class TaskEventsHead(SubprocessModule):
                 message=f"Failed to deserialize task events request: {e}",
             )
 
-        events_data = add_events_request.events_data
-        self._events.extend(events_data.events)
+        task_events, dropped_task_attempts = convert_to_task_events(add_events_request)
+        self._store.record_data_loss_from_worker(dropped_task_attempts)
+        for task_event in task_events:
+            self._store.add_or_replace_task_event(task_event)
         logger.debug(
-            "Received %d task events (%d total buffered)",
-            len(events_data.events),
-            len(self._events),
+            "Received %d task events (%d attempts stored)",
+            len(task_events),
+            self._store.num_task_events_stored,
         )
         return dashboard_optional_utils.rest_response(
             status_code=dashboard_utils.HTTPStatusCode.OK,
@@ -128,11 +132,20 @@ class TaskEventsHead(SubprocessModule):
             except Exception:
                 logger.exception("Failed handling job-finished notifications.")
 
+    async def _gc_job_summary_loop(self) -> None:
+        while True:
+            await asyncio.sleep(GC_JOB_SUMMARY_INTERVAL_S)
+            try:
+                self._store.gc_job_summary()
+            except Exception:
+                logger.exception("Failed trimming task-event job summaries.")
+
     async def run(self):
         await super().run()
         for coro in (
             self._subscribe_for_worker_deaths(),
             self._subscribe_for_finished_jobs(),
+            self._gc_job_summary_loop(),
         ):
             task = asyncio.create_task(coro)
             self._background_tasks.add(task)

--- a/python/ray/dashboard/modules/task_events/tests/test_gc_policy.py
+++ b/python/ray/dashboard/modules/task_events/tests/test_gc_policy.py
@@ -1,0 +1,46 @@
+import sys
+
+import pytest
+
+from ray.core.generated import gcs_pb2
+from ray.core.generated.common_pb2 import TaskStatus, TaskType
+from ray.dashboard.modules.task_events.gc_policy import FinishedTaskActorTaskGcPolicy
+
+
+def _finished_event() -> gcs_pb2.TaskEvents:
+    event = gcs_pb2.TaskEvents()
+    event.state_updates.state_ts_ns[TaskStatus.FINISHED] = 1
+    return event
+
+
+def _typed_event(task_type) -> gcs_pb2.TaskEvents:
+    event = gcs_pb2.TaskEvents()
+    event.task_info.type = task_type
+    return event
+
+
+def test_max_priority():
+    assert FinishedTaskActorTaskGcPolicy().max_priority == 3
+
+
+def test_priority_tiers():
+    policy = FinishedTaskActorTaskGcPolicy()
+    assert policy.get_task_list_priority(_finished_event()) == 0
+    assert policy.get_task_list_priority(_typed_event(TaskType.ACTOR_TASK)) == 1
+    assert (
+        policy.get_task_list_priority(_typed_event(TaskType.ACTOR_CREATION_TASK)) == 1
+    )
+    assert policy.get_task_list_priority(_typed_event(TaskType.NORMAL_TASK)) == 2
+    # Empty event: neither finished nor an actor task -> lowest priority.
+    assert policy.get_task_list_priority(gcs_pb2.TaskEvents()) == 2
+
+
+def test_finished_wins_over_actor():
+    policy = FinishedTaskActorTaskGcPolicy()
+    event = _typed_event(TaskType.ACTOR_TASK)
+    event.state_updates.state_ts_ns[TaskStatus.FINISHED] = 1
+    assert policy.get_task_list_priority(event) == 0
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/dashboard/modules/task_events/tests/test_ray_event_converter.py
+++ b/python/ray/dashboard/modules/task_events/tests/test_ray_event_converter.py
@@ -1,0 +1,224 @@
+import sys
+
+import pytest
+
+from ray._raylet import JobID, TaskID
+from ray.core.generated.common_pb2 import (
+    FunctionDescriptor,
+    Language,
+    TaskAttempt,
+    TaskStatus,
+    TaskType,
+)
+from ray.core.generated.events_actor_task_definition_event_pb2 import (
+    ActorTaskDefinitionEvent,
+)
+from ray.core.generated.events_base_event_pb2 import RayEvent
+from ray.core.generated.events_event_aggregator_service_pb2 import (
+    AddEventsRequest,
+    RayEventsData,
+    TaskEventsMetadata,
+)
+from ray.core.generated.events_task_definition_event_pb2 import TaskDefinitionEvent
+from ray.core.generated.events_task_lifecycle_event_pb2 import TaskLifecycleEvent
+from ray.core.generated.events_task_profile_events_pb2 import TaskProfileEvents
+from ray.core.generated.profile_events_pb2 import ProfileEventEntry, ProfileEvents
+from ray.dashboard.modules.task_events import ray_event_converter as rec
+
+
+def _ids():
+    job = JobID.from_int(1)
+    return job, TaskID.for_fake_task(job)
+
+
+def _python_fd(module_name="", class_name="", function_name=""):
+    fd = FunctionDescriptor()
+    fd.python_function_descriptor.module_name = module_name
+    fd.python_function_descriptor.class_name = class_name
+    fd.python_function_descriptor.function_name = function_name
+    return fd
+
+
+def test_call_string_python_no_class():
+    assert rec._call_string(_python_fd(function_name="mymod.myfunc")) == "myfunc"
+
+
+def test_call_string_python_with_class():
+    fd = _python_fd(class_name="pkg.MyCls", function_name="pkg.MyCls.m")
+    assert rec._call_string(fd) == "MyCls.m"
+
+
+def test_call_string_java_and_cpp_and_empty():
+    java = FunctionDescriptor()
+    java.java_function_descriptor.class_name = "C"
+    java.java_function_descriptor.function_name = "f"
+    assert rec._call_string(java) == "C.f"
+
+    cpp = FunctionDescriptor()
+    cpp.cpp_function_descriptor.function_name = "g"
+    assert rec._call_string(cpp) == "g"
+
+    assert rec._call_string(FunctionDescriptor()) == ""
+
+
+def test_convert_task_definition_event():
+    job, tid = _ids()
+    event = TaskDefinitionEvent(
+        task_id=tid.binary(),
+        task_attempt=0,
+        job_id=job.binary(),
+        task_type=TaskType.NORMAL_TASK,
+        task_name="foo",
+        parent_task_id=tid.binary(),
+        task_func=_python_fd(function_name="mymod.foo"),
+        language=Language.PYTHON,
+        serialized_runtime_env="{}",
+    )
+    event.required_resources["CPU"] = 1.0
+
+    task_event = rec._convert_task_definition_event(event)
+
+    assert task_event.task_id == tid.binary()
+    assert task_event.attempt_number == 0
+    assert task_event.job_id == job.binary()
+    info = task_event.task_info
+    assert info.type == TaskType.NORMAL_TASK
+    assert info.name == "foo"
+    assert info.func_or_class_name == "foo"
+    assert info.language == Language.PYTHON
+    assert info.required_resources["CPU"] == 1.0
+    assert info.runtime_env_info.serialized_runtime_env == "{}"
+
+
+def test_convert_task_lifecycle_event():
+    job, tid = _ids()
+    event = TaskLifecycleEvent(
+        task_id=tid.binary(),
+        task_attempt=0,
+        job_id=job.binary(),
+        worker_pid=42,
+        node_id=b"n" * 28,
+    )
+    transition = event.state_transitions.add()
+    transition.state = TaskStatus.RUNNING
+    transition.timestamp.seconds = 5
+    transition.timestamp.nanos = 123
+
+    task_event = rec._convert_task_lifecycle_event(event)
+
+    state = task_event.state_updates
+    assert state.worker_pid == 42
+    assert state.node_id == b"n" * 28
+    assert state.state_ts_ns[TaskStatus.RUNNING] == 5 * 10**9 + 123
+
+
+def test_convert_task_lifecycle_event_copies_set_task_log_info_fields():
+    # A start event reports the paths and start offsets; the end offsets arrive in a
+    # later event. Only the fields the event set should cross over, so the unset ones
+    # stay absent and a later merge can fill them without clobbering.
+    job, tid = _ids()
+    event = TaskLifecycleEvent(
+        task_id=tid.binary(), task_attempt=0, job_id=job.binary()
+    )
+    event.task_log_info.stdout_file = "/logs/out"
+    event.task_log_info.stderr_file = "/logs/err"
+    event.task_log_info.stdout_start = 10
+    event.task_log_info.stderr_start = 20
+
+    log_info = rec._convert_task_lifecycle_event(event).state_updates.task_log_info
+
+    assert log_info.stdout_file == "/logs/out"
+    assert log_info.stderr_file == "/logs/err"
+    assert log_info.stdout_start == 10
+    assert log_info.stderr_start == 20
+    assert not log_info.HasField("stdout_end")
+    assert not log_info.HasField("stderr_end")
+
+
+def test_convert_actor_task_definition_event():
+    job, tid = _ids()
+    event = ActorTaskDefinitionEvent(
+        task_id=tid.binary(),
+        task_attempt=0,
+        job_id=job.binary(),
+        actor_task_name="act",
+        parent_task_id=tid.binary(),
+        actor_id=b"a" * 16,
+        actor_func=_python_fd(function_name="m.run"),
+        language=Language.PYTHON,
+    )
+
+    task_event = rec._convert_actor_task_definition_event(event)
+
+    info = task_event.task_info
+    assert info.type == TaskType.ACTOR_TASK
+    assert info.name == "act"
+    assert info.actor_id == b"a" * 16
+    assert info.func_or_class_name == "run"
+
+
+def test_convert_task_profile_events():
+    job, tid = _ids()
+    profile = ProfileEvents()
+    entry = ProfileEventEntry(event_name="e")
+    profile.events.append(entry)
+    event = TaskProfileEvents(
+        task_id=tid.binary(),
+        attempt_number=0,
+        job_id=job.binary(),
+        profile_events=profile,
+    )
+
+    task_event = rec._convert_task_profile_events(event)
+
+    assert task_event.task_id == tid.binary()
+    assert len(task_event.profile_events.events) == 1
+
+
+def test_convert_dispatches_and_returns_dropped_attempts():
+    job, tid = _ids()
+    definition = TaskDefinitionEvent(
+        task_id=tid.binary(),
+        task_attempt=0,
+        job_id=job.binary(),
+        task_type=TaskType.NORMAL_TASK,
+        task_name="foo",
+        task_func=_python_fd(function_name="foo"),
+    )
+    request = AddEventsRequest(
+        events_data=RayEventsData(
+            events=[
+                RayEvent(
+                    event_type=RayEvent.EventType.TASK_DEFINITION_EVENT,
+                    task_definition_event=definition,
+                )
+            ],
+            task_events_metadata=TaskEventsMetadata(
+                dropped_task_attempts=[
+                    TaskAttempt(task_id=tid.binary(), attempt_number=3)
+                ]
+            ),
+        )
+    )
+
+    task_events, dropped = rec.convert_to_task_events(request)
+
+    assert len(task_events) == 1
+    assert task_events[0].task_info.name == "foo"
+    assert len(dropped) == 1
+    assert dropped[0].attempt_number == 3
+
+
+def test_convert_raises_on_unsupported_event_type():
+    request = AddEventsRequest(
+        events_data=RayEventsData(
+            events=[RayEvent(event_type=RayEvent.EventType.DRIVER_JOB_LIFECYCLE_EVENT)]
+        )
+    )
+
+    with pytest.raises(AssertionError):
+        rec.convert_to_task_events(request)
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/dashboard/modules/task_events/tests/test_task_event_storage.py
+++ b/python/ray/dashboard/modules/task_events/tests/test_task_event_storage.py
@@ -1,0 +1,133 @@
+import sys
+
+import pytest
+
+from ray._raylet import JobID, TaskID
+from ray.core.generated import gcs_pb2
+from ray.core.generated.common_pb2 import TaskAttempt, TaskStatus, TaskType
+from ray.dashboard.modules.task_events import task_event_storage as tes
+
+_JOB = JobID.from_int(1).binary()
+
+
+def _task_id(n: int) -> bytes:
+    return bytes([n]) * 24
+
+
+def _event(
+    task_id, attempt=0, task_type=None, finished=False, name=""
+) -> gcs_pb2.TaskEvents:
+    event = gcs_pb2.TaskEvents(task_id=task_id, attempt_number=attempt, job_id=_JOB)
+    if task_type is not None:
+        event.task_info.type = task_type
+        event.task_info.name = name
+    if finished:
+        event.state_updates.state_ts_ns[TaskStatus.FINISHED] = 1
+    return event
+
+
+def test_add_and_merge_dedups_by_attempt():
+    store = tes.TaskEventStorage()
+    store.add_or_replace_task_event(
+        _event(_task_id(1), task_type=TaskType.NORMAL_TASK, name="foo")
+    )
+    store.add_or_replace_task_event(_event(_task_id(1), finished=True))
+
+    assert store.num_task_events_stored == 1
+    stored = store.get_task_event((_task_id(1), 0))
+    assert stored.task_info.name == "foo"
+    assert TaskStatus.FINISHED in stored.state_updates.state_ts_ns
+    assert store.stats[tes.STAT_TOTAL_REPORTED] == 2
+
+
+def test_task_type_counters_increment_once():
+    store = tes.TaskEventStorage()
+    store.add_or_replace_task_event(_event(_task_id(1), task_type=TaskType.NORMAL_TASK))
+    store.add_or_replace_task_event(_event(_task_id(2), task_type=TaskType.ACTOR_TASK))
+
+    assert store.stats[tes._TASK_TYPE_STAT[TaskType.NORMAL_TASK]] == 1
+    assert store.stats[tes._TASK_TYPE_STAT[TaskType.ACTOR_TASK]] == 1
+
+
+def test_eviction_prefers_lower_priority_tier():
+    store = tes.TaskEventStorage(max_num_task_events=2)
+    store.add_or_replace_task_event(_event(_task_id(1), task_type=TaskType.NORMAL_TASK))
+    store.add_or_replace_task_event(_event(_task_id(2), task_type=TaskType.ACTOR_TASK))
+    store.add_or_replace_task_event(_event(_task_id(3), finished=True))
+
+    assert store.num_task_events_stored == 2
+    assert store.get_task_event((_task_id(3), 0)) is None
+    assert store.get_task_event((_task_id(1), 0)) is not None
+    assert store.get_task_event((_task_id(2), 0)) is not None
+    assert store.stats[tes.STAT_TOTAL_ATTEMPTS_DROPPED] == 1
+
+
+def test_evicted_attempt_is_rejected():
+    store = tes.TaskEventStorage(max_num_task_events=1)
+    store.add_or_replace_task_event(_event(_task_id(1), task_type=TaskType.NORMAL_TASK))
+    store.add_or_replace_task_event(_event(_task_id(2), finished=True))
+
+    # The finished attempt was the lowest tier, so it was evicted; re-adding is rejected.
+    assert store.get_task_event((_task_id(2), 0)) is None
+    store.add_or_replace_task_event(_event(_task_id(2), finished=True))
+    assert store.get_task_event((_task_id(2), 0)) is None
+
+
+def test_profile_events_truncated_fifo(monkeypatch):
+    monkeypatch.setattr(tes, "MAX_NUM_PROFILE_EVENTS_PER_TASK", 2)
+    store = tes.TaskEventStorage()
+    store.add_or_replace_task_event(_event(_task_id(1), task_type=TaskType.NORMAL_TASK))
+
+    update = gcs_pb2.TaskEvents(task_id=_task_id(1), attempt_number=0, job_id=_JOB)
+    for i in range(4):
+        update.profile_events.events.add().event_name = f"e{i}"
+    store.add_or_replace_task_event(update)
+
+    kept = store.get_task_event((_task_id(1), 0)).profile_events.events
+    assert [e.event_name for e in kept] == ["e2", "e3"]
+    assert store.stats[tes.STAT_TOTAL_PROFILE_DROPPED] == 2
+
+
+def test_record_data_loss_evicts_and_rejects():
+    store = tes.TaskEventStorage()
+    task_id = TaskID.for_fake_task(JobID.from_int(1)).binary()
+    store.add_or_replace_task_event(_event(task_id, task_type=TaskType.NORMAL_TASK))
+
+    store.record_data_loss_from_worker([TaskAttempt(task_id=task_id, attempt_number=0)])
+    assert store.get_task_event((task_id, 0)) is None
+
+    store.add_or_replace_task_event(_event(task_id, task_type=TaskType.NORMAL_TASK))
+    assert store.get_task_event((task_id, 0)) is None
+
+
+def test_nil_ids_skipped_but_counted_as_reported():
+    store = tes.TaskEventStorage()
+    store.add_or_replace_task_event(gcs_pb2.TaskEvents())
+
+    assert store.num_task_events_stored == 0
+    assert store.stats[tes.STAT_TOTAL_REPORTED] == 1
+
+
+def test_job_summary_on_job_ends_clears_drops():
+    summary = tes.JobTaskSummary()
+    summary.record_task_attempt_dropped((_task_id(1), 0))
+    assert summary.should_drop_task_attempt((_task_id(1), 0))
+
+    summary.on_job_ends()
+    assert not summary.should_drop_task_attempt((_task_id(1), 0))
+
+
+def test_job_summary_gc_trims_over_cap(monkeypatch):
+    monkeypatch.setattr(tes, "MAX_DROPPED_TASK_ATTEMPTS_PER_JOB", 4)
+    summary = tes.JobTaskSummary()
+    for i in range(10):
+        summary.record_task_attempt_dropped((_task_id(i), 0))
+
+    summary.gc_old_dropped_task_attempts(_JOB)
+
+    # 10 tracked, cap 4 -> 6 evicted; total-ever count is preserved.
+    assert summary.num_task_attempts_dropped == 10
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/dashboard/modules/task_events/tests/test_task_events_head.py
+++ b/python/ray/dashboard/modules/task_events/tests/test_task_events_head.py
@@ -1,3 +1,4 @@
+import asyncio
 import sys
 from unittest.mock import AsyncMock
 
@@ -9,10 +10,20 @@ from ray._common.ray_constants import (
     LOGGING_ROTATE_BACKUP_COUNT,
     LOGGING_ROTATE_BYTES,
 )
+from ray._common.test_utils import async_wait_for_condition
+from ray._raylet import JobID
 from ray.core.generated import events_event_aggregator_service_pb2, gcs_pb2
+from ray.core.generated.common_pb2 import TaskType
 from ray.core.generated.events_base_event_pb2 import RayEvent
+from ray.core.generated.events_task_definition_event_pb2 import TaskDefinitionEvent
 from ray.dashboard.modules.task_events.task_events_head import TaskEventsHead
 from ray.dashboard.subprocesses.module import SubprocessModuleConfig
+
+_JOB = JobID.from_int(1).binary()
+
+
+def _task_id(n: int) -> bytes:
+    return bytes([n]) * 24
 
 
 def _make_config() -> SubprocessModuleConfig:
@@ -36,10 +47,21 @@ def _make_head() -> TaskEventsHead:
     return TaskEventsHead(_make_config())
 
 
-def _make_add_events_request(num_events: int) -> bytes:
+def _make_add_events_request(num_events: int, start: int = 0) -> bytes:
     events_data = events_event_aggregator_service_pb2.RayEventsData()
-    for i in range(num_events):
-        events_data.events.append(RayEvent(event_id=f"event_{i}".encode()))
+    for i in range(start, start + num_events):
+        events_data.events.append(
+            RayEvent(
+                event_type=RayEvent.EventType.TASK_DEFINITION_EVENT,
+                task_definition_event=TaskDefinitionEvent(
+                    task_id=_task_id(i),
+                    task_attempt=0,
+                    job_id=_JOB,
+                    task_type=TaskType.NORMAL_TASK,
+                    task_name=f"task_{i}",
+                ),
+            )
+        )
     request = events_event_aggregator_service_pb2.AddEventsRequest(
         events_data=events_data
     )
@@ -55,23 +77,23 @@ def _fake_request(body: bytes):
 @pytest.mark.asyncio
 async def test_add_task_events_buffers_events():
     head = _make_head()
-    assert head.num_events_received == 0
+    assert head.num_task_events_stored == 0
 
     body = _make_add_events_request(num_events=2)
     response = await head.add_task_events(_fake_request(body))
 
     assert response.status == 200
-    assert head.num_events_received == 2
+    assert head.num_task_events_stored == 2
 
 
 @pytest.mark.asyncio
 async def test_add_task_events_accumulates_across_requests():
     head = _make_head()
 
-    await head.add_task_events(_fake_request(_make_add_events_request(num_events=2)))
-    await head.add_task_events(_fake_request(_make_add_events_request(num_events=3)))
+    await head.add_task_events(_fake_request(_make_add_events_request(2, start=0)))
+    await head.add_task_events(_fake_request(_make_add_events_request(3, start=2)))
 
-    assert head.num_events_received == 5
+    assert head.num_task_events_stored == 5
 
 
 @pytest.mark.asyncio
@@ -81,7 +103,7 @@ async def test_add_task_events_empty_payload():
     response = await head.add_task_events(_fake_request(_make_add_events_request(0)))
 
     assert response.status == 200
-    assert head.num_events_received == 0
+    assert head.num_task_events_stored == 0
 
 
 @pytest.mark.asyncio
@@ -96,7 +118,7 @@ async def test_add_task_events_bad_payload_returns_error():
     # Malformed body must not raise; the handler returns an error response and
     # nothing is buffered.
     assert response.status != 200
-    assert head.num_events_received == 0
+    assert head.num_task_events_stored == 0
 
 
 def test_deserialize_request_roundtrip():
@@ -135,6 +157,95 @@ def test_handle_job_update_ignores_running_job():
     head._handle_job_update(gcs_pb2.JobTableData(job_id=b"job_1", is_dead=False))
 
     assert head.num_finished_jobs_received == 0
+
+
+class _FakeSubscriber:
+    """Delivers a canned batch on the first poll, then parks so the loop settles."""
+
+    def __init__(self, messages):
+        self._messages = messages
+        self._delivered = False
+
+    async def subscribe(self):
+        pass
+
+    async def poll(self, batch_size, timeout=None):
+        if self._delivered:
+            await asyncio.sleep(3600)
+            return []
+        self._delivered = True
+        return self._messages
+
+
+async def _cancel(task: asyncio.Task) -> None:
+    task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass
+
+
+@pytest.mark.asyncio
+async def test_gc_job_summary_loop_trims_over_cap(monkeypatch):
+    monkeypatch.setattr(
+        "ray.dashboard.modules.task_events.task_events_head.GC_JOB_SUMMARY_INTERVAL_S",
+        0.01,
+    )
+    monkeypatch.setattr(
+        "ray.dashboard.modules.task_events.task_event_storage."
+        "MAX_DROPPED_TASK_ATTEMPTS_PER_JOB",
+        2,
+    )
+    head = _make_head()
+    summary = head._store._summary(_JOB)
+    for i in range(10):
+        summary.record_task_attempt_dropped((_task_id(i), 0))
+    assert len(summary._dropped_task_attempts) == 10
+
+    task = asyncio.create_task(head._gc_job_summary_loop())
+    try:
+        await async_wait_for_condition(lambda: len(summary._dropped_task_attempts) < 10)
+    finally:
+        await _cancel(task)
+
+
+@pytest.mark.asyncio
+async def test_worker_death_subscription_loop_buffers(monkeypatch):
+    head = _make_head()
+    worker_delta = gcs_pb2.WorkerDeltaData(worker_id=b"worker_1", node_id=b"node_1")
+    fake = _FakeSubscriber([(b"key", worker_delta)])
+    monkeypatch.setattr(
+        "ray.dashboard.modules.task_events.task_events_head."
+        "GcsAioWorkerDeltaSubscriber",
+        lambda address=None: fake,
+    )
+
+    task = asyncio.create_task(head._subscribe_for_worker_deaths())
+    try:
+        await async_wait_for_condition(lambda: head.num_dead_workers_received == 1)
+    finally:
+        await _cancel(task)
+
+
+@pytest.mark.asyncio
+async def test_job_subscription_loop_buffers_only_finished(monkeypatch):
+    head = _make_head()
+    running = gcs_pb2.JobTableData(job_id=b"job_1", is_dead=False)
+    finished = gcs_pb2.JobTableData(job_id=b"job_2", is_dead=True)
+    fake = _FakeSubscriber([(b"k1", running), (b"k2", finished)])
+    monkeypatch.setattr(
+        "ray.dashboard.modules.task_events.task_events_head.GcsAioJobSubscriber",
+        lambda address=None: fake,
+    )
+
+    task = asyncio.create_task(head._subscribe_for_finished_jobs())
+    try:
+        await async_wait_for_condition(lambda: head.num_finished_jobs_received == 1)
+    finally:
+        await _cancel(task)
+
+    # The running job was filtered out; only the finished one was buffered.
+    assert head.num_finished_jobs_received == 1
 
 
 if __name__ == "__main__":

--- a/python/ray/includes/ray_config.pxd
+++ b/python/ray/includes/ray_config.pxd
@@ -88,3 +88,12 @@ cdef extern from "ray/common/ray_config.h" nogil:
         c_bool start_python_gc_manager_thread() const
 
         c_bool enable_task_events_to_dashboard_head() const
+
+        # TODO: Deprecate this once task events are fully moved out of GCS.
+        int64_t task_events_max_num_task_in_gcs() const
+
+        int64_t task_events_max_num_profile_events_per_task() const
+
+        int64_t task_events_max_dropped_task_attempts_tracked_per_job_in_gcs() const
+
+        int64_t task_events_gc_job_summary_interval_ms() const

--- a/python/ray/includes/ray_config.pxi
+++ b/python/ray/includes/ray_config.pxi
@@ -143,3 +143,20 @@ cdef class Config:
     @staticmethod
     def enable_task_events_to_dashboard_head():
         return RayConfig.instance().enable_task_events_to_dashboard_head()
+
+    @staticmethod
+    def task_events_max_num_task_in_gcs():
+        return RayConfig.instance().task_events_max_num_task_in_gcs()
+
+    @staticmethod
+    def task_events_max_num_profile_events_per_task():
+        return RayConfig.instance().task_events_max_num_profile_events_per_task()
+
+    @staticmethod
+    def task_events_max_dropped_task_attempts_tracked_per_job_in_gcs():
+        return (RayConfig.instance()
+                .task_events_max_dropped_task_attempts_tracked_per_job_in_gcs())
+
+    @staticmethod
+    def task_events_gc_job_summary_interval_ms():
+        return RayConfig.instance().task_events_gc_job_summary_interval_ms()

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -601,6 +601,10 @@ RAY_CONFIG(int64_t, task_events_dropped_task_attempt_batch_size, 10 * 1000)
 /// this duration for in-flight gRPC calls to complete before stopping the io_service.
 RAY_CONFIG(int64_t, task_events_shutdown_flush_timeout_ms, 5000)
 
+/// Interval in milliseconds at which the dashboard-head task-event store trims each job's
+/// tracked dropped-attempt set (GcJobSummary).
+RAY_CONFIG(int64_t, task_events_gc_job_summary_interval_ms, 5 * 1000)
+
 /// The delay in ms that GCS should mark any running tasks from a job as failed.
 /// Setting this value too smaller might result in some finished tasks marked as failed by
 /// GCS.


### PR DESCRIPTION
Cherry-pick of #65123 (master commit 471d3cc765c3426ce46a0eb87e0bcbb164ca41a9) onto `releases/2.58.0`.

Fresh single-commit pick against the current release head for a clean reviewable diff. Intentionally parallels #65295 (earlier cherry-pick of the same commit); one of the two should be closed in favor of the other. Applies cleanly without 4/n, but per series order it should merge after the 4/n cherry-pick (#65353 / #65291).

Clean cherry-pick, no conflicts (`git cherry-pick -x -s`). AI-assisted (Claude Code); submitted and reviewed by @elliot-barn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)