### PR TITLE
[cherry-pick][2.58.0][core][taskEvents out of GCS][6/n] Reconcile task states on worker death and job notifications (#65141)

### DIFF
--- a/python/ray/dashboard/modules/task_events/task_event_manager.py
+++ b/python/ray/dashboard/modules/task_events/task_event_manager.py
@@ -1,0 +1,227 @@
+import asyncio
+import logging
+from typing import List, Optional, Set
+
+import ray
+from ray._private.gcs_pubsub import GcsAioJobSubscriber, GcsAioWorkerDeltaSubscriber
+from ray.core.generated import gcs_pb2, gcs_service_pb2, gcs_service_pb2_grpc
+from ray.dashboard.modules.task_events.task_event_storage import (
+    GC_JOB_SUMMARY_INTERVAL_S,
+    TaskEventStorage,
+)
+
+logger = logging.getLogger(__name__)
+
+# Max notifications drained from a GCS pubsub subscriber per poll.
+_SUBSCRIBER_POLL_BATCH_SIZE = 100
+# Delay before failing a dead worker's tasks, so in-flight FINISHED events can still land.
+_MARK_FAILED_ON_WORKER_DEAD_DELAY_S = (
+    ray._config.gcs_mark_task_failed_on_worker_dead_delay_ms() / 1000
+)
+# Delay before failing a finished job's tasks, for the same reason.
+_MARK_FAILED_ON_JOB_DONE_DELAY_S = (
+    ray._config.gcs_mark_task_failed_on_job_done_delay_ms() / 1000
+)
+# Timeout for the GCS table fetches used to reconcile dead workers and finished jobs.
+_GCS_INFO_FETCH_TIMEOUT_S = 30
+
+
+class TaskEventManager:
+    """Reconciles the in-memory task-event store against GCS pubsub: marks a dead
+    worker's or finished job's running tasks failed, and periodically GCs per-job
+    summaries.
+    """
+
+    def __init__(
+        self,
+        store: TaskEventStorage,
+        gcs_address: str,
+        gcs_aio_channel,
+    ):
+        self._store = store
+        self._gcs_address = gcs_address
+        self._gcs_aio_channel = gcs_aio_channel
+        self._background_tasks: Set[asyncio.Task] = set()
+        self._worker_info_stub = None
+        self._job_info_stub = None
+
+    def start(self) -> None:
+        """Spawn the subscription and GC loops on the running event loop."""
+        self._spawn(self._subscribe_for_worker_deaths())
+        self._spawn(self._subscribe_for_finished_jobs())
+        self._spawn(self._gc_job_summary_loop())
+
+    def _handle_worker_delta(self, worker_delta: gcs_pb2.WorkerDeltaData) -> None:
+        # GCS_WORKER_DELTA_CHANNEL only carries failures, since it is published
+        # only when GCS receives a worker failure event. So every message is a death.
+        self._spawn(self._on_worker_dead(worker_delta.worker_id))
+
+    def _handle_job_update(self, job_data: gcs_pb2.JobTableData) -> None:
+        # GCS_JOB_CHANNEL fires on both job start and finish; only act on finished jobs.
+        if job_data.is_dead:
+            self._spawn(self._on_job_finished(job_data.job_id, job_data.end_time))
+
+    async def _on_worker_dead(self, worker_id: bytes) -> None:
+        # Fetch the dead worker's exit info concurrently with the delay: we start the
+        # fetch immediately so the record is less likely to be trimmed from the worker
+        # table first, and the delay lets in-flight FINISHED events land, so the two
+        # overlap instead of adding up. If the fetch comes back empty (record evicted, or
+        # a transient failure), we still fail the tasks — just without exit details.
+        # TODO(karticam): avoid this round-trip by having the worker-death subscription
+        #   carry the fields we need. PR #64887 moves worker events to the one-event
+        #   framework; migrating those to the dashboard head would give full worker data
+        #   inline (like node_head, which acts on the subscription payload) and drop this RPC.
+        worker_table_data, _ = await asyncio.gather(
+            self._get_worker_info(worker_id),
+            asyncio.sleep(_MARK_FAILED_ON_WORKER_DEAD_DELAY_S),
+        )
+        if worker_table_data is None:
+            logger.warning(
+                f"Could not fetch exit info for dead worker {worker_id.hex()}; marking "
+                "its tasks failed without exit details."
+            )
+        else:
+            logger.debug(
+                f"Marking all running tasks of worker {worker_id.hex()} as failed."
+            )
+        self._store.mark_tasks_failed_on_worker_dead(worker_id, worker_table_data)
+
+    async def _on_job_finished(self, job_id: bytes, end_time_ms: int) -> None:
+        # Delay so in-flight FINISHED events can still land before we fail the tasks.
+        await asyncio.sleep(_MARK_FAILED_ON_JOB_DONE_DELAY_S)
+        logger.info(f"Marking all running tasks of job {job_id.hex()} as failed.")
+        self._store.mark_tasks_failed_on_job_ends(job_id, end_time_ms * 10**6)
+        self._store.update_job_summary_on_job_done(job_id)
+
+    async def _get_worker_info(
+        self, worker_id: bytes
+    ) -> Optional[gcs_pb2.WorkerTableData]:
+        if self._worker_info_stub is None:
+            self._worker_info_stub = gcs_service_pb2_grpc.WorkerInfoGcsServiceStub(
+                self._gcs_aio_channel
+            )
+        try:
+            reply = await self._worker_info_stub.GetWorkerInfo(
+                gcs_service_pb2.GetWorkerInfoRequest(worker_id=worker_id),
+                timeout=_GCS_INFO_FETCH_TIMEOUT_S,
+            )
+        except Exception as e:
+            # A transient GCS/RPC failure must not sink the reconciliation task; treat it
+            # like a missing record so the caller still fails the worker's tasks.
+            logger.warning(f"Failed to fetch worker info for {worker_id.hex()}: {e}")
+            return None
+        if not reply.HasField("worker_table_data"):
+            return None
+        return reply.worker_table_data
+
+    async def _get_all_worker_info(self) -> List[gcs_pb2.WorkerTableData]:
+        if self._worker_info_stub is None:
+            self._worker_info_stub = gcs_service_pb2_grpc.WorkerInfoGcsServiceStub(
+                self._gcs_aio_channel
+            )
+        # Empty request → GCS returns every worker (no limit); the is_alive filter can't
+        # select dead-only server-side (only `true` is respected), so the caller filters.
+        reply = await self._worker_info_stub.GetAllWorkerInfo(
+            gcs_service_pb2.GetAllWorkerInfoRequest(),
+            timeout=_GCS_INFO_FETCH_TIMEOUT_S,
+        )
+        return reply.worker_table_data
+
+    async def _get_all_job_info(self) -> List[gcs_pb2.JobTableData]:
+        if self._job_info_stub is None:
+            self._job_info_stub = gcs_service_pb2_grpc.JobInfoGcsServiceStub(
+                self._gcs_aio_channel
+            )
+        # Empty request → GCS returns every job (no limit).
+        reply = await self._job_info_stub.GetAllJobInfo(
+            gcs_service_pb2.GetAllJobInfoRequest(),
+            timeout=_GCS_INFO_FETCH_TIMEOUT_S,
+        )
+        return reply.job_info_list
+
+    async def _reconcile_dead_workers_on_startup(self) -> None:
+        # GCS pubsub does not replay worker deaths from before we subscribed, so snapshot
+        # the worker table once and fail tasks for any already-dead worker. This must run
+        # AFTER subscribe() so a death between the snapshot and the subscription is still
+        # delivered over pubsub — no gap (see node_head._subscribe_for_node_updates).
+        try:
+            # Overlap the snapshot fetch with the same delay _on_worker_dead uses, so
+            # in-flight FINISHED events can land before we fail the tasks.
+            worker_infos, _ = await asyncio.gather(
+                self._get_all_worker_info(),
+                asyncio.sleep(_MARK_FAILED_ON_WORKER_DEAD_DELAY_S),
+            )
+        except Exception:
+            logger.exception("Failed to reconcile dead workers on startup.")
+            return
+        for worker_table_data in worker_infos:
+            if not worker_table_data.is_alive:
+                self._store.mark_tasks_failed_on_worker_dead(
+                    worker_table_data.worker_address.worker_id, worker_table_data
+                )
+
+    async def _reconcile_finished_jobs_on_startup(self) -> None:
+        # GCS pubsub does not replay job finishes from before we subscribed, so snapshot
+        # the job table once and fail tasks for any already-finished job. This must run
+        # AFTER subscribe() so a finish between the snapshot and the subscription is still
+        # delivered over pubsub.
+        try:
+            # Overlap the snapshot fetch with the same delay _on_job_finished uses, so
+            # in-flight FINISHED events can land before we fail the tasks.
+            job_infos, _ = await asyncio.gather(
+                self._get_all_job_info(),
+                asyncio.sleep(_MARK_FAILED_ON_JOB_DONE_DELAY_S),
+            )
+        except Exception:
+            logger.exception("Failed to reconcile finished jobs on startup.")
+            return
+        for job_data in job_infos:
+            if job_data.is_dead:
+                self._store.mark_tasks_failed_on_job_ends(
+                    job_data.job_id, job_data.end_time * 10**6
+                )
+                self._store.update_job_summary_on_job_done(job_data.job_id)
+
+    async def _subscribe_for_worker_deaths(self) -> None:
+        subscriber = GcsAioWorkerDeltaSubscriber(address=self._gcs_address)
+        await subscriber.subscribe()
+        # Backfill deaths from before the subscription (pubsub won't replay them). Order
+        # matters: subscribe first, then snapshot, so nothing falls between the two.
+        await self._reconcile_dead_workers_on_startup()
+        while True:
+            try:
+                for _, worker_delta in await subscriber.poll(
+                    batch_size=_SUBSCRIBER_POLL_BATCH_SIZE
+                ):
+                    self._handle_worker_delta(worker_delta)
+            except Exception:
+                logger.exception("Failed handling worker-death notifications.")
+
+    async def _subscribe_for_finished_jobs(self) -> None:
+        subscriber = GcsAioJobSubscriber(address=self._gcs_address)
+        await subscriber.subscribe()
+        # Backfill finishes from before the subscription (pubsub won't replay them).
+        # Spawn it (unlike the worker path) so the 15s job-done delay doesn't stall the
+        # poll loop; a finish also seen via pubsub is fine since marking is idempotent.
+        self._spawn(self._reconcile_finished_jobs_on_startup())
+        while True:
+            try:
+                for _, job_data in await subscriber.poll(
+                    batch_size=_SUBSCRIBER_POLL_BATCH_SIZE
+                ):
+                    self._handle_job_update(job_data)
+            except Exception:
+                logger.exception("Failed handling job-finished notifications.")
+
+    async def _gc_job_summary_loop(self) -> None:
+        while True:
+            await asyncio.sleep(GC_JOB_SUMMARY_INTERVAL_S)
+            try:
+                self._store.gc_job_summary()
+            except Exception:
+                logger.exception("Failed trimming task-event job summaries.")
+
+    def _spawn(self, coro) -> None:
+        task = asyncio.create_task(coro)
+        self._background_tasks.add(task)
+        task.add_done_callback(self._background_tasks.discard)

--- a/python/ray/dashboard/modules/task_events/task_event_query.py
+++ b/python/ray/dashboard/modules/task_events/task_event_query.py
@@ -1,0 +1,161 @@
+"""Read-path query over the task-event store — answers ``GetTaskEvents`` requests.
+
+Candidate events are selected via the store's indices where an equality filter allows it,
+then the full filter set is applied and the result truncated to the requested limit.
+"""
+from ray.core.generated import gcs_pb2, gcs_service_pb2
+from ray.core.generated.common_pb2 import TaskStatus, TaskType
+from ray.dashboard.modules.task_events.task_event_storage import TaskEventStorage
+
+_EQUAL = gcs_service_pb2.FilterPredicate.EQUAL
+_NOT_EQUAL = gcs_service_pb2.FilterPredicate.NOT_EQUAL
+
+# GcsStatus.code for an invalid argument.
+_INVALID_ARGUMENT_STATUS_CODE = 34
+
+# TaskStatus values highest first: a task's latest state is the highest-valued status
+# present in its state timestamps.
+_TASK_STATUS_DESC = sorted(TaskStatus.values(), reverse=True)
+
+
+def _apply_predicate(predicate: int, actual, expected) -> bool:
+    if predicate == _EQUAL:
+        return actual == expected
+    if predicate == _NOT_EQUAL:
+        return actual != expected
+    raise ValueError(f"Unknown filter predicate: {predicate}")
+
+
+def _apply_predicate_ignore_case(predicate: int, actual: str, expected: str) -> bool:
+    return _apply_predicate(predicate, actual.lower(), expected.lower())
+
+
+def _latest_state_name(task_event: gcs_pb2.TaskEvents) -> str:
+    state_ts_ns = task_event.state_updates.state_ts_ns
+    latest = TaskStatus.NIL
+    for status in _TASK_STATUS_DESC:
+        if status in state_ts_ns:
+            latest = status
+            break
+    return TaskStatus.Name(latest)
+
+
+def _passes_filters(
+    task_event: gcs_pb2.TaskEvents,
+    filters: gcs_service_pb2.GetTaskEventsRequest.Filters,
+) -> bool:
+    if not task_event.HasField("task_info"):
+        return False
+    task_info = task_event.task_info
+    if filters.exclude_driver and task_info.type == TaskType.DRIVER_TASK:
+        return False
+    for task_filter in filters.task_filters:
+        if not _apply_predicate(
+            task_filter.predicate, task_event.task_id, task_filter.task_id
+        ):
+            return False
+    for job_filter in filters.job_filters:
+        if not _apply_predicate(
+            job_filter.predicate, task_info.job_id, job_filter.job_id
+        ):
+            return False
+    for actor_filter in filters.actor_filters:
+        if not _apply_predicate(
+            actor_filter.predicate, task_info.actor_id, actor_filter.actor_id
+        ):
+            return False
+    for name_filter in filters.task_name_filters:
+        if not _apply_predicate_ignore_case(
+            name_filter.predicate, task_info.name, name_filter.task_name
+        ):
+            return False
+    if len(filters.state_filters) > 0:
+        state_name = _latest_state_name(task_event)
+        for state_filter in filters.state_filters:
+            if not _apply_predicate_ignore_case(
+                state_filter.predicate, state_name, state_filter.state
+            ):
+                return False
+    return True
+
+
+def _select_candidates(
+    store: TaskEventStorage,
+    request: gcs_service_pb2.GetTaskEventsRequest,
+    reply: gcs_service_pb2.GetTaskEventsReply,
+):
+    """Pick candidate events via index where an equality filter allows it, else scan all.
+
+    A single equality filter on task id or job id uses that index; multiple equality ids
+    short-circuit to an empty result; anything else scans all stored events. Populates the
+    reply's dropped counts at the same scope as the candidates (per-job or global).
+    """
+    filters = request.filters
+    if len(filters.task_filters) > 0:
+        task_ids = {f.task_id for f in filters.task_filters if f.predicate == _EQUAL}
+        if len(task_ids) == 1:
+            return store.get_task_events_by_tasks(task_ids)
+        if len(task_ids) > 1:
+            return []
+    elif len(filters.job_filters) > 0:
+        job_ids = {f.job_id for f in filters.job_filters if f.predicate == _EQUAL}
+        if len(job_ids) == 1:
+            job_id = next(iter(job_ids))
+            candidates = store.get_task_events_by_job(job_id)
+            summary = store.job_summary(job_id)
+            if summary is not None:
+                reply.num_profile_task_events_dropped = (
+                    summary.num_profile_events_dropped
+                )
+                reply.num_status_task_events_dropped = summary.num_task_attempts_dropped
+            return candidates
+        if len(job_ids) > 1:
+            return []
+
+    candidates = store.get_all_task_events()
+    reply.num_profile_task_events_dropped = store.num_profile_events_dropped()
+    reply.num_status_task_events_dropped = store.num_task_attempts_dropped()
+    return candidates
+
+
+def get_task_events(
+    store: TaskEventStorage, request: gcs_service_pb2.GetTaskEventsRequest
+) -> gcs_service_pb2.GetTaskEventsReply:
+    """Answer a ``GetTaskEventsRequest``: select candidates, filter, truncate to limit."""
+    reply = gcs_service_pb2.GetTaskEventsReply()
+    # Every reply carries a status field (OK unless a bad predicate below).
+    reply.status.SetInParent()
+    candidates = _select_candidates(store, request, reply)
+
+    limit = request.limit if request.HasField("limit") else -1
+    count = 0
+    num_status_truncated = 0
+    num_profile_truncated = 0
+    num_truncated = 0
+    num_filtered = 0
+    try:
+        # Iterate newest-first so a limit keeps the most recent events.
+        for task_event in reversed(candidates):
+            if not _passes_filters(task_event, request.filters):
+                num_filtered += 1
+                continue
+            if limit < 0 or count < limit:
+                count += 1
+                reply.events_by_task.add().CopyFrom(task_event)
+            else:
+                num_profile_truncated += len(task_event.profile_events.events)
+                num_status_truncated += 1 if task_event.HasField("state_updates") else 0
+                num_truncated += 1
+    except ValueError as e:
+        reply.Clear()
+        reply.status.code = _INVALID_ARGUMENT_STATUS_CODE
+        reply.status.message = str(e)
+        return reply
+
+    # Truncated events count as dropped for the caller's data-loss accounting.
+    reply.num_profile_task_events_dropped += num_profile_truncated
+    reply.num_status_task_events_dropped += num_status_truncated
+    reply.num_total_stored = len(candidates)
+    reply.num_truncated = num_truncated
+    reply.num_filtered_on_gcs = num_filtered
+    return reply

--- a/python/ray/dashboard/modules/task_events/task_event_storage.py
+++ b/python/ray/dashboard/modules/task_events/task_event_storage.py
@@ -14,7 +14,7 @@ from typing import Dict, List, Optional, Set, Tuple
 import ray
 from ray._raylet import JobID, TaskID
 from ray.core.generated import gcs_pb2
-from ray.core.generated.common_pb2 import TaskType
+from ray.core.generated.common_pb2 import ErrorType, RayErrorInfo, TaskStatus, TaskType
 from ray.dashboard.modules.task_events.gc_policy import FinishedTaskActorTaskGcPolicy
 
 logger = logging.getLogger(__name__)
@@ -224,6 +224,67 @@ class TaskEventStorage:
             if attempt in self._primary_index:
                 self._remove_task_attempt(attempt)
 
+    def mark_tasks_failed_on_worker_dead(
+        self,
+        worker_id: bytes,
+        worker_table_data: Optional[gcs_pb2.WorkerTableData],
+    ) -> None:
+        """Mark all non-terminal task attempts run by a dead worker as failed.
+
+        ``worker_table_data`` is None when the worker's record could not be fetched from
+        GCS. The tasks are still failed so they don't linger as running, but without exit
+        details and stamped with the current time instead of the worker's end time.
+        """
+        # TODO(karticam): there are edge cases where _worker_index might not have all tasks
+        #  for the worker when we receive worker death notification since some task events
+        #  might not have reached us to populate the index. So we might not mark all tasks
+        #  as failed. Check the comment thread below for more details:
+        #  https://github.com/ray-project/ray/pull/65141#discussion_r3734119692
+        attempts = self._worker_index.get(worker_id)
+        if attempts is None:
+            return
+        error_info = RayErrorInfo(error_type=ErrorType.WORKER_DIED)
+        if worker_table_data is not None:
+            error_info.error_message = (
+                f"Worker running the task ({worker_id.hex()}) died with exit_type: "
+                f"{worker_table_data.exit_type} with error_message: "
+                f"{worker_table_data.exit_detail}"
+            )
+            failed_ts_ns = worker_table_data.end_time_ms * 10**6
+        else:
+            error_info.error_message = (
+                f"Worker running the task ({worker_id.hex()}) died, but its exit details "
+                "could not be fetched from GCS: either GCS evicted the worker's "
+                "record or the GetWorkerInfo request failed (e.g. timed out or GCS was"
+                " unavailable)."
+            )
+            failed_ts_ns = time.time_ns()
+        for attempt in list(attempts):
+            self._mark_task_attempt_failed_if_needed(attempt, failed_ts_ns, error_info)
+
+    def mark_tasks_failed_on_job_ends(
+        self, job_id: bytes, job_finish_time_ns: int
+    ) -> None:
+        """Mark all non-terminal task attempts of a finished job as failed."""
+        attempts = self._job_index.get(job_id)
+        if attempts is None:
+            return
+        error_info = RayErrorInfo(error_type=ErrorType.WORKER_DIED)
+        error_info.error_message = (
+            f"Job finishes ({job_id.hex()}) as driver exits. "
+            "Marking all non-terminal tasks as failed."
+        )
+        for attempt in list(attempts):
+            self._mark_task_attempt_failed_if_needed(
+                attempt, job_finish_time_ns, error_info
+            )
+
+    def update_job_summary_on_job_done(self, job_id: bytes) -> None:
+        """Clear a finished job's dropped-attempt tracking (no more events will arrive)."""
+        summary = self._job_task_summary.get(job_id)
+        if summary is not None:
+            summary.on_job_ends()
+
     def gc_job_summary(self) -> None:
         for job_id, summary in self._job_task_summary.items():
             summary.gc_old_dropped_task_attempts(job_id)
@@ -242,6 +303,49 @@ class TaskEventStorage:
 
     def job_summary(self, job_id: bytes) -> Optional[JobTaskSummary]:
         return self._job_task_summary.get(job_id)
+
+    def get_all_task_events(self) -> List[gcs_pb2.TaskEvents]:
+        """All stored task events, higher-priority tiers first, oldest-first within a tier."""
+        result: List[gcs_pb2.TaskEvents] = []
+        for tier in range(self._gc_policy.max_priority - 1, -1, -1):
+            result.extend(self._tiers[tier].values())
+        return result
+
+    def get_task_events_by_job(self, job_id: bytes) -> List[gcs_pb2.TaskEvents]:
+        """All stored task events for the given job."""
+        return self._events_for_attempts(self._job_index.get(job_id))
+
+    def get_task_events_by_tasks(
+        self, task_ids: Set[bytes]
+    ) -> List[gcs_pb2.TaskEvents]:
+        """All stored task events for the given task ids."""
+        attempts: Set[TaskAttempt] = set()
+        for task_id in task_ids:
+            attempts |= self._task_index.get(task_id, set())
+        return self._events_for_attempts(attempts)
+
+    def _events_for_attempts(
+        self, attempts: Optional[Set[TaskAttempt]]
+    ) -> List[gcs_pb2.TaskEvents]:
+        if not attempts:
+            return []
+        return [
+            self._tiers[self._primary_index[attempt]][attempt] for attempt in attempts
+        ]
+
+    def num_profile_events_dropped(self) -> int:
+        """Profile events dropped across all jobs (for read-path data-loss reporting)."""
+        return sum(
+            summary.num_profile_events_dropped
+            for summary in self._job_task_summary.values()
+        )
+
+    def num_task_attempts_dropped(self) -> int:
+        """Task attempts dropped across all jobs (for read-path data-loss reporting)."""
+        return sum(
+            summary.num_task_attempts_dropped
+            for summary in self._job_task_summary.values()
+        )
 
     def _summary(self, job_id: bytes) -> JobTaskSummary:
         summary = self._job_task_summary.get(job_id)
@@ -341,3 +445,21 @@ class TaskEventStorage:
                 oldest = next(iter(self._tiers[tier]))
                 self._remove_task_attempt(oldest)
                 return
+
+    @staticmethod
+    def _is_task_terminated(task_event: gcs_pb2.TaskEvents) -> bool:
+        """Whether the task attempt has reported a FINISHED or FAILED state."""
+        if not task_event.HasField("state_updates"):
+            return False
+        state_ts_ns = task_event.state_updates.state_ts_ns
+        return TaskStatus.FINISHED in state_ts_ns or TaskStatus.FAILED in state_ts_ns
+
+    def _mark_task_attempt_failed_if_needed(
+        self, attempt: TaskAttempt, failed_ts_ns: int, error_info: RayErrorInfo
+    ) -> None:
+        task_event = self._tiers[self._primary_index[attempt]][attempt]
+        # Don't fail a task attempt that already reached a terminal state.
+        if self._is_task_terminated(task_event):
+            return
+        task_event.state_updates.state_ts_ns[TaskStatus.FAILED] = failed_ts_ns
+        task_event.state_updates.error_info.CopyFrom(error_info)

--- a/python/ray/dashboard/modules/task_events/task_events_head.py
+++ b/python/ray/dashboard/modules/task_events/task_events_head.py
@@ -1,46 +1,37 @@
-import asyncio
-import collections
 import logging
-from typing import Set
 
 import aiohttp.web
 
 import ray
 import ray.dashboard.optional_utils as dashboard_optional_utils
 import ray.dashboard.utils as dashboard_utils
-from ray._private.gcs_pubsub import GcsAioJobSubscriber, GcsAioWorkerDeltaSubscriber
-from ray.core.generated import events_event_aggregator_service_pb2, gcs_pb2
-from ray.dashboard.modules.task_events.ray_event_converter import convert_to_task_events
-from ray.dashboard.modules.task_events.task_event_storage import (
-    GC_JOB_SUMMARY_INTERVAL_S,
-    TaskEventStorage,
+from ray.core.generated import (
+    events_event_aggregator_service_pb2,
+    gcs_service_pb2,
 )
+from ray.dashboard.modules.task_events import task_event_query
+from ray.dashboard.modules.task_events.ray_event_converter import convert_to_task_events
+from ray.dashboard.modules.task_events.task_event_manager import TaskEventManager
+from ray.dashboard.modules.task_events.task_event_storage import TaskEventStorage
 from ray.dashboard.subprocesses.module import SubprocessModule
 from ray.dashboard.subprocesses.routes import SubprocessRouteTable as routes
 
 logger = logging.getLogger(__name__)
 
-# Max notifications drained from a GCS pubsub subscriber per poll.
-_SUBSCRIBER_POLL_BATCH_SIZE = 100
-
 
 class TaskEventsHead(SubprocessModule):
-    """Dashboard-head sink for task events and their reconciliation signals.
+    """Dashboard-head sink for task events.
 
-    Receives task events over HTTP from the per-node aggregator agents (which POST an
-    ``AddEventsRequest`` payload) and stores them, and subscribes to GCS pubsub for the
-    worker-death and job-finished notifications needed to reconcile task state. Everything
-    is held in memory.
+    Defines the HTTP API external clients interact with. Events
+    are held in memory in a ``TaskEventStorage``; the background upkeep of that store
+    (reconciling it against GCS worker-death and job-finished signals, plus periodic GC) is
+    delegated to a ``TaskEventManager``.
     """
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._store = TaskEventStorage()
-        # TODO(karticam): consume these worker-death / job-finished notifications to fail
-        #   the affected tasks in the store. Will be done in the next PR.
-        self._dead_workers = collections.deque()
-        self._finished_jobs = collections.deque()
-        self._background_tasks: Set[asyncio.Task] = set()
+        self._manager = None
 
     @classmethod
     def is_enabled(cls) -> bool:
@@ -52,16 +43,6 @@ class TaskEventsHead(SubprocessModule):
     def num_task_events_stored(self) -> int:
         """Number of task attempts currently held in the store (for tests)."""
         return self._store.num_task_events_stored
-
-    @property
-    def num_dead_workers_received(self) -> int:
-        """Number of worker-death notifications received (for tests)."""
-        return len(self._dead_workers)
-
-    @property
-    def num_finished_jobs_received(self) -> int:
-        """Number of job-finished notifications received (for tests)."""
-        return len(self._finished_jobs)
 
     def _deserialize_request(
         self, body: bytes
@@ -97,56 +78,30 @@ class TaskEventsHead(SubprocessModule):
             message="",
         )
 
-    def _handle_worker_delta(self, worker_delta: gcs_pb2.WorkerDeltaData) -> None:
-        """Record a worker-death notification. GCS_WORKER_DELTA_CHANNEL only carries
-        failures, so every message is a death."""
-        self._dead_workers.append(worker_delta)
+    @routes.post("/api/task_events/query")
+    async def get_task_events(
+        self, request: aiohttp.web.Request
+    ) -> aiohttp.web.Response:
+        """Answer a serialized ``GetTaskEventsRequest`` with a serialized reply.
 
-    def _handle_job_update(self, job_data: gcs_pb2.JobTableData) -> None:
-        """Record a job-finished notification. GCS_JOB_CHANNEL fires on both job start and
-        finish; keep only finished jobs (``is_dead``) to mirror ``OnJobFinished``."""
-        if job_data.is_dead:
-            self._finished_jobs.append(job_data)
-
-    async def _subscribe_for_worker_deaths(self) -> None:
-        subscriber = GcsAioWorkerDeltaSubscriber(address=self.gcs_address)
-        await subscriber.subscribe()
-        while True:
-            try:
-                for _, worker_delta in await subscriber.poll(
-                    batch_size=_SUBSCRIBER_POLL_BATCH_SIZE
-                ):
-                    self._handle_worker_delta(worker_delta)
-            except Exception:
-                logger.exception("Failed handling worker-death notifications.")
-
-    async def _subscribe_for_finished_jobs(self) -> None:
-        subscriber = GcsAioJobSubscriber(address=self.gcs_address)
-        await subscriber.subscribe()
-        while True:
-            try:
-                for _, job_data in await subscriber.poll(
-                    batch_size=_SUBSCRIBER_POLL_BATCH_SIZE
-                ):
-                    self._handle_job_update(job_data)
-            except Exception:
-                logger.exception("Failed handling job-finished notifications.")
-
-    async def _gc_job_summary_loop(self) -> None:
-        while True:
-            await asyncio.sleep(GC_JOB_SUMMARY_INTERVAL_S)
-            try:
-                self._store.gc_job_summary()
-            except Exception:
-                logger.exception("Failed trimming task-event job summaries.")
+        Internal read endpoint for the State API (``StateHead``); the request/reply protos
+        match GCS's ``GetTaskEvents`` so the caller is transport-only.
+        """
+        body = await request.read()
+        try:
+            query_request = gcs_service_pb2.GetTaskEventsRequest.FromString(body)
+            reply = task_event_query.get_task_events(self._store, query_request)
+        except Exception as e:
+            logger.warning(f"Failed to query task events: {e}")
+            return aiohttp.web.Response(status=400, text=str(e))
+        return aiohttp.web.Response(
+            body=reply.SerializeToString(),
+            content_type="application/octet-stream",
+        )
 
     async def run(self):
         await super().run()
-        for coro in (
-            self._subscribe_for_worker_deaths(),
-            self._subscribe_for_finished_jobs(),
-            self._gc_job_summary_loop(),
-        ):
-            task = asyncio.create_task(coro)
-            self._background_tasks.add(task)
-            task.add_done_callback(self._background_tasks.discard)
+        self._manager = TaskEventManager(
+            self._store, self.gcs_address, self.aiogrpc_gcs_channel
+        )
+        self._manager.start()

--- a/python/ray/dashboard/modules/task_events/tests/test_task_event_manager.py
+++ b/python/ray/dashboard/modules/task_events/tests/test_task_event_manager.py
@@ -1,0 +1,276 @@
+import asyncio
+import sys
+from unittest.mock import AsyncMock
+
+import pytest
+
+from ray._common.test_utils import async_wait_for_condition
+from ray._raylet import JobID
+from ray.core.generated import gcs_pb2
+from ray.core.generated.common_pb2 import TaskStatus, TaskType
+from ray.dashboard.modules.task_events.task_event_manager import TaskEventManager
+from ray.dashboard.modules.task_events.task_event_storage import TaskEventStorage
+
+_MANAGER = "ray.dashboard.modules.task_events.task_event_manager"
+_JOB = JobID.from_int(1).binary()
+_WORKER = b"worker_1"
+_WORKER_2 = b"worker_2"
+
+
+def _worker_table_data(worker_id: bytes, is_alive: bool) -> gcs_pb2.WorkerTableData:
+    data = gcs_pb2.WorkerTableData(is_alive=is_alive, exit_detail="boom", end_time_ms=5)
+    data.worker_address.worker_id = worker_id
+    return data
+
+
+def _task_id(n: int) -> bytes:
+    return bytes([n]) * 24
+
+
+def _make_manager() -> TaskEventManager:
+    return TaskEventManager(TaskEventStorage(), "127.0.0.1:6379", None)
+
+
+def _add_stored_task(manager, task_id, worker=None, job=_JOB):
+    event = gcs_pb2.TaskEvents(task_id=task_id, attempt_number=0, job_id=job)
+    event.task_info.type = TaskType.NORMAL_TASK
+    if worker is not None:
+        event.state_updates.worker_id = worker
+    manager._store.add_or_replace_task_event(event)
+
+
+def _is_failed(manager, task_id) -> bool:
+    task_event = manager._store.get_task_event((task_id, 0))
+    return (
+        task_event is not None
+        and TaskStatus.FAILED in task_event.state_updates.state_ts_ns
+    )
+
+
+class _FakeSubscriber:
+    """Delivers a canned batch on the first poll, then parks so the loop settles."""
+
+    def __init__(self, messages):
+        self._messages = messages
+        self._delivered = False
+
+    async def subscribe(self):
+        pass
+
+    async def poll(self, batch_size, timeout=None):
+        if self._delivered:
+            await asyncio.sleep(3600)
+            return []
+        self._delivered = True
+        return self._messages
+
+
+async def _cancel(task: asyncio.Task) -> None:
+    task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass
+
+
+@pytest.mark.asyncio
+async def test_handle_worker_delta_fails_tasks(monkeypatch):
+    monkeypatch.setattr(f"{_MANAGER}._MARK_FAILED_ON_WORKER_DEAD_DELAY_S", 0.0)
+    manager = _make_manager()
+    _add_stored_task(manager, _task_id(1), worker=_WORKER)
+
+    async def fake_get(worker_id):
+        assert worker_id == _WORKER
+        return gcs_pb2.WorkerTableData(exit_detail="boom", end_time_ms=5)
+
+    monkeypatch.setattr(manager, "_get_worker_info", fake_get)
+
+    manager._handle_worker_delta(gcs_pb2.WorkerDeltaData(worker_id=_WORKER))
+
+    await async_wait_for_condition(lambda: _is_failed(manager, _task_id(1)))
+
+
+@pytest.mark.asyncio
+async def test_handle_worker_delta_missing_worker_info_still_fails(monkeypatch):
+    monkeypatch.setattr(f"{_MANAGER}._MARK_FAILED_ON_WORKER_DEAD_DELAY_S", 0.0)
+    manager = _make_manager()
+    _add_stored_task(manager, _task_id(1), worker=_WORKER)
+
+    async def fake_get(worker_id):
+        return None
+
+    monkeypatch.setattr(manager, "_get_worker_info", fake_get)
+
+    manager._handle_worker_delta(gcs_pb2.WorkerDeltaData(worker_id=_WORKER))
+
+    # Even without worker table data, the task is failed — with a fallback message.
+    await async_wait_for_condition(lambda: _is_failed(manager, _task_id(1)))
+    error = manager._store.get_task_event((_task_id(1), 0)).state_updates.error_info
+    assert "could not be fetched" in error.error_message
+
+
+@pytest.mark.asyncio
+async def test_get_worker_info_returns_none_on_rpc_failure():
+    manager = _make_manager()
+
+    stub = AsyncMock()
+    stub.GetWorkerInfo.side_effect = RuntimeError("gcs unavailable")
+    manager._worker_info_stub = stub
+
+    # A failing fetch must be swallowed (returns None) so the spawned reconciliation task
+    # doesn't die silently; the caller then fails the tasks without exit details.
+    assert await manager._get_worker_info(_WORKER) is None
+
+
+@pytest.mark.asyncio
+async def test_handle_job_update_finished_fails_tasks(monkeypatch):
+    monkeypatch.setattr(f"{_MANAGER}._MARK_FAILED_ON_JOB_DONE_DELAY_S", 0.0)
+    manager = _make_manager()
+    _add_stored_task(manager, _task_id(1))
+
+    manager._handle_job_update(
+        gcs_pb2.JobTableData(job_id=_JOB, is_dead=True, end_time=5)
+    )
+
+    await async_wait_for_condition(lambda: _is_failed(manager, _task_id(1)))
+
+
+@pytest.mark.asyncio
+async def test_handle_job_update_ignores_running_job():
+    manager = _make_manager()
+    _add_stored_task(manager, _task_id(1))
+
+    manager._handle_job_update(gcs_pb2.JobTableData(job_id=_JOB, is_dead=False))
+    await asyncio.sleep(0.05)
+
+    assert not _is_failed(manager, _task_id(1))
+
+
+@pytest.mark.asyncio
+async def test_gc_job_summary_loop_trims_over_cap(monkeypatch):
+    monkeypatch.setattr(f"{_MANAGER}.GC_JOB_SUMMARY_INTERVAL_S", 0.01)
+    monkeypatch.setattr(
+        "ray.dashboard.modules.task_events.task_event_storage."
+        "MAX_DROPPED_TASK_ATTEMPTS_PER_JOB",
+        2,
+    )
+    manager = _make_manager()
+    summary = manager._store._summary(_JOB)
+    for i in range(10):
+        summary.record_task_attempt_dropped((_task_id(i), 0))
+    assert len(summary._dropped_task_attempts) == 10
+
+    task = asyncio.create_task(manager._gc_job_summary_loop())
+    try:
+        await async_wait_for_condition(lambda: len(summary._dropped_task_attempts) < 10)
+    finally:
+        await _cancel(task)
+
+
+@pytest.mark.asyncio
+async def test_worker_death_subscription_loop_reconciles(monkeypatch):
+    monkeypatch.setattr(f"{_MANAGER}._MARK_FAILED_ON_WORKER_DEAD_DELAY_S", 0.0)
+    manager = _make_manager()
+    _add_stored_task(manager, _task_id(1), worker=_WORKER)
+
+    async def fake_get(worker_id):
+        return gcs_pb2.WorkerTableData(exit_detail="boom", end_time_ms=5)
+
+    monkeypatch.setattr(manager, "_get_worker_info", fake_get)
+
+    # Isolate the subscription path from the startup backfill (no real GCS here).
+    async def no_backfill():
+        return []
+
+    monkeypatch.setattr(manager, "_get_all_worker_info", no_backfill)
+
+    fake = _FakeSubscriber([(b"key", gcs_pb2.WorkerDeltaData(worker_id=_WORKER))])
+    monkeypatch.setattr(
+        f"{_MANAGER}.GcsAioWorkerDeltaSubscriber", lambda address=None: fake
+    )
+
+    task = asyncio.create_task(manager._subscribe_for_worker_deaths())
+    try:
+        await async_wait_for_condition(lambda: _is_failed(manager, _task_id(1)))
+    finally:
+        await _cancel(task)
+
+
+@pytest.mark.asyncio
+async def test_reconcile_dead_workers_on_startup(monkeypatch):
+    monkeypatch.setattr(f"{_MANAGER}._MARK_FAILED_ON_WORKER_DEAD_DELAY_S", 0.0)
+    manager = _make_manager()
+    _add_stored_task(manager, _task_id(1), worker=_WORKER)
+    _add_stored_task(manager, _task_id(2), worker=_WORKER_2)
+
+    async def fake_get_all():
+        return [
+            _worker_table_data(_WORKER, is_alive=False),
+            _worker_table_data(_WORKER_2, is_alive=True),
+        ]
+
+    monkeypatch.setattr(manager, "_get_all_worker_info", fake_get_all)
+
+    await manager._reconcile_dead_workers_on_startup()
+
+    # The dead worker's task is failed; the live worker's task is left alone.
+    assert _is_failed(manager, _task_id(1))
+    assert not _is_failed(manager, _task_id(2))
+
+
+@pytest.mark.asyncio
+async def test_reconcile_finished_jobs_on_startup(monkeypatch):
+    monkeypatch.setattr(f"{_MANAGER}._MARK_FAILED_ON_JOB_DONE_DELAY_S", 0.0)
+    manager = _make_manager()
+    finished_job = JobID.from_int(1).binary()
+    running_job = JobID.from_int(2).binary()
+    _add_stored_task(manager, _task_id(1), job=finished_job)
+    _add_stored_task(manager, _task_id(2), job=running_job)
+
+    async def fake_get_all():
+        return [
+            gcs_pb2.JobTableData(job_id=finished_job, is_dead=True),
+            gcs_pb2.JobTableData(job_id=running_job, is_dead=False),
+        ]
+
+    monkeypatch.setattr(manager, "_get_all_job_info", fake_get_all)
+
+    await manager._reconcile_finished_jobs_on_startup()
+
+    # The finished job's task is failed; the running job's task is left alone.
+    assert _is_failed(manager, _task_id(1))
+    assert not _is_failed(manager, _task_id(2))
+
+
+@pytest.mark.asyncio
+async def test_job_subscription_loop_reconciles_only_finished(monkeypatch):
+    monkeypatch.setattr(f"{_MANAGER}._MARK_FAILED_ON_JOB_DONE_DELAY_S", 0.0)
+    manager = _make_manager()
+    running_job = JobID.from_int(1).binary()
+    finished_job = JobID.from_int(2).binary()
+    _add_stored_task(manager, _task_id(1), job=running_job)
+    _add_stored_task(manager, _task_id(2), job=finished_job)
+
+    fake = _FakeSubscriber(
+        [
+            (b"k1", gcs_pb2.JobTableData(job_id=running_job, is_dead=False)),
+            (
+                b"k2",
+                gcs_pb2.JobTableData(job_id=finished_job, is_dead=True, end_time=5),
+            ),
+        ]
+    )
+    monkeypatch.setattr(f"{_MANAGER}.GcsAioJobSubscriber", lambda address=None: fake)
+
+    task = asyncio.create_task(manager._subscribe_for_finished_jobs())
+    try:
+        await async_wait_for_condition(lambda: _is_failed(manager, _task_id(2)))
+    finally:
+        await _cancel(task)
+
+    # The running job was ignored; its task is not failed.
+    assert not _is_failed(manager, _task_id(1))
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/dashboard/modules/task_events/tests/test_task_event_query.py
+++ b/python/ray/dashboard/modules/task_events/tests/test_task_event_query.py
@@ -1,0 +1,561 @@
+import sys
+
+import pytest
+
+from ray._raylet import JobID, TaskID
+from ray.core.generated import gcs_pb2, gcs_service_pb2
+from ray.core.generated.common_pb2 import TaskAttempt, TaskStatus, TaskType
+from ray.dashboard.modules.task_events import task_event_query as q
+from ray.dashboard.modules.task_events.task_event_storage import TaskEventStorage
+
+_EQUAL = gcs_service_pb2.FilterPredicate.EQUAL
+_NOT_EQUAL = gcs_service_pb2.FilterPredicate.NOT_EQUAL
+
+_JOB = JobID.from_int(1).binary()
+_JOB_B = JobID.from_int(2).binary()
+
+
+def _task_id(n: int) -> bytes:
+    return bytes([n]) * 24
+
+
+def _event(
+    task_id,
+    *,
+    job_id=_JOB,
+    task_type=TaskType.NORMAL_TASK,
+    name="",
+    actor_id=b"",
+    states=None,
+) -> gcs_pb2.TaskEvents:
+    event = gcs_pb2.TaskEvents(task_id=task_id, attempt_number=0, job_id=job_id)
+    event.task_info.type = task_type
+    event.task_info.name = name
+    event.task_info.job_id = job_id
+    if actor_id:
+        event.task_info.actor_id = actor_id
+    for status, ts in (states or {}).items():
+        event.state_updates.state_ts_ns[status] = ts
+    return event
+
+
+def _request(limit=None, exclude_driver=False) -> gcs_service_pb2.GetTaskEventsRequest:
+    request = gcs_service_pb2.GetTaskEventsRequest()
+    request.filters.exclude_driver = exclude_driver
+    if limit is not None:
+        request.limit = limit
+    return request
+
+
+def _add_filter(request, kind, value, predicate=_EQUAL):
+    filters = request.filters
+    if kind == "job":
+        f = filters.job_filters.add()
+        f.job_id = value
+    elif kind == "task":
+        f = filters.task_filters.add()
+        f.task_id = value
+    elif kind == "actor":
+        f = filters.actor_filters.add()
+        f.actor_id = value
+    elif kind == "name":
+        f = filters.task_name_filters.add()
+        f.task_name = value
+    elif kind == "state":
+        f = filters.state_filters.add()
+        f.state = value
+    f.predicate = predicate
+
+
+def _store(*events) -> TaskEventStorage:
+    store = TaskEventStorage()
+    for event in events:
+        store.add_or_replace_task_event(event)
+    return store
+
+
+def _task_ids(reply):
+    return {e.task_id for e in reply.events_by_task}
+
+
+def test_no_filters_returns_all():
+    store = _store(_event(_task_id(1)), _event(_task_id(2)), _event(_task_id(3)))
+
+    reply = q.get_task_events(store, _request())
+
+    assert _task_ids(reply) == {_task_id(1), _task_id(2), _task_id(3)}
+    assert reply.num_total_stored == 3
+    assert reply.num_truncated == 0
+    assert reply.num_filtered_on_gcs == 0
+    assert reply.num_profile_task_events_dropped == 0
+    assert reply.num_status_task_events_dropped == 0
+
+
+def test_job_filter_returns_only_that_job():
+    store = _store(
+        _event(_task_id(1), job_id=_JOB),
+        _event(_task_id(2), job_id=_JOB),
+        _event(_task_id(3), job_id=_JOB_B),
+    )
+
+    request = _request()
+    _add_filter(request, "job", _JOB)
+    reply = q.get_task_events(store, request)
+
+    assert _task_ids(reply) == {_task_id(1), _task_id(2)}
+    # Candidate set is the job's events, so total-stored is scoped to the job.
+    assert reply.num_total_stored == 2
+
+
+def test_task_filter_returns_only_that_task():
+    store = _store(_event(_task_id(1)), _event(_task_id(2)))
+
+    request = _request()
+    _add_filter(request, "task", _task_id(1))
+    reply = q.get_task_events(store, request)
+
+    assert _task_ids(reply) == {_task_id(1)}
+    # Single equality task filter uses the index, so total-stored is scoped to it.
+    assert reply.num_total_stored == 1
+
+
+def test_task_filter_not_equal_scans_and_filters():
+    store = _store(_event(_task_id(1)), _event(_task_id(2)), _event(_task_id(3)))
+
+    request = _request()
+    _add_filter(request, "task", _task_id(1), predicate=_NOT_EQUAL)
+    reply = q.get_task_events(store, request)
+
+    assert _task_ids(reply) == {_task_id(2), _task_id(3)}
+    # A NOT_EQUAL filter can't use the index, so it scans all events.
+    assert reply.num_total_stored == 3
+    assert reply.num_filtered_on_gcs == 1
+
+
+def test_multiple_equal_task_ids_returns_empty():
+    store = _store(_event(_task_id(1)), _event(_task_id(2)))
+
+    request = _request()
+    _add_filter(request, "task", _task_id(1))
+    _add_filter(request, "task", _task_id(2))
+    reply = q.get_task_events(store, request)
+
+    assert len(reply.events_by_task) == 0
+    assert reply.num_total_stored == 0
+
+
+def test_multiple_not_equal_task_ids_scans():
+    store = _store(_event(_task_id(1)), _event(_task_id(2)), _event(_task_id(3)))
+
+    request = _request()
+    _add_filter(request, "task", _task_id(1), predicate=_NOT_EQUAL)
+    _add_filter(request, "task", _task_id(2), predicate=_NOT_EQUAL)
+    reply = q.get_task_events(store, request)
+
+    assert _task_ids(reply) == {_task_id(3)}
+    assert reply.num_total_stored == 3
+    assert reply.num_filtered_on_gcs == 2
+
+
+def test_task_equal_and_not_equal_mixed():
+    store = _store(_event(_task_id(1)), _event(_task_id(2)), _event(_task_id(3)))
+
+    request = _request()
+    _add_filter(request, "task", _task_id(1), predicate=_NOT_EQUAL)
+    _add_filter(request, "task", _task_id(2), predicate=_EQUAL)
+    reply = q.get_task_events(store, request)
+
+    # The single EQUAL id drives index selection; the NOT_EQUAL is applied on top.
+    assert _task_ids(reply) == {_task_id(2)}
+    assert reply.num_total_stored == 1
+    assert reply.num_filtered_on_gcs == 0
+
+
+def test_job_filter_not_equal_scans_and_filters():
+    store = _store(
+        _event(_task_id(1), job_id=_JOB),
+        _event(_task_id(2), job_id=_JOB_B),
+    )
+
+    request = _request()
+    _add_filter(request, "job", _JOB, predicate=_NOT_EQUAL)
+    reply = q.get_task_events(store, request)
+
+    assert _task_ids(reply) == {_task_id(2)}
+    assert reply.num_total_stored == 2
+    assert reply.num_filtered_on_gcs == 1
+
+
+def test_multiple_equal_job_ids_returns_empty():
+    store = _store(_event(_task_id(1), job_id=_JOB), _event(_task_id(2), job_id=_JOB_B))
+
+    request = _request()
+    _add_filter(request, "job", _JOB)
+    _add_filter(request, "job", _JOB_B)
+    reply = q.get_task_events(store, request)
+
+    assert len(reply.events_by_task) == 0
+
+
+def test_multiple_not_equal_job_ids_scans():
+    _JOB_C = JobID.from_int(3).binary()
+    store = _store(
+        _event(_task_id(1), job_id=_JOB),
+        _event(_task_id(2), job_id=_JOB_B),
+        _event(_task_id(3), job_id=_JOB_C),
+    )
+
+    request = _request()
+    _add_filter(request, "job", _JOB, predicate=_NOT_EQUAL)
+    _add_filter(request, "job", _JOB_B, predicate=_NOT_EQUAL)
+    reply = q.get_task_events(store, request)
+
+    assert _task_ids(reply) == {_task_id(3)}
+    assert reply.num_total_stored == 3
+    assert reply.num_filtered_on_gcs == 2
+
+
+def test_job_equal_and_not_equal_mixed():
+    _JOB_C = JobID.from_int(3).binary()
+    store = _store(
+        _event(_task_id(1), job_id=_JOB),
+        _event(_task_id(2), job_id=_JOB_B),
+        _event(_task_id(3), job_id=_JOB_C),
+    )
+
+    request = _request()
+    _add_filter(request, "job", _JOB, predicate=_EQUAL)
+    _add_filter(request, "job", _JOB_B, predicate=_NOT_EQUAL)
+    reply = q.get_task_events(store, request)
+
+    # The single EQUAL job drives index selection; the NOT_EQUAL is applied on top.
+    assert _task_ids(reply) == {_task_id(1)}
+    assert reply.num_total_stored == 1
+    assert reply.num_filtered_on_gcs == 0
+
+
+def test_task_and_job_combined_filter():
+    # Task 1 is in job A; requiring it also be in job B filters it out.
+    store = _store(
+        _event(_task_id(1), job_id=_JOB),
+        _event(_task_id(2), job_id=_JOB_B),
+    )
+
+    request = _request()
+    _add_filter(request, "task", _task_id(1))
+    _add_filter(request, "job", _JOB_B)
+    reply = q.get_task_events(store, request)
+
+    assert len(reply.events_by_task) == 0
+    # Candidates come from the single-task index; the job filter drops the one candidate.
+    assert reply.num_total_stored == 1
+    assert reply.num_filtered_on_gcs == 1
+
+
+def test_task_equal_and_job_not_equal_combined():
+    store = _store(
+        _event(_task_id(1), job_id=_JOB),
+        _event(_task_id(2), job_id=_JOB_B),
+    )
+
+    request = _request()
+    _add_filter(request, "task", _task_id(1))
+    _add_filter(request, "job", _JOB, predicate=_NOT_EQUAL)
+    reply = q.get_task_events(store, request)
+
+    assert len(reply.events_by_task) == 0
+    assert reply.num_total_stored == 1
+    assert reply.num_filtered_on_gcs == 1
+
+
+def test_exclude_driver():
+    store = _store(
+        _event(_task_id(1), task_type=TaskType.NORMAL_TASK),
+        _event(_task_id(2), task_type=TaskType.DRIVER_TASK),
+    )
+
+    reply = q.get_task_events(store, _request(exclude_driver=True))
+
+    assert _task_ids(reply) == {_task_id(1)}
+    assert reply.num_filtered_on_gcs == 1
+
+
+def test_include_driver():
+    store = _store(
+        _event(_task_id(1), task_type=TaskType.NORMAL_TASK),
+        _event(_task_id(2), task_type=TaskType.DRIVER_TASK),
+    )
+
+    reply = q.get_task_events(store, _request(exclude_driver=False))
+
+    assert _task_ids(reply) == {_task_id(1), _task_id(2)}
+    assert reply.num_filtered_on_gcs == 0
+
+
+_ACTOR_A = b"a" * 16
+_ACTOR_B = b"b" * 16
+
+
+def _actor_store() -> TaskEventStorage:
+    return _store(
+        _event(_task_id(1), task_type=TaskType.ACTOR_TASK, actor_id=_ACTOR_A),
+        _event(_task_id(2), task_type=TaskType.ACTOR_TASK, actor_id=_ACTOR_B),
+        _event(_task_id(3)),
+    )
+
+
+def test_actor_filter():
+    request = _request()
+    _add_filter(request, "actor", _ACTOR_A)
+    reply = q.get_task_events(_actor_store(), request)
+
+    assert _task_ids(reply) == {_task_id(1)}
+    assert reply.num_filtered_on_gcs == 2
+
+
+def test_actor_filter_not_equal():
+    request = _request()
+    _add_filter(request, "actor", _ACTOR_A, predicate=_NOT_EQUAL)
+    reply = q.get_task_events(_actor_store(), request)
+
+    # Non-actor tasks have an empty actor id, so they also satisfy != actor_a.
+    assert _task_ids(reply) == {_task_id(2), _task_id(3)}
+    assert reply.num_filtered_on_gcs == 1
+
+
+def test_multiple_equal_actor_ids_returns_empty():
+    request = _request()
+    _add_filter(request, "actor", _ACTOR_A)
+    _add_filter(request, "actor", _ACTOR_B)
+    reply = q.get_task_events(_actor_store(), request)
+
+    assert len(reply.events_by_task) == 0
+    assert reply.num_filtered_on_gcs == 3
+
+
+def _name_store() -> TaskEventStorage:
+    return _store(
+        _event(_task_id(1), name="Foo"),
+        _event(_task_id(2), name="Bar"),
+        _event(_task_id(3), name="Baz"),
+    )
+
+
+def test_name_filter_is_case_insensitive():
+    request = _request()
+    _add_filter(request, "name", "foo")
+    reply = q.get_task_events(_name_store(), request)
+
+    assert _task_ids(reply) == {_task_id(1)}
+    assert reply.num_filtered_on_gcs == 2
+
+
+def test_name_filter_not_equal():
+    request = _request()
+    _add_filter(request, "name", "FOO", predicate=_NOT_EQUAL)
+    reply = q.get_task_events(_name_store(), request)
+
+    assert _task_ids(reply) == {_task_id(2), _task_id(3)}
+    assert reply.num_filtered_on_gcs == 1
+
+
+def test_multiple_equal_names_returns_empty():
+    request = _request()
+    _add_filter(request, "name", "Foo")
+    _add_filter(request, "name", "Bar")
+    reply = q.get_task_events(_name_store(), request)
+
+    assert len(reply.events_by_task) == 0
+    assert reply.num_filtered_on_gcs == 3
+
+
+def _state_store() -> TaskEventStorage:
+    # Latest state is the highest-valued status present: RUNNING + FINISHED -> FINISHED.
+    return _store(
+        _event(_task_id(1), states={TaskStatus.RUNNING: 1, TaskStatus.FINISHED: 2}),
+        _event(_task_id(2), states={TaskStatus.RUNNING: 1}),
+        _event(_task_id(3)),  # no state updates -> latest state NIL
+    )
+
+
+@pytest.mark.parametrize(
+    "state,expected",
+    [
+        ("finished", {1}),
+        ("RUNNING", {2}),
+        ("nil", {3}),
+    ],
+)
+def test_state_filter_uses_latest_state(state, expected):
+    request = _request()
+    _add_filter(request, "state", state)
+    reply = q.get_task_events(_state_store(), request)
+
+    assert _task_ids(reply) == {_task_id(n) for n in expected}
+
+
+def test_state_filter_not_equal():
+    request = _request()
+    _add_filter(request, "state", "RUNNING", predicate=_NOT_EQUAL)
+    reply = q.get_task_events(_state_store(), request)
+
+    assert _task_ids(reply) == {_task_id(1), _task_id(3)}
+    assert reply.num_filtered_on_gcs == 1
+
+
+def test_multiple_equal_states_returns_empty():
+    request = _request()
+    _add_filter(request, "state", "RUNNING")
+    _add_filter(request, "state", "NIL")
+    reply = q.get_task_events(_state_store(), request)
+
+    assert len(reply.events_by_task) == 0
+    assert reply.num_filtered_on_gcs == 3
+
+
+def test_not_equal_predicate():
+    store = _store(_event(_task_id(1)), _event(_task_id(2)))
+
+    request = _request()
+    _add_filter(request, "task", _task_id(1), predicate=_NOT_EQUAL)
+    reply = q.get_task_events(store, request)
+
+    assert _task_ids(reply) == {_task_id(2)}
+
+
+def test_name_and_actor_combined_no_match():
+    # task_id(1) has the name but no actor; nothing satisfies both.
+    store = _store(
+        _event(_task_id(1), name="foo"),
+        _event(_task_id(2), task_type=TaskType.ACTOR_TASK, actor_id=_ACTOR_A),
+    )
+
+    request = _request()
+    _add_filter(request, "name", "foo")
+    _add_filter(request, "actor", _ACTOR_A)
+    reply = q.get_task_events(store, request)
+
+    assert len(reply.events_by_task) == 0
+
+
+def test_actor_and_state_combined():
+    store = _store(
+        _event(
+            _task_id(1),
+            task_type=TaskType.ACTOR_TASK,
+            actor_id=_ACTOR_A,
+            states={TaskStatus.RUNNING: 1},
+        ),
+        _event(
+            _task_id(2),
+            task_type=TaskType.ACTOR_TASK,
+            actor_id=_ACTOR_A,
+            states={TaskStatus.FINISHED: 1},
+        ),
+    )
+
+    request = _request()
+    _add_filter(request, "actor", _ACTOR_A)
+    _add_filter(request, "state", "running")
+    reply = q.get_task_events(store, request)
+
+    assert _task_ids(reply) == {_task_id(1)}
+    assert reply.num_filtered_on_gcs == 1
+
+
+def test_invalid_predicate_returns_invalid_argument_status():
+    store = _store(_event(_task_id(1)))
+
+    request = _request()
+    _add_filter(request, "task", _task_id(1), predicate=100)
+    reply = q.get_task_events(store, request)
+
+    assert reply.status.code == q._INVALID_ARGUMENT_STATUS_CODE
+    assert len(reply.events_by_task) == 0
+
+
+def test_success_reply_has_ok_status():
+    store = _store(_event(_task_id(1)))
+
+    reply = q.get_task_events(store, _request())
+
+    assert reply.HasField("status")
+    assert reply.status.code == 0
+
+
+def test_limit_truncates_and_counts_dropped():
+    store = _store(
+        _event(_task_id(1), states={TaskStatus.RUNNING: 1}),
+        _event(_task_id(2), states={TaskStatus.RUNNING: 1}),
+        _event(_task_id(3), states={TaskStatus.RUNNING: 1}),
+    )
+
+    reply = q.get_task_events(store, _request(limit=1))
+
+    assert len(reply.events_by_task) == 1
+    assert reply.num_total_stored == 3
+    assert reply.num_truncated == 2
+    # Truncated status events are reported as dropped.
+    assert reply.num_status_task_events_dropped == 2
+
+
+@pytest.mark.parametrize(
+    "limit,expected_kept",
+    [
+        (2, 2),  # partial
+        (0, 0),  # keep nothing, everything truncated
+        (-1, 3),  # unlimited
+    ],
+)
+def test_limit_boundaries(limit, expected_kept):
+    store = _store(
+        _event(_task_id(1), states={TaskStatus.RUNNING: 1}),
+        _event(_task_id(2), states={TaskStatus.RUNNING: 1}),
+        _event(_task_id(3), states={TaskStatus.RUNNING: 1}),
+    )
+
+    reply = q.get_task_events(store, _request(limit=limit))
+
+    num_truncated = 3 - expected_kept
+    assert len(reply.events_by_task) == expected_kept
+    assert reply.num_total_stored == 3
+    assert reply.num_truncated == num_truncated
+    assert reply.num_status_task_events_dropped == num_truncated
+
+
+def test_limit_keeps_most_recent():
+    # Insert oldest-to-newest; a limit must keep the most recently added events.
+    events = [_event(_task_id(n), states={TaskStatus.RUNNING: 1}) for n in range(1, 21)]
+    store = _store(*events)
+
+    reply = q.get_task_events(store, _request(limit=5))
+
+    newest_five = {_task_id(n) for n in range(16, 21)}
+    assert _task_ids(reply) == newest_five
+    assert reply.num_truncated == 15
+
+
+def test_global_dropped_counts_reported():
+    store = _store(_event(_task_id(1)))
+    dropped = TaskID.for_fake_task(JobID.from_int(1)).binary()
+    store.record_data_loss_from_worker([TaskAttempt(task_id=dropped, attempt_number=0)])
+
+    reply = q.get_task_events(store, _request())
+
+    assert reply.num_status_task_events_dropped == 1
+
+
+def test_per_job_dropped_counts_reported():
+    store = _store(_event(_task_id(1), job_id=JobID.from_int(1).binary()))
+    dropped = TaskID.for_fake_task(JobID.from_int(1)).binary()
+    store.record_data_loss_from_worker([TaskAttempt(task_id=dropped, attempt_number=0)])
+
+    request = _request()
+    _add_filter(request, "job", JobID.from_int(1).binary())
+    reply = q.get_task_events(store, request)
+
+    assert reply.num_status_task_events_dropped == 1
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/dashboard/modules/task_events/tests/test_task_event_storage.py
+++ b/python/ray/dashboard/modules/task_events/tests/test_task_event_storage.py
@@ -2,9 +2,9 @@ import sys
 
 import pytest
 
-from ray._raylet import JobID, TaskID
+from ray._raylet import JobID, TaskID, WorkerID
 from ray.core.generated import gcs_pb2
-from ray.core.generated.common_pb2 import TaskAttempt, TaskStatus, TaskType
+from ray.core.generated.common_pb2 import ErrorType, TaskAttempt, TaskStatus, TaskType
 from ray.dashboard.modules.task_events import task_event_storage as tes
 
 _JOB = JobID.from_int(1).binary()
@@ -15,7 +15,7 @@ def _task_id(n: int) -> bytes:
 
 
 def _event(
-    task_id, attempt=0, task_type=None, finished=False, name=""
+    task_id, attempt=0, task_type=None, finished=False, name="", worker=None
 ) -> gcs_pb2.TaskEvents:
     event = gcs_pb2.TaskEvents(task_id=task_id, attempt_number=attempt, job_id=_JOB)
     if task_type is not None:
@@ -23,6 +23,8 @@ def _event(
         event.task_info.name = name
     if finished:
         event.state_updates.state_ts_ns[TaskStatus.FINISHED] = 1
+    if worker is not None:
+        event.state_updates.worker_id = worker
     return event
 
 
@@ -127,6 +129,85 @@ def test_job_summary_gc_trims_over_cap(monkeypatch):
 
     # 10 tracked, cap 4 -> 6 evicted; total-ever count is preserved.
     assert summary.num_task_attempts_dropped == 10
+
+
+_WORKER = WorkerID.from_random().binary()
+
+
+def test_mark_tasks_failed_on_worker_dead():
+    store = tes.TaskEventStorage()
+    store.add_or_replace_task_event(
+        _event(_task_id(1), task_type=TaskType.NORMAL_TASK, worker=_WORKER)
+    )
+
+    store.mark_tasks_failed_on_worker_dead(
+        _WORKER, gcs_pb2.WorkerTableData(exit_detail="boom", end_time_ms=5)
+    )
+
+    state = store.get_task_event((_task_id(1), 0)).state_updates
+    assert state.state_ts_ns[TaskStatus.FAILED] == 5 * 10**6
+    assert state.error_info.error_type == ErrorType.WORKER_DIED
+    assert "boom" in state.error_info.error_message
+
+
+def test_mark_tasks_failed_on_worker_dead_without_worker_data():
+    store = tes.TaskEventStorage()
+    store.add_or_replace_task_event(
+        _event(_task_id(1), task_type=TaskType.NORMAL_TASK, worker=_WORKER)
+    )
+
+    # No worker table data (record evicted, or the fetch failed): the task is still failed,
+    # stamped with a best-effort time and a message noting the details are unavailable.
+    store.mark_tasks_failed_on_worker_dead(_WORKER, None)
+
+    state = store.get_task_event((_task_id(1), 0)).state_updates
+    assert state.state_ts_ns[TaskStatus.FAILED] > 0
+    assert state.error_info.error_type == ErrorType.WORKER_DIED
+    assert "could not be fetched" in state.error_info.error_message
+
+
+def test_mark_tasks_failed_on_worker_dead_skips_terminated():
+    store = tes.TaskEventStorage()
+    store.add_or_replace_task_event(
+        _event(
+            _task_id(1), task_type=TaskType.NORMAL_TASK, worker=_WORKER, finished=True
+        )
+    )
+
+    store.mark_tasks_failed_on_worker_dead(
+        _WORKER, gcs_pb2.WorkerTableData(end_time_ms=5)
+    )
+
+    state = store.get_task_event((_task_id(1), 0)).state_updates
+    assert TaskStatus.FAILED not in state.state_ts_ns
+
+
+def test_mark_tasks_failed_on_worker_dead_unknown_worker_is_noop():
+    store = tes.TaskEventStorage()
+    # No tasks indexed for this worker; must not raise.
+    store.mark_tasks_failed_on_worker_dead(_WORKER, gcs_pb2.WorkerTableData())
+
+
+def test_mark_tasks_failed_on_job_ends():
+    store = tes.TaskEventStorage()
+    store.add_or_replace_task_event(_event(_task_id(1), task_type=TaskType.NORMAL_TASK))
+
+    store.mark_tasks_failed_on_job_ends(_JOB, 9)
+
+    state = store.get_task_event((_task_id(1), 0)).state_updates
+    assert state.state_ts_ns[TaskStatus.FAILED] == 9
+    assert state.error_info.error_type == ErrorType.WORKER_DIED
+
+
+def test_update_job_summary_on_job_done_clears_drops():
+    store = tes.TaskEventStorage()
+    summary = store._summary(_JOB)
+    summary.record_task_attempt_dropped((_task_id(1), 0))
+    assert summary.should_drop_task_attempt((_task_id(1), 0))
+
+    store.update_job_summary_on_job_done(_JOB)
+
+    assert not summary.should_drop_task_attempt((_task_id(1), 0))
 
 
 if __name__ == "__main__":

--- a/python/ray/dashboard/modules/task_events/tests/test_task_events_head.py
+++ b/python/ray/dashboard/modules/task_events/tests/test_task_events_head.py
@@ -1,4 +1,3 @@
-import asyncio
 import sys
 from unittest.mock import AsyncMock
 
@@ -10,12 +9,16 @@ from ray._common.ray_constants import (
     LOGGING_ROTATE_BACKUP_COUNT,
     LOGGING_ROTATE_BYTES,
 )
-from ray._common.test_utils import async_wait_for_condition
 from ray._raylet import JobID
-from ray.core.generated import events_event_aggregator_service_pb2, gcs_pb2
+from ray.core.generated import (
+    events_event_aggregator_service_pb2,
+    gcs_pb2,
+    gcs_service_pb2,
+)
 from ray.core.generated.common_pb2 import TaskType
 from ray.core.generated.events_base_event_pb2 import RayEvent
 from ray.core.generated.events_task_definition_event_pb2 import TaskDefinitionEvent
+from ray.dashboard.modules.task_events import task_event_query
 from ray.dashboard.modules.task_events.task_events_head import TaskEventsHead
 from ray.dashboard.subprocesses.module import SubprocessModuleConfig
 
@@ -74,6 +77,14 @@ def _fake_request(body: bytes):
     return request
 
 
+def _add_stored_task(head, task_id, worker=None, job=_JOB):
+    event = gcs_pb2.TaskEvents(task_id=task_id, attempt_number=0, job_id=job)
+    event.task_info.type = TaskType.NORMAL_TASK
+    if worker is not None:
+        event.state_updates.worker_id = worker
+    head._store.add_or_replace_task_event(event)
+
+
 @pytest.mark.asyncio
 async def test_add_task_events_buffers_events():
     head = _make_head()
@@ -130,122 +141,36 @@ def test_deserialize_request_roundtrip():
     assert len(request.events_data.events) == 1
 
 
-def test_handle_worker_delta_buffers():
+@pytest.mark.asyncio
+async def test_get_task_events_endpoint_roundtrip():
     head = _make_head()
-    assert head.num_dead_workers_received == 0
+    _add_stored_task(head, _task_id(1))
 
-    head._handle_worker_delta(
-        gcs_pb2.WorkerDeltaData(worker_id=b"worker_1", node_id=b"node_1")
-    )
+    query = gcs_service_pb2.GetTaskEventsRequest()
+    response = await head.get_task_events(_fake_request(query.SerializeToString()))
 
-    assert head.num_dead_workers_received == 1
-
-
-def test_handle_job_update_buffers_finished_job():
-    head = _make_head()
-
-    head._handle_job_update(
-        gcs_pb2.JobTableData(job_id=b"job_1", is_dead=True, end_time=123)
-    )
-
-    assert head.num_finished_jobs_received == 1
-
-
-def test_handle_job_update_ignores_running_job():
-    head = _make_head()
-
-    head._handle_job_update(gcs_pb2.JobTableData(job_id=b"job_1", is_dead=False))
-
-    assert head.num_finished_jobs_received == 0
-
-
-class _FakeSubscriber:
-    """Delivers a canned batch on the first poll, then parks so the loop settles."""
-
-    def __init__(self, messages):
-        self._messages = messages
-        self._delivered = False
-
-    async def subscribe(self):
-        pass
-
-    async def poll(self, batch_size, timeout=None):
-        if self._delivered:
-            await asyncio.sleep(3600)
-            return []
-        self._delivered = True
-        return self._messages
-
-
-async def _cancel(task: asyncio.Task) -> None:
-    task.cancel()
-    try:
-        await task
-    except asyncio.CancelledError:
-        pass
+    assert response.status == 200
+    reply = gcs_service_pb2.GetTaskEventsReply()
+    reply.ParseFromString(response.body)
+    assert [event.task_id for event in reply.events_by_task] == [_task_id(1)]
 
 
 @pytest.mark.asyncio
-async def test_gc_job_summary_loop_trims_over_cap(monkeypatch):
-    monkeypatch.setattr(
-        "ray.dashboard.modules.task_events.task_events_head.GC_JOB_SUMMARY_INTERVAL_S",
-        0.01,
-    )
-    monkeypatch.setattr(
-        "ray.dashboard.modules.task_events.task_event_storage."
-        "MAX_DROPPED_TASK_ATTEMPTS_PER_JOB",
-        2,
-    )
+async def test_get_task_events_invalid_predicate_returns_status_in_reply():
     head = _make_head()
-    summary = head._store._summary(_JOB)
-    for i in range(10):
-        summary.record_task_attempt_dropped((_task_id(i), 0))
-    assert len(summary._dropped_task_attempts) == 10
+    _add_stored_task(head, _task_id(1))
 
-    task = asyncio.create_task(head._gc_job_summary_loop())
-    try:
-        await async_wait_for_condition(lambda: len(summary._dropped_task_attempts) < 10)
-    finally:
-        await _cancel(task)
+    query = gcs_service_pb2.GetTaskEventsRequest()
+    task_filter = query.filters.task_filters.add()
+    task_filter.task_id = _task_id(1)
+    task_filter.predicate = 100
+    response = await head.get_task_events(_fake_request(query.SerializeToString()))
 
-
-@pytest.mark.asyncio
-async def test_worker_death_subscription_loop_buffers(monkeypatch):
-    head = _make_head()
-    worker_delta = gcs_pb2.WorkerDeltaData(worker_id=b"worker_1", node_id=b"node_1")
-    fake = _FakeSubscriber([(b"key", worker_delta)])
-    monkeypatch.setattr(
-        "ray.dashboard.modules.task_events.task_events_head."
-        "GcsAioWorkerDeltaSubscriber",
-        lambda address=None: fake,
-    )
-
-    task = asyncio.create_task(head._subscribe_for_worker_deaths())
-    try:
-        await async_wait_for_condition(lambda: head.num_dead_workers_received == 1)
-    finally:
-        await _cancel(task)
-
-
-@pytest.mark.asyncio
-async def test_job_subscription_loop_buffers_only_finished(monkeypatch):
-    head = _make_head()
-    running = gcs_pb2.JobTableData(job_id=b"job_1", is_dead=False)
-    finished = gcs_pb2.JobTableData(job_id=b"job_2", is_dead=True)
-    fake = _FakeSubscriber([(b"k1", running), (b"k2", finished)])
-    monkeypatch.setattr(
-        "ray.dashboard.modules.task_events.task_events_head.GcsAioJobSubscriber",
-        lambda address=None: fake,
-    )
-
-    task = asyncio.create_task(head._subscribe_for_finished_jobs())
-    try:
-        await async_wait_for_condition(lambda: head.num_finished_jobs_received == 1)
-    finally:
-        await _cancel(task)
-
-    # The running job was filtered out; only the finished one was buffered.
-    assert head.num_finished_jobs_received == 1
+    assert response.status == 200
+    reply = gcs_service_pb2.GetTaskEventsReply()
+    reply.ParseFromString(response.body)
+    assert reply.status.code == task_event_query._INVALID_ARGUMENT_STATUS_CODE
+    assert len(reply.events_by_task) == 0
 
 
 if __name__ == "__main__":

--- a/python/ray/dashboard/modules/task_events/tests/test_task_events_head_integration.py
+++ b/python/ray/dashboard/modules/task_events/tests/test_task_events_head_integration.py
@@ -11,15 +11,19 @@ from ray._common.ray_constants import (
     LOGGING_ROTATE_BYTES,
 )
 from ray._common.test_utils import async_wait_for_condition, run_string_as_driver
+from ray.dashboard.modules.task_events.task_event_manager import TaskEventManager
 from ray.dashboard.modules.task_events.task_events_head import TaskEventsHead
 from ray.dashboard.subprocesses.module import SubprocessModuleConfig
 from ray.tests.conftest import *  # noqa
 
+_MANAGER = "ray.dashboard.modules.task_events.task_event_manager"
 
-def _make_head(gcs_address: str) -> TaskEventsHead:
-    """Build a TaskEventsHead directly in the test's driver process (not as its usual
-    separate SubprocessModule) so the test can drive its subscription loops and read its
-    in-memory buffers in-process. Test-only."""
+
+def _make_manager(gcs_address: str) -> TaskEventManager:
+    """Build a TaskEventManager directly in the test's driver process (not inside its usual
+    separate SubprocessModule) so the test can drive its subscription loops and inspect its
+    in-memory store in-process. Reuses TaskEventsHead only to obtain a GCS aio channel wired
+    to the test cluster. Test-only."""
     config = SubprocessModuleConfig(
         cluster_id_hex="deadbeef",
         gcs_address=gcs_address,
@@ -34,7 +38,8 @@ def _make_head(gcs_address: str) -> TaskEventsHead:
         logging_rotate_backup_count=LOGGING_ROTATE_BACKUP_COUNT,
         socket_dir="/tmp",
     )
-    return TaskEventsHead(config)
+    head = TaskEventsHead(config)
+    return TaskEventManager(head._store, head.gcs_address, head.aiogrpc_gcs_channel)
 
 
 async def _stop(subscription: asyncio.Task) -> None:
@@ -46,12 +51,23 @@ async def _stop(subscription: asyncio.Task) -> None:
 
 
 @pytest.mark.asyncio
-async def test_worker_death_lands_in_buffer(ray_start_regular):
-    """A killed worker's failure is delivered over GCS pubsub and buffered by the head."""
+async def test_worker_death_triggers_reconciliation(ray_start_regular, monkeypatch):
+    """A killed worker's failure is delivered over GCS pubsub, its exit info is fetched,
+    and the manager fails that worker's tasks."""
+    monkeypatch.setattr(f"{_MANAGER}._MARK_FAILED_ON_WORKER_DEAD_DELAY_S", 0.0)
     gcs_address = ray_start_regular["gcs_address"]
-    head = _make_head(gcs_address)
+    manager = _make_manager(gcs_address)
 
-    subscription = asyncio.create_task(head._subscribe_for_worker_deaths())
+    marked_workers = []
+    original = manager._store.mark_tasks_failed_on_worker_dead
+
+    def record(worker_id, worker_table_data):
+        marked_workers.append(worker_id)
+        return original(worker_id, worker_table_data)
+
+    monkeypatch.setattr(manager._store, "mark_tasks_failed_on_worker_dead", record)
+
+    subscription = asyncio.create_task(manager._subscribe_for_worker_deaths())
     try:
         # Let the subscription register before triggering the death: GCS only queues
         # messages for a subscriber once its subscription is established.
@@ -66,35 +82,50 @@ async def test_worker_death_lands_in_buffer(ray_start_regular):
         worker_id = bytes.fromhex(await actor.get_worker_id.remote())
         ray.kill(actor, no_restart=True)
 
-        await async_wait_for_condition(
-            lambda: worker_id in {wd.worker_id for wd in head._dead_workers},
-            timeout=30,
-        )
+        # Reaching the store call means the worker delta arrived and GetWorkerInfo
+        # returned the dead worker's exit info (otherwise reconciliation returns early).
+        await async_wait_for_condition(lambda: worker_id in marked_workers, timeout=30)
     finally:
         await _stop(subscription)
 
 
 @pytest.mark.asyncio
-async def test_job_finished_lands_in_buffer(ray_start_regular):
-    """A finished job is delivered over GCS pubsub and buffered by the head."""
+async def test_job_finished_triggers_reconciliation(ray_start_regular, monkeypatch):
+    """A finished job is delivered over GCS pubsub and the manager fails that job's
+    tasks. Running-job updates are ignored, so only the finished job is acted on."""
+    monkeypatch.setattr(f"{_MANAGER}._MARK_FAILED_ON_JOB_DONE_DELAY_S", 0.0)
     gcs_address = ray_start_regular["gcs_address"]
-    head = _make_head(gcs_address)
+    manager = _make_manager(gcs_address)
 
-    subscription = asyncio.create_task(head._subscribe_for_finished_jobs())
+    marked_jobs = []
+    original = manager._store.mark_tasks_failed_on_job_ends
+
+    def record(job_id, job_finish_time_ns):
+        marked_jobs.append(job_id)
+        return original(job_id, job_finish_time_ns)
+
+    monkeypatch.setattr(manager._store, "mark_tasks_failed_on_job_ends", record)
+
+    subscription = asyncio.create_task(manager._subscribe_for_finished_jobs())
     try:
         await asyncio.sleep(2)
 
-        # A driver that connects and immediately exits, finishing its job. Run it off the
-        # event loop so the subscription keeps polling while the subprocess runs.
-        driver = f'import ray\nray.init(address="{gcs_address}")\n'
-        await asyncio.get_running_loop().run_in_executor(
+        # A driver that connects, reports its job id, and exits (finishing its job). Run
+        # it off the event loop so the subscription keeps polling while it runs.
+        driver = (
+            "import ray\n"
+            f'ray.init(address="{gcs_address}")\n'
+            'print("JOBID:" + ray.get_runtime_context().get_job_id())\n'
+        )
+        output = await asyncio.get_running_loop().run_in_executor(
             None, run_string_as_driver, driver
         )
-
-        await async_wait_for_condition(
-            lambda: any(job.is_dead for job in head._finished_jobs),
-            timeout=30,
+        job_line = next(
+            line for line in output.splitlines() if line.startswith("JOBID:")
         )
+        job_id = bytes.fromhex(job_line[len("JOBID:") :].strip())
+
+        await async_wait_for_condition(lambda: job_id in marked_jobs, timeout=30)
     finally:
         await _stop(subscription)
 

--- a/python/ray/includes/ray_config.pxd
+++ b/python/ray/includes/ray_config.pxd
@@ -97,3 +97,7 @@ cdef extern from "ray/common/ray_config.h" nogil:
         int64_t task_events_max_dropped_task_attempts_tracked_per_job_in_gcs() const
 
         int64_t task_events_gc_job_summary_interval_ms() const
+
+        uint64_t gcs_mark_task_failed_on_worker_dead_delay_ms() const
+
+        uint64_t gcs_mark_task_failed_on_job_done_delay_ms() const

--- a/python/ray/includes/ray_config.pxi
+++ b/python/ray/includes/ray_config.pxi
@@ -160,3 +160,11 @@ cdef class Config:
     @staticmethod
     def task_events_gc_job_summary_interval_ms():
         return RayConfig.instance().task_events_gc_job_summary_interval_ms()
+
+    @staticmethod
+    def gcs_mark_task_failed_on_worker_dead_delay_ms():
+        return RayConfig.instance().gcs_mark_task_failed_on_worker_dead_delay_ms()
+
+    @staticmethod
+    def gcs_mark_task_failed_on_job_done_delay_ms():
+        return RayConfig.instance().gcs_mark_task_failed_on_job_done_delay_ms()


### PR DESCRIPTION
Cherry-pick of #65141 (master commit 328e6b7646facad6dc92e37b8db2b478b2089a87) onto `releases/2.58.0`.

Fresh single-commit pick against the current release head for a clean reviewable diff. Intentionally parallels #65303 (earlier cherry-pick of the same commit); one of the two should be closed in favor of the other. Applies cleanly on the current head, but per series order it should merge after 4/n (#65353/#65291) and 5/n (#65354/#65295).

Clean cherry-pick, no conflicts (`git cherry-pick -x -s`). AI-assisted (Claude Code); submitted and reviewed by @elliot-barn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)