### PR TITLE
[cherry-pick][2.58.0][core][taskEvents out of GCS][8/n] Reroute state head to task events head for state APIs. (#65160)

### DIFF
--- a/python/ray/_private/state_api_test_utils.py
+++ b/python/ray/_private/state_api_test_utils.py
@@ -1,6 +1,7 @@
 import asyncio
 import concurrent.futures
 import logging
+import os
 import pprint
 import time
 import traceback
@@ -349,8 +350,14 @@ def get_state_api_manager(gcs_address: str) -> StateAPIManager:
     gcs_client = GcsClient(address=gcs_address)
     gcs_channel = GcsChannel(gcs_address=gcs_address, aio=True)
     gcs_channel.connect()
+    # Task events are read from the dashboard head, which the client reaches over the
+    # subprocess module's socket rather than through the GCS channel.
+    node = ray._private.worker.global_worker.node
     state_api_data_source_client = StateDataSourceClient(
-        gcs_channel.channel(), gcs_client
+        gcs_channel.channel(),
+        gcs_client,
+        dashboard_socket_dir=os.path.join(node.get_session_dir_path(), "sockets"),
+        dashboard_session_name=node.session_name,
     )
     return StateAPIManager(
         state_api_data_source_client,

--- a/python/ray/dashboard/modules/reporter/reporter_head.py
+++ b/python/ray/dashboard/modules/reporter/reporter_head.py
@@ -1087,7 +1087,10 @@ class ReportHead(SubprocessModule):
     async def run(self):
         await super().run()
         self._state_api_data_source_client = StateDataSourceClient(
-            self.aiogrpc_gcs_channel, self.gcs_client
+            self.aiogrpc_gcs_channel,
+            self.gcs_client,
+            dashboard_socket_dir=self._config.socket_dir,
+            dashboard_session_name=self._config.session_name,
         )
         # Set up the state API in order to fetch task information.
         # This is only used to get task info. If we have Task APIs in GcsClient we can

--- a/python/ray/dashboard/modules/state/state_head.py
+++ b/python/ray/dashboard/modules/state/state_head.py
@@ -351,7 +351,10 @@ class StateHead(SubprocessModule, RateLimitedModule):
         await SubprocessModule.run(self)
         gcs_channel = self.aiogrpc_gcs_channel
         self._state_api_data_source_client = StateDataSourceClient(
-            gcs_channel, self.gcs_client
+            gcs_channel,
+            self.gcs_client,
+            dashboard_socket_dir=self._config.socket_dir,
+            dashboard_session_name=self._config.session_name,
         )
         self._state_api = StateAPIManager(
             self._state_api_data_source_client,

--- a/python/ray/tests/test_state_api_data_source_client_get.py
+++ b/python/ray/tests/test_state_api_data_source_client_get.py
@@ -1,3 +1,4 @@
+import asyncio
 import os
 import signal
 import sys
@@ -5,6 +6,7 @@ import uuid
 from collections import Counter
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import aiohttp
 import pytest
 from click.testing import CliRunner
 
@@ -601,6 +603,53 @@ def test_list_get_tasks(shutdown_only):
 
     wait_for_condition(verify)
     print(list_tasks())
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="Exercises the POSIX unix-socket hop between the StateHead and "
+    "TaskEventsHead subprocesses.",
+)
+def test_list_tasks_reads_from_dashboard_head(monkeypatch, shutdown_only):
+    """End-to-end: with ``RAY_enable_task_events_to_dashboard_head`` on, ``ray list
+    tasks`` reads from the ``TaskEventsHead`` subprocess over its unix socket, not GCS.
+    """
+    # Feed task events into the dashboard-head store via the aggregator, and read them
+    # back from there instead of GCS. The single umbrella flag enables both the publish
+    # path and the read reroute.
+    monkeypatch.setenv("RAY_enable_core_worker_ray_event_to_aggregator", "1")
+    monkeypatch.setenv("RAY_enable_core_worker_task_event_to_gcs", "0")
+    monkeypatch.setenv("RAY_enable_task_events_to_dashboard_head", "1")
+
+    ray_context = ray.init(num_cpus=2)
+    wait_for_aggregator_agent_if_enabled(
+        ray_context.address_info["address"],
+        ray_context.address_info["node_id"],
+    )
+    job_id = ray.get_runtime_context().get_job_id()
+
+    @ray.remote
+    def f():
+        return 1
+
+    names = [f"dh_task_{i}" for i in range(3)]
+    ray.get([f.options(name=name).remote() for name in names])
+
+    def verify():
+        tasks = list_tasks()
+        names_seen = {task["name"] for task in tasks}
+        assert set(names).issubset(names_seen), (names, names_seen)
+        for task in tasks:
+            assert task["job_id"] == job_id
+
+        # The filter is serialized into the request and applied on the dashboard-head
+        # side, so a correct filtered result also proves the request survived the wire.
+        filtered = list_tasks(filters=[("name", "=", names[0])])
+        assert len(filtered) == 1
+        assert filtered[0]["name"] == names[0]
+        return True
+
+    wait_for_condition(verify, timeout=30)
 
 
 @pytest.mark.parametrize(
@@ -1473,6 +1522,107 @@ def test_get_actor_timeout_multiplier(shutdown_only):
     # This should work without timeout issues
     result = get_actor(actor_id, timeout=1)
     assert result["actor_id"] == actor_id
+
+
+class _FakeAsyncResponse:
+    """Minimal aiohttp-style response usable as an async context manager."""
+
+    def __init__(self, status, body=b""):
+        self.status = status
+        self.reason = "test-reason"
+        self._body = body
+
+    async def read(self):
+        return self._body
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+def _task_info_client(**kwargs):
+    return StateDataSourceClient(
+        gcs_channel=MagicMock(), gcs_client=MagicMock(), **kwargs
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_all_task_info_reads_from_gcs_by_default(monkeypatch):
+    monkeypatch.setattr(
+        "ray.util.state.state_manager._READ_TASK_EVENTS_FROM_DASHBOARD_HEAD", False
+    )
+    client = _task_info_client()
+    expected = GetTaskEventsReply()
+    client._gcs_task_info_stub.GetTaskEvents = AsyncMock(return_value=expected)
+
+    reply = await client.get_all_task_info()
+
+    client._gcs_task_info_stub.GetTaskEvents.assert_awaited_once()
+    assert reply is expected
+
+
+@pytest.mark.asyncio
+async def test_get_all_task_info_reads_from_dashboard_head_when_enabled(monkeypatch):
+    monkeypatch.setattr(
+        "ray.util.state.state_manager._READ_TASK_EVENTS_FROM_DASHBOARD_HEAD", True
+    )
+    client = _task_info_client(
+        dashboard_socket_dir="/tmp/sock", dashboard_session_name="session-1"
+    )
+    expected = GetTaskEventsReply(num_status_task_events_dropped=3)
+    session = MagicMock()
+    session.post = MagicMock(
+        return_value=_FakeAsyncResponse(200, expected.SerializeToString())
+    )
+    client._task_events_head_session = session
+
+    reply = await client.get_all_task_info()
+
+    session.post.assert_called_once()
+    assert session.post.call_args.args[0] == "http://localhost/api/task_events/query"
+    # The co-located socket call is trusted, so no auth header is attached.
+    assert "headers" not in session.post.call_args.kwargs
+    assert reply.num_status_task_events_dropped == 3
+
+
+@pytest.mark.asyncio
+async def test_get_all_task_info_from_dashboard_head_non_2xx_raises(monkeypatch):
+    monkeypatch.setattr(
+        "ray.util.state.state_manager._READ_TASK_EVENTS_FROM_DASHBOARD_HEAD", True
+    )
+    client = _task_info_client(
+        dashboard_socket_dir="/tmp/sock", dashboard_session_name="session-1"
+    )
+    session = MagicMock()
+    session.post = MagicMock(return_value=_FakeAsyncResponse(500))
+    client._task_events_head_session = session
+
+    with pytest.raises(DataSourceUnavailable):
+        await client.get_all_task_info()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "transport_error", [aiohttp.ClientError("boom"), asyncio.TimeoutError()]
+)
+async def test_get_all_task_info_from_dashboard_head_unreachable_raises(
+    monkeypatch, transport_error
+):
+    monkeypatch.setattr(
+        "ray.util.state.state_manager._READ_TASK_EVENTS_FROM_DASHBOARD_HEAD", True
+    )
+    client = _task_info_client(
+        dashboard_socket_dir="/tmp/sock", dashboard_session_name="session-1"
+    )
+    session = MagicMock()
+    # An unreachable dashboard head raises a transport error, not an HTTP status.
+    session.post = MagicMock(side_effect=transport_error)
+    client._task_events_head_session = session
+
+    with pytest.raises(DataSourceUnavailable):
+        await client.get_all_task_info()
 
 
 if __name__ == "__main__":

--- a/python/ray/util/state/state_manager.py
+++ b/python/ray/util/state/state_manager.py
@@ -1,3 +1,4 @@
+import asyncio
 import dataclasses
 import inspect
 import json
@@ -9,6 +10,7 @@ import aiohttp
 import grpc
 from grpc.aio._call import UnaryStreamCall
 
+import ray
 import ray.dashboard.consts as dashboard_consts
 import ray.dashboard.modules.log.log_consts as log_consts
 from ray._common.network_utils import build_address
@@ -64,6 +66,11 @@ _STATE_MANAGER_GRPC_OPTIONS = [
     ("grpc.max_send_message_length", ray_constants.GRPC_CPP_MAX_MESSAGE_SIZE),
     ("grpc.max_receive_message_length", ray_constants.GRPC_CPP_MAX_MESSAGE_SIZE),
 ]
+
+# Serve the State API's task queries from the dashboard-head store instead of GCS.
+_READ_TASK_EVENTS_FROM_DASHBOARD_HEAD = (
+    ray._config.enable_task_events_to_dashboard_head()
+)
 
 
 def handle_grpc_network_errors(func):
@@ -126,11 +133,28 @@ class StateDataSourceClient:
     - throw a ValueError if it cannot find the source.
     """
 
-    def __init__(self, gcs_channel: grpc.aio.Channel, gcs_client: GcsClient):
+    def __init__(
+        self,
+        gcs_channel: grpc.aio.Channel,
+        gcs_client: GcsClient,
+        dashboard_socket_dir: Optional[str] = None,
+        dashboard_session_name: Optional[str] = None,
+    ):
         self.register_gcs_client(gcs_channel)
         self._job_client = JobInfoStorageClient(gcs_client)
         self._gcs_client = gcs_client
         self._client_session = aiohttp.ClientSession()
+        self._dashboard_socket_dir = dashboard_socket_dir
+        self._dashboard_session_name = dashboard_session_name
+        if _READ_TASK_EVENTS_FROM_DASHBOARD_HEAD and (
+            dashboard_socket_dir is None or dashboard_session_name is None
+        ):
+            raise ValueError(
+                "Cannot read task events from the dashboard head: the dashboard "
+                "subprocess socket directory and session name were not provided to "
+                "StateDataSourceClient."
+            )
+        self._task_events_head_session: Optional[aiohttp.ClientSession] = None
 
     def register_gcs_client(self, gcs_channel: grpc.aio.Channel):
         self._gcs_actor_info_stub = gcs_service_pb2_grpc.ActorInfoGcsServiceStub(
@@ -228,7 +252,6 @@ class StateDataSourceClient:
         )
         return reply
 
-    @handle_grpc_network_errors
     async def get_all_task_info(
         self,
         timeout: int = None,
@@ -236,7 +259,17 @@ class StateDataSourceClient:
         filters: Optional[List[Tuple[str, PredicateType, SupportedFilterType]]] = None,
         exclude_driver: bool = False,
     ) -> Optional[GetTaskEventsReply]:
+        request = self._build_task_events_request(limit, filters, exclude_driver)
+        if _READ_TASK_EVENTS_FROM_DASHBOARD_HEAD:
+            return await self._get_task_events_from_dashboard_head(request, timeout)
+        return await self._get_task_events_from_gcs(request, timeout)
 
+    def _build_task_events_request(
+        self,
+        limit: int,
+        filters: Optional[List[Tuple[str, PredicateType, SupportedFilterType]]],
+        exclude_driver: bool,
+    ) -> GetTaskEventsRequest:
         if filters is None:
             filters = []
 
@@ -289,9 +322,48 @@ class StateDataSourceClient:
 
         req_filters.exclude_driver = exclude_driver
 
-        request = GetTaskEventsRequest(limit=limit, filters=req_filters)
-        reply = await self._gcs_task_info_stub.GetTaskEvents(request, timeout=timeout)
-        return reply
+        return GetTaskEventsRequest(limit=limit, filters=req_filters)
+
+    @handle_grpc_network_errors
+    async def _get_task_events_from_gcs(
+        self, request: GetTaskEventsRequest, timeout: int = None
+    ) -> Optional[GetTaskEventsReply]:
+        return await self._gcs_task_info_stub.GetTaskEvents(request, timeout=timeout)
+
+    async def _get_task_events_from_dashboard_head(
+        self, request: GetTaskEventsRequest, timeout: int = None
+    ) -> Optional[GetTaskEventsReply]:
+        if self._task_events_head_session is None:
+            from ray.dashboard.subprocesses.utils import get_http_session_to_module
+
+            self._task_events_head_session = get_http_session_to_module(
+                "TaskEventsHead",
+                self._dashboard_socket_dir,
+                self._dashboard_session_name,
+            )
+        client_timeout = aiohttp.ClientTimeout(total=timeout)
+        try:
+            async with self._task_events_head_session.post(
+                "http://localhost/api/task_events/query",
+                data=request.SerializeToString(),
+                timeout=client_timeout,
+            ) as resp:
+                if 200 <= resp.status < 300:
+                    reply = GetTaskEventsReply()
+                    reply.ParseFromString(await resp.read())
+                    return reply
+                raise DataSourceUnavailable(
+                    "Failed to query task events from the dashboard head. "
+                    f"Response is {resp.status}, reason {resp.reason}"
+                )
+        except (aiohttp.ClientError, asyncio.TimeoutError) as e:
+            # An unreachable dashboard head (connection refused, socket gone, timeout)
+            # must surface as DataSourceUnavailable so list_tasks shows the normal
+            # failure warning instead of a raw error, matching the GCS gRPC path.
+            raise DataSourceUnavailable(
+                "Failed to query task events from the dashboard head; it may be down "
+                "or unreachable."
+            ) from e
 
     @handle_grpc_network_errors
     async def get_all_placement_group_info(


### PR DESCRIPTION
Cherry-pick of #65160 (master commit 12436ea75080433a9134cfa362b3dbb98fe9e73f) onto `releases/2.58.0`.

Fresh single-commit pick against the current release head (through 6/n; 7/n #65158 needs no separate pick — its content shipped inside the 6/n squash, verified). Supersedes #65356 (created from a stale branch by mistake, closed) and parallels old #65304 (closed).

Clean cherry-pick, no conflicts (`git cherry-pick -x -s`); 5 files, +243/−8. AI-assisted (Claude Code); submitted and reviewed by @elliot-barn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)