### PR TITLE
[cherry-pick][2.58.0][core][taskEvents out of GCS][9/n] Reroute ray.timeline to task events head (#65218)

### DIFF
--- a/python/ray/_private/state.py
+++ b/python/ray/_private/state.py
@@ -3,21 +3,120 @@ import logging
 import sys
 from collections import defaultdict
 from threading import Lock
-from typing import Dict, Optional
+from typing import Dict, List, Optional
+
+import requests
 
 import ray
 from ray._common.constants import HEAD_NODE_RESOURCE_NAME, NODE_ID_PREFIX
 from ray._common.utils import binary_to_hex, decode, hex_to_binary
+from ray._private import ray_constants
 from ray._private.client_mode_hook import client_mode_hook
 from ray._private.protobuf_compat import message_to_dict
 from ray._private.utils import (
     validate_actor_state_name,
 )
 from ray._raylet import GcsClientOptions, GlobalStateAccessor
-from ray.core.generated import autoscaler_pb2, common_pb2, gcs_pb2
+from ray.core.generated import autoscaler_pb2, common_pb2, gcs_pb2, gcs_service_pb2
 from ray.util.annotations import DeveloperAPI
 
 logger = logging.getLogger(__name__)
+
+# Timeout for the synchronous task-events query to the dashboard head.
+_DASHBOARD_HEAD_QUERY_TIMEOUT_S = 30
+# Dashboard-head route that answers task-events queries.
+_TASK_EVENTS_QUERY_PATH = "/api/task_events/query"
+# GcsStatus.code value for a successful reply.
+_GCS_STATUS_CODE_OK = 0
+# Read task events (for ray.timeline / profiling) from the dashboard head instead of GCS.
+_READ_TASK_EVENTS_FROM_DASHBOARD_HEAD = (
+    ray._config.enable_task_events_to_dashboard_head()
+)
+
+
+class TaskEventsHeadClient:
+    """Synchronous client for the dashboard-head task-events query endpoint.
+
+    Resolves and caches the endpoint address on first use, reuses one HTTP session, and
+    attaches the cluster auth token on every request, so repeated ``ray.timeline`` calls
+    don't re-resolve the address or reopen connections.
+    """
+
+    def __init__(self, accessor: GlobalStateAccessor):
+        self._accessor = accessor
+        self._session = requests.Session()
+        self._endpoint = None
+
+    def close(self):
+        """Close the underlying HTTP session and its connection pool."""
+        self._session.close()
+
+    def _get_endpoint(self) -> str:
+        if self._endpoint is None:
+            address = self._accessor.get_internal_kv(
+                ray_constants.KV_NAMESPACE_DASHBOARD,
+                ray_constants.DASHBOARD_ADDRESS.encode(),
+            )
+            if not address:
+                raise RuntimeError(
+                    "Could not find the dashboard address to read task events from the "
+                    "dashboard head. Is the dashboard running?"
+                )
+            address = address.decode()
+            if not address.startswith(("http://", "https://")):
+                address = f"http://{address}"
+            self._endpoint = f"{address}{_TASK_EVENTS_QUERY_PATH}"
+        return self._endpoint
+
+    def get_task_events(self, timeout: int) -> List["gcs_pb2.TaskEvents"]:
+        """Return all task events (as ``TaskEvents`` protos) from the head.
+
+        No ``limit`` is set, so the head returns everything in its store, matching the
+        unbounded GCS ``GetAllTaskEvents`` path this replaces.
+        """
+        from ray._private.authentication.http_token_authentication import (
+            format_authentication_http_error,
+            get_auth_headers_if_auth_enabled,
+        )
+
+        endpoint = self._get_endpoint()
+        request = gcs_service_pb2.GetTaskEventsRequest()
+        headers = {"Content-Type": "application/octet-stream"}
+        headers.update(get_auth_headers_if_auth_enabled(headers))
+        try:
+            response = self._session.post(
+                endpoint,
+                data=request.SerializeToString(),
+                headers=headers,
+                timeout=timeout,
+            )
+        except requests.RequestException as e:
+            # Any request failure may mean the head is unreachable or restarted at a new
+            # address; drop the cached endpoint so the next call re-resolves it. This is
+            # slightly conservative though.
+            self._endpoint = None
+            raise RuntimeError(
+                f"Failed to reach the dashboard head at {endpoint} to read task events. "
+                "Is the dashboard running?"
+            ) from e
+        if not (200 <= response.status_code < 300):
+            auth_error = format_authentication_http_error(
+                response.status_code, response.text
+            )
+            if auth_error:
+                raise RuntimeError(auth_error)
+            raise RuntimeError(
+                f"Failed to read task events from the dashboard head at {endpoint}: "
+                f"HTTP {response.status_code} {response.reason}."
+            )
+        reply = gcs_service_pb2.GetTaskEventsReply()
+        reply.ParseFromString(response.content)
+        if reply.status.code != _GCS_STATUS_CODE_OK:
+            raise RuntimeError(
+                "The dashboard head rejected the task-events query: "
+                f"{reply.status.message}"
+            )
+        return list(reply.events_by_task)
 
 
 class GlobalState:
@@ -34,6 +133,7 @@ class GlobalState:
         self.gcs_options = None
         self._global_state_accessor = None
         self._init_lock = Lock()
+        self._task_events_head_client = None
 
     def _connect_and_get_accessor(self) -> GlobalStateAccessor:
         """
@@ -69,6 +169,11 @@ class GlobalState:
             self.gcs_options = None
             if self._global_state_accessor is not None:
                 self._global_state_accessor = None
+            # Drop the cached task-events client (closing its HTTP session) so it doesn't
+            # keep a stale accessor across a reconnect; the next call rebuilds it.
+            if self._task_events_head_client is not None:
+                self._task_events_head_client.close()
+                self._task_events_head_client = None
 
     def _initialize_global_state(self, gcs_options: GcsClientOptions):
         """Set args for lazily initialization of the GlobalState object.
@@ -240,13 +345,9 @@ class GlobalState:
                 ]
             }
         """
-        accessor = self._connect_and_get_accessor()
-
         result = defaultdict(list)
-        task_events = accessor.get_task_events()
-        for i in range(len(task_events)):
-            event = gcs_pb2.TaskEvents.FromString(task_events[i])
-            profile = event.profile_events
+        for task_event in self._get_all_task_events():
+            profile = task_event.profile_events
             if not profile:
                 continue
 
@@ -272,6 +373,49 @@ class GlobalState:
                 result[component_id].append(profile_event)
 
         return dict(result)
+
+    def _get_all_task_events(self) -> List["gcs_pb2.TaskEvents"]:
+        """Return all task events (as ``TaskEvents`` protos) for timeline/profiling.
+
+        Reads from the dashboard head when the task-events-to-dashboard-head migration is
+        enabled, otherwise from GCS.
+        """
+        if _READ_TASK_EVENTS_FROM_DASHBOARD_HEAD:
+            return self._get_task_events_head_client().get_task_events(
+                _DASHBOARD_HEAD_QUERY_TIMEOUT_S
+            )
+        accessor = self._connect_and_get_accessor()
+        return [
+            gcs_pb2.TaskEvents.FromString(task_event)
+            for task_event in accessor.get_task_events()
+        ]
+
+    def _get_task_events_head_client(self) -> "TaskEventsHeadClient":
+        """Lazily build and cache the reusable dashboard-head task-events client."""
+        # Ensure we're connected, then read the accessor under the lock and build against
+        # that.
+        self._connect_and_get_accessor()
+        with self._init_lock:
+            accessor = self._global_state_accessor
+            if accessor is None:
+                # don't build the client against a None accessor
+                raise ray.exceptions.RaySystemError(
+                    "Ray was disconnected while reading task events; please retry."
+                )
+            if (
+                self._task_events_head_client is None
+                # if the accessor with client is diff from actual accessor
+                # build client with the new accessor
+                or self._task_events_head_client._accessor is not accessor
+            ):
+                # Close the stale client's HTTP session before replacing it.
+                if self._task_events_head_client is not None:
+                    self._task_events_head_client.close()
+                self._task_events_head_client = TaskEventsHeadClient(accessor)
+            # TODO(karticam): There might be an edgy race condition where accessor
+            #  could go invalid after returning the client. so client makes request
+            #  with an invalid accessor.
+            return self._task_events_head_client
 
     def get_placement_group_by_name(self, placement_group_name, ray_namespace):
         accessor = self._connect_and_get_accessor()
@@ -1039,6 +1183,7 @@ def timeline(filename: Optional[str] = None):
         raise RuntimeError(
             "Ray has not been started yet. Timeline requires Ray to be initialized first."
         )
+
     return state.chrome_tracing_dump(filename=filename)
 
 

--- a/python/ray/tests/test_state_api_2.py
+++ b/python/ray/tests/test_state_api_2.py
@@ -6,17 +6,21 @@ import tempfile
 from collections import defaultdict
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 import pytest
 import requests
 
 import ray
-from ray._common.test_utils import wait_for_condition
+import ray._private.state
+from ray._common.test_utils import run_string_as_driver, wait_for_condition
+from ray._common.utils import binary_to_hex
 from ray._private.profiling import chrome_tracing_dump
 from ray._private.test_utils import (
     check_call_subprocess,
     wait_for_aggregator_agent_if_enabled,
 )
+from ray.core.generated import gcs_pb2, gcs_service_pb2
 from ray.util.state import (
     get_actor,
     list_actors,
@@ -403,6 +407,199 @@ def test_ray_timeline(shutdown_only):
             return True
 
         wait_for_condition(verify, timeout=20, retry_interval_ms=1000)
+
+
+def _profile_task_event(component_type, component_id, event_name):
+    task_event = gcs_pb2.TaskEvents()
+    profile = task_event.profile_events
+    profile.component_type = component_type
+    profile.component_id = component_id
+    profile.node_ip_address = "1.2.3.4"
+    entry = profile.events.add()
+    entry.event_name = event_name
+    entry.start_time = 1
+    entry.end_time = 2
+    entry.extra_data = "{}"
+    return task_event
+
+
+def test_profile_events_reads_from_dashboard_head(monkeypatch):
+    """With the migration flag on, profile_events() fetches task events from the dashboard
+    head through a reused client that resolves the address once and reuses its session."""
+    monkeypatch.setattr(
+        "ray._private.state._READ_TASK_EVENTS_FROM_DASHBOARD_HEAD", True
+    )
+
+    component_id = b"\x01" * 28
+    reply = gcs_service_pb2.GetTaskEventsReply()
+    reply.status.SetInParent()
+    reply.events_by_task.add().CopyFrom(
+        _profile_task_event("worker", component_id, "task:execute")
+    )
+
+    gs = ray._private.state.GlobalState()
+    accessor = MagicMock()
+    accessor.get_internal_kv.return_value = b"127.0.0.1:8265"
+    monkeypatch.setattr(gs, "_connect_and_get_accessor", lambda: accessor)
+    # The client getter reads _global_state_accessor directly so set it too.
+    gs._global_state_accessor = accessor
+
+    session = MagicMock()
+    session.post.return_value = MagicMock(
+        status_code=200, content=reply.SerializeToString()
+    )
+    with patch("requests.Session", return_value=session):
+        result = gs.profile_events()
+        gs.profile_events()  # second call reuses the cached endpoint + session
+
+    accessor.get_task_events.assert_not_called()
+    # Address resolved once and the session reused across both timeline calls.
+    assert accessor.get_internal_kv.call_count == 1
+    assert session.post.call_count == 2
+    assert session.post.call_args.args[0].endswith("/api/task_events/query")
+    assert result[binary_to_hex(component_id)][0]["event_type"] == "task:execute"
+
+
+def test_profile_events_reads_from_gcs_by_default(monkeypatch):
+    """With the migration flag off, profile_events() reads from GCS via the accessor and
+    never builds the dashboard-head client."""
+    monkeypatch.setattr(
+        "ray._private.state._READ_TASK_EVENTS_FROM_DASHBOARD_HEAD", False
+    )
+
+    component_id = b"\x02" * 28
+    task_event = _profile_task_event("driver", component_id, "driver:startup")
+
+    gs = ray._private.state.GlobalState()
+    accessor = MagicMock()
+    accessor.get_task_events.return_value = [task_event.SerializeToString()]
+    monkeypatch.setattr(gs, "_connect_and_get_accessor", lambda: accessor)
+
+    with patch("requests.Session") as mock_session_cls:
+        result = gs.profile_events()
+
+    accessor.get_task_events.assert_called_once()
+    mock_session_cls.assert_not_called()
+    assert result[binary_to_hex(component_id)][0]["event_type"] == "driver:startup"
+
+
+def test_profile_events_gcs_and_head_paths_return_same_data(monkeypatch):
+    """Migration parity: the GCS read path and the dashboard-head read path return the
+    same profile_events() output for the same set of stored task events."""
+    component_id = b"\x03" * 28
+    events = [
+        _profile_task_event("worker", component_id, "task:execute"),
+        _profile_task_event("driver", component_id, "driver:startup"),
+    ]
+
+    # GCS path (flag off): the accessor returns serialized TaskEvents.
+    monkeypatch.setattr(
+        "ray._private.state._READ_TASK_EVENTS_FROM_DASHBOARD_HEAD", False
+    )
+    gs_gcs = ray._private.state.GlobalState()
+    gcs_accessor = MagicMock()
+    gcs_accessor.get_task_events.return_value = [e.SerializeToString() for e in events]
+    monkeypatch.setattr(gs_gcs, "_connect_and_get_accessor", lambda: gcs_accessor)
+    result_gcs = gs_gcs.profile_events()
+
+    # Dashboard-head path (flag on): the head returns the same events in a reply.
+    monkeypatch.setattr(
+        "ray._private.state._READ_TASK_EVENTS_FROM_DASHBOARD_HEAD", True
+    )
+    reply = gcs_service_pb2.GetTaskEventsReply()
+    reply.status.SetInParent()
+    for e in events:
+        reply.events_by_task.add().CopyFrom(e)
+    gs_head = ray._private.state.GlobalState()
+    head_accessor = MagicMock()
+    head_accessor.get_internal_kv.return_value = b"127.0.0.1:8265"
+    monkeypatch.setattr(gs_head, "_connect_and_get_accessor", lambda: head_accessor)
+    gs_head._global_state_accessor = head_accessor
+    session = MagicMock()
+    session.post.return_value = MagicMock(
+        status_code=200, content=reply.SerializeToString()
+    )
+    with patch("requests.Session", return_value=session):
+        result_head = gs_head.profile_events()
+
+    # Both read paths surface identical profiling data.
+    assert result_gcs == result_head
+    assert result_gcs[binary_to_hex(component_id)][0]["event_type"] == "task:execute"
+
+
+# Driver for the GCS-vs-head timeline parity e2e. Run once per backend via
+# run_string_as_driver
+_TIMELINE_PARITY_DRIVER = """
+import ray
+from ray._common.test_utils import wait_for_condition
+
+
+@ray.remote
+def f():
+    import time
+
+    time.sleep(0.2)
+
+
+ray.init(num_cpus=4)
+ray.get([f.remote() for _ in range(5)])
+
+
+def task_execute_count():
+    return sum(1 for event in ray.timeline() if event.get("cat") == "task:execute")
+
+
+# Profile events propagate asynchronously; wait until every task-execute span lands.
+wait_for_condition(lambda: task_execute_count() >= 5, timeout=90, retry_interval_ms=3000)
+print("TASK_EXECUTE_COUNT:" + str(task_execute_count()))
+"""
+
+# Task-event routing flags this test sets explicitly; stripped from the inherited env so
+# the event_routing_config fixture's settings don't leak into the driver subprocesses.
+_TASK_EVENT_FLAG_ENV = (
+    "RAY_enable_ray_event",
+    "RAY_enable_ray_task_event_recorder",
+    "RAY_enable_task_events_to_dashboard_head",
+    "RAY_enable_core_worker_task_event_to_gcs",
+    "RAY_enable_core_worker_ray_event_to_aggregator",
+)
+
+
+def _run_timeline_parity_driver(flag_overrides):
+    env = {k: v for k, v in os.environ.items() if k not in _TASK_EVENT_FLAG_ENV}
+    # ray.timeline() only records profile events when profiling is on (see
+    # GlobalState.chrome_tracing_dump).
+    env["RAY_PROFILING"] = "1"
+    env.update(flag_overrides)
+    out = run_string_as_driver(_TIMELINE_PARITY_DRIVER, env=env)
+    marker = "TASK_EXECUTE_COUNT:"
+    matches = [line for line in out.splitlines() if line.startswith(marker)]
+    assert matches, f"driver did not report a count; output:\n{out}"
+    return int(matches[-1][len(marker) :])
+
+
+def test_timeline_gcs_and_head_paths_produce_same_events():
+    """End-to-end parity: the same workload run through the GCS path and through the
+    dashboard-head path (recorder -> aggregator -> head) surfaces the same number of
+    ray.timeline() task-execute events. Two driver subprocesses are used because the
+    read/publish switches are baked at `import ray` and can't be flipped in-process.
+    """
+    gcs_count = _run_timeline_parity_driver(
+        {"RAY_enable_core_worker_task_event_to_gcs": "1"}
+    )
+    head_count = _run_timeline_parity_driver(
+        {
+            "RAY_enable_ray_event": "1",
+            "RAY_enable_ray_task_event_recorder": "1",
+            "RAY_enable_task_events_to_dashboard_head": "1",
+            "RAY_enable_core_worker_task_event_to_gcs": "0",
+        }
+    )
+
+    assert (
+        gcs_count >= 5
+    ), f"GCS-path timeline had too few task:execute events: {gcs_count}"
+    assert gcs_count == head_count
 
 
 def test_state_init_multiple_threads(shutdown_only):


### PR DESCRIPTION
Cherry-pick of #65218 (master commit f8afb7d78fd666ab2b3b114ee9d9935b192c8320) onto `releases/2.58.0`.

Fresh single-commit pick against the current release head (8/n merged via #65357). Parallels old #65337, which should be closed in favor of this one.

Clean cherry-pick, no conflicts (`git cherry-pick -x -s`); 2 files, +351/−9. AI-assisted (Claude Code); submitted and reviewed by @elliot-barn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)