### PR TITLE
[cherry-pick][2.58.0][core][taskEvents out of GCS][2.5/n] Optimize ray task event recorder (#65288)

### DIFF
--- a/src/ray/core_worker/BUILD.bazel
+++ b/src/ray/core_worker/BUILD.bazel
@@ -215,6 +215,8 @@ ray_cc_library(
         "//src/ray/observability:ray_task_event_recorder",
         "//src/ray/observability:ray_task_lifecycle_event",
         "//src/ray/observability:ray_task_profile_event",
+        "//src/ray/observability:task_event_populators",
+        "//src/ray/observability:task_state_update",
         "//src/ray/protobuf:export_task_event_cc_proto",
         "//src/ray/protobuf:gcs_cc_proto",
         "//src/ray/rpc:event_aggregator_client",

--- a/src/ray/core_worker/task_event_buffer.cc
+++ b/src/ray/core_worker/task_event_buffer.cc
@@ -21,46 +21,18 @@
 #include <vector>
 
 #include "ray/common/grpc_util.h"
-#include "ray/common/scheduling/label_selector.h"
 #include "ray/observability/ray_actor_task_definition_event.h"
 #include "ray/observability/ray_task_definition_event.h"
 #include "ray/observability/ray_task_event_recorder.h"
 #include "ray/observability/ray_task_lifecycle_event.h"
 #include "ray/observability/ray_task_profile_event.h"
+#include "ray/observability/task_event_populators.h"
 #include "ray/util/graceful_shutdown.h"
 
 namespace ray {
 namespace core {
 
 namespace worker {
-
-namespace {
-
-rpc::events::TaskLifecycleEvent::TaskLogInfo TaskLogInfoToLifecycleEvent(
-    const rpc::TaskLogInfo &src) {
-  rpc::events::TaskLifecycleEvent::TaskLogInfo dest;
-  if (src.has_stdout_file()) {
-    dest.set_stdout_file(src.stdout_file());
-  }
-  if (src.has_stderr_file()) {
-    dest.set_stderr_file(src.stderr_file());
-  }
-  if (src.has_stdout_start()) {
-    dest.set_stdout_start(src.stdout_start());
-  }
-  if (src.has_stdout_end()) {
-    dest.set_stdout_end(src.stdout_end());
-  }
-  if (src.has_stderr_start()) {
-    dest.set_stderr_start(src.stderr_start());
-  }
-  if (src.has_stderr_end()) {
-    dest.set_stderr_end(src.stderr_end());
-  }
-  return dest;
-}
-
-}  // namespace
 
 TaskEvent::TaskEvent(TaskID task_id,
                      JobID job_id,
@@ -127,39 +99,39 @@ void TaskStatusEvent::ToRpcTaskEvents(rpc::TaskEvents *rpc_task_events) {
     return;
   }
 
-  if (state_update_->node_id_.has_value()) {
+  if (state_update_->node_id.has_value()) {
     RAY_CHECK(task_status_ == rpc::TaskStatus::SUBMITTED_TO_WORKER)
         << "When task status changes to SUBMITTED_TO_WORKER, the Node ID should be "
            "included in the status update";
-    dst_state_update->set_node_id(state_update_->node_id_->Binary());
+    dst_state_update->set_node_id(state_update_->node_id->Binary());
   }
 
-  if (state_update_->worker_id_.has_value()) {
+  if (state_update_->worker_id.has_value()) {
     RAY_CHECK(task_status_ == rpc::TaskStatus::SUBMITTED_TO_WORKER)
         << "When task status changes to SUBMITTED_TO_WORKER, Worker ID should be "
            "included in the status update";
-    dst_state_update->set_worker_id(state_update_->worker_id_->Binary());
+    dst_state_update->set_worker_id(state_update_->worker_id->Binary());
   }
 
-  if (state_update_->error_info_.has_value()) {
-    *(dst_state_update->mutable_error_info()) = *state_update_->error_info_;
+  if (state_update_->error_info.has_value()) {
+    *(dst_state_update->mutable_error_info()) = *state_update_->error_info;
   }
 
-  if (state_update_->task_log_info_.has_value()) {
+  if (state_update_->task_log_info.has_value()) {
     dst_state_update->mutable_task_log_info()->MergeFrom(
-        state_update_->task_log_info_.value());
+        state_update_->task_log_info.value());
   }
 
-  if (!state_update_->actor_repr_name_.empty()) {
-    dst_state_update->set_actor_repr_name(state_update_->actor_repr_name_);
+  if (!state_update_->actor_repr_name.empty()) {
+    dst_state_update->set_actor_repr_name(state_update_->actor_repr_name);
   }
 
-  if (state_update_->pid_.has_value()) {
-    dst_state_update->set_worker_pid(state_update_->pid_.value());
+  if (state_update_->pid.has_value()) {
+    dst_state_update->set_worker_pid(state_update_->pid.value());
   }
 
-  if (state_update_->is_debugger_paused_.has_value()) {
-    dst_state_update->set_is_debugger_paused(state_update_->is_debugger_paused_.value());
+  if (state_update_->is_debugger_paused.has_value()) {
+    dst_state_update->set_is_debugger_paused(state_update_->is_debugger_paused.value());
   }
 }
 
@@ -183,159 +155,38 @@ void TaskStatusEvent::ToRpcTaskExportEvents(
     return;
   }
 
-  if (state_update_->node_id_.has_value()) {
+  if (state_update_->node_id.has_value()) {
     RAY_CHECK(task_status_ == rpc::TaskStatus::SUBMITTED_TO_WORKER)
         << "Node ID should be included when task status changes to "
            "SUBMITTED_TO_WORKER.";
-    dst_state_update->set_node_id(state_update_->node_id_->Binary());
+    dst_state_update->set_node_id(state_update_->node_id->Binary());
   }
 
-  if (state_update_->worker_id_.has_value()) {
+  if (state_update_->worker_id.has_value()) {
     RAY_CHECK(task_status_ == rpc::TaskStatus::SUBMITTED_TO_WORKER)
         << "Worker ID should be included when task status changes to "
            "SUBMITTED_TO_WORKER.";
-    dst_state_update->set_worker_id(state_update_->worker_id_->Binary());
+    dst_state_update->set_worker_id(state_update_->worker_id->Binary());
   }
 
-  if (state_update_->error_info_.has_value()) {
+  if (state_update_->error_info.has_value()) {
     auto error_info = dst_state_update->mutable_error_info();
-    error_info->set_error_message((*state_update_->error_info_).error_message());
-    error_info->set_error_type((*state_update_->error_info_).error_type());
+    error_info->set_error_message((*state_update_->error_info).error_message());
+    error_info->set_error_type((*state_update_->error_info).error_type());
   }
 
-  if (state_update_->task_log_info_.has_value()) {
+  if (state_update_->task_log_info.has_value()) {
     rpc::ExportTaskEventData::TaskLogInfo export_task_log_info;
-    gcs::TaskLogInfoToExport(state_update_->task_log_info_.value(),
-                             &export_task_log_info);
+    gcs::TaskLogInfoToExport(state_update_->task_log_info.value(), &export_task_log_info);
     dst_state_update->mutable_task_log_info()->MergeFrom(export_task_log_info);
   }
 
-  if (state_update_->pid_.has_value()) {
-    dst_state_update->set_worker_pid(state_update_->pid_.value());
+  if (state_update_->pid.has_value()) {
+    dst_state_update->set_worker_pid(state_update_->pid.value());
   }
 
-  if (state_update_->is_debugger_paused_.has_value()) {
-    dst_state_update->set_is_debugger_paused(state_update_->is_debugger_paused_.value());
-  }
-}
-
-// Assuming the task_spec_ it not null
-// populate the TaskDefinitionEvent or ActorTaskDefinitionEvent
-template <typename T>
-void TaskStatusEvent::PopulateRpcRayTaskDefinitionEvent(T &definition_event_data) {
-  // Task identifier
-  definition_event_data.set_task_id(task_id_.Binary());
-  definition_event_data.set_task_attempt(attempt_number_);
-
-  // Common fields
-  definition_event_data.set_language(task_spec_->GetLanguage());
-  const auto &required_resources = task_spec_->GetRequiredResources().GetResourceMap();
-  definition_event_data.mutable_required_resources()->insert(
-      std::make_move_iterator(required_resources.begin()),
-      std::make_move_iterator(required_resources.end()));
-  definition_event_data.set_serialized_runtime_env(
-      task_spec_->RuntimeEnvInfo().serialized_runtime_env());
-  definition_event_data.set_job_id(job_id_.Binary());
-  // NOTE: we set the parent task id of a task to the submitter task id, where the
-  // submitter  task id is:
-  // - For concurrent actors: the actor creation task's task id.
-  // - Otherwise: the CoreWorker main thread's task id.
-  definition_event_data.set_parent_task_id(task_spec_->SubmitterTaskId().Binary());
-  definition_event_data.set_placement_group_id(
-      task_spec_->PlacementGroupBundleId().first.Binary());
-  const auto &labels = task_spec_->GetMessage().labels();
-  definition_event_data.mutable_ref_ids()->insert(labels.begin(), labels.end());
-  const auto &call_site = task_spec_->GetMessage().call_site();
-  if (!call_site.empty()) {
-    definition_event_data.set_call_site(call_site);
-  }
-  const auto &label_selector = task_spec_->GetMessage().label_selector();
-  if (label_selector.label_constraints_size() > 0) {
-    *definition_event_data.mutable_label_selector() =
-        ray::LabelSelector(label_selector).ToStringMap();
-  }
-
-  const auto &fallback_strategy = task_spec_->GetMessage().fallback_strategy();
-  if (fallback_strategy.options_size() > 0) {
-    definition_event_data.mutable_fallback_strategy()->CopyFrom(fallback_strategy);
-  }
-
-  // Specific fields
-  if constexpr (std::is_same_v<T, rpc::events::ActorTaskDefinitionEvent>) {
-    definition_event_data.mutable_actor_func()->CopyFrom(
-        task_spec_->FunctionDescriptor()->GetMessage());
-    definition_event_data.set_actor_id(task_spec_->ActorId().Binary());
-    definition_event_data.set_actor_task_name(task_spec_->GetName());
-  } else {
-    definition_event_data.mutable_task_func()->CopyFrom(
-        task_spec_->FunctionDescriptor()->GetMessage());
-    definition_event_data.set_task_type(task_spec_->GetMessage().type());
-    definition_event_data.set_task_name(task_spec_->GetName());
-  }
-  if (task_spec_->IsDetachedActor()) {
-    definition_event_data.set_is_detached_actor(true);
-  }
-}
-
-void TaskStatusEvent::PopulateRpcRayTaskLifecycleEvent(
-    rpc::events::TaskLifecycleEvent &lifecycle_event_data,
-    google::protobuf::Timestamp timestamp) {
-  // Task identifier
-  lifecycle_event_data.set_task_id(task_id_.Binary());
-  lifecycle_event_data.set_task_attempt(attempt_number_);
-
-  // Task state
-  if (task_status_ != rpc::TaskStatus::NIL) {
-    rpc::events::TaskLifecycleEvent::StateTransition state_transition;
-    state_transition.set_state(task_status_);
-    state_transition.mutable_timestamp()->CopyFrom(timestamp);
-    *lifecycle_event_data.mutable_state_transitions()->Add() =
-        std::move(state_transition);
-  }
-
-  lifecycle_event_data.set_job_id(job_id_.Binary());
-
-  // Task property updates
-  if (!state_update_.has_value()) {
-    return;
-  }
-
-  if (state_update_->error_info_.has_value()) {
-    lifecycle_event_data.mutable_ray_error_info()->CopyFrom(*state_update_->error_info_);
-  }
-
-  if (!state_update_->actor_repr_name_.empty()) {
-    lifecycle_event_data.set_actor_repr_name(state_update_->actor_repr_name_);
-  }
-
-  if (state_update_->node_id_.has_value()) {
-    RAY_CHECK(task_status_ == rpc::TaskStatus::SUBMITTED_TO_WORKER)
-            .WithField("TaskStatus", task_status_)
-        << "Node ID should be included when task status changes to "
-           "SUBMITTED_TO_WORKER.";
-    lifecycle_event_data.set_node_id(state_update_->node_id_->Binary());
-  }
-
-  if (state_update_->worker_id_.has_value()) {
-    RAY_CHECK(task_status_ == rpc::TaskStatus::SUBMITTED_TO_WORKER)
-            .WithField("TaskStatus", task_status_)
-        << "Worker ID should be included when task status changes to "
-           "SUBMITTED_TO_WORKER.";
-    lifecycle_event_data.set_worker_id(state_update_->worker_id_->Binary());
-  }
-
-  if (state_update_->pid_.has_value()) {
-    lifecycle_event_data.set_worker_pid(state_update_->pid_.value());
-  }
-
-  if (state_update_->is_debugger_paused_.has_value()) {
-    lifecycle_event_data.set_is_debugger_paused(
-        state_update_->is_debugger_paused_.value());
-  }
-
-  if (state_update_->task_log_info_.has_value()) {
-    *lifecycle_event_data.mutable_task_log_info() =
-        TaskLogInfoToLifecycleEvent(state_update_->task_log_info_.value());
+  if (state_update_->is_debugger_paused.has_value()) {
+    dst_state_update->set_is_debugger_paused(state_update_->is_debugger_paused.value());
   }
 }
 
@@ -371,11 +222,13 @@ void TaskStatusEvent::ToRpcRayEvents(RayEventsTuple &ray_events_tuple) {
     if (is_actor_task_event_) {
       auto actor_task_definition_event =
           ray_events_tuple.task_definition_event->mutable_actor_task_definition_event();
-      PopulateRpcRayTaskDefinitionEvent(*actor_task_definition_event);
+      ray::observability::PopulateTaskDefinitionEvent(
+          *task_spec_, task_id_, job_id_, attempt_number_, *actor_task_definition_event);
     } else {
       auto task_definition_event =
           ray_events_tuple.task_definition_event->mutable_task_definition_event();
-      PopulateRpcRayTaskDefinitionEvent(*task_definition_event);
+      ray::observability::PopulateTaskDefinitionEvent(
+          *task_spec_, task_id_, job_id_, attempt_number_, *task_definition_event);
     }
   }
 
@@ -387,35 +240,40 @@ void TaskStatusEvent::ToRpcRayEvents(RayEventsTuple &ray_events_tuple) {
                                 timestamp);
   auto task_lifecycle_event =
       ray_events_tuple.task_lifecycle_event.value().mutable_task_lifecycle_event();
-  PopulateRpcRayTaskLifecycleEvent(*task_lifecycle_event, timestamp);
+  ray::observability::AppendTaskLifecycleUpdate(task_id_,
+                                                job_id_,
+                                                attempt_number_,
+                                                task_status_,
+                                                timestamp_,
+                                                state_update_,
+                                                *task_lifecycle_event);
 }
 
 std::vector<std::unique_ptr<ray::observability::RayEventInterface>>
 TaskStatusEvent::ToRayEventInterfaces() {
   std::vector<std::unique_ptr<ray::observability::RayEventInterface>> events;
-  google::protobuf::Timestamp timestamp = AbslTimeNanosToProtoTimestamp(timestamp_);
 
   // Definition event (static metadata): only when the task spec is attached.
   // The recorder de-dups definition events per attempt via no-op merge.
   if (task_spec_) {
     if (is_actor_task_event_) {
-      rpc::events::ActorTaskDefinitionEvent definition_event_data;
-      PopulateRpcRayTaskDefinitionEvent(definition_event_data);
       events.push_back(std::make_unique<ray::observability::RayActorTaskDefinitionEvent>(
-          std::move(definition_event_data), session_name_, timestamp_));
+          task_spec_, task_id_, job_id_, attempt_number_, session_name_, timestamp_));
     } else {
-      rpc::events::TaskDefinitionEvent definition_event_data;
-      PopulateRpcRayTaskDefinitionEvent(definition_event_data);
       events.push_back(std::make_unique<ray::observability::RayTaskDefinitionEvent>(
-          std::move(definition_event_data), session_name_, timestamp_));
+          task_spec_, task_id_, job_id_, attempt_number_, session_name_, timestamp_));
     }
   }
 
   // Lifecycle event (dynamic state transition): always produced.
-  rpc::events::TaskLifecycleEvent lifecycle_event_data;
-  PopulateRpcRayTaskLifecycleEvent(lifecycle_event_data, timestamp);
-  events.push_back(std::make_unique<ray::observability::RayTaskLifecycleEvent>(
-      std::move(lifecycle_event_data), session_name_, timestamp_));
+  events.push_back(
+      std::make_unique<ray::observability::RayTaskLifecycleEvent>(task_id_,
+                                                                  job_id_,
+                                                                  attempt_number_,
+                                                                  task_status_,
+                                                                  state_update_,
+                                                                  session_name_,
+                                                                  timestamp_));
 
   return events;
 }
@@ -663,6 +521,13 @@ Status TaskEventBufferImpl::Start(bool auto_flush) {
 
   enabled_ = true;
 
+  // Record only while one of the destinations above is live. When the recorder handles
+  // the aggregator send and GCS/export are off, buffered events are dropped at flush, so
+  // filling the ring on the task's call path is pure overhead.
+  recording_enabled_ = send_task_events_to_gcs_enabled_ ||
+                       task_event_buffer_to_aggregator_enabled_ ||
+                       export_event_write_enabled_;
+
   if (!auto_flush) {
     return Status::OK();
   }
@@ -736,7 +601,7 @@ void TaskEventBufferImpl::Stop() {
   }
 }
 
-bool TaskEventBufferImpl::Enabled() const { return enabled_; }
+bool TaskEventBufferImpl::Enabled() const { return enabled_ && recording_enabled_; }
 
 void TaskEventBufferImpl::GetTaskStatusEventsToSend(
     std::vector<std::shared_ptr<TaskEvent>> *status_events_to_send,
@@ -1160,7 +1025,7 @@ void TaskEventBufferImpl::AddTaskEvent(std::unique_ptr<TaskEvent> task_event) {
 
 void TaskEventBufferImpl::AddTaskStatusEvent(std::unique_ptr<TaskEvent> status_event) {
   absl::MutexLock lock(&mutex_);
-  if (!enabled_) {
+  if (!Enabled()) {
     return;
   }
   std::shared_ptr<TaskEvent> status_event_shared_ptr = std::move(status_event);
@@ -1207,7 +1072,7 @@ void TaskEventBufferImpl::AddTaskStatusEvent(std::unique_ptr<TaskEvent> status_e
 
 void TaskEventBufferImpl::AddTaskProfileEvent(std::unique_ptr<TaskEvent> profile_event) {
   absl::MutexLock lock(&profile_mutex_);
-  if (!enabled_) {
+  if (!Enabled()) {
     return;
   }
   std::shared_ptr<TaskEvent> profile_event_shared_ptr = std::move(profile_event);

--- a/src/ray/core_worker/task_event_buffer.h
+++ b/src/ray/core_worker/task_event_buffer.h
@@ -32,6 +32,7 @@
 #include "ray/gcs_rpc_client/gcs_client.h"
 #include "ray/observability/ray_event_interface.h"
 #include "ray/observability/ray_event_recorder_interface.h"
+#include "ray/observability/task_state_update.h"
 #include "ray/rpc/event_aggregator_client.h"
 #include "ray/util/clock.h"
 #include "ray/util/counter_map.h"
@@ -121,45 +122,7 @@ class TaskEvent {
 /// TaskStatusEvent is generated when a task changes its status.
 class TaskStatusEvent : public TaskEvent {
  public:
-  /// A class that contain data that will be converted to rpc::TaskStateUpdate
-  struct TaskStateUpdate {
-    TaskStateUpdate() = default;
-
-    explicit TaskStateUpdate(const std::optional<const rpc::RayErrorInfo> &error_info)
-        : error_info_(error_info) {}
-
-    TaskStateUpdate(const NodeID &node_id, const WorkerID &worker_id)
-        : node_id_(node_id), worker_id_(worker_id) {}
-
-    explicit TaskStateUpdate(rpc::TaskLogInfo task_log_info)
-        : task_log_info_(std::move(task_log_info)) {}
-
-    TaskStateUpdate(std::string actor_repr_name, uint32_t pid)
-        : actor_repr_name_(std::move(actor_repr_name)), pid_(pid) {}
-
-    explicit TaskStateUpdate(uint32_t pid) : pid_(pid) {}
-
-    explicit TaskStateUpdate(bool is_debugger_paused)
-        : is_debugger_paused_(is_debugger_paused) {}
-
-   private:
-    friend class TaskStatusEvent;
-
-    /// Node id if it's a SUBMITTED_TO_WORKER status change.
-    std::optional<NodeID> node_id_ = std::nullopt;
-    /// Worker id if it's a SUBMITTED_TO_WORKER status change.
-    std::optional<WorkerID> worker_id_ = std::nullopt;
-    /// Task error info.
-    std::optional<rpc::RayErrorInfo> error_info_ = std::nullopt;
-    /// Task log info.
-    std::optional<rpc::TaskLogInfo> task_log_info_ = std::nullopt;
-    /// Actor task repr name.
-    std::string actor_repr_name_;
-    /// Worker's pid if it's a RUNNING status change.
-    std::optional<uint32_t> pid_ = std::nullopt;
-    /// If the task is paused by the debugger.
-    std::optional<bool> is_debugger_paused_ = std::nullopt;
-  };
+  using TaskStateUpdate = observability::TaskStateUpdate;
 
   explicit TaskStatusEvent(
       TaskID task_id,
@@ -199,16 +162,6 @@ class TaskStatusEvent : public TaskEvent {
   bool IsProfileEvent() const override { return false; }
 
  private:
-  // Helper functions to populate the task definition event of rpc::events::RayEvent
-  // This function assumes task_spec_ is not null.
-  template <typename T>
-  void PopulateRpcRayTaskDefinitionEvent(T &definition_event_data);
-
-  // Helper functions to populate the task lifecycle event of rpc::events::RayEvent
-  void PopulateRpcRayTaskLifecycleEvent(
-      rpc::events::TaskLifecycleEvent &lifecycle_event_data,
-      google::protobuf::Timestamp timestamp);
-
   // Helper functions to populate the base fields of rpc::events::RayEvent
   void PopulateRpcRayEventBaseFields(rpc::events::RayEvent &ray_event,
                                      bool is_definition_event,
@@ -628,6 +581,11 @@ class TaskEventBufferImpl : public TaskEventBuffer {
   /// True if the TaskEventBuffer is enabled.
   std::atomic<bool> enabled_ = false;
 
+  /// True while at least one destination below is live. Owns whether events are
+  /// recorded; enabled_ owns the io thread and GCS client lifecycle, so Stop() still
+  /// tears them down when nothing is being recorded.
+  std::atomic<bool> recording_enabled_ = false;
+
   /// Circular buffered task status events.
   boost::circular_buffer<std::shared_ptr<TaskEvent>> status_events_
       ABSL_GUARDED_BY(mutex_);
@@ -704,6 +662,7 @@ class TaskEventBufferImpl : public TaskEventBuffer {
   FRIEND_TEST(TaskEventBufferTestDroppedAttemptsOnly,
               TestFlushSendsDroppedAttemptsWithoutEvents);
   FRIEND_TEST(TaskEventBufferTestRecorderSwitch, TestRecorderTakesOverAggregatorSend);
+  FRIEND_TEST(TaskEventBufferTestNoDestination, TestNoRecordingWhenNoDestination);
 };
 
 }  // namespace worker

--- a/src/ray/core_worker/tests/task_event_buffer_test.cc
+++ b/src/ray/core_worker/tests/task_event_buffer_test.cc
@@ -84,13 +84,16 @@ class MockEventAggregatorAddEvents
 class TaskEventBufferTest : public ::testing::Test {
  public:
   TaskEventBufferTest() {
+    // The buffer records only while one of its destinations is enabled, so name one
+    // here to exercise the ring.
     RayConfig::instance().initialize(
         R"(
 {
   "task_events_report_interval_ms": 1000,
   "task_events_max_num_status_events_buffer_on_worker": 100,
   "task_events_send_batch_size": 100,
-  "task_events_shutdown_flush_timeout_ms": 100
+  "task_events_shutdown_flush_timeout_ms": 100,
+  "enable_core_worker_task_event_to_gcs": true
 }
   )");
 
@@ -460,6 +463,36 @@ TEST_F(TaskEventBufferTest, TestAddEvents) {
   // Test add profile events
   task_event_buffer_->AddTaskEvent(GenProfileTaskEvent(task_id_1, 1));
   ASSERT_EQ(task_event_buffer_->GetNumTaskEventsStored(), 2);
+}
+
+// Buffer configured with no destination live (GCS, aggregator and export all off, and the
+// recorder disabled). The buffer should short-circuit and record nothing.
+class TaskEventBufferTestNoDestination : public TaskEventBufferTest {
+ public:
+  TaskEventBufferTestNoDestination() : TaskEventBufferTest() {
+    RayConfig::instance().initialize(
+        R"(
+{
+  "task_events_report_interval_ms": 1000,
+  "task_events_max_num_status_events_buffer_on_worker": 100,
+  "task_events_send_batch_size": 100,
+  "task_events_shutdown_flush_timeout_ms": 100,
+  "enable_ray_task_event_recorder": false,
+  "enable_core_worker_task_event_to_gcs": false,
+  "enable_core_worker_ray_event_to_aggregator": false
+}
+  )");
+  }
+};
+
+TEST_F(TaskEventBufferTestNoDestination, TestNoRecordingWhenNoDestination) {
+  ASSERT_FALSE(task_event_buffer_->Enabled());
+
+  auto task_id = RandomTaskId();
+  task_event_buffer_->AddTaskEvent(GenStatusTaskEvent(task_id, 0));
+  task_event_buffer_->AddTaskEvent(GenProfileTaskEvent(task_id, 1));
+
+  ASSERT_EQ(task_event_buffer_->GetNumTaskEventsStored(), 0);
 }
 
 TEST_P(TaskEventBufferTestDifferentDestination, TestFlushEvents) {
@@ -1736,29 +1769,25 @@ INSTANTIATE_TEST_SUITE_P(TaskEventBufferTest,
                          TaskEventBufferTestDifferentDestination,
                          ::testing::Values(DifferentDestination{true, true},
                                            DifferentDestination{true, false},
-                                           DifferentDestination{false, true},
-                                           DifferentDestination{false, false}));
+                                           DifferentDestination{false, true}));
 
 INSTANTIATE_TEST_SUITE_P(TaskEventBufferTest,
                          TaskEventBufferTestBatchSendDifferentDestination,
                          ::testing::Values(DifferentDestination{true, true},
                                            DifferentDestination{true, false},
-                                           DifferentDestination{false, true},
-                                           DifferentDestination{false, false}));
+                                           DifferentDestination{false, true}));
 
 INSTANTIATE_TEST_SUITE_P(TaskEventBufferTest,
                          TaskEventBufferTestDroppedAttemptsOnly,
                          ::testing::Values(DifferentDestination{true, true},
                                            DifferentDestination{true, false},
-                                           DifferentDestination{false, true},
-                                           DifferentDestination{false, false}));
+                                           DifferentDestination{false, true}));
 
 INSTANTIATE_TEST_SUITE_P(TaskEventBufferTest,
                          TaskEventBufferTestLimitBufferDifferentDestination,
                          ::testing::Values(DifferentDestination{true, true},
                                            DifferentDestination{true, false},
-                                           DifferentDestination{false, true},
-                                           DifferentDestination{false, false}));
+                                           DifferentDestination{false, true}));
 
 }  // namespace worker
 

--- a/src/ray/observability/BUILD.bazel
+++ b/src/ray/observability/BUILD.bazel
@@ -179,6 +179,39 @@ ray_cc_library(
 )
 
 ray_cc_library(
+    name = "task_state_update",
+    hdrs = [
+        "task_state_update.h",
+    ],
+    deps = [
+        "//src/ray/common:id",
+        "//src/ray/protobuf:common_cc_proto",
+        "//src/ray/protobuf:gcs_cc_proto",
+    ],
+)
+
+ray_cc_library(
+    name = "task_event_populators",
+    srcs = [
+        "task_event_populators.cc",
+    ],
+    hdrs = [
+        "task_event_populators.h",
+    ],
+    deps = [
+        ":task_state_update",
+        "//src/ray/common:grpc_util",
+        "//src/ray/common:id",
+        "//src/ray/common:task_common",
+        "//src/ray/common/scheduling:label_selector",
+        "//src/ray/protobuf/public:events_actor_task_definition_event_cc_proto",
+        "//src/ray/protobuf/public:events_task_definition_event_cc_proto",
+        "//src/ray/protobuf/public:events_task_lifecycle_event_cc_proto",
+        "//src/ray/util:logging",
+    ],
+)
+
+ray_cc_library(
     name = "ray_task_definition_event",
     srcs = [
         "ray_task_definition_event.cc",
@@ -188,8 +221,14 @@ ray_cc_library(
     ],
     deps = [
         ":ray_event",
+        ":task_event_populators",
         ":task_ray_event_interface",
+        "//src/ray/common:id",
+        "//src/ray/common:task_common",
         "//src/ray/protobuf/public:events_task_definition_event_cc_proto",
+        "//src/ray/util:logging",
+        "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/strings:str_format",
     ],
 )
 
@@ -217,8 +256,14 @@ ray_cc_library(
     ],
     deps = [
         ":ray_event",
+        ":task_event_populators",
         ":task_ray_event_interface",
+        "//src/ray/common:id",
+        "//src/ray/common:task_common",
         "//src/ray/protobuf/public:events_actor_task_definition_event_cc_proto",
+        "//src/ray/util:logging",
+        "@com_google_absl//absl/strings",
+        "@com_google_absl//absl/strings:str_format",
     ],
 )
 
@@ -232,8 +277,12 @@ ray_cc_library(
     ],
     deps = [
         ":ray_event",
+        ":task_event_populators",
         ":task_ray_event_interface",
+        ":task_state_update",
+        "//src/ray/common:id",
         "//src/ray/protobuf/public:events_task_lifecycle_event_cc_proto",
+        "@com_google_absl//absl/strings",
     ],
 )
 

--- a/src/ray/observability/ray_actor_task_definition_event.cc
+++ b/src/ray/observability/ray_actor_task_definition_event.cc
@@ -14,18 +14,23 @@
 
 #include "ray/observability/ray_actor_task_definition_event.h"
 
+#include <memory>
 #include <string>
 #include <utility>
 
-#include "absl/strings/escaping.h"
+#include "absl/strings/str_cat.h"
 #include "absl/strings/str_format.h"
+#include "ray/observability/task_event_populators.h"
 #include "ray/util/logging.h"
 
 namespace ray {
 namespace observability {
 
 RayActorTaskDefinitionEvent::RayActorTaskDefinitionEvent(
-    rpc::events::ActorTaskDefinitionEvent data,
+    std::shared_ptr<const TaskSpecification> task_spec,
+    const TaskID &task_id,
+    const JobID &job_id,
+    int32_t task_attempt,
     const std::string &session_name,
     int64_t timestamp)
     : RayEvent<rpc::events::ActorTaskDefinitionEvent>(
@@ -34,16 +39,20 @@ RayActorTaskDefinitionEvent::RayActorTaskDefinitionEvent(
           rpc::events::RayEvent::INFO,
           "",
           session_name,
-          timestamp) {
-  data_ = std::move(data);
+          timestamp),
+      task_spec_(std::move(task_spec)),
+      task_id_(task_id),
+      job_id_(job_id),
+      task_attempt_(task_attempt) {
+  RAY_CHECK(task_spec_ != nullptr);
 }
 
 std::string RayActorTaskDefinitionEvent::GetEntityId() const {
-  return data_.task_id() + std::to_string(data_.task_attempt());
+  return absl::StrCat(task_id_.Binary(), task_attempt_);
 }
 
 TaskAttemptId RayActorTaskDefinitionEvent::GetTaskAttempt() const {
-  return {data_.task_id(), data_.task_attempt()};
+  return {task_id_.Binary(), task_attempt_};
 }
 
 void RayActorTaskDefinitionEvent::MergeData(
@@ -51,13 +60,17 @@ void RayActorTaskDefinitionEvent::MergeData(
   RAY_CHECK(false) << absl::StrFormat(
       "MergeData called on actor task definition event for task %s attempt %d; only "
       "one definition event is expected per task attempt.",
-      absl::BytesToHexString(data_.task_id()),
-      data_.task_attempt());
+      task_id_.Hex(),
+      task_attempt_);
 }
 
 ray::rpc::events::RayEvent RayActorTaskDefinitionEvent::SerializeData() && {
   ray::rpc::events::RayEvent event;
-  event.mutable_actor_task_definition_event()->Swap(&data_);
+  PopulateTaskDefinitionEvent(*task_spec_,
+                              task_id_,
+                              job_id_,
+                              task_attempt_,
+                              *event.mutable_actor_task_definition_event());
   return event;
 }
 

--- a/src/ray/observability/ray_actor_task_definition_event.h
+++ b/src/ray/observability/ray_actor_task_definition_event.h
@@ -14,8 +14,12 @@
 
 #pragma once
 
+#include <cstdint>
+#include <memory>
 #include <string>
 
+#include "ray/common/id.h"
+#include "ray/common/task/task_spec.h"
 #include "ray/observability/ray_event.h"
 #include "ray/observability/task_ray_event_interface.h"
 #include "src/ray/protobuf/public/events_actor_task_definition_event.pb.h"
@@ -31,15 +35,17 @@ template class RayEvent<rpc::events::ActorTaskDefinitionEvent>;
  * Like the task definition event, exactly one is produced per attempt, so MergeData must
  * never be called (it RAY_CHECK-fails).
  *
- * TODO(karticam): built EAGERLY like RayTaskDefinitionEvent. Benchmark if this adds
- * latency and then maybe implement lazy serialization (see RayTaskDefinitionEvent; the
- * same follow-up applies there).
+ * Like RayTaskDefinitionEvent, the proto is built when the event is serialized
+ * for export rather than when it is recorded.
  */
 class RayActorTaskDefinitionEvent
     : public RayEvent<rpc::events::ActorTaskDefinitionEvent>,
       public TaskRayEventInterface {
  public:
-  RayActorTaskDefinitionEvent(rpc::events::ActorTaskDefinitionEvent data,
+  RayActorTaskDefinitionEvent(std::shared_ptr<const TaskSpecification> task_spec,
+                              const TaskID &task_id,
+                              const JobID &job_id,
+                              int32_t task_attempt,
                               const std::string &session_name,
                               int64_t timestamp);
 
@@ -50,6 +56,12 @@ class RayActorTaskDefinitionEvent
  protected:
   void MergeData(RayEvent<rpc::events::ActorTaskDefinitionEvent> &&other) override;
   ray::rpc::events::RayEvent SerializeData() && override;
+
+ private:
+  std::shared_ptr<const TaskSpecification> task_spec_;
+  TaskID task_id_;
+  JobID job_id_;
+  int32_t task_attempt_;
 };
 
 }  // namespace observability

--- a/src/ray/observability/ray_event_recorder_base.cc
+++ b/src/ray/observability/ray_event_recorder_base.cc
@@ -148,13 +148,15 @@ void RayEventRecorderBase::SendRequest(rpc::events::AddEventsRequest &&request) 
           // add logic for error recovery.
           RAY_LOG(ERROR) << "Failed to record ray event: " << status.ToString();
         }
-        // Signal under mutex to avoid lost wakeup race condition
-        {
-          absl::MutexLock grpc_lock(&grpc_completion_mutex_);
-          grpc_in_progress_ = false;
-          grpc_completion_cv_.Signal();
-        }
+        MarkGrpcDone();
       });
+}
+
+void RayEventRecorderBase::MarkGrpcDone() {
+  // Signal under mutex to avoid lost wakeup race condition
+  absl::MutexLock grpc_lock(&grpc_completion_mutex_);
+  grpc_in_progress_ = false;
+  grpc_completion_cv_.Signal();
 }
 
 }  // namespace observability

--- a/src/ray/observability/ray_event_recorder_base.h
+++ b/src/ray/observability/ray_event_recorder_base.h
@@ -66,8 +66,14 @@ class RayEventRecorderBase : public RayEventRecorderInterface {
 
   // Send a populated request to the event aggregator, tracking the in-flight
   // gRPC so shutdown can drain. Sets grpc_in_progress_; the completion callback resets
-  // it. Call while holding mutex_.
+  // it.
   void SendRequest(rpc::events::AddEventsRequest &&request);
+
+  /**
+   * @brief Clear grpc_in_progress_ and wake a shutdown waiter. Needed by an export that
+   * marks the send in progress before it knows whether it has anything to send.
+   */
+  void MarkGrpcDone();
 
   rpc::EventAggregatorClient &event_aggregator_client_;
   std::shared_ptr<PeriodicalRunnerInterface> periodical_runner_;

--- a/src/ray/observability/ray_task_definition_event.cc
+++ b/src/ray/observability/ray_task_definition_event.cc
@@ -14,35 +14,45 @@
 
 #include "ray/observability/ray_task_definition_event.h"
 
+#include <memory>
 #include <string>
 #include <utility>
 
-#include "absl/strings/escaping.h"
+#include "absl/strings/str_cat.h"
 #include "absl/strings/str_format.h"
+#include "ray/observability/task_event_populators.h"
 #include "ray/util/logging.h"
 
 namespace ray {
 namespace observability {
 
-RayTaskDefinitionEvent::RayTaskDefinitionEvent(rpc::events::TaskDefinitionEvent data,
-                                               const std::string &session_name,
-                                               int64_t timestamp)
+RayTaskDefinitionEvent::RayTaskDefinitionEvent(
+    std::shared_ptr<const TaskSpecification> task_spec,
+    const TaskID &task_id,
+    const JobID &job_id,
+    int32_t task_attempt,
+    const std::string &session_name,
+    int64_t timestamp)
     : RayEvent<rpc::events::TaskDefinitionEvent>(
           rpc::events::RayEvent::CORE_WORKER,
           rpc::events::RayEvent::TASK_DEFINITION_EVENT,
           rpc::events::RayEvent::INFO,
           "",
           session_name,
-          timestamp) {
-  data_ = std::move(data);
+          timestamp),
+      task_spec_(std::move(task_spec)),
+      task_id_(task_id),
+      job_id_(job_id),
+      task_attempt_(task_attempt) {
+  RAY_CHECK(task_spec_ != nullptr);
 }
 
 std::string RayTaskDefinitionEvent::GetEntityId() const {
-  return data_.task_id() + std::to_string(data_.task_attempt());
+  return absl::StrCat(task_id_.Binary(), task_attempt_);
 }
 
 TaskAttemptId RayTaskDefinitionEvent::GetTaskAttempt() const {
-  return {data_.task_id(), data_.task_attempt()};
+  return {task_id_.Binary(), task_attempt_};
 }
 
 void RayTaskDefinitionEvent::MergeData(
@@ -50,13 +60,17 @@ void RayTaskDefinitionEvent::MergeData(
   RAY_CHECK(false) << absl::StrFormat(
       "MergeData called on task definition event for task %s attempt %d; only one "
       "definition event is expected per task attempt.",
-      absl::BytesToHexString(data_.task_id()),
-      data_.task_attempt());
+      task_id_.Hex(),
+      task_attempt_);
 }
 
 ray::rpc::events::RayEvent RayTaskDefinitionEvent::SerializeData() && {
   ray::rpc::events::RayEvent event;
-  event.mutable_task_definition_event()->Swap(&data_);
+  PopulateTaskDefinitionEvent(*task_spec_,
+                              task_id_,
+                              job_id_,
+                              task_attempt_,
+                              *event.mutable_task_definition_event());
   return event;
 }
 

--- a/src/ray/observability/ray_task_definition_event.h
+++ b/src/ray/observability/ray_task_definition_event.h
@@ -14,8 +14,12 @@
 
 #pragma once
 
+#include <cstdint>
+#include <memory>
 #include <string>
 
+#include "ray/common/id.h"
+#include "ray/common/task/task_spec.h"
 #include "ray/observability/ray_event.h"
 #include "ray/observability/task_ray_event_interface.h"
 #include "src/ray/protobuf/public/events_task_definition_event.pb.h"
@@ -33,19 +37,16 @@ template class RayEvent<rpc::events::TaskDefinitionEvent>;
  * spec-carrying status event), so MergeData must never be called; therefore
  * RAY_CHECK fails.
  *
- * TODO(karticam): this proto is built EAGERLY -- the caller passes a fully-populated
- * TaskDefinitionEvent, constructed at task-submission time. The legacy TaskEventBuffer
- * instead deferred definition-proto building to the flush thread, keeping it off the task
- * submission/execution critical path. Building the proto eagerly here might increase
- * latency in the task submission time. Benchmark this and if it regresses, implement lazy
- * serialization. Definition events are the only ones eligible for deferral since they are
- * never merged, so the proto need not exist before the recorder's grouping step.
- * Lifecycle/profile are mergeable and must stay eager.
+ * The event keeps a reference to the task spec and builds the proto when it is
+ * serialized for export, so the conversion stays off the task's call path.
  */
 class RayTaskDefinitionEvent : public RayEvent<rpc::events::TaskDefinitionEvent>,
                                public TaskRayEventInterface {
  public:
-  RayTaskDefinitionEvent(rpc::events::TaskDefinitionEvent data,
+  RayTaskDefinitionEvent(std::shared_ptr<const TaskSpecification> task_spec,
+                         const TaskID &task_id,
+                         const JobID &job_id,
+                         int32_t task_attempt,
                          const std::string &session_name,
                          int64_t timestamp);
 
@@ -56,6 +57,12 @@ class RayTaskDefinitionEvent : public RayEvent<rpc::events::TaskDefinitionEvent>
  protected:
   void MergeData(RayEvent<rpc::events::TaskDefinitionEvent> &&other) override;
   ray::rpc::events::RayEvent SerializeData() && override;
+
+ private:
+  std::shared_ptr<const TaskSpecification> task_spec_;
+  TaskID task_id_;
+  JobID job_id_;
+  int32_t task_attempt_;
 };
 
 }  // namespace observability

--- a/src/ray/observability/ray_task_event_recorder.cc
+++ b/src/ray/observability/ray_task_event_recorder.cc
@@ -140,65 +140,74 @@ void RayTaskEventRecorder::AddProfileEvent(std::unique_ptr<RayEventInterface> ev
   profile_events_itr->second.push_back(std::move(event));
 }
 
-void RayTaskEventRecorder::ExportEvents() {
-  absl::MutexLock lock(&mutex_);
-  if (status_events_.empty() && profile_events_.empty() &&
-      dropped_task_attempts_unreported_.empty()) {
-    return;
-  }
-  // Skip if there's already an in-flight gRPC call to avoid overlapping requests.
-  if (grpc_in_progress_) {
-    RAY_LOG_EVERY_N_OR_DEBUG(WARNING, 100)
-        << "Previous RayTaskEventRecorder export in progress: new events will be "
-           "exported once previous export completes.";
-    return;
-  }
-
+RayTaskEventRecorder::EventsToSend RayTaskEventRecorder::TakeEventsToSend() {
   // TODO(karticam): Unlike TaskEventBufferImpl::FlushEvents, which sends a bounded batch
   // per flush, this drains the entire buffer so one export can potentially be a large
   // gRPC. This will be bounded once batching lands in the RayEventRecorder export path
   // (PR #60045).
-
-  absl::flat_hash_set<TaskAttemptId> dropped_to_send =
-      std::move(dropped_task_attempts_unreported_);
+  EventsToSend to_send;
+  to_send.dropped_to_send = std::move(dropped_task_attempts_unreported_);
   dropped_task_attempts_unreported_.clear();
 
   // Collect events to export, skipping any whose attempt was dropped
-  std::list<std::unique_ptr<RayEventInterface>> events;
   size_t num_skipped = 0;
   for (auto &event : status_events_) {
-    if (dropped_to_send.contains(GetTaskAttemptOrDie(event))) {
+    if (to_send.dropped_to_send.contains(GetTaskAttemptOrDie(event))) {
       num_skipped++;
       continue;
     }
-    events.push_back(std::move(event));
+    to_send.events.push_back(std::move(event));
   }
   status_events_.clear();
   for (auto &[attempt, profile_vec] : profile_events_) {
-    if (dropped_to_send.contains(attempt)) {
+    if (to_send.dropped_to_send.contains(attempt)) {
       num_skipped += profile_vec.size();
       continue;
     }
     for (auto &event : profile_vec) {
-      events.push_back(std::move(event));
+      to_send.events.push_back(std::move(event));
     }
   }
   profile_events_.clear();
   num_profile_events_buffered_ = 0;
-  RecordDropped(num_skipped);
 
+  RecordDropped(num_skipped);
+  return to_send;
+}
+
+void RayTaskEventRecorder::ExportEvents() {
+  EventsToSend to_send;
+  {
+    absl::MutexLock lock(&mutex_);
+    if (status_events_.empty() && profile_events_.empty() &&
+        dropped_task_attempts_unreported_.empty()) {
+      return;
+    }
+    // Skip if there's already an in-flight gRPC call to avoid overlapping requests.
+    if (grpc_in_progress_.exchange(true)) {
+      RAY_LOG_EVERY_N_OR_DEBUG(WARNING, 100)
+          << "Previous RayTaskEventRecorder export in progress: new events will be "
+             "exported once previous export completes.";
+      return;
+    }
+    to_send = TakeEventsToSend();
+  }
+
+  // Grouping, serialization and send run outside of mutex so they never
+  // block AddEvents on the task's call path.
   rpc::events::AddEventsRequest request;
   rpc::events::RayEventsData *data = request.mutable_events_data();
-  GroupAndSerializeEvents(std::move(events), data);
+  GroupAndSerializeEvents(std::move(to_send.events), data);
 
   rpc::events::TaskEventsMetadata *metadata = data->mutable_task_events_metadata();
-  for (const auto &attempt : dropped_to_send) {
+  for (const auto &attempt : to_send.dropped_to_send) {
     rpc::TaskAttempt *rpc_attempt = metadata->add_dropped_task_attempts();
     rpc_attempt->set_task_id(attempt.first);
     rpc_attempt->set_attempt_number(attempt.second);
   }
 
   if (data->events_size() == 0 && metadata->dropped_task_attempts_size() == 0) {
+    MarkGrpcDone();
     return;
   }
 

--- a/src/ray/observability/ray_task_event_recorder.h
+++ b/src/ray/observability/ray_task_event_recorder.h
@@ -15,6 +15,7 @@
 #pragma once
 
 #include <boost/circular_buffer.hpp>
+#include <list>
 #include <memory>
 #include <string_view>
 #include <vector>
@@ -77,6 +78,20 @@ class RayTaskEventRecorder : public RayEventRecorderBase {
   void AddProfileEvent(std::unique_ptr<RayEventInterface> event,
                        const TaskAttemptId &attempt)
       ABSL_EXCLUSIVE_LOCKS_REQUIRED(mutex_);
+
+  struct EventsToSend {
+    std::list<std::unique_ptr<RayEventInterface>> events;
+    absl::flat_hash_set<TaskAttemptId> dropped_to_send;
+  };
+
+  /**
+   * @brief Move the buffered events and the dropped task attempts to report out of the
+   * buffers so that the caller can group, serialize and send them without holding mutex_.
+   * Events belonging to a dropped attempt are discarded so that a task attempt is either
+   * sent in full or not at all.
+   * @return The events to export and the task attempts to report as dropped.
+   */
+  EventsToSend TakeEventsToSend() ABSL_EXCLUSIVE_LOCKS_REQUIRED(mutex_);
 
   // Read the task attempt of an event; the event must implement TaskRayEventInterface.
   static TaskAttemptId GetTaskAttemptOrDie(

--- a/src/ray/observability/ray_task_lifecycle_event.cc
+++ b/src/ray/observability/ray_task_lifecycle_event.cc
@@ -14,45 +14,67 @@
 
 #include "ray/observability/ray_task_lifecycle_event.h"
 
+#include <optional>
 #include <string>
 #include <utility>
+
+#include "absl/strings/str_cat.h"
+#include "ray/observability/task_event_populators.h"
 
 namespace ray {
 namespace observability {
 
-RayTaskLifecycleEvent::RayTaskLifecycleEvent(rpc::events::TaskLifecycleEvent data,
-                                             const std::string &session_name,
-                                             int64_t timestamp)
+RayTaskLifecycleEvent::RayTaskLifecycleEvent(
+    const TaskID &task_id,
+    const JobID &job_id,
+    int32_t task_attempt,
+    rpc::TaskStatus task_status,
+    const std::optional<const TaskStateUpdate> &state_update,
+    const std::string &session_name,
+    int64_t timestamp)
     : RayEvent<rpc::events::TaskLifecycleEvent>(
           rpc::events::RayEvent::CORE_WORKER,
           rpc::events::RayEvent::TASK_LIFECYCLE_EVENT,
           rpc::events::RayEvent::INFO,
           "",
           session_name,
-          timestamp) {
-  data_ = std::move(data);
+          timestamp),
+      task_id_(task_id),
+      job_id_(job_id),
+      task_attempt_(task_attempt) {
+  status_changes_.push_back({task_status, timestamp, state_update});
 }
 
 std::string RayTaskLifecycleEvent::GetEntityId() const {
-  return data_.task_id() + std::to_string(data_.task_attempt());
+  return absl::StrCat(task_id_.Binary(), task_attempt_);
 }
 
 TaskAttemptId RayTaskLifecycleEvent::GetTaskAttempt() const {
-  return {data_.task_id(), data_.task_attempt()};
+  return {task_id_.Binary(), task_attempt_};
 }
 
 void RayTaskLifecycleEvent::MergeData(RayEvent<rpc::events::TaskLifecycleEvent> &&other) {
   auto &&other_event = static_cast<RayTaskLifecycleEvent &&>(other);
-  // MergeFrom concatenates the repeated state_transitions (preserving chronological
-  // order, since the recorder merges later events into the earlier accumulator) and
-  // overlays the dynamic scalar/message fields (node_id, worker_id, error_info, etc.)
-  // that individual lifecycle events set.
-  data_.MergeFrom(other_event.data_);
+  // The recorder merges later events into the earlier accumulator, so appending keeps the
+  // status changes in chronological order.
+  for (auto &status_change : other_event.status_changes_) {
+    status_changes_.push_back(std::move(status_change));
+  }
 }
 
 ray::rpc::events::RayEvent RayTaskLifecycleEvent::SerializeData() && {
   ray::rpc::events::RayEvent event;
-  event.mutable_task_lifecycle_event()->Swap(&data_);
+  rpc::events::TaskLifecycleEvent *lifecycle_event_data =
+      event.mutable_task_lifecycle_event();
+  for (const StatusChange &status_change : status_changes_) {
+    AppendTaskLifecycleUpdate(task_id_,
+                              job_id_,
+                              task_attempt_,
+                              status_change.task_status,
+                              status_change.timestamp,
+                              status_change.state_update,
+                              *lifecycle_event_data);
+  }
   return event;
 }
 

--- a/src/ray/observability/ray_task_lifecycle_event.h
+++ b/src/ray/observability/ray_task_lifecycle_event.h
@@ -14,10 +14,15 @@
 
 #pragma once
 
+#include <cstdint>
+#include <optional>
 #include <string>
+#include <vector>
 
+#include "ray/common/id.h"
 #include "ray/observability/ray_event.h"
 #include "ray/observability/task_ray_event_interface.h"
+#include "ray/observability/task_state_update.h"
 #include "src/ray/protobuf/public/events_task_lifecycle_event.pb.h"
 
 namespace ray {
@@ -32,11 +37,19 @@ template class RayEvent<rpc::events::TaskLifecycleEvent>;
  *
  * Multiple lifecycle events for the same task attempt are merged by the recorder into a
  * single time series via MergeData.
+ *
+ * Each recorded status change is kept as-is and the whole series is turned into
+ * a proto when the event is serialized for export, so the conversion stays off the task's
+ * call path.
  */
 class RayTaskLifecycleEvent : public RayEvent<rpc::events::TaskLifecycleEvent>,
                               public TaskRayEventInterface {
  public:
-  RayTaskLifecycleEvent(rpc::events::TaskLifecycleEvent data,
+  RayTaskLifecycleEvent(const TaskID &task_id,
+                        const JobID &job_id,
+                        int32_t task_attempt,
+                        rpc::TaskStatus task_status,
+                        const std::optional<const TaskStateUpdate> &state_update,
                         const std::string &session_name,
                         int64_t timestamp);
 
@@ -50,6 +63,20 @@ class RayTaskLifecycleEvent : public RayEvent<rpc::events::TaskLifecycleEvent>,
  protected:
   void MergeData(RayEvent<rpc::events::TaskLifecycleEvent> &&other) override;
   ray::rpc::events::RayEvent SerializeData() && override;
+
+ private:
+  // One recorded status change of the task attempt.
+  struct StatusChange {
+    rpc::TaskStatus task_status;
+    int64_t timestamp;
+    std::optional<TaskStateUpdate> state_update;
+  };
+
+  TaskID task_id_;
+  JobID job_id_;
+  int32_t task_attempt_;
+  // Status changes of this attempt, in the order they were recorded.
+  std::vector<StatusChange> status_changes_;
 };
 
 }  // namespace observability

--- a/src/ray/observability/task_event_populators.cc
+++ b/src/ray/observability/task_event_populators.cc
@@ -1,0 +1,123 @@
+// Copyright 2026 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "ray/observability/task_event_populators.h"
+
+#include <utility>
+
+#include "ray/common/grpc_util.h"
+#include "ray/util/logging.h"
+
+namespace ray {
+namespace observability {
+
+namespace {
+
+rpc::events::TaskLifecycleEvent::TaskLogInfo TaskLogInfoToLifecycleEvent(
+    const rpc::TaskLogInfo &src) {
+  rpc::events::TaskLifecycleEvent::TaskLogInfo dest;
+  if (src.has_stdout_file()) {
+    dest.set_stdout_file(src.stdout_file());
+  }
+  if (src.has_stderr_file()) {
+    dest.set_stderr_file(src.stderr_file());
+  }
+  if (src.has_stdout_start()) {
+    dest.set_stdout_start(src.stdout_start());
+  }
+  if (src.has_stdout_end()) {
+    dest.set_stdout_end(src.stdout_end());
+  }
+  if (src.has_stderr_start()) {
+    dest.set_stderr_start(src.stderr_start());
+  }
+  if (src.has_stderr_end()) {
+    dest.set_stderr_end(src.stderr_end());
+  }
+  return dest;
+}
+
+}  // namespace
+
+void AppendTaskLifecycleUpdate(const TaskID &task_id,
+                               const JobID &job_id,
+                               int32_t task_attempt,
+                               rpc::TaskStatus task_status,
+                               int64_t timestamp,
+                               const std::optional<TaskStateUpdate> &state_update,
+                               rpc::events::TaskLifecycleEvent &lifecycle_event_data) {
+  // Task identifier
+  lifecycle_event_data.set_task_id(task_id.Binary());
+  lifecycle_event_data.set_task_attempt(task_attempt);
+
+  // Task state
+  if (task_status != rpc::TaskStatus::NIL) {
+    rpc::events::TaskLifecycleEvent::StateTransition state_transition;
+    state_transition.set_state(task_status);
+    *state_transition.mutable_timestamp() = AbslTimeNanosToProtoTimestamp(timestamp);
+    *lifecycle_event_data.mutable_state_transitions()->Add() =
+        std::move(state_transition);
+  }
+
+  lifecycle_event_data.set_job_id(job_id.Binary());
+
+  // Task property updates
+  if (!state_update.has_value()) {
+    return;
+  }
+
+  if (state_update->error_info.has_value()) {
+    lifecycle_event_data.mutable_ray_error_info()->CopyFrom(*state_update->error_info);
+  }
+
+  if (!state_update->actor_repr_name.empty()) {
+    lifecycle_event_data.set_actor_repr_name(state_update->actor_repr_name);
+  }
+
+  if (state_update->node_id.has_value()) {
+    RAY_CHECK(task_status == rpc::TaskStatus::SUBMITTED_TO_WORKER)
+            .WithField("TaskStatus", task_status)
+        << "Node ID should be included when task status changes to "
+           "SUBMITTED_TO_WORKER.";
+    lifecycle_event_data.set_node_id(state_update->node_id->Binary());
+  }
+
+  if (state_update->worker_id.has_value()) {
+    RAY_CHECK(task_status == rpc::TaskStatus::SUBMITTED_TO_WORKER)
+            .WithField("TaskStatus", task_status)
+        << "Worker ID should be included when task status changes to "
+           "SUBMITTED_TO_WORKER.";
+    lifecycle_event_data.set_worker_id(state_update->worker_id->Binary());
+  }
+
+  if (state_update->pid.has_value()) {
+    lifecycle_event_data.set_worker_pid(state_update->pid.value());
+  }
+
+  if (state_update->is_debugger_paused.has_value()) {
+    lifecycle_event_data.set_is_debugger_paused(state_update->is_debugger_paused.value());
+  }
+
+  if (state_update->task_log_info.has_value()) {
+    // Merge rather than overwrite: log start and log end arrive as two separate updates
+    // carrying disjoint sub-fields (file paths + start offsets vs. end offsets), so an
+    // assignment would drop whichever came first. Matches the GCS path in
+    // ToRpcTaskEvents.
+    lifecycle_event_data.mutable_task_log_info()->MergeFrom(
+        TaskLogInfoToLifecycleEvent(state_update->task_log_info.value()));
+  }
+}
+
+}  // namespace observability
+}  // namespace ray

--- a/src/ray/observability/task_event_populators.h
+++ b/src/ray/observability/task_event_populators.h
@@ -1,0 +1,109 @@
+// Copyright 2026 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cstdint>
+#include <optional>
+#include <type_traits>
+
+#include "ray/common/id.h"
+#include "ray/common/scheduling/label_selector.h"
+#include "ray/common/task/task_spec.h"
+#include "ray/observability/task_state_update.h"
+#include "src/ray/protobuf/public/events_actor_task_definition_event.pb.h"
+#include "src/ray/protobuf/public/events_task_definition_event.pb.h"
+#include "src/ray/protobuf/public/events_task_lifecycle_event.pb.h"
+
+namespace ray {
+namespace observability {
+
+/**
+ * @brief Populate the static metadata of a task attempt into a
+ * TaskDefinitionEvent or an ActorTaskDefinitionEvent.
+ */
+template <typename T>
+void PopulateTaskDefinitionEvent(const TaskSpecification &task_spec,
+                                 const TaskID &task_id,
+                                 const JobID &job_id,
+                                 int32_t task_attempt,
+                                 T &definition_event_data) {
+  // Task identifier
+  definition_event_data.set_task_id(task_id.Binary());
+  definition_event_data.set_task_attempt(task_attempt);
+
+  // Common fields
+  definition_event_data.set_language(task_spec.GetLanguage());
+  const auto &required_resources = task_spec.GetRequiredResources().GetResourceMap();
+  definition_event_data.mutable_required_resources()->insert(required_resources.begin(),
+                                                             required_resources.end());
+  definition_event_data.set_serialized_runtime_env(
+      task_spec.RuntimeEnvInfo().serialized_runtime_env());
+  definition_event_data.set_job_id(job_id.Binary());
+  // NOTE: we set the parent task id of a task to the submitter task id, where the
+  // submitter  task id is:
+  // - For concurrent actors: the actor creation task's task id.
+  // - Otherwise: the CoreWorker main thread's task id.
+  definition_event_data.set_parent_task_id(task_spec.SubmitterTaskId().Binary());
+  definition_event_data.set_placement_group_id(
+      task_spec.PlacementGroupBundleId().first.Binary());
+  const auto &labels = task_spec.GetMessage().labels();
+  definition_event_data.mutable_ref_ids()->insert(labels.begin(), labels.end());
+  const auto &call_site = task_spec.GetMessage().call_site();
+  if (!call_site.empty()) {
+    definition_event_data.set_call_site(call_site);
+  }
+  const auto &label_selector = task_spec.GetMessage().label_selector();
+  if (label_selector.label_constraints_size() > 0) {
+    *definition_event_data.mutable_label_selector() =
+        ray::LabelSelector(label_selector).ToStringMap();
+  }
+
+  const auto &fallback_strategy = task_spec.GetMessage().fallback_strategy();
+  if (fallback_strategy.options_size() > 0) {
+    definition_event_data.mutable_fallback_strategy()->CopyFrom(fallback_strategy);
+  }
+
+  // Specific fields
+  if constexpr (std::is_same_v<T, rpc::events::ActorTaskDefinitionEvent>) {
+    definition_event_data.mutable_actor_func()->CopyFrom(
+        task_spec.FunctionDescriptor()->GetMessage());
+    definition_event_data.set_actor_id(task_spec.ActorId().Binary());
+    definition_event_data.set_actor_task_name(task_spec.GetName());
+  } else {
+    definition_event_data.mutable_task_func()->CopyFrom(
+        task_spec.FunctionDescriptor()->GetMessage());
+    definition_event_data.set_task_type(task_spec.GetMessage().type());
+    definition_event_data.set_task_name(task_spec.GetName());
+  }
+  if (task_spec.IsDetachedActor()) {
+    definition_event_data.set_is_detached_actor(true);
+  }
+}
+
+/**
+ * @brief Append one status change of a task attempt to a TaskLifecycleEvent,
+ * along with the task property updates the change carries. Repeated calls accumulate the
+ * state transitions of a single attempt into one event.
+ */
+void AppendTaskLifecycleUpdate(const TaskID &task_id,
+                               const JobID &job_id,
+                               int32_t task_attempt,
+                               rpc::TaskStatus task_status,
+                               int64_t timestamp,
+                               const std::optional<TaskStateUpdate> &state_update,
+                               rpc::events::TaskLifecycleEvent &lifecycle_event_data);
+
+}  // namespace observability
+}  // namespace ray

--- a/src/ray/observability/task_state_update.h
+++ b/src/ray/observability/task_state_update.h
@@ -1,0 +1,67 @@
+// Copyright 2026 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <utility>
+
+#include "ray/common/id.h"
+#include "src/ray/protobuf/common.pb.h"
+#include "src/ray/protobuf/gcs.pb.h"
+
+namespace ray {
+namespace observability {
+
+/// A class that contain data that will be converted to rpc::TaskStateUpdate
+struct TaskStateUpdate {
+  TaskStateUpdate() = default;
+
+  explicit TaskStateUpdate(const std::optional<const rpc::RayErrorInfo> &error_info_arg)
+      : error_info(error_info_arg) {}
+
+  TaskStateUpdate(const NodeID &node_id_arg, const WorkerID &worker_id_arg)
+      : node_id(node_id_arg), worker_id(worker_id_arg) {}
+
+  explicit TaskStateUpdate(rpc::TaskLogInfo task_log_info_arg)
+      : task_log_info(std::move(task_log_info_arg)) {}
+
+  TaskStateUpdate(std::string actor_repr_name_arg, uint32_t pid_arg)
+      : actor_repr_name(std::move(actor_repr_name_arg)), pid(pid_arg) {}
+
+  explicit TaskStateUpdate(uint32_t pid_arg) : pid(pid_arg) {}
+
+  explicit TaskStateUpdate(bool is_debugger_paused_arg)
+      : is_debugger_paused(is_debugger_paused_arg) {}
+
+  /// Node id if it's a SUBMITTED_TO_WORKER status change.
+  std::optional<NodeID> node_id = std::nullopt;
+  /// Worker id if it's a SUBMITTED_TO_WORKER status change.
+  std::optional<WorkerID> worker_id = std::nullopt;
+  /// Task error info.
+  std::optional<rpc::RayErrorInfo> error_info = std::nullopt;
+  /// Task log info.
+  std::optional<rpc::TaskLogInfo> task_log_info = std::nullopt;
+  /// Actor task repr name.
+  std::string actor_repr_name;
+  /// Worker's pid if it's a RUNNING status change.
+  std::optional<uint32_t> pid = std::nullopt;
+  /// If the task is paused by the debugger.
+  std::optional<bool> is_debugger_paused = std::nullopt;
+};
+
+}  // namespace observability
+}  // namespace ray

--- a/src/ray/observability/tests/BUILD.bazel
+++ b/src/ray/observability/tests/BUILD.bazel
@@ -107,12 +107,50 @@ ray_cc_test(
 )
 
 ray_cc_test(
+    name = "ray_task_definition_event_test",
+    size = "small",
+    srcs = ["ray_task_definition_event_test.cc"],
+    tags = ["team:core"],
+    deps = [
+        "//src/ray/common:function_descriptor",
+        "//src/ray/common:id",
+        "//src/ray/common:task_common",
+        "//src/ray/observability:ray_task_definition_event",
+    ],
+)
+
+ray_cc_test(
+    name = "ray_actor_task_definition_event_test",
+    size = "small",
+    srcs = ["ray_actor_task_definition_event_test.cc"],
+    tags = ["team:core"],
+    deps = [
+        "//src/ray/common:function_descriptor",
+        "//src/ray/common:id",
+        "//src/ray/common:task_common",
+        "//src/ray/observability:ray_actor_task_definition_event",
+    ],
+)
+
+ray_cc_test(
     name = "ray_worker_lifecycle_event_test",
     size = "small",
     srcs = ["ray_worker_lifecycle_event_test.cc"],
     tags = ["team:core"],
     deps = [
         "//src/ray/observability:ray_worker_lifecycle_event",
+    ],
+)
+
+ray_cc_test(
+    name = "ray_task_lifecycle_event_test",
+    size = "small",
+    srcs = ["ray_task_lifecycle_event_test.cc"],
+    tags = ["team:core"],
+    deps = [
+        "//src/ray/common:id",
+        "//src/ray/observability:ray_task_lifecycle_event",
+        "//src/ray/observability:task_state_update",
     ],
 )
 

--- a/src/ray/observability/tests/ray_actor_task_definition_event_test.cc
+++ b/src/ray/observability/tests/ray_actor_task_definition_event_test.cc
@@ -1,0 +1,124 @@
+// Copyright 2026 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "ray/observability/ray_actor_task_definition_event.h"
+
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <utility>
+
+#include "gtest/gtest.h"
+#include "ray/common/function_descriptor.h"
+#include "ray/common/id.h"
+#include "ray/common/task/task_spec.h"
+#include "ray/common/task/task_util.h"
+
+namespace ray {
+namespace observability {
+
+class RayActorTaskDefinitionEventTest : public ::testing::Test {
+ public:
+  std::shared_ptr<const TaskSpecification> BuildActorTaskSpec(const TaskID &task_id,
+                                                              const ActorID &actor_id) {
+    TaskSpecBuilder builder;
+    rpc::Address empty_address;
+    rpc::JobConfig config;
+    std::unordered_map<std::string, double> resources = {{"CPU", 1}};
+    std::unordered_map<std::string, std::string> labels = {{"label1", "value1"}};
+    builder.SetCommonTaskSpec(task_id,
+                              "dummy_actor_task",
+                              Language::PYTHON,
+                              FunctionDescriptorBuilder::BuildPython(
+                                  "dummy_module", "dummy_class", "dummy_function", ""),
+                              JobID::Nil(),
+                              config,
+                              TaskID::Nil(),
+                              0,
+                              TaskID::Nil(),
+                              empty_address,
+                              1,
+                              false,
+                              false,
+                              -1,
+                              resources,
+                              resources,
+                              "",
+                              0,
+                              TaskID::Nil(),
+                              "",
+                              std::make_shared<rpc::RuntimeEnvInfo>(),
+                              "",
+                              true,
+                              labels);
+    const ObjectID actor_creation_dummy_object_id =
+        ObjectID::FromIndex(TaskID::ForActorCreationTask(actor_id), /*index=*/1);
+    builder.SetActorTaskSpec(actor_id,
+                             actor_creation_dummy_object_id,
+                             /*max_retries=*/0,
+                             /*retry_exceptions=*/false,
+                             /*serialized_retry_exception_allowlist=*/"",
+                             /*concurrency_group_sequence_number=*/0,
+                             /*tensor_transport=*/std::nullopt,
+                             /*is_detached_actor=*/false);
+    return std::make_shared<const TaskSpecification>(
+        std::move(builder).ConsumeAndBuild());
+  }
+};
+
+// The actor task spec is turned into an ActorTaskDefinitionEvent when the event is
+// serialized.
+TEST_F(RayActorTaskDefinitionEventTest, TestSerialize) {
+  ActorID actor_id = ActorID::FromHex("f4ce02420592ca68c1738a0d01000000");
+  TaskID task_id = TaskID::ForActorTask(JobID::FromInt(1), TaskID::Nil(), 0, actor_id);
+  JobID job_id = JobID::FromInt(1);
+  auto task_spec = BuildActorTaskSpec(task_id, actor_id);
+
+  RayActorTaskDefinitionEvent event(task_spec,
+                                    task_id,
+                                    job_id,
+                                    /*task_attempt=*/2,
+                                    "sess1",
+                                    /*timestamp=*/1000);
+
+  ASSERT_EQ(event.GetEntityId(), task_id.Binary() + "2");
+  ASSERT_EQ(event.GetTaskAttempt().first, task_id.Binary());
+  ASSERT_EQ(event.GetTaskAttempt().second, 2);
+
+  auto serialized_event = std::move(event).Serialize().value();
+
+  ASSERT_EQ(serialized_event.source_type(), rpc::events::RayEvent::CORE_WORKER);
+  ASSERT_EQ(serialized_event.event_type(),
+            rpc::events::RayEvent::ACTOR_TASK_DEFINITION_EVENT);
+  ASSERT_EQ(serialized_event.severity(), rpc::events::RayEvent::INFO);
+  ASSERT_EQ(serialized_event.session_name(), "sess1");
+  ASSERT_TRUE(serialized_event.has_actor_task_definition_event());
+
+  const auto &definition = serialized_event.actor_task_definition_event();
+  ASSERT_EQ(definition.task_id(), task_id.Binary());
+  ASSERT_EQ(definition.task_attempt(), 2);
+  ASSERT_EQ(definition.job_id(), job_id.Binary());
+  ASSERT_EQ(definition.actor_task_name(), "dummy_actor_task");
+  ASSERT_EQ(definition.actor_id(), actor_id.Binary());
+  ASSERT_EQ(definition.language(), Language::PYTHON);
+  ASSERT_EQ(definition.actor_func().python_function_descriptor().module_name(),
+            "dummy_module");
+  ASSERT_EQ(definition.actor_func().python_function_descriptor().function_name(),
+            "dummy_function");
+  ASSERT_EQ(definition.required_resources().at("CPU"), 1);
+  ASSERT_EQ(definition.ref_ids().at("label1"), "value1");
+}
+
+}  // namespace observability
+}  // namespace ray

--- a/src/ray/observability/tests/ray_task_definition_event_test.cc
+++ b/src/ray/observability/tests/ray_task_definition_event_test.cc
@@ -1,0 +1,110 @@
+// Copyright 2026 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "ray/observability/ray_task_definition_event.h"
+
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <utility>
+
+#include "gtest/gtest.h"
+#include "ray/common/function_descriptor.h"
+#include "ray/common/id.h"
+#include "ray/common/task/task_spec.h"
+#include "ray/common/task/task_util.h"
+
+namespace ray {
+namespace observability {
+
+class RayTaskDefinitionEventTest : public ::testing::Test {
+ public:
+  std::shared_ptr<const TaskSpecification> BuildTaskSpec(const TaskID &task_id) {
+    TaskSpecBuilder builder;
+    rpc::Address empty_address;
+    rpc::JobConfig config;
+    std::unordered_map<std::string, double> resources = {{"CPU", 1}};
+    std::unordered_map<std::string, std::string> labels = {{"label1", "value1"}};
+    builder.SetCommonTaskSpec(task_id,
+                              "dummy_task",
+                              Language::PYTHON,
+                              FunctionDescriptorBuilder::BuildPython(
+                                  "dummy_module", "dummy_class", "dummy_function", ""),
+                              JobID::Nil(),
+                              config,
+                              TaskID::Nil(),
+                              0,
+                              TaskID::Nil(),
+                              empty_address,
+                              1,
+                              false,
+                              false,
+                              -1,
+                              resources,
+                              resources,
+                              "",
+                              0,
+                              TaskID::Nil(),
+                              "",
+                              std::make_shared<rpc::RuntimeEnvInfo>(),
+                              "",
+                              true,
+                              labels);
+    return std::make_shared<const TaskSpecification>(
+        std::move(builder).ConsumeAndBuild());
+  }
+};
+
+// The task spec is turned into a TaskDefinitionEvent when the event is serialized.
+TEST_F(RayTaskDefinitionEventTest, TestSerialize) {
+  TaskID task_id = TaskID::FromRandom(JobID::FromInt(1));
+  JobID job_id = JobID::FromInt(1);
+  auto task_spec = BuildTaskSpec(task_id);
+
+  RayTaskDefinitionEvent event(task_spec,
+                               task_id,
+                               job_id,
+                               /*task_attempt=*/2,
+                               "sess1",
+                               /*timestamp=*/1000);
+
+  ASSERT_EQ(event.GetEntityId(), task_id.Binary() + "2");
+  ASSERT_EQ(event.GetTaskAttempt().first, task_id.Binary());
+  ASSERT_EQ(event.GetTaskAttempt().second, 2);
+
+  auto serialized_event = std::move(event).Serialize().value();
+
+  ASSERT_EQ(serialized_event.source_type(), rpc::events::RayEvent::CORE_WORKER);
+  ASSERT_EQ(serialized_event.event_type(), rpc::events::RayEvent::TASK_DEFINITION_EVENT);
+  ASSERT_EQ(serialized_event.severity(), rpc::events::RayEvent::INFO);
+  ASSERT_EQ(serialized_event.session_name(), "sess1");
+  ASSERT_TRUE(serialized_event.has_task_definition_event());
+
+  const auto &definition = serialized_event.task_definition_event();
+  ASSERT_EQ(definition.task_id(), task_id.Binary());
+  ASSERT_EQ(definition.task_attempt(), 2);
+  ASSERT_EQ(definition.job_id(), job_id.Binary());
+  ASSERT_EQ(definition.task_name(), "dummy_task");
+  ASSERT_EQ(definition.language(), Language::PYTHON);
+  ASSERT_EQ(definition.task_func().python_function_descriptor().module_name(),
+            "dummy_module");
+  ASSERT_EQ(definition.task_func().python_function_descriptor().function_name(),
+            "dummy_function");
+  ASSERT_EQ(definition.required_resources().at("CPU"), 1);
+  ASSERT_EQ(definition.ref_ids().at("label1"), "value1");
+  ASSERT_FALSE(definition.is_detached_actor());
+}
+
+}  // namespace observability
+}  // namespace ray

--- a/src/ray/observability/tests/ray_task_lifecycle_event_test.cc
+++ b/src/ray/observability/tests/ray_task_lifecycle_event_test.cc
@@ -1,0 +1,164 @@
+// Copyright 2026 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "ray/observability/ray_task_lifecycle_event.h"
+
+#include <memory>
+#include <optional>
+#include <utility>
+
+#include "gtest/gtest.h"
+#include "ray/common/id.h"
+#include "ray/observability/task_state_update.h"
+
+namespace ray {
+namespace observability {
+
+class RayTaskLifecycleEventTest : public ::testing::Test {};
+
+// Merging the status changes of one attempt produces a single event holding the whole
+// state-transition series, and a later change does not clear the properties reported by
+// an earlier one.
+TEST_F(RayTaskLifecycleEventTest, TestMergeAndSerialize) {
+  TaskID task_id = TaskID::FromRandom(JobID::FromInt(1));
+  JobID job_id = JobID::FromInt(1);
+  NodeID node_id = NodeID::FromRandom();
+  WorkerID worker_id = WorkerID::FromRandom();
+
+  auto event1 = std::make_unique<RayTaskLifecycleEvent>(
+      task_id,
+      job_id,
+      /*task_attempt=*/0,
+      rpc::TaskStatus::SUBMITTED_TO_WORKER,
+      std::optional<const TaskStateUpdate>(TaskStateUpdate(node_id, worker_id)),
+      "sess1",
+      /*timestamp=*/1000);
+
+  auto event2 = std::make_unique<RayTaskLifecycleEvent>(
+      task_id,
+      job_id,
+      /*task_attempt=*/0,
+      rpc::TaskStatus::RUNNING,
+      std::optional<const TaskStateUpdate>(TaskStateUpdate(static_cast<uint32_t>(4321))),
+      "sess1",
+      /*timestamp=*/2000);
+
+  ASSERT_EQ(event1->GetEntityId(), event2->GetEntityId());
+  ASSERT_EQ(event1->GetTaskAttempt().first, task_id.Binary());
+  ASSERT_EQ(event1->GetTaskAttempt().second, 0);
+
+  event1->Merge(std::move(*event2));
+  auto serialized_event = std::move(*event1).Serialize().value();
+
+  ASSERT_EQ(serialized_event.source_type(), rpc::events::RayEvent::CORE_WORKER);
+  ASSERT_EQ(serialized_event.event_type(), rpc::events::RayEvent::TASK_LIFECYCLE_EVENT);
+  ASSERT_EQ(serialized_event.severity(), rpc::events::RayEvent::INFO);
+  ASSERT_EQ(serialized_event.session_name(), "sess1");
+  ASSERT_TRUE(serialized_event.has_task_lifecycle_event());
+
+  const auto &lifecycle = serialized_event.task_lifecycle_event();
+  ASSERT_EQ(lifecycle.task_id(), task_id.Binary());
+  ASSERT_EQ(lifecycle.task_attempt(), 0);
+  ASSERT_EQ(lifecycle.job_id(), job_id.Binary());
+
+  ASSERT_EQ(lifecycle.state_transitions_size(), 2);
+  ASSERT_EQ(lifecycle.state_transitions(0).state(), rpc::TaskStatus::SUBMITTED_TO_WORKER);
+  ASSERT_EQ(lifecycle.state_transitions(0).timestamp().nanos(), 1000);
+  ASSERT_EQ(lifecycle.state_transitions(1).state(), rpc::TaskStatus::RUNNING);
+  ASSERT_EQ(lifecycle.state_transitions(1).timestamp().nanos(), 2000);
+
+  // The node/worker reported by the first change survive the merge with a change that
+  // does not carry them, and the second change's pid is applied.
+  ASSERT_EQ(lifecycle.node_id(), node_id.Binary());
+  ASSERT_EQ(lifecycle.worker_id(), worker_id.Binary());
+  ASSERT_EQ(lifecycle.worker_pid(), 4321);
+}
+
+// A status change with no state update contributes only its state transition.
+TEST_F(RayTaskLifecycleEventTest, TestSerializeWithoutStateUpdate) {
+  TaskID task_id = TaskID::FromRandom(JobID::FromInt(2));
+
+  RayTaskLifecycleEvent event(task_id,
+                              JobID::FromInt(2),
+                              /*task_attempt=*/3,
+                              rpc::TaskStatus::FINISHED,
+                              std::nullopt,
+                              "sess2",
+                              /*timestamp=*/5000);
+
+  auto serialized_event = std::move(event).Serialize().value();
+  const auto &lifecycle = serialized_event.task_lifecycle_event();
+  ASSERT_EQ(lifecycle.task_attempt(), 3);
+  ASSERT_EQ(lifecycle.state_transitions_size(), 1);
+  ASSERT_EQ(lifecycle.state_transitions(0).state(), rpc::TaskStatus::FINISHED);
+  ASSERT_EQ(lifecycle.state_transitions(0).timestamp().nanos(), 5000);
+  ASSERT_TRUE(lifecycle.node_id().empty());
+  ASSERT_EQ(lifecycle.worker_pid(), 0);
+  ASSERT_FALSE(lifecycle.has_is_debugger_paused());
+}
+
+// Log start and log end arrive as two separate updates carrying disjoint task_log_info
+// sub-fields. Merging them must accumulate all six fields, not let the later update
+// overwrite the earlier one's file paths and start offsets.
+TEST_F(RayTaskLifecycleEventTest, TestMergeCombinesTaskLogInfo) {
+  TaskID task_id = TaskID::FromRandom(JobID::FromInt(1));
+  JobID job_id = JobID::FromInt(1);
+
+  rpc::TaskLogInfo start_log;
+  start_log.set_stdout_file("out.log");
+  start_log.set_stderr_file("err.log");
+  start_log.set_stdout_start(10);
+  start_log.set_stderr_start(20);
+
+  rpc::TaskLogInfo end_log;
+  end_log.set_stdout_end(100);
+  end_log.set_stderr_end(200);
+
+  auto log_start = std::make_unique<RayTaskLifecycleEvent>(
+      task_id,
+      job_id,
+      /*task_attempt=*/0,
+      rpc::TaskStatus::NIL,
+      std::optional<const TaskStateUpdate>(TaskStateUpdate(start_log)),
+      "sess1",
+      /*timestamp=*/1000);
+
+  auto log_end = std::make_unique<RayTaskLifecycleEvent>(
+      task_id,
+      job_id,
+      /*task_attempt=*/0,
+      rpc::TaskStatus::NIL,
+      std::optional<const TaskStateUpdate>(TaskStateUpdate(end_log)),
+      "sess1",
+      /*timestamp=*/2000);
+
+  log_start->Merge(std::move(*log_end));
+  auto serialized_event = std::move(*log_start).Serialize().value();
+  const auto &lifecycle = serialized_event.task_lifecycle_event();
+
+  // NIL log-only updates carry no state transition.
+  ASSERT_EQ(lifecycle.state_transitions_size(), 0);
+
+  ASSERT_TRUE(lifecycle.has_task_log_info());
+  const auto &log_info = lifecycle.task_log_info();
+  ASSERT_EQ(log_info.stdout_file(), "out.log");
+  ASSERT_EQ(log_info.stderr_file(), "err.log");
+  ASSERT_EQ(log_info.stdout_start(), 10);
+  ASSERT_EQ(log_info.stderr_start(), 20);
+  ASSERT_EQ(log_info.stdout_end(), 100);
+  ASSERT_EQ(log_info.stderr_end(), 200);
+}
+
+}  // namespace observability
+}  // namespace ray


### PR DESCRIPTION
Cherry-pick of #65288 (master commit 56479c46aaaf15237892feb5a58fa97e54d47fbc) onto `releases/2.58.0`.

Fresh single-commit pick against the current release head (9/n merged via #65358). Note: despite the "2.5/n" label, this merged to master after 9/n and before 10/n — this cherry-pick preserves that chronological order. Parallels old #65338, which should be closed in favor of this one.

Clean cherry-pick, no conflicts (`git cherry-pick -x -s`); 22 files, +1096/−330. AI-assisted (Claude Code); submitted and reviewed by @elliot-barn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)