### PR TITLE
[cherry-pick][2.58.0][core][taskEvents out of GCS][10/n] Fix bugs found after migration (#65247)

### DIFF
--- a/python/ray/_private/state.py
+++ b/python/ray/_private/state.py
@@ -1184,6 +1184,14 @@ def timeline(filename: Optional[str] = None):
             "Ray has not been started yet. Timeline requires Ray to be initialized first."
         )
 
+    logger.warning(
+        "In the near future, ray.timeline() will read task profiling events from the Ray "
+        "dashboard (API server) instead of from GCS. If you have already turned on "
+        "RAY_enable_task_events_to_dashboard_head, ray.timeline() reads from the dashboard "
+        "now. Make sure your Ray cluster is started with the dashboard running if you want "
+        "to use ray.timeline()."
+    )
+
     return state.chrome_tracing_dump(filename=filename)
 
 

--- a/python/ray/dashboard/modules/aggregator/tests/test_aggregator_agent.py
+++ b/python/ray/dashboard/modules/aggregator/tests/test_aggregator_agent.py
@@ -167,10 +167,15 @@ def test_aggregator_agent_http_target_not_enabled(
     expected_http_target_enabled,
     expected_event_processing_enabled,
 ):
-    # This test isolates HTTP-target enablement, so hold GCS publishing off regardless of
-    # its module-level default (which is read at import, not from the test env).
+    # This test isolates HTTP-target enablement, so hold the other publishers off
+    # regardless of their module-level defaults (read at import, not from the test env).
     monkeypatch.setattr(
         "ray.dashboard.modules.aggregator.aggregator_agent.PUBLISH_EVENTS_TO_GCS",
+        False,
+    )
+    monkeypatch.setattr(
+        "ray.dashboard.modules.aggregator.aggregator_agent."
+        "PUBLISH_TASK_EVENTS_TO_DASHBOARD_HEAD",
         False,
     )
     dashboard_agent = MagicMock()
@@ -1317,6 +1322,9 @@ def _get_dashboard_head_events_from_httpserver(httpserver):
                 "RAY_enable_task_events_to_dashboard_head": "1",
                 "RAY_DASHBOARD_AGGREGATOR_AGENT_PUBLISH_EVENTS_TO_EXTERNAL_HTTP_SERVICE": "True",
                 "RAY_DASHBOARD_AGGREGATOR_AGENT_EVENTS_EXPORT_ADDR": _EVENT_AGGREGATOR_AGENT_TARGET_ADDR,
+                # This test asserts the aggregator receives only the injected event, so
+                # keep the core from emitting its own ray events into the aggregator.
+                "RAY_enable_ray_event": "0",
             },
         },
     ],
@@ -1496,13 +1504,16 @@ def test_aggregator_agent_publish_to_both_gcs_and_http(
 
     agg_stub.AddEvents(request)
 
-    # Verify HTTP received the event
-    wait_for_condition(lambda: len(httpserver.log) == 1)
-    req, _ = httpserver.log[0]
-    req_json = json.loads(req.data)
-    assert len(req_json) == 1
-    assert req_json[0]["eventType"] == "TASK_DEFINITION_EVENT"
-    assert req_json[0]["taskDefinitionEvent"]["taskName"] == unique_task_name
+    # Verify HTTP received the event. Other producers share this publisher, so look for
+    # the task event across every POST instead of expecting it alone in the first one.
+    def _task_event_received():
+        return any(
+            event["eventType"] == "TASK_DEFINITION_EVENT"
+            and event["taskDefinitionEvent"]["taskName"] == unique_task_name
+            for event in _get_json_events_from_httpserver(httpserver)
+        )
+
+    wait_for_condition(_task_event_received)
 
     # Verify GCS stored the event and fields match
     _wait_for_and_verify_task_definition_event_in_gcs(unique_task_name, event)

--- a/python/ray/dashboard/modules/task_events/ray_event_converter.py
+++ b/python/ray/dashboard/modules/task_events/ray_event_converter.py
@@ -91,16 +91,22 @@ _TASK_LOG_INFO_FIELDS = (
 )
 
 
-def _convert_task_log_info(src, dst) -> None:
-    """Copy only the fields the event actually set.
+def _convert_task_log_info(src_event_log_info, dst_state_update_log_info) -> None:
+    """Copy the set log-info fields from the incoming event into the ``TaskEvents``.
 
-    The log paths and start offsets arrive when the task starts and the end offsets in a
-    later event, so copying an unset field would overwrite what the earlier event
-    reported once the two are merged.
+    ``src_event_log_info`` is the ``task_log_info`` on the incoming ``TaskLifecycleEvent``;
+    ``dst_state_update_log_info`` is the ``state_updates.task_log_info`` on the ``TaskEvents``
+    being built.
+
+    Only fields actually set in the incoming event are copied: the log paths and start
+    offsets arrive when the task starts and the end offsets in a later event, so copying an
+    unset field would overwrite what the earlier event reported once the two are merged.
     """
     for field in _TASK_LOG_INFO_FIELDS:
-        if src.HasField(field):
-            setattr(dst, field, getattr(src, field))
+        if src_event_log_info.HasField(field):
+            setattr(
+                dst_state_update_log_info, field, getattr(src_event_log_info, field)
+            )
 
 
 def _convert_task_lifecycle_event(event) -> gcs_pb2.TaskEvents:

--- a/python/ray/tests/resource_isolation/test_resource_isolation_integration.py
+++ b/python/ray/tests/resource_isolation/test_resource_isolation_integration.py
@@ -86,8 +86,13 @@ _EXPECTED_DASHBOARD_MODULES = [
     "ray.dashboard.modules.state.state_head.StateHead",
     "ray.dashboard.modules.train.train_head.TrainHead",
 ]
-# TaskEventsHead is intentionally omitted: it is gated off by default
-# (RAY_enable_task_events_to_dashboard_head) and so does not run as a subprocess here.
+# TaskEventsHead only runs as a subprocess when the migration flag is on. Mirror the
+# loader (is_enabled reads the same flag) so the expected count tracks the flag rather
+# than assuming a fixed default.
+if ray._config.enable_task_events_to_dashboard_head():
+    _EXPECTED_DASHBOARD_MODULES.append(
+        "ray.dashboard.modules.task_events.task_events_head.TaskEventsHead"
+    )
 
 # The list of processes expected to be started in the system cgroup
 # with default params for 'ray start' and 'ray.init(...)'

--- a/python/ray/tests/test_memory_pressure.py
+++ b/python/ray/tests/test_memory_pressure.py
@@ -1,3 +1,4 @@
+import os
 import sys
 import time
 from math import ceil
@@ -35,7 +36,13 @@ def get_local_state_client():
     )
 
     gcs_client = ray._private.worker.global_worker.gcs_client
-    return StateDataSourceClient(gcs_channel, gcs_client)
+    node = ray._private.worker.global_worker.node
+    return StateDataSourceClient(
+        gcs_channel,
+        gcs_client,
+        dashboard_socket_dir=os.path.join(node.get_session_dir_path(), "sockets"),
+        dashboard_session_name=node.session_name,
+    )
 
 
 @pytest.fixture

--- a/python/ray/tests/test_state_api.py
+++ b/python/ray/tests/test_state_api.py
@@ -122,7 +122,13 @@ def state_source_client(gcs_address):
         gcs_address, GRPC_CHANNEL_OPTIONS, asynchronous=True
     )
     gcs_client = GcsClient(address=gcs_address)
-    client = StateDataSourceClient(gcs_channel=gcs_channel, gcs_client=gcs_client)
+    node = ray._private.worker.global_worker.node
+    client = StateDataSourceClient(
+        gcs_channel=gcs_channel,
+        gcs_client=gcs_client,
+        dashboard_socket_dir=os.path.join(node.get_session_dir_path(), "sockets"),
+        dashboard_session_name=node.session_name,
+    )
     return client
 
 
@@ -1390,7 +1396,10 @@ def test_state_api_rate_limit_with_failure(monkeypatch, shutdown_only):
     # Set environment
     with monkeypatch.context() as m:
         m.setenv("RAY_STATE_SERVER_MAX_HTTP_REQUEST", "3")
-        # These make list_nodes, list_workers, list_actors never return in 20secs
+        # Pin the read path to GCS so list_tasks stays a delayable GCS
+        # GetTaskEvents query.
+        m.setenv("RAY_enable_task_events_to_dashboard_head", "0")
+        # These make list_tasks, list_workers, list_actors never return in 20secs
         m.setenv(
             "RAY_testing_asio_delay_us",
             (

--- a/python/ray/tests/test_state_api_data_source_client_get.py
+++ b/python/ray/tests/test_state_api_data_source_client_get.py
@@ -70,7 +70,13 @@ def state_source_client(gcs_address):
         gcs_address, GRPC_CHANNEL_OPTIONS, asynchronous=True
     )
     gcs_client = GcsClient(address=gcs_address)
-    client = StateDataSourceClient(gcs_channel=gcs_channel, gcs_client=gcs_client)
+    node = ray._private.worker.global_worker.node
+    client = StateDataSourceClient(
+        gcs_channel=gcs_channel,
+        gcs_client=gcs_client,
+        dashboard_socket_dir=os.path.join(node.get_session_dir_path(), "sockets"),
+        dashboard_session_name=node.session_name,
+    )
     return client
 
 
@@ -1140,7 +1146,14 @@ def test_get_id_not_found(shutdown_only):
 @patch.object(
     StateDataSourceClient, "__init__", lambda self, gcs_channel, gcs_client: None
 )
-async def test_state_data_source_client_get_all_task_info_no_early_return():
+async def test_state_data_source_client_get_all_task_info_no_early_return(monkeypatch):
+    # Force the GCS read path. get_all_task_info routes on the module-level constant
+    # _READ_TASK_EVENTS_FROM_DASHBOARD_HEAD, computed once at import from
+    # ray._config.enable_task_events_to_dashboard_head(), so patch the constant.
+    monkeypatch.setattr(
+        "ray.util.state.state_manager._READ_TASK_EVENTS_FROM_DASHBOARD_HEAD", False
+    )
+
     #  Setup
     mock_gcs_task_info_stub = AsyncMock(TaskInfoGcsServiceStub)
 

--- a/python/ray/tests/test_task_events_2.py
+++ b/python/ray/tests/test_task_events_2.py
@@ -288,8 +288,19 @@ def test_fault_tolerance_detached_actor(shutdown_only):
     )
 
 
-def test_fault_tolerance_job_failed(shutdown_only):
+def test_fault_tolerance_job_failed(shutdown_only, monkeypatch):
+    # These delays are read by the dashboard-head store from ray._config; set them via
+    # env vars so the head subprocess picks them up even if _system_config does not
+    # propagate to the head's ray._config.
+    monkeypatch.setenv("RAY_gcs_mark_task_failed_on_job_done_delay_ms", "1000")
+    monkeypatch.setenv("RAY_gcs_mark_task_failed_on_worker_dead_delay_ms", "30000")
     sys_config = _SYSTEM_CONFIG.copy()
+
+    # We set the config here again after setting env variables for the GCS path. If
+    # we don't set it then _SYSTEM_CONFIG takes effect, which has both the delays
+    # set to 1000ms. This is because system config overrides the env variable setting.
+    # Since, we specifically want the delays to be 1000 and 30000, we set the config
+    # again.
     config = {
         "gcs_mark_task_failed_on_job_done_delay_ms": 1000,
         # make worker failure not trigger task failure
@@ -451,7 +462,7 @@ def test_fault_tolerance_nested_actors_failed(shutdown_only):
     )
 
 
-def test_ray_intentional_errors(shutdown_only):
+def test_ray_intentional_errors(shutdown_only, monkeypatch):
     """
     Test in the below cases, ray task should not be marked as failure:
     1. ray.actor_exit_actor()
@@ -475,6 +486,9 @@ def test_ray_intentional_errors(shutdown_only):
     # Avoid worker-dead marking racing with max_calls task completion.
     sys_config = _SYSTEM_CONFIG.copy()
     sys_config["gcs_mark_task_failed_on_worker_dead_delay_ms"] = 30000
+    # Read by the dashboard-head store from ray._config; set via env var so the head
+    # subprocess picks it up even if _system_config does not propagate to the head.
+    monkeypatch.setenv("RAY_gcs_mark_task_failed_on_worker_dead_delay_ms", "30000")
     ray.init(num_cpus=1, _system_config=sys_config)
 
     a = Actor.remote()
@@ -943,10 +957,14 @@ def test_task_logs_info_running_task(shutdown_only):
 
 
 @pytest.mark.asyncio
-async def test_task_events_gc_jobs(shutdown_only):
+async def test_task_events_gc_jobs(shutdown_only, monkeypatch):
     """
     Test that later jobs should override previous jobs' task events.
     """
+    # The dashboard-head store reads its cap from ray._config at import time. Set it via
+    # the env var so the head subprocess picks it up even if _system_config does not
+    # propagate to the head's ray._config.
+    monkeypatch.setenv("RAY_task_events_max_num_task_in_gcs", "3")
     ctx = ray.init(
         num_cpus=8,
         _system_config={
@@ -996,7 +1014,7 @@ ray.get([f.options(name="f.{task_name}").remote() for _ in range(10)])
         )
 
 
-def test_task_events_gc_default_policy(shutdown_only):
+def test_task_events_gc_default_policy(shutdown_only, monkeypatch):
     @ray.remote
     def finish_task():
         pass
@@ -1020,6 +1038,9 @@ def test_task_events_gc_default_policy(shutdown_only):
     def error_task():
         raise ValueError("Expected to fail")
 
+    # Read by the dashboard-head store from ray._config; set via env var so the head
+    # subprocess picks it up even if _system_config does not propagate to the head.
+    monkeypatch.setenv("RAY_task_events_max_num_task_in_gcs", "5")
     ray_context = ray.init(
         num_cpus=8,
         _system_config={


### PR DESCRIPTION
Cherry-pick of #65247 (master commit 4a3d4ea3ed5299ef1be28c20cfc237033f643b3e) onto `releases/2.58.0`. Final part of the series — the branch now carries 1/n–6/n (7/n shipped inside the 6/n squash), 8/n, 9/n, and 2.5/n in master-chronological order.

**One conflict, manually resolved** (`test_aggregator_agent.py`): the original commit adds `"RAY_enable_ray_event": "0"` (+ comment) to a test env dict and deletes two adjacent TODO comment lines that exist only on master (from an unpicked commit). The release branch never had those TODO lines, so the resolution takes the addition as-is; the resulting test content matches master's post-#65247 state for that hunk. All other 7 files applied cleanly.

`git cherry-pick -x -s`; 8 files, +107/−27 (vs +106/−29 on master — delta is exactly the two never-present TODO deletions). Pre-commit hooks pass. AI-assisted (Claude Code); submitted and reviewed by @elliot-barn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)