### PR TITLE
[core] Fix RemoveSubmittedTaskReferences abandoning the batch on a missing ID

### DIFF
--- a/src/ray/core_worker/reference_counter.cc
+++ b/src/ray/core_worker/reference_counter.cc
@@ -619,7 +619,7 @@ void ReferenceCounter::RemoveSubmittedTaskReferences(
     if (it == object_id_refs_.end()) {
       RAY_LOG(WARNING) << "Tried to decrease ref count for nonexistent object ID: "
                        << argument_id;
-      return;
+      continue;
     }
     RAY_CHECK(it->second.submitted_task_ref_count > 0);
     it->second.submitted_task_ref_count--;


### PR DESCRIPTION
## Why are these changes needed?

Fixes #65320. `ReferenceCounter::RemoveSubmittedTaskReferences` walks a batch of argument IDs and drops each one's submitted-task ref. When an ID is not found in `object_id_refs_`, it logs a warning and **returns**, skipping every remaining argument in the batch:

```cpp
auto it = object_id_refs_.find(argument_id);
if (it == object_id_refs_.end()) {
  RAY_LOG(WARNING) << "Tried to decrease ref count for nonexistent object ID: " << argument_id;
  return;                                  // skips every remaining argument
}
```

Every argument after the missing one keeps its `submitted_task_ref_count` (and `lineage_ref_count` when `release_lineage` is true). `RefCount()` never reaches zero for those objects, so `DeleteReferenceInternal` never runs — the plasma value stays pinned and the task spec stays pinned as lineage for the lifetime of the process. Both common callers pass `release_lineage=true`, so the lineage leak is the usual outcome.

Every sibling batch loop in this same file treats a missing/ineligible entry as *skip-this-one* rather than *abandon-the-batch* — `ReleaseLineageReferences`, `FreePlasmaObjects`, and `PopAndClearLocalBorrowers` all use `continue`. `git blame` shows the `return` predates the wrapping `for` loop: it dates to when the function handled a single object (`e50aa99be1e`, 2019-12), and the loop was added two months later (`4c2de7be540`, 2020-02) without revisiting it — i.e. a refactor leftover, not a deliberate abort.

This changes the `return` to `continue` so one missing ID no longer leaks the ref counts of every argument after it in the batch.

## Note on reachability / testing

As the issue notes, under correct accounting this branch cannot fire (`EraseReference` is CHECK-gated on `RefCount() == 0`, which includes `submitted_task_ref_count`, so an entry with a live submitted ref is never erased). The branch only fires after an upstream double-decrement has already occurred — a bug class that has recurred (e.g. #56123, #18908). So this is defensive: when that situation does arise, it should degrade to "skip the bad ID and correctly release the rest" instead of leaking every subsequent object for the process lifetime, matching how the sibling loops already behave.

Because this is a one-token change to match the file's existing convention, I did not add a dedicated test (constructing the missing-entry state requires reproducing an upstream double-decrement). Happy to add a targeted unit test if maintainers would prefer one — guidance welcome on the preferred way to set up that state in the reference-counter tests.

## Related issue number

Closes #65320

## Checks

- [x] I've made sure the change is scoped to a single, self-contained fix matching the existing `continue`-on-skip convention used by the sibling loops in this file.
