### PR TITLE
[ci] Record why the Serve request-router API exemptions exist

### DIFF
--- a/ci/ray_ci/doc/cmd_check_api_discrepancy.py
+++ b/ci/ray_ci/doc/cmd_check_api_discrepancy.py
@@ -119,7 +119,29 @@ TEAM_API_CONFIGS = {
         "head_doc_file": "doc/source/serve/api/index.md",
         "white_list_apis": set(),
         "tracked_doc_debt": {
-            # private versions of request router APIs
+            # Request-router extension surface. All eight are @PublicAPI classes
+            # DEFINED under ray.serve._private.*, which the API policy in
+            # doc/source/ray-contribute/api-policy.md forbids at every exposure
+            # level ("Can this API be private ...? No").
+            #
+            # Seven of them are re-exported by the public ray.serve.request_router
+            # module and documented in this file's own head_doc_file under that
+            # public path, so they look documented to a reader. They are not
+            # documented under the name this check uses: Module._fullname names
+            # every symbol f"{__module__}.{__qualname__}", the definition site.
+            # Deleting these seven entries fails the check with all seven reported
+            # as undocumented, so the exemption is load-bearing today.
+            #
+            # The resolution is to move the definitions into the public
+            # ray/serve/request_router.py that currently only re-exports them. Then
+            # the canonical name is the public path, the autosummary entry matches,
+            # and these entries can be deleted outright. That is a Serve-owned
+            # source change; until it happens this stays tracked debt rather than a
+            # permanent exemption, because the underlying policy violation is real.
+            #
+            # PowerOfTwoChoicesRequestRouter is the one symbol absent from both the
+            # public re-export list and the autosummary, so it additionally needs
+            # documenting or de-annotating.
             "ray.serve._private.common.ReplicaID",
             "ray.serve._private.request_router.common.PendingRequest",
             "ray.serve._private.request_router.pow_2_router.PowerOfTwoChoicesRequestRouter",


### PR DESCRIPTION
Comment-only. Both serve exemption sets are byte-identical to master, verified by an AST diff; nothing about what the check accepts changes.

## What the comment said, and why it was wrong

The eight request-router entries in the serve team's `tracked_doc_debt` were labelled "private versions of request router APIs", which doesn't say what's owed or to whom.

All eight are `@PublicAPI` classes **defined** under `ray.serve._private.*`. `doc/source/ray-contribute/api-policy.md` forbids that at every exposure level:

> Can this API be private (either inside the `_internal` module or has an underscore prefix)? — **No**

So these entries record a **policy violation at the definition site**, not a documentation gap. That distinction changes who fixes them and how.

## Why they're exempt even though they look documented

Seven of the eight are re-exported by the public `ray.serve.request_router` module and are listed in this team's own `head_doc_file` under `serve.request_router.*`. To a reader they're documented.

They aren't documented under the name the check uses. `Module._fullname` names every symbol `f"{__module__}.{__qualname__}"` — the definition site — so a symbol documented under a re-export path can never match its canonical `ray.serve._private.*` name.

I verified the exemptions are load-bearing rather than stale by deleting the seven and running the serve check:

```
Public APIs that are NOT documented:
	ray.serve._private.common.ReplicaID
	ray.serve._private.request_router.common.PendingRequest
	ray.serve._private.request_router.request_router.RequestRouter
	ray.serve._private.request_router.replica_wrapper.RunningReplica
	ray.serve._private.request_router.request_router.FIFOMixin
	ray.serve._private.request_router.request_router.LocalityMixin
	ray.serve._private.request_router.request_router.MultiplexMixin
Some public serve APIs are not documented. Please document them.
```

Baseline exits 0, the delete arm exits 1, and that's the only variable between the two runs.

## What would actually clear them

Move the definitions into the public `ray/serve/request_router.py` that currently only re-exports them. The canonical name then *is* the public path, the autosummary entry matches, and the entries can be deleted outright.

That's a Serve-owned source change and I'm not proposing it here. Until it happens these stay `tracked_doc_debt`, because the underlying policy violation is real. I considered reclassifying them as permanent exemptions and decided against it: that would record a policy violation as intended behavior.

`PowerOfTwoChoicesRequestRouter` is the one symbol absent from **both** the public re-export list and the autosummary, so it additionally needs documenting or de-annotating.

## Note for reviewers

I'm a docs-side contributor, not a Serve code owner. This touches no annotation, no Serve source file, and no check behavior. It's a comment so the next person reading this config can tell what's owed and who owns it.

Happy to be told the relocation is unwanted and the policy should instead bless private-definition-plus-public-re-export as a pattern. That'd be a fine outcome too — it just wants deciding once and applying uniformly, rather than being settled per symbol in this file.
