### PR TITLE
[serve] Extend controller benchmark sweep to 8K replicas

### DIFF
--- a/python/ray/serve/_private/benchmarks/common.py
+++ b/python/ray/serve/_private/benchmarks/common.py
@@ -358,24 +358,7 @@ class Benchmarker:
 # See https://github.com/ray-project/ray/issues/60680 for more details.
 
 CONTROLLER_BENCH_CONFIG = {
-    "checkpoints": [
-        1,
-        2,
-        4,
-        8,
-        16,
-        32,
-        64,
-        128,
-        256,
-        512,
-        1024,
-        2048,
-        3072,
-        4096,
-        6144,
-        8192,
-    ],
+    "checkpoints": [1, 2, 4, 8, 16, 32, 64, 128, 1024, 2048, 3072, 4096, 8192],
     "marination_period_s": 180,
     "sample_interval_s": 5,
 }

--- a/python/ray/serve/_private/benchmarks/common.py
+++ b/python/ray/serve/_private/benchmarks/common.py
@@ -374,7 +374,6 @@ CONTROLLER_BENCH_CONFIG = {
         3072,
         4096,
         8192,
-        16384,
     ],
     "marination_period_s": 180,
     "sample_interval_s": 5,
@@ -382,12 +381,12 @@ CONTROLLER_BENCH_CONFIG = {
 
 _CONTROLLER_AUTOSCALING_CONFIG = {
     "min_replicas": 1,
-    "max_replicas": 16384,
+    "max_replicas": 8192,
     "target_ongoing_requests": 1,
     "upscale_delay_s": 1,
 }
 
-_CONTROLLER_WAITER_TIMEOUT_S = 3600
+_CONTROLLER_WAITER_TIMEOUT_S = 2400
 # Halve the reservation as the target doubles past 4096 so peak cluster CPU stays
 # flat (~1638 CPU, ~205 nodes); these replicas are idle waiters, so a lighter
 # reservation changes packing density only, not per-replica work.
@@ -402,7 +401,7 @@ def _controller_replica_num_cpus(target_replicas: int) -> float:
 
 
 # SignalActor from ray._common.test_utils; use high max_concurrency for many
-# concurrent waiters (up to 16384 in controller benchmark).
+# concurrent waiters (up to 8192 in controller benchmark).
 _SignalActorForController = _SignalActor.options(max_concurrency=100000)
 
 

--- a/python/ray/serve/_private/benchmarks/common.py
+++ b/python/ray/serve/_private/benchmarks/common.py
@@ -374,6 +374,7 @@ CONTROLLER_BENCH_CONFIG = {
         3072,
         4096,
         8192,
+        16384,
     ],
     "marination_period_s": 180,
     "sample_interval_s": 5,
@@ -381,27 +382,27 @@ CONTROLLER_BENCH_CONFIG = {
 
 _CONTROLLER_AUTOSCALING_CONFIG = {
     "min_replicas": 1,
-    "max_replicas": 8192,
+    "max_replicas": 16384,
     "target_ongoing_requests": 1,
     "upscale_delay_s": 1,
 }
 
-_CONTROLLER_WAITER_TIMEOUT_S = 2400
+_CONTROLLER_WAITER_TIMEOUT_S = 3600
+# Halve the reservation as the target doubles past 4096 so peak cluster CPU stays
+# flat (~1638 CPU, ~205 nodes); these replicas are idle waiters, so a lighter
+# reservation changes packing density only, not per-replica work.
 _CONTROLLER_REPLICA_NUM_CPUS = 0.4
-# The 0.4 reservation would need ~410 nodes at 8192; these replicas are idle
-# waiters, so a lighter one changes packing density only, not per-replica work.
 _CONTROLLER_DENSE_PACK_ABOVE = 4096
-_CONTROLLER_DENSE_PACK_NUM_CPUS = 0.2
 
 
 def _controller_replica_num_cpus(target_replicas: int) -> float:
-    if target_replicas > _CONTROLLER_DENSE_PACK_ABOVE:
-        return _CONTROLLER_DENSE_PACK_NUM_CPUS
-    return _CONTROLLER_REPLICA_NUM_CPUS
+    if target_replicas <= _CONTROLLER_DENSE_PACK_ABOVE:
+        return _CONTROLLER_REPLICA_NUM_CPUS
+    return _CONTROLLER_REPLICA_NUM_CPUS * _CONTROLLER_DENSE_PACK_ABOVE / target_replicas
 
 
 # SignalActor from ray._common.test_utils; use high max_concurrency for many
-# concurrent waiters (up to 8192 in controller benchmark).
+# concurrent waiters (up to 16384 in controller benchmark).
 _SignalActorForController = _SignalActor.options(max_concurrency=100000)
 
 

--- a/python/ray/serve/_private/benchmarks/common.py
+++ b/python/ray/serve/_private/benchmarks/common.py
@@ -700,7 +700,8 @@ async def run_controller_benchmark(
             hello_world = ControllerBenchHelloWorld.bind(signal_actor)
             app = ControllerBenchMetricsGenerator.options(
                 ray_actor_options={
-                    "num_cpus": _controller_replica_num_cpus(target_replicas)
+                    **(ControllerBenchMetricsGenerator.ray_actor_options or {}),
+                    "num_cpus": _controller_replica_num_cpus(target_replicas),
                 }
             ).bind(hello_world)
             handle = serve.run(app, name="default", route_prefix=None)

--- a/python/ray/serve/_private/benchmarks/common.py
+++ b/python/ray/serve/_private/benchmarks/common.py
@@ -358,7 +358,23 @@ class Benchmarker:
 # See https://github.com/ray-project/ray/issues/60680 for more details.
 
 CONTROLLER_BENCH_CONFIG = {
-    "checkpoints": [1, 2, 4, 8, 16, 32, 64, 128, 1024, 2048, 3072, 4096, 8192],
+    "checkpoints": [
+        1,
+        2,
+        4,
+        8,
+        16,
+        32,
+        64,
+        128,
+        256,
+        512,
+        1024,
+        2048,
+        3072,
+        4096,
+        8192,
+    ],
     "marination_period_s": 180,
     "sample_interval_s": 5,
 }

--- a/python/ray/serve/_private/benchmarks/common.py
+++ b/python/ray/serve/_private/benchmarks/common.py
@@ -358,22 +358,51 @@ class Benchmarker:
 # See https://github.com/ray-project/ray/issues/60680 for more details.
 
 CONTROLLER_BENCH_CONFIG = {
-    "checkpoints": [1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 3072, 4096],
+    "checkpoints": [
+        1,
+        2,
+        4,
+        8,
+        16,
+        32,
+        64,
+        128,
+        256,
+        512,
+        1024,
+        2048,
+        3072,
+        4096,
+        6144,
+        8192,
+    ],
     "marination_period_s": 180,
     "sample_interval_s": 5,
 }
 
 _CONTROLLER_AUTOSCALING_CONFIG = {
     "min_replicas": 1,
-    "max_replicas": 4096,
+    "max_replicas": 8192,
     "target_ongoing_requests": 1,
     "upscale_delay_s": 1,
 }
 
-_CONTROLLER_WAITER_TIMEOUT_S = 1200
+_CONTROLLER_WAITER_TIMEOUT_S = 2400
+_CONTROLLER_REPLICA_NUM_CPUS = 0.4
+# The 0.4 reservation would need ~410 nodes at 8192; these replicas are idle
+# waiters, so a lighter one changes packing density only, not per-replica work.
+_CONTROLLER_DENSE_PACK_ABOVE = 4096
+_CONTROLLER_DENSE_PACK_NUM_CPUS = 0.2
+
+
+def _controller_replica_num_cpus(target_replicas: int) -> float:
+    if target_replicas > _CONTROLLER_DENSE_PACK_ABOVE:
+        return _CONTROLLER_DENSE_PACK_NUM_CPUS
+    return _CONTROLLER_REPLICA_NUM_CPUS
+
 
 # SignalActor from ray._common.test_utils; use high max_concurrency for many
-# concurrent waiters (up to 4096 in controller benchmark).
+# concurrent waiters (up to 8192 in controller benchmark).
 _SignalActorForController = _SignalActor.options(max_concurrency=100000)
 
 
@@ -401,7 +430,7 @@ class ControllerBenchHelloWorld:
     autoscaling_config=_CONTROLLER_AUTOSCALING_CONFIG,
     max_ongoing_requests=2,
     graceful_shutdown_timeout_s=1,
-    ray_actor_options={"num_cpus": 0.4},
+    ray_actor_options={"num_cpus": _CONTROLLER_REPLICA_NUM_CPUS},
 )
 class ControllerBenchMetricsGenerator:
     """Autoscaling deployment that generates handle metrics to stress the controller."""
@@ -669,7 +698,11 @@ async def run_controller_benchmark(
     try:
         for checkpoint_idx, target_replicas in enumerate(checkpoints):
             hello_world = ControllerBenchHelloWorld.bind(signal_actor)
-            app = ControllerBenchMetricsGenerator.bind(hello_world)
+            app = ControllerBenchMetricsGenerator.options(
+                ray_actor_options={
+                    "num_cpus": _controller_replica_num_cpus(target_replicas)
+                }
+            ).bind(hello_world)
             handle = serve.run(app, name="default", route_prefix=None)
 
             samples = await _controller_run_checkpoint(

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -1670,7 +1670,7 @@
     project_id: prj_lhlrf1u5yv8qz9qg3xzw8fkiiq
 
   run:
-    timeout: 21600
+    timeout: 28800
     long_running: false
     script: python workloads/microbenchmarks.py --run-controller
 

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -1670,7 +1670,7 @@
     project_id: prj_lhlrf1u5yv8qz9qg3xzw8fkiiq
 
   run:
-    timeout: 28800
+    timeout: 21600
     long_running: false
     script: python workloads/microbenchmarks.py --run-controller
 

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -1670,7 +1670,7 @@
     project_id: prj_lhlrf1u5yv8qz9qg3xzw8fkiiq
 
   run:
-    timeout: 14400
+    timeout: 21600
     long_running: false
     script: python workloads/microbenchmarks.py --run-controller
 

--- a/release/serve_tests/compute_tpl_8_cpu_autoscaling.yaml
+++ b/release/serve_tests/compute_tpl_8_cpu_autoscaling.yaml
@@ -8,8 +8,8 @@ advanced_instance_config:
           Value: '24'
 
 head_node:
-    # 8 cpus, x86, 32G mem, 10Gb NIC, $0.384/hr on demand
-    instance_type: m5.2xlarge
+    # 16 cpus, x86, 64G mem, 10Gb NIC, $0.768/hr on demand
+    instance_type: m5.4xlarge
     resources:
       CPU: 0
       proxy: 1

--- a/release/serve_tests/compute_tpl_8_cpu_autoscaling.yaml
+++ b/release/serve_tests/compute_tpl_8_cpu_autoscaling.yaml
@@ -8,8 +8,8 @@ advanced_instance_config:
           Value: '24'
 
 head_node:
-    # 16 cpus, x86, 64G mem, 10Gb NIC, $0.768/hr on demand
-    instance_type: m5.4xlarge
+    # 32 cpus, x86, 128G mem, 10Gb NIC, $1.536/hr on demand
+    instance_type: m5.8xlarge
     resources:
       CPU: 0
       proxy: 1

--- a/release/serve_tests/compute_tpl_8_cpu_autoscaling.yaml
+++ b/release/serve_tests/compute_tpl_8_cpu_autoscaling.yaml
@@ -8,8 +8,8 @@ advanced_instance_config:
           Value: '24'
 
 head_node:
-    # 32 cpus, x86, 128G mem, 10Gb NIC, $1.536/hr on demand
-    instance_type: m5.8xlarge
+    # 16 cpus, x86, 64G mem, 10Gb NIC, $0.768/hr on demand
+    instance_type: m5.4xlarge
     resources:
       CPU: 0
       proxy: 1


### PR DESCRIPTION
This PR extends the controller benchmark sweep to 8192 replicas so it 
covers the current scaling targets.

The CPU reservation halves as the target doubles past 4096, num_cpus=0.4 at or below
4096, 0.2 at 8192. That pins peak cluster demand at ~1638 CPU (~205 nodes) at
every high-N checkpoint, so the existing 220-node cap still holds: no `max_nodes`
change and no cost increase. Checkpoints at or below 4096 keep the 0.4
reservation so their historical series stay comparable. These replicas are idle
waiters blocked on a signal actor, so the lighter reservation changes packing
density only, not per-replica work. It is written as a rule rather than a second
constant so the invariant (peak CPU stays flat) is explicit and extending the
sweep later is a one-line change.

The head node moves to m5.4xlarge. Node count is unchanged at ~205, but actor
count doubles at 8192, and m5.2xlarge is known to starve `gcs_server` at higher
replica counts.

Raises the healthy-wait ceiling to 2400s and the release test timeout to 21600s
to cover the additional ramp.

Caveat for reading the resulting curve: 8192 runs at a lighter CPU reservation
than the 256-4096 points, so there is a packing-density discontinuity above 4096.
The existing series are unchanged.
