### PR TITLE
[ci] Pin all four team:ml ray-core notebooks in doc rules golden file

### DIFF
--- a/.buildkite/test.rules.test.txt
+++ b/.buildkite/test.rules.test.txt
@@ -96,6 +96,8 @@ doc/source/ray-observability/example.py: core_doc
 # The four ray-core notebooks whose targets are tagged team:ml route to ml_doc,
 # because the core step filters targets by team and would not execute them.
 doc/source/ray-core/examples/plot_hyperparameter.ipynb: ml_doc
+doc/source/ray-core/examples/batch_prediction.ipynb: ml_doc
+doc/source/ray-core/examples/plot_parameter_server.ipynb: ml_doc
 doc/source/ray-core/examples/plot_pong_example.ipynb: ml_doc
 # highly_parallel.ipynb is the exception: the ml docs example step excludes its
 # tag, so no step runs it. It routes to the build instead.

--- a/.buildkite/test.rules.test.txt
+++ b/.buildkite/test.rules.test.txt
@@ -1,7 +1,12 @@
-# Test cases for Ray CI test rules
-# Based on ci/pipeline/test_conditional_testing.py _TESTS_YAML
+# Unit tests for test.rules.txt
 #
-# Format: file: tag1 tag2 tag3
+# Format: file_path: tag1 tag2 tag3
+#
+# Run by `rayci test-rules`, which pairs each *.rules.txt in this directory
+# with its *.rules.test.txt companion by name. Each rules file is evaluated on
+# its own, so the tags expected below are the ones test.rules.txt emits by
+# itself; the "always lint" that always.rules.txt contributes to every real
+# build is covered by always.rules.test.txt instead.
 
 # === CI/Pipeline ===
 


### PR DESCRIPTION
## Why this change is needed

`.buildkite/test.rules.txt` routes four `team:ml`-tagged Ray Core notebooks to the `ml_doc` tag, because the core docs example step filters Bazel targets by team and would not execute them:

```
doc/source/ray-core/examples/plot_hyperparameter.ipynb
doc/source/ray-core/examples/batch_prediction.ipynb
doc/source/ray-core/examples/plot_parameter_server.ipynb
doc/source/ray-core/examples/plot_pong_example.ipynb
@ ml_doc
```

The companion golden file `.buildkite/test.rules.test.txt` has a comment describing "the four ray-core notebooks," but pins only two of them: `plot_hyperparameter.ipynb` and `plot_pong_example.ipynb`.

That leaves `batch_prediction.ipynb` and `plot_parameter_server.ipynb` unguarded. A future edit to the rules that stopped routing either notebook to `ml_doc` would send it to `core_doc` instead, where the team filter means no step executes it, and the golden suite would still pass. The routing for these notebooks is deliberately non-obvious, which is exactly why it should be pinned.

## What this changes

Adds the two missing golden cases so all four rule entries have matching assertions. No change to `test.rules.txt`, so no change to what CI runs today.

## Verification

`rayci test-rules` passes with the two added cases, and both notebooks are confirmed present and documented as `team:ml` in `doc/source/ray-core/examples/BUILD.bazel`.
