### PR TITLE
[doc] Only build unpinned templates from main-branch builds

### DIFF
--- a/doc/source/template_collections.py
+++ b/doc/source/template_collections.py
@@ -236,7 +236,18 @@ def _resolve_template_url(name):
     data = json.loads(
         _urlopen_read_with_retries(api_url, _TEMPLATE_CHANNEL_TIMEOUT_S)
     )
-    branch = data.get("tmpl_branch")
+    # A channel response with no `tmpl_branch` is schema drift, not a
+    # feature-branch build, and it needs a different fix than "add a pin" -- so
+    # say so rather than reporting a branch of None. Either way the build stops:
+    # if the branch can't be confirmed as `main`, the content isn't publishable.
+    if "tmpl_branch" not in data:
+        raise RuntimeError(
+            f"sphinx-collections: {api_url} returned no 'tmpl_branch', so the "
+            f"build for unpinned template {name!r} can't be confirmed to come "
+            f"from {_TEMPLATE_RELEASE_BRANCH!r}. The templates.ci.ray.io channel "
+            f"schema has probably changed; update this branch check to match it."
+        )
+    branch = data["tmpl_branch"]
     if branch != _TEMPLATE_RELEASE_BRANCH:
         raise RuntimeError(
             f"sphinx-collections: refusing to build unpinned template {name!r} "

--- a/doc/source/template_collections.py
+++ b/doc/source/template_collections.py
@@ -40,6 +40,9 @@ logger = logging.getLogger(__name__)
 _TEMPLATES_CI_BASE = "https://templates.ci.ray.io"
 _TEMPLATE_CHANNEL_API = _TEMPLATES_CI_BASE + "/templates/{name}/latest/channel.json"
 
+# The only templates-repo branch whose builds may be rendered into these docs.
+_TEMPLATE_RELEASE_BRANCH = "main"
+
 # Hard timeouts on the templates.ci.ray.io HTTP calls. The doc build previously
 # stalled when the templates host was slow or unresponsive (#63112 revert);
 # explicit timeouts let urlopen surface a TimeoutError instead of hanging
@@ -188,7 +191,10 @@ _TEMPLATE_COLLECTIONS = {
 # `latest` let a template's notebook rename silently break an otherwise-unchanged
 # docs build the moment the rebuilt artifact was promoted.) Pins are bumped by
 # the auto-bump workflow in anyscale/docs from each template's
-# latest/channel.json `tmpl_build_id`; prefer that PR over hand-editing the JSON.
+# latest/channel.json `tmpl_build_id`, but only when that build came from the
+# templates repo's `main` branch -- `latest` tracks the most recent build on any
+# branch, including unmerged template PRs. Prefer that PR over hand-editing the
+# JSON.
 #
 # Pinning assumes templates.ci.ray.io retains per-build artifacts. If an old
 # build is removed, its stale pin no longer fetches.
@@ -205,6 +211,13 @@ def _resolve_template_url(name):
     channel API. A template not yet in ``_TEMPLATE_PINS`` -- e.g. one just added
     to ``_TEMPLATE_COLLECTIONS`` -- falls back to ``latest`` with a warning so
     it still builds until a pin is added.
+
+    That fallback accepts only a ``main`` build. ``latest`` tracks the most
+    recent build on *any* templates-repo branch, so it's regularly a build from
+    an unmerged template PR; rendering one would publish unreviewed content to
+    docs.ray.io, and nothing downstream would notice because that content builds
+    fine. templates.ci.ray.io exposes no main-only channel to ask instead, so
+    this fails the build with an error naming the fix (pin the template).
     """
     build_id = _TEMPLATE_PINS.get(name)
     if build_id is not None:
@@ -223,6 +236,18 @@ def _resolve_template_url(name):
     data = json.loads(
         _urlopen_read_with_retries(api_url, _TEMPLATE_CHANNEL_TIMEOUT_S)
     )
+    branch = data.get("tmpl_branch")
+    if branch != _TEMPLATE_RELEASE_BRANCH:
+        raise RuntimeError(
+            f"sphinx-collections: refusing to build unpinned template {name!r} "
+            f"from build {data.get('tmpl_build_id')!r}, which came from branch "
+            f"{branch!r} rather than {_TEMPLATE_RELEASE_BRANCH!r}. "
+            f"templates.ci.ray.io publishes 'latest' for whichever build ran "
+            f"most recently on any branch, so this would render content from an "
+            f"unmerged template PR into the published docs. Add a pin for "
+            f"{name!r} to template_pins.json (a build id from a "
+            f"{_TEMPLATE_RELEASE_BRANCH!r} build) instead of relying on 'latest'."
+        )
     # Replace the ascommon:/// protocol with the templates.ci.ray.io base URL,
     # then append /build.zip to get the docs build archive.
     url = data["url"].replace("ascommon:///", _TEMPLATES_CI_BASE + "/")


### PR DESCRIPTION
## Why are these changes needed?

`_resolve_template_url` falls back to a template's `latest` build when it has no entry in `template_pins.json`, so a newly added template still builds before its pin lands.

But `templates.ci.ray.io` publishes `latest` for whichever build ran most recently on **any** branch, so `latest` is regularly a build from an unmerged template PR. As of today, for example:

```
$ curl -s https://templates.ci.ray.io/templates/mcp-ray-serve/latest/channel.json
  "tmpl_build_id": "20260803-194950",
  "tmpl_branch": "fix/mcp-ray-serve-router-runtime-env",
```

Taking that path would render unreviewed template content into the published docs, and nothing downstream would catch it: the branch content builds fine, so `fail_on_warning` stays green. It just isn't the content that shipped.

`templates.ci.ray.io` exposes no main-only channel to ask instead (`/main`, `/stable`, `/latest-main` all return 403), so the fallback can't silently pick a better build.

## What this changes

Check `tmpl_branch` on the resolved channel and fail the build with an error naming the fix (add a pin) rather than rendering off-`main` content.

Every template in `_TEMPLATE_COLLECTIONS` is currently pinned, so **this changes no existing build** — it guards the newly-added-template path, which is exactly when the fallback fires and exactly when nobody is looking closely at where the content came from.

Verified against live channel data: pinned templates resolve unchanged with no channel-API call, and an unpinned `mcp-ray-serve` raises:

```
sphinx-collections: refusing to build unpinned template 'mcp-ray-serve' from build
'20260803-194950', which came from branch 'fix/mcp-ray-serve-router-runtime-env'
rather than 'main'. ... Add a pin for 'mcp-ray-serve' to template_pins.json
```

The companion change to the auto-bump job that maintains these pins applies the same rule, so a bump PR holds a template at its existing pin instead of advancing it to an off-`main` build. Without that, three of the pins in the current open bump PR (#65172) would have moved to feature-branch builds.

## Related issue number

Follow-up to #64637 (build-id pinning), which made docs builds reproducible but left the unpinned fallback resolving `latest` unconditionally.

## Checks

- [x] I've signed off every commit (`git commit -s`).
- [x] I've made sure the tests are passing.
- Testing Strategy
   - [x] Manual verification against live `templates.ci.ray.io` channel data (both the pinned path and the guard path).
   - [x] This PR is not tested (no behavior change for any currently-pinned template).
