### PR TITLE
[serve][test] Wait for controller after chat-template test

### DIFF
--- a/release/llm_tests/serve/test_llm_serve_integration.py
+++ b/release/llm_tests/serve/test_llm_serve_integration.py
@@ -477,7 +477,7 @@ def test_chat_completion_with_default_chat_template_kwargs():
     assert response.status_code == 200, response.text
     assert response.json()["choices"][0]["message"]["content"]
 
-    serve.shutdown()
+    shutdown_serve_and_wait_for_controller()
     time.sleep(1)
 
 


### PR DESCRIPTION
## Why

The direct-streaming suite runs the chat-template test immediately before the fault-tolerance test. Its plain `serve.shutdown()` can return before the controller exits, causing the next test to reconnect during shutdown. Release build 103893 reproduced this error three times.

## What

Use the controller-waiting shutdown helper added in #65116.

## Testing

- `pre-commit run --files release/llm_tests/serve/test_llm_serve_integration.py`

## Duplicate work and AI assistance

No existing PR covers this fix. AI assistance was used to investigate the failure and prepare the change. The submitter reviewed the change and test result.
