### PR TITLE
[docs] Drop private-module import from LLM Serve doc examples

### DIFF
--- a/doc/source/llm/doc_code/serve/custom_vllm/custom_vllm_example.py
+++ b/doc/source/llm/doc_code/serve/custom_vllm/custom_vllm_example.py
@@ -14,7 +14,6 @@ import time
 import urllib.request
 
 from ray import serve
-from ray.serve._private.constants import SERVE_DEFAULT_APP_NAME
 from ray.serve.schema import ApplicationStatus
 
 _original_serve_run = serve.run
@@ -63,7 +62,7 @@ start_time = time.time()
 while (
     status != ApplicationStatus.RUNNING and time.time() - start_time < timeout_seconds
 ):
-    status = serve.status().applications[SERVE_DEFAULT_APP_NAME].status
+    status = next(iter(serve.status().applications.values())).status
     if status in [ApplicationStatus.DEPLOY_FAILED, ApplicationStatus.UNHEALTHY]:
         raise AssertionError(f"Deployment failed with status: {status}")
     time.sleep(1)

--- a/doc/source/llm/doc_code/serve/custom_vllm/custom_vllm_yaml_config_example.py
+++ b/doc/source/llm/doc_code/serve/custom_vllm/custom_vllm_yaml_config_example.py
@@ -17,7 +17,6 @@ import yaml
 
 from ray import serve
 from ray.serve import llm
-from ray.serve._private.constants import SERVE_DEFAULT_APP_NAME
 from ray.serve.schema import ApplicationStatus
 
 config_path = os.path.join(os.path.dirname(__file__), "custom_vllm_config.yaml")
@@ -35,7 +34,7 @@ start_time = time.time()
 while (
     status != ApplicationStatus.RUNNING and time.time() - start_time < timeout_seconds
 ):
-    status = serve.status().applications[SERVE_DEFAULT_APP_NAME].status
+    status = next(iter(serve.status().applications.values())).status
     if status in [ApplicationStatus.DEPLOY_FAILED, ApplicationStatus.UNHEALTHY]:
         raise AssertionError(f"Deployment failed with status: {status}")
     time.sleep(1)

--- a/doc/source/llm/doc_code/serve/direct_streaming/direct_streaming_custom_router_example.py
+++ b/doc/source/llm/doc_code/serve/direct_streaming/direct_streaming_custom_router_example.py
@@ -13,7 +13,6 @@ build_openai_app call signature) for direct streaming.
 import time
 from ray import serve
 from ray.serve.schema import ApplicationStatus
-from ray.serve._private.constants import SERVE_DEFAULT_APP_NAME
 from ray.serve import llm
 
 _original_serve_run = serve.run
@@ -73,7 +72,7 @@ start_time = time.time()
 while (
     status != ApplicationStatus.RUNNING and time.time() - start_time < timeout_seconds
 ):
-    status = serve.status().applications[SERVE_DEFAULT_APP_NAME].status
+    status = next(iter(serve.status().applications.values())).status
 
     if status in [ApplicationStatus.DEPLOY_FAILED, ApplicationStatus.UNHEALTHY]:
         raise AssertionError(f"Deployment failed with status: {status}")

--- a/doc/source/llm/doc_code/serve/direct_streaming/direct_streaming_example.py
+++ b/doc/source/llm/doc_code/serve/direct_streaming/direct_streaming_example.py
@@ -17,7 +17,6 @@ direct-streaming test suite.
 import time
 from ray import serve
 from ray.serve.schema import ApplicationStatus
-from ray.serve._private.constants import SERVE_DEFAULT_APP_NAME
 from ray.serve import llm
 
 _original_serve_run = serve.run
@@ -73,7 +72,7 @@ start_time = time.time()
 while (
     status != ApplicationStatus.RUNNING and time.time() - start_time < timeout_seconds
 ):
-    status = serve.status().applications[SERVE_DEFAULT_APP_NAME].status
+    status = next(iter(serve.status().applications.values())).status
 
     if status in [ApplicationStatus.DEPLOY_FAILED, ApplicationStatus.UNHEALTHY]:
         raise AssertionError(f"Deployment failed with status: {status}")

--- a/doc/source/llm/doc_code/serve/direct_streaming/direct_streaming_yaml_config_example.py
+++ b/doc/source/llm/doc_code/serve/direct_streaming/direct_streaming_yaml_config_example.py
@@ -19,7 +19,6 @@ import os
 import yaml
 from ray import serve
 from ray.serve.schema import ApplicationStatus
-from ray.serve._private.constants import SERVE_DEFAULT_APP_NAME
 from ray.serve import llm
 
 
@@ -47,7 +46,7 @@ start_time = time.time()
 while (
     status != ApplicationStatus.RUNNING and time.time() - start_time < timeout_seconds
 ):
-    status = serve.status().applications[SERVE_DEFAULT_APP_NAME].status
+    status = next(iter(serve.status().applications.values())).status
 
     if status in [ApplicationStatus.DEPLOY_FAILED, ApplicationStatus.UNHEALTHY]:
         raise AssertionError(f"Deployment failed with status: {status}")

--- a/doc/source/llm/doc_code/serve/multi_gpu/bundle_per_worker_example.py
+++ b/doc/source/llm/doc_code/serve/multi_gpu/bundle_per_worker_example.py
@@ -11,7 +11,6 @@ Structure:
 import time
 from ray import serve
 from ray.serve.schema import ApplicationStatus
-from ray.serve._private.constants import SERVE_DEFAULT_APP_NAME
 from ray.serve import llm
 
 _original_serve_run = serve.run
@@ -76,7 +75,7 @@ start_time = time.time()
 while (
     status != ApplicationStatus.RUNNING and time.time() - start_time < timeout_seconds
 ):
-    status = serve.status().applications[SERVE_DEFAULT_APP_NAME].status
+    status = next(iter(serve.status().applications.values())).status
 
     if status in [ApplicationStatus.DEPLOY_FAILED, ApplicationStatus.UNHEALTHY]:
         raise AssertionError(f"Deployment failed with status: {status}")

--- a/doc/source/llm/doc_code/serve/multi_gpu/dp_autoscaling_example.py
+++ b/doc/source/llm/doc_code/serve/multi_gpu/dp_autoscaling_example.py
@@ -10,7 +10,6 @@ Structure:
 import time
 from ray import serve
 from ray.serve.schema import ApplicationStatus
-from ray.serve._private.constants import SERVE_DEFAULT_APP_NAME
 from ray.serve import llm
 
 _original_serve_run = serve.run
@@ -77,7 +76,7 @@ start_time = time.time()
 while (
     status != ApplicationStatus.RUNNING and time.time() - start_time < timeout_seconds
 ):
-    status = serve.status().applications[SERVE_DEFAULT_APP_NAME].status
+    status = next(iter(serve.status().applications.values())).status
 
     if status in [ApplicationStatus.DEPLOY_FAILED, ApplicationStatus.UNHEALTHY]:
         raise AssertionError(f"Deployment failed with status: {status}")

--- a/doc/source/llm/doc_code/serve/multi_gpu/dp_basic_example.py
+++ b/doc/source/llm/doc_code/serve/multi_gpu/dp_basic_example.py
@@ -10,7 +10,6 @@ Structure:
 import time
 from ray import serve
 from ray.serve.schema import ApplicationStatus
-from ray.serve._private.constants import SERVE_DEFAULT_APP_NAME
 from ray.serve import llm
 
 _original_serve_run = serve.run
@@ -70,7 +69,7 @@ start_time = time.time()
 while (
     status != ApplicationStatus.RUNNING and time.time() - start_time < timeout_seconds
 ):
-    status = serve.status().applications[SERVE_DEFAULT_APP_NAME].status
+    status = next(iter(serve.status().applications.values())).status
 
     if status in [ApplicationStatus.DEPLOY_FAILED, ApplicationStatus.UNHEALTHY]:
         raise AssertionError(f"Deployment failed with status: {status}")

--- a/doc/source/llm/doc_code/serve/multi_gpu/dp_pd_example.py
+++ b/doc/source/llm/doc_code/serve/multi_gpu/dp_pd_example.py
@@ -10,7 +10,6 @@ Structure:
 import time
 from ray import serve
 from ray.serve.schema import ApplicationStatus
-from ray.serve._private.constants import SERVE_DEFAULT_APP_NAME
 from ray.serve import llm
 
 # Check if NIXL is available (required for NixlConnector)
@@ -104,7 +103,7 @@ start_time = time.time()
 while (
     status != ApplicationStatus.RUNNING and time.time() - start_time < timeout_seconds
 ):
-    status = serve.status().applications[SERVE_DEFAULT_APP_NAME].status
+    status = next(iter(serve.status().applications.values())).status
 
     if status in [ApplicationStatus.DEPLOY_FAILED, ApplicationStatus.UNHEALTHY]:
         raise AssertionError(f"Deployment failed with status: {status}")

--- a/doc/source/llm/doc_code/serve/prefix_aware_router/prefix_aware_example.py
+++ b/doc/source/llm/doc_code/serve/prefix_aware_router/prefix_aware_example.py
@@ -10,7 +10,6 @@ Structure:
 import time
 from ray import serve
 from ray.serve.schema import ApplicationStatus
-from ray.serve._private.constants import SERVE_DEFAULT_APP_NAME
 from ray.serve import llm
 
 _original_serve_run = serve.run
@@ -74,7 +73,7 @@ start_time = time.time()
 while (
     status != ApplicationStatus.RUNNING and time.time() - start_time < timeout_seconds
 ):
-    status = serve.status().applications[SERVE_DEFAULT_APP_NAME].status
+    status = next(iter(serve.status().applications.values())).status
 
     if status in [ApplicationStatus.DEPLOY_FAILED, ApplicationStatus.UNHEALTHY]:
         raise AssertionError(f"Deployment failed with status: {status}")

--- a/doc/source/llm/doc_code/serve/qwen/llm_yaml_config_example.py
+++ b/doc/source/llm/doc_code/serve/qwen/llm_yaml_config_example.py
@@ -12,7 +12,6 @@ import os
 import yaml
 from ray import serve
 from ray.serve.schema import ApplicationStatus
-from ray.serve._private.constants import SERVE_DEFAULT_APP_NAME
 from ray.serve import llm
 
 
@@ -40,7 +39,7 @@ start_time = time.time()
 while (
     status != ApplicationStatus.RUNNING and time.time() - start_time < timeout_seconds
 ):
-    status = serve.status().applications[SERVE_DEFAULT_APP_NAME].status
+    status = next(iter(serve.status().applications.values())).status
 
     if status in [ApplicationStatus.DEPLOY_FAILED, ApplicationStatus.UNHEALTHY]:
         raise AssertionError(f"Deployment failed with status: {status}")

--- a/doc/source/llm/doc_code/serve/qwen/qwen_example.py
+++ b/doc/source/llm/doc_code/serve/qwen/qwen_example.py
@@ -10,7 +10,6 @@ Structure:
 import time
 from ray import serve
 from ray.serve.schema import ApplicationStatus
-from ray.serve._private.constants import SERVE_DEFAULT_APP_NAME
 from ray.serve import llm
 
 _original_serve_run = serve.run
@@ -74,7 +73,7 @@ start_time = time.time()
 while (
     status != ApplicationStatus.RUNNING and time.time() - start_time < timeout_seconds
 ):
-    status = serve.status().applications[SERVE_DEFAULT_APP_NAME].status
+    status = next(iter(serve.status().applications.values())).status
 
     if status in [ApplicationStatus.DEPLOY_FAILED, ApplicationStatus.UNHEALTHY]:
         raise AssertionError(f"Deployment failed with status: {status}")

--- a/doc/source/llm/doc_code/serve/transcription/transcription_example.py
+++ b/doc/source/llm/doc_code/serve/transcription/transcription_example.py
@@ -12,7 +12,6 @@ import openai
 import requests
 from ray import serve
 from ray.serve.schema import ApplicationStatus
-from ray.serve._private.constants import SERVE_DEFAULT_APP_NAME
 from ray.serve import llm
 
 _original_serve_run = serve.run
@@ -66,7 +65,7 @@ start_time = time.time()
 while (
     status != ApplicationStatus.RUNNING and time.time() - start_time < timeout_seconds
 ):
-    status = serve.status().applications[SERVE_DEFAULT_APP_NAME].status
+    status = next(iter(serve.status().applications.values())).status
 
     if status in [ApplicationStatus.DEPLOY_FAILED, ApplicationStatus.UNHEALTHY]:
         raise AssertionError(f"Deployment failed with status: {status}")


### PR DESCRIPTION
## Description

The 13 LLM Serve documentation examples under `doc/source/llm/doc_code/serve/` each imported `SERVE_DEFAULT_APP_NAME` from `ray.serve._private.constants` so their CI polling loop could look up the deployed application by name:

```python
from ray.serve._private.constants import SERVE_DEFAULT_APP_NAME
...
status = serve.status().applications[SERVE_DEFAULT_APP_NAME].status
```

These files are executed by CI, so this couples the doc build to a private Serve module. It also buys nothing: every one of the 13 calls `serve.run(app)` exactly once with no `name=`, so there is exactly one application and the loop never needs to name it.

This replaces the keyed lookup with the single application's status:

```python
status = next(iter(serve.status().applications.values())).status
```

**No published example content changes.** Every edited line sits outside the `literalinclude` marker regions these files expose to the docs, so the rendered pages are byte-identical. Three of the files (`custom_vllm_yaml_config_example.py`, `direct_streaming_yaml_config_example.py`, `llm_yaml_config_example.py`) aren't referenced by any doc page at all and exist purely as CI tests.

## Related issues

Related to #58624, which covers the separate `ray.serve._private.common.DeploymentID` case in `doc/source/serve/doc_code/autoscaling_policy.py`. That one needs a symbol relocated and is not addressed here.

## Additional information

Part of a broader pass removing private-module imports from executed documentation examples. This is the mechanical subset: one repeated pattern, no public API change, no rendered-doc change.

`black` and `ruff` report the same findings on these files before and after this change (5 files black would reformat, 20 ruff errors), all pre-existing and inside published example regions, so this PR leaves them alone. Note that `doc/source/` is excluded from the repo's pre-commit hooks, so those tools were run directly rather than via `pre-commit`.
