### PR TITLE
[release] Make hello_world.azure release test manual

### DIFF
--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -102,6 +102,7 @@
         cluster_compute: hello_world_compute_config_gce.yaml
     - __suffix__: azure
       env: azure
+      frequency: manual
       cluster:
         anyscale_sdk_2026: true
         cluster_compute: hello_world_compute_config_azure.yaml


### PR DESCRIPTION
## Why are these changes needed?

Switches the `azure` variation of the `hello_world` release test from the inherited `frequency: nightly` to `frequency: manual`, so it no longer runs on the nightly schedule and is only triggered on demand.

This follows the existing pattern — several other cloud variations in `release_tests.yaml` already override frequency per-variation (e.g. the `gce` variations with `frequency: manual`).

Not a duplicate: no open PR touches the hello_world release test frequency.

## Related issue number

N/A

## Checks

- Validated `release/release_tests.yaml` parses and the azure variation carries `frequency: manual` after the change.
- One-line YAML change; the release pipeline's config validation exercises it in CI.
- AI assistance (Claude Code) was used for this change; reviewed by the submitter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)