### PR TITLE
[cherry-pick][2.58.0][ci] Give ray-wheel-minimal-build a distinct wanda image name (#65318)

### DIFF
--- a/.buildkite/_wheel-build.rayci.yml
+++ b/.buildkite/_wheel-build.rayci.yml
@@ -58,6 +58,7 @@ steps:
       JDK_SUFFIX: "-jdk"
       RAY_JAVA_IMAGE: "cr.ray.io/rayproject/ray-java-build"
       RAY_DASHBOARD_IMAGE: "cr.ray.io/rayproject/ray-dashboard"
+      WHEEL_NAME_SUFFIX: ""
     tags:
       - release_wheels
       - linux_wheels
@@ -66,6 +67,10 @@ steps:
       - ray-java-build
       - ray-dashboard-build
 
+  # Exercises the no-java/no-dashboard wheel build path. WHEEL_NAME_SUFFIX
+  # keeps its wanda image name distinct from the real py3.13 wheel: both
+  # builds otherwise publish to the same name, and whichever finishes last
+  # silently replaces the full wheel for every downstream consumer.
   - name: ray-wheel-minimal-build
     label: "wanda: wheel-minimal py3.13 (x86_64)"
     wanda: ci/docker/ray-wheel.wanda.yaml
@@ -77,6 +82,7 @@ steps:
       JDK_SUFFIX: ""
       RAY_JAVA_IMAGE: "scratch"
       RAY_DASHBOARD_IMAGE: "scratch"
+      WHEEL_NAME_SUFFIX: "-minimal"
     tags:
       - release_wheels
       - linux_wheels

--- a/.buildkite/linux_aarch64.rayci.yml
+++ b/.buildkite/linux_aarch64.rayci.yml
@@ -216,6 +216,7 @@ steps:
       JDK_SUFFIX: "-jdk"
       RAY_JAVA_IMAGE: "cr.ray.io/rayproject/ray-java-build-aarch64"
       RAY_DASHBOARD_IMAGE: "cr.ray.io/rayproject/ray-dashboard-aarch64"
+      WHEEL_NAME_SUFFIX: ""
     tags:
       - release_wheels
       - linux_wheels

--- a/ci/build/build_wheel.py
+++ b/ci/build/build_wheel.py
@@ -68,6 +68,7 @@ class BuildConfig:
             "IS_LOCAL_BUILD": "true",
             "RAY_JAVA_IMAGE": java_image,
             "RAY_DASHBOARD_IMAGE": dashboard_image,
+            "WHEEL_NAME_SUFFIX": "",
         }
 
     @classmethod

--- a/ci/docker/ray-wheel.wanda.yaml
+++ b/ci/docker/ray-wheel.wanda.yaml
@@ -1,4 +1,4 @@
-name: "ray-wheel-py$PYTHON_VERSION$ARCH_SUFFIX"
+name: "ray-wheel-py$PYTHON_VERSION$ARCH_SUFFIX$WHEEL_NAME_SUFFIX"
 disable_caching: true
 froms:
   - "rayproject/manylinux2014:$MANYLINUX_VERSION$JDK_SUFFIX-$HOSTTYPE"


### PR DESCRIPTION
Cherry-pick of #65318 (merge commit d1d60b9fffbc121ff396dec22493aaaa5170c5b6) onto `releases/2.58.0`. Clean pick, no conflicts.

## Why are these changes needed?

`ray-wheel-minimal-build` publishes to the same wanda image name as the real py3.13 wheel build, so the last writer wins — when the minimal build finishes last, the dashboard-less/jar-less wheel silently replaces the full wheel for every downstream consumer (wheel S3 upload, all py3.13 x86_64 images, CI test containers). This gives the minimal build a distinct image name so release wheel artifacts on 2.58.0 can't be silently clobbered.

Not a duplicate: no existing cherry-pick PR for #65318 targets this branch.

## Checks

- `git cherry-pick -x -s` applied cleanly; 4 files, +9/-1, identical to the master change.
- AI assistance (Claude Code) was used to prepare this cherry-pick; reviewed by the submitter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)