### PR TITLE
[docs] Import LLMServer from its public path in the plugin example

### DIFF
--- a/doc/source/llm/doc_code/serve/custom_vllm/qwen3_reward_plugin/serve_hook.py
+++ b/doc/source/llm/doc_code/serve/custom_vllm/qwen3_reward_plugin/serve_hook.py
@@ -1,7 +1,7 @@
 # __serve_hook_start__
 """LLMServer subclass for ``LLMConfig.server_cls``: importing it registers the plugin."""
 
-from ray.llm._internal.serve.core.server.llm_server import LLMServer
+from ray.serve.llm import LLMServer
 
 from qwen3_reward_plugin import register
 


### PR DESCRIPTION
## Description

The reward-model plugin example imports `LLMServer` from a private module:

```python
from ray.llm._internal.serve.core.server.llm_server import LLMServer
```

This one is inside the `literalinclude` region, so it renders on the docs page. It's the first line a reader copies when writing their own `LLMConfig.server_cls` plugin, which means the docs are actively teaching people to depend on `ray.llm._internal`.

`LLMServer` is already public and needs no promotion:

- `ray.serve.llm` re-exports it and lists `"LLMServer"` in `__all__`.
- `ray.serve.llm.deployment` defines it as a `@PublicAPI(stability="stable")` subclass of the internal class.

Since the public class subclasses the internal one, subclassing it is equivalent for `server_cls`. The `LLMServer` docstring already recommends the public import path in its own usage example.

## Related issues

None.

## Additional information

Part of a pass removing private-module imports from documentation examples. Sibling PR #65381 covers the `SERVE_DEFAULT_APP_NAME` cluster in the LLM Serve CI scaffolding. The two are independent and can merge in any order.

`black` reports the same result on this file before and after the change (pre-existing, untouched). Note `doc/source/` is excluded from the repo's pre-commit hooks, so it was run directly.
