### PR TITLE
[docs] Use public Ray Data APIs in two rendered examples

### DIFF
--- a/doc/source/data/aggregating-data.rst
+++ b/doc/source/data/aggregating-data.rst
@@ -110,7 +110,6 @@ Here's an example of creating a custom aggregator that calculates the Mean of va
 
     import numpy as np
     from ray.data.aggregate import AggregateFnV2
-    from ray.data._internal.util import is_null
     from ray.data.block import Block, BlockAccessor, AggType, U
     import pyarrow.compute as pc
     from typing import List, Optional
@@ -143,7 +142,7 @@ Here's an example of creating a custom aggregator that calculates the Mean of va
 
             sum_ = block_acc.sum(self._target_col_name, self._ignore_nulls)
 
-            if is_null(sum_):
+            if sum_ is None or (isinstance(sum_, float) and np.isnan(sum_)):
                 # In case of ignore_nulls=False and column containing 'null'
                 # return as is (to prevent unnecessary type conversions, when, for ex,
                 # using Pandas and returning None)

--- a/doc/source/data/doc_code/custom_datasource_example.py
+++ b/doc/source/data/doc_code/custom_datasource_example.py
@@ -25,18 +25,15 @@ class ImageDatasource(FileBasedDatasource):
         import io
         import numpy as np
         from PIL import Image
-        from ray.data._internal.delegating_block_builder import DelegatingBlockBuilder
+        from ray.data.block import BlockAccessor
 
         data = f.readall()
         image = Image.open(io.BytesIO(data))
         image = image.convert(self.mode)
 
         # Each block contains one row
-        builder = DelegatingBlockBuilder()
         array = np.asarray(image)
-        item = {"image": array}
-        builder.add(item)
-        yield builder.build()
+        yield BlockAccessor.batch_to_block({"image": np.array([array])})
 # __read_stream_end__
 
 # __read_datasource_start__


### PR DESCRIPTION
## Description

Two Ray Data examples import from private modules. Both imports sit inside rendered example regions, so they're code readers copy directly.

### `aggregating-data.rst` — `is_null`

The custom-aggregator example imported `is_null` from `ray.data._internal.util` for one null guard. It's a two-line helper:

```python
def is_null(value): return value is None or is_nan(value)
def is_nan(value):  return isinstance(value, float) and np.isnan(value)
```

Inlined it. The example already imports `numpy as np`.

Checked equivalence against the private helper across 20 value types (`None`, Python and NumPy NaN, ints, floats, strings, containers, `Decimal`, `date`, `ndarray`) — zero mismatches. That includes the `np.float32` NaN case: it isn't a Python `float`, so neither the helper nor the inlined check treats it as null.

### `custom_datasource_example.py` — `DelegatingBlockBuilder`

The custom-`Datasource` example used `DelegatingBlockBuilder` to build a one-row block. `BlockAccessor.batch_to_block` is the public entry point for precisely this, documented as "Create a block from user-facing data formats", and lives in `ray.data.block` — a module the example already imports `Block` from.

```python
# before
builder = DelegatingBlockBuilder()
array = np.asarray(image)
item = {"image": array}
builder.add(item)
yield builder.build()

# after
array = np.asarray(image)
yield BlockAccessor.batch_to_block({"image": np.array([array])})
```

Shorter, and drops the private import.

## Related issues

None.

## Additional information

Verification, run locally against Ray 2.57.0 / PyArrow 25.0.1:

- The new `batch_to_block` call produces a block **equal** to the one the builder produced (`old.equals(new)` is `True`), with the same `ArrowTensorTypeV2` schema and the same `ndarray` row type — so the datasink's `Image.fromarray(row[column])` is unaffected.
- Ran the datasource example end to end: read 3 images, correct schema, wrote through the datasink, correct roundtrip shape.
- Ran the `Mean` aggregator, including the `ignore_nulls=False` path that exercises the inlined null check.

Part of a pass removing private-module imports from documentation examples. Independent of the sibling LLM and Serve PRs; no ordering constraint.

`black` reports this file unchanged before and after. Note `doc/source/` is excluded from the repo's pre-commit hooks, so it was run directly.
