### PR TITLE
[doc] State that the ray-ml images are deprecated, and stop recommending them

### DIFF
--- a/doc/source/cluster/kubernetes/user-guides/gpu.rst
+++ b/doc/source/cluster/kubernetes/user-guides/gpu.rst
@@ -209,7 +209,7 @@ If this admission controller is not enabled for your Kubernetes cluster, you may
    ...
    containers:
    - name: ray-node
-     image: rayproject/ray:nightly-gpu
+     image: rayproject/ray:2.57.0-gpu
      ...
 
 Node selectors and node labels

--- a/doc/source/cluster/kubernetes/user-guides/gpu.rst
+++ b/doc/source/cluster/kubernetes/user-guides/gpu.rst
@@ -21,10 +21,9 @@ Dependencies for GPU-based machine learning
 ___________________________________________
 
 The `Ray Docker Hub <https://hub.docker.com/r/rayproject/>`_ hosts CUDA-based container images packaged
-with Ray and certain machine learning libraries.
-For example, the image ``rayproject/ray-ml:2.6.3-gpu`` is ideal for running GPU-based ML workloads with Ray 2.6.3.
-The Ray ML images are packaged with dependencies (such as TensorFlow and PyTorch) needed for the Ray Libraries that are used in these docs.
-To add custom dependencies, use one, or both, of the following methods:
+with Ray. For example, the image ``rayproject/ray:2.57.0-gpu`` runs GPU-based workloads with Ray 2.57.0.
+These images don't include machine learning libraries such as TensorFlow and PyTorch, so add the ones
+your workload needs with one, or both, of the following methods:
 
 * Building a docker image using one of the official :ref:`Ray docker images <docker-images>` as base.
 * Using :ref:`Ray Runtime environments <runtime-environments>`.
@@ -51,7 +50,7 @@ to 5 GPU workers.
         ...
         containers:
          - name: ray-node
-           image: rayproject/ray-ml:2.6.3-gpu
+           image: rayproject/ray:2.57.0-gpu
            ...
            resources:
             nvidia.com/gpu: 1 # Optional, included just for documentation.

--- a/doc/source/cluster/vms/configs/xgboost-benchmark.yaml
+++ b/doc/source/cluster/vms/configs/xgboost-benchmark.yaml
@@ -9,8 +9,14 @@ cluster_name: ray-cluster-xgboost-benchmark
 max_workers: 9
 
 docker:
-  image: "rayproject/ray-ml:2.0.0"
+  image: "rayproject/ray:2.57.0"
   container_name: "ray_container"
+
+# The rayproject/ray images don't include XGBoost, so install it in the container.
+# The constraint file ships in the image and pins the version Ray tested against
+# for this release.
+setup_commands:
+  - pip install -c /home/ray/requirements_compiled.txt xgboost
 
 provider:
   type: aws

--- a/doc/source/cluster/vms/configs/xgboost-benchmark.yaml
+++ b/doc/source/cluster/vms/configs/xgboost-benchmark.yaml
@@ -12,11 +12,12 @@ docker:
   image: "rayproject/ray:2.57.0"
   container_name: "ray_container"
 
-# The rayproject/ray images don't include XGBoost, so install it in the container.
-# The constraint file ships in the image and pins the version Ray tested against
-# for this release.
+# The rayproject/ray images don't include XGBoost or LightGBM. The benchmark script
+# imports both at module load, even when run with the xgboost framework, so install
+# both. The constraint file ships in the image and pins the versions Ray tested
+# against for this release.
 setup_commands:
-  - pip install -c /home/ray/requirements_compiled.txt xgboost
+  - pip install -c /home/ray/requirements_compiled.txt xgboost lightgbm
 
 provider:
   type: aws

--- a/doc/source/ray-overview/installation.rst
+++ b/doc/source/ray-overview/installation.rst
@@ -332,13 +332,17 @@ The images include Ray and all required dependencies. It comes with anaconda and
   .. code-block:: dockerfile
 
     FROM rayproject/ray:2.57.0-py311-gpu
-    RUN pip install torch -c /home/ray/requirements_compiled.txt
+    RUN pip install xgboost -c /home/ray/requirements_compiled.txt
 
   or declare the packages in a :ref:`runtime environment <runtime-environments>`.
 
   Every ``rayproject/ray`` image ships the constraint file at ``/home/ray/requirements_compiled.txt``.
   Passing it with ``-c`` installs the exact library version that Ray tested against for that release.
   Drop the flag to get the newest version instead.
+
+  Don't use the constraint file to install PyTorch or TensorFlow on a GPU image. It's compiled
+  against a CPU-only PyTorch index, so it can resolve a CPU build and silently leave you without
+  GPU support. Install those packages from the index that matches your CUDA version instead.
 
 Images are `tagged` with the format ``{Ray version}[-{Python version}][-{Platform}]``. ``Ray version`` tag can be one of the following:
 

--- a/doc/source/ray-overview/installation.rst
+++ b/doc/source/ray-overview/installation.rst
@@ -318,6 +318,28 @@ Docker Source Images
 Users can pull a Docker image from the ``rayproject/ray`` `Docker Hub repository <https://hub.docker.com/r/rayproject/ray>`__.
 The images include Ray and all required dependencies. It comes with anaconda and various versions of Python.
 
+.. note::
+
+  The ``rayproject/ray-ml`` images are deprecated. Ray no longer publishes them: the last standard
+  release tag is ``2.30.0``, and publishing stopped entirely as of Ray 2.50. The ``latest`` and
+  ``latest-gpu`` tags still resolve, but they haven't moved since Ray 2.30.0, so a build that pulls
+  them gets an old Ray without any error. See `Deprecating ray-ml images
+  <https://github.com/ray-project/ray/issues/46378>`__ for the reasoning.
+
+  The ``rayproject/ray`` images don't ship machine learning libraries such as PyTorch, TensorFlow,
+  or XGBoost. To get them, either build an image on a ``rayproject/ray`` base:
+
+  .. code-block:: dockerfile
+
+    FROM rayproject/ray:2.57.0-py311-gpu
+    RUN pip install torch -c /home/ray/requirements_compiled.txt
+
+  or declare the packages in a :ref:`runtime environment <runtime-environments>`.
+
+  Every ``rayproject/ray`` image ships the constraint file at ``/home/ray/requirements_compiled.txt``.
+  Passing it with ``-c`` installs the exact library version that Ray tested against for that release.
+  Drop the flag to get the newest version instead.
+
 Images are `tagged` with the format ``{Ray version}[-{Python version}][-{Platform}]``. ``Ray version`` tag can be one of the following:
 
 .. list-table::


### PR DESCRIPTION
## Why

Ray announced the `rayproject/ray-ml` deprecation in #46378 and, in a follow-up comment on that issue, stopped publishing the images entirely as of Ray 2.50 — "not even with `-deprecated` tags." Nothing a reader can see says so. That issue went stale and was closed, and the deprecation never reached the docs.

The gap costs the reader real time, because the frozen tags don't fail loudly. Verified against Docker Hub on 2026-08-11:

| Tag | Status |
|---|---|
| `ray-ml:latest`, `ray-ml:latest-gpu` | 200, frozen at the `2.30.0` digest, last pushed 2024-06-20 |
| `ray-ml:2.31.0` … `2.57.0` | 404 |
| `ray-ml` newest push of any kind | `nightly-*` on 2025-10-01 |

A 404 teaches the reader something. A 200 serving a two-year-old Ray teaches them nothing. `ray-overview/installation.rst`, the canonical image reference, documents `rayproject/ray` only and has never mentioned `ray-ml`, so a reader arriving with an existing `ray-ml` reference finds no explanation for its absence.

## What changed

**`ray-overview/installation.rst`** — adds the deprecation statement to the `docker-images` section, where a reader looking for image guidance lands. States what replaces it: build on a `rayproject/ray` base, or declare the packages in a runtime environment. Documents the constraint file every `rayproject/ray` image ships at `/home/ray/requirements_compiled.txt`, which installs the exact library version Ray tested against for that release. Links #46378 for the rationale rather than restating it.

**`cluster/kubernetes/user-guides/gpu.rst`** — recommended `ray-ml:2.6.3-gpu` as "ideal for running GPU-based ML workloads," in both prose and a config snippet. Now recommends `ray:2.57.0-gpu` and says plainly that the image doesn't include TensorFlow or PyTorch. The page already pointed at custom images and runtime environments as the way to add dependencies; that guidance just contradicted the recommendation above it.

**`cluster/vms/configs/xgboost-benchmark.yaml`** — ran the XGBoostTrainer benchmark on `ray-ml:2.0.0`. Now uses `ray:2.57.0`, plus a `setup_commands` entry that installs `xgboost` against the image's constraint file. `xgboost` appears nowhere in `python/setup.py`, so `ray[all]` doesn't include it and a bare image swap would have broken the benchmark.

## Deliberately not in this PR

Four other `ray-ml` references remain in `doc/source`, each blocked on something outside this change:

- `cluster/vms/references/ray-cluster-configuration.rst` and `cluster/kubernetes/user-guides/config.md` — already covered by #65339 and #65336 respectively. Excluded to avoid conflicts.
- `cluster/kubernetes/examples/mobilenet-rayservice.md`, `stable-diffusion-rayservice.md`, and `rayjob-batch-inference-example.md` — these describe sample manifests that live in `ray-project/kuberay`, and the prose accurately reports what those manifests do. Rewriting the prose alone would put the docs at odds with the file the reader applies.

That last group needs a heads-up, because those three examples are broken today rather than merely stale. On both kuberay `v1.6.0` and `master`, `ray-service.mobilenet.yaml`, `ray-service.stable-diffusion.yaml`, and `ray-job.batch-inference.yaml` all pin `rayproject/ray-ml:2.46.0.0e19ea-py39-{cpu,gpu}`, which 404s. Following any of those three examples ends in `ImagePullBackOff`. Fixing them isn't a tag bump either: `mobilenet` needs `tensorflow` and the other two need `torch`, all of which came from the `ray-ml` image, so each manifest needs `runtime_env` additions. Happy to take that on in kuberay if maintainers agree on the approach, or to defer to whoever owns those samples.

Separately, `ray-job.batch-inference.yaml`'s image tag is already out of sync with the snippet quoted in `rayjob-batch-inference-example.md` (`2.6.3-gpu` in the docs vs. `2.46.0.0e19ea-py39-gpu` in the manifest), independent of the deprecation.

## One thing outside docs scope

The frozen `ray-ml:latest` and `latest-gpu` tags are the actual trap. A deprecation notice helps readers who come to the docs; removing or re-tagging those two on Docker Hub would help everyone with an existing Dockerfile or manifest that references them. Not something I can do from a docs PR, but worth a decision from whoever owns the registry.

## Testing

Docs-only prose, RST, and cluster-config YAML; no code paths touched.

- `pre-commit run --files <the three changed files>` — every hook reports "no files to check." No pre-commit hook currently covers prose under `doc/source`.
- Every replacement tag verified live against the Docker Hub registry API: `rayproject/ray` `2.57.0`, `2.57.0-gpu`, `2.57.0-cpu`, `2.57.0-py311-gpu`, `2.57.0-py311-cpu` all return 200, pushed 2026-08-11.
- `xgboost-benchmark.yaml` parses under `yaml.safe_load`.
- `xgboost==2.1.0` confirmed pinned in `python/requirements_compiled.txt`, so the constraint comment in that file is accurate.
- Confirmed `setup_commands` run inside the container when `docker.image` is set: `DockerCommandRunner.run` with the default `run_env="auto"` routes any command not beginning with `docker` through `docker exec`.
- Confirmed the constraint file's in-image path: `docker/base-deps/Dockerfile` copies it to `/home/ray/requirements_compiled.txt`.
- Cross-reference targets confirmed present: `runtime-environments` (`ray-core/handling-dependencies.rst:52`) and `docker-images` (`ray-overview/installation.rst:313`).
- `installation.rst` parsed with docutils; the only diagnostics in the changed range are the expected Sphinx-only `:ref:` role.

I did not run the 100Gi XGBoost benchmark or apply the KubeRay snippet, which need cloud resources I don't have here.

## AI assistance

AI assistance (Claude Code) was used to inventory the `ray-ml` references and draft these edits. I reviewed every changed line and ran the verification above.
