### PR TITLE
[Fix][Core] Give `canceled_tasks_` its own mutex to break a lock-order cycle

### DIFF
--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -885,6 +885,7 @@ void CoreWorker::HandleOwnerDied(const WorkerID &dead_owner) {
         to_erase.push_back(generator_id);
         // Mark the gen task canceled so the executor loop bails before the
         // next gen.send instead of running another iteration of user code.
+        absl::MutexLock canceled_lock(&canceled_tasks_mutex_);
         canceled_tasks_.insert(generator_id.TaskId());
       }
     }
@@ -2616,7 +2617,7 @@ Status CoreWorker::CancelTask(const ObjectID &object_id,
 bool CoreWorker::IsTaskCanceled(const TaskID &task_id) const {
   // Check if the task is canceled on executor side. Check the canceled_tasks_ which is
   // populated when CancelTask RPC is received.
-  absl::MutexLock lock(&mutex_);
+  absl::MutexLock lock(&canceled_tasks_mutex_);
   return canceled_tasks_.find(task_id) != canceled_tasks_.end();
 }
 
@@ -3144,7 +3145,10 @@ Status CoreWorker::ExecuteTask(
     size_t erased = running_tasks_.erase(task_spec.TaskId());
     RAY_CHECK(erased == 1);
     // Clean up cancellation state for this task
-    canceled_tasks_.erase(task_spec.TaskId());
+    {
+      absl::MutexLock canceled_lock(&canceled_tasks_mutex_);
+      canceled_tasks_.erase(task_spec.TaskId());
+    }
     if (task_spec.IsNormalTask()) {
       resource_ids_.clear();
     }
@@ -4323,6 +4327,7 @@ void CoreWorker::CancelTaskOnExecutor(TaskID task_id,
     requested_task_running = main_thread_task_id_ == task_id;
 
     if (requested_task_running) {
+      absl::MutexLock canceled_lock(&canceled_tasks_mutex_);
       canceled_tasks_.insert(task_id);
     }
   }
@@ -4379,6 +4384,7 @@ void CoreWorker::CancelActorTaskOnExecutor(WorkerID caller_worker_id,
         is_running = running_tasks_.find(task_id) != running_tasks_.end();
 
         if (is_running) {
+          absl::MutexLock canceled_lock(&canceled_tasks_mutex_);
           canceled_tasks_.insert(task_id);
         }
       }

--- a/src/ray/core_worker/core_worker.h
+++ b/src/ray/core_worker/core_worker.h
@@ -2028,8 +2028,8 @@ class CoreWorker : public std::enable_shared_from_this<CoreWorker> {
   ///
   /// This has its own mutex because IsTaskCanceled() is called from check_signals
   /// while the process-level core_worker_ lock is held, and taking mutex_ there
-  /// closes a lock-order cycle. Always acquire this after mutex_, never before.
-  mutable absl::Mutex canceled_tasks_mutex_;
+  /// closes a lock-order cycle.
+  mutable absl::Mutex canceled_tasks_mutex_ ABSL_ACQUIRED_AFTER(mutex_);
   absl::flat_hash_set<TaskID> canceled_tasks_ ABSL_GUARDED_BY(canceled_tasks_mutex_);
 
   /// Actor repr name if overrides by the user, empty string if not.

--- a/src/ray/core_worker/core_worker.h
+++ b/src/ray/core_worker/core_worker.h
@@ -2025,7 +2025,12 @@ class CoreWorker : public std::enable_shared_from_this<CoreWorker> {
   /// We have to track this separately because cancellation requests come from submitter
   /// thread than the thread executing the task, so we cannot get the cancellation status
   /// from the thread-local WorkerThreadContext.
-  absl::flat_hash_set<TaskID> canceled_tasks_ ABSL_GUARDED_BY(mutex_);
+  ///
+  /// This has its own mutex because IsTaskCanceled() is called from check_signals
+  /// while the process-level core_worker_ lock is held, and taking mutex_ there
+  /// closes a lock-order cycle. Always acquire this after mutex_, never before.
+  mutable absl::Mutex canceled_tasks_mutex_;
+  absl::flat_hash_set<TaskID> canceled_tasks_ ABSL_GUARDED_BY(canceled_tasks_mutex_);
 
   /// Actor repr name if overrides by the user, empty string if not.
   std::string actor_repr_name_ ABSL_GUARDED_BY(mutex_);


### PR DESCRIPTION
## Description

PR #65184 creates a mutex cycle for potential deadlock: `core_worker_` (reader) → `CoreWorker::mutex_` → `ReferenceCounter::mutex_` → `ActorTaskSubmitter::mu_` → `core_worker_` (reader)

In practice, we need 5 threads to trigger the deadlock, which won't happen in today's Ray code because we don't have 5 threads. So this PR is just a refactor. This potential deadlock is detected by the built-in deadlock detector in `absl::Mutex`:

<img width="1187" height="709" alt="image" src="https://github.com/user-attachments/assets/b496e2fc-e219-48d7-bef8-67a294ad3583" />

- **T1**: `ray.get` / `ray.wait` → `CoreWorker::Wait()` → `CoreWorkerMemoryStore::Wait()` → `GetImpl()` → `check_signals` (`python/ray/_raylet.pyx`) → `CoreWorkerProcess::ShouldInterruptTaskForCancellation()` → acquire **L1** → `CoreWorker::ShouldInterruptTaskForCancellation()` → `CoreWorker::IsTaskCanceled()` → blocks acquiring **L2**
- **T2**: `CoreWorker::HandleGetCoreWorkerStats()` → acquire **L2** → `ReferenceCounter::NumObjectIDsInScope()` → blocks acquiring **L3**
- **T3**: `CoreWorker::RemoveLocalReference()` → `ReferenceCounter::RemoveLocalReference()` → acquire **L3** → `RemoveLocalReferenceInternal()` → `OnObjectOutOfScopeOrFreed()` → `on_object_out_of_scope_or_freed_callbacks` (Registered in `ActorTaskSubmitter::NotifyGCSWhenActorOutOfScope`) → blocks acquiring **L4**
- **T4**: `ActorTaskSubmitter::ConnectActor()` → acquire **L4** → `SendPendingTasks()` → `PushActorTask()` → `CoreWorkerClientPool::GetOrConnect()` → `core_worker_client_factory_` (lambda function here https://github.com/ray-project/ray/blob/19cb4230646bf6654d1eda0726a2e388f58874b8/src/ray/core_worker/core_worker_process.cc#L353-L363) → `CoreWorkerProcessImpl::GetCoreWorker()` → blocks acquiring **L1** for read
- **T5**: `CoreWorkerProcessImpl::ShutdownDriver()` → blocks acquiring **L1** in write mode behind T1's read hold.

This PR gives `canceled_tasks_` its own innermost mutex so `IsTaskCanceled()` no longer takes `CoreWorker::mutex_`, thus breaks the T1 edge in the diagram above. Lock order is always `mutex_` → `canceled_tasks_mutex_`, and the writer sites take the new lock nested inside their existing `mutex_` blocks, so nothing observable changes.

## Related issues
N/A

## Additional information
N/A