### PR TITLE
[Data] Chunk DataFrame emission in WebDatasetDatasource._read_stream

### DIFF
--- a/python/ray/data/_internal/datasource/webdataset_datasource.py
+++ b/python/ray/data/_internal/datasource/webdataset_datasource.py
@@ -443,6 +443,11 @@ class WebDatasetDatasource(FileBasedDatasource):
         default_decoder = partial(
             _default_decoder, allow_unsafe=self._allow_unsafe_deserialization
         )
+
+        # Yield 1 dataframe per chunk of 512 samples. Last chunk may be smaller.
+        rows = []
+        chunk_size = 512
+
         for sample in samples:
             if self.decoder is not None:
                 sample = _apply_list(self.decoder, sample, default=default_decoder)
@@ -461,9 +466,15 @@ class WebDatasetDatasource(FileBasedDatasource):
                     if k not in sample:
                         sample[k] = []
                     sample[k].append(v)
-            yield pd.DataFrame(
+            rows.append(
                 {
-                    k: v if isinstance(v, list) and len(v) == 1 else [v]
+                    k: v[0] if isinstance(v, list) and len(v) == 1 else v
                     for k, v in sample.items()
                 }
             )
+            if len(rows) >= chunk_size:
+                yield pd.DataFrame.from_records(rows)
+                rows = []
+
+        if len(rows) > 0:
+            yield pd.DataFrame.from_records(rows)

--- a/python/ray/data/_internal/datasource/webdataset_datasource.py
+++ b/python/ray/data/_internal/datasource/webdataset_datasource.py
@@ -18,6 +18,9 @@ ALLOW_UNSAFE_DESERIALIZATION_ENV_VAR = (
     "RAY_DATA_WEBDATASET_ALLOW_UNSAFE_DESERIALIZATION"
 )
 
+# Number of samples accumulated into each emitted DataFrame block.
+WEBDATASET_READ_CHUNK_SIZE = 512
+
 
 if TYPE_CHECKING:
     import pyarrow
@@ -444,9 +447,8 @@ class WebDatasetDatasource(FileBasedDatasource):
             _default_decoder, allow_unsafe=self._allow_unsafe_deserialization
         )
 
-        # Yield 1 dataframe per chunk of 512 samples. Last chunk may be smaller.
+        # Accumulate samples into chunks.
         rows = []
-        chunk_size = 512
 
         for sample in samples:
             if self.decoder is not None:
@@ -472,7 +474,7 @@ class WebDatasetDatasource(FileBasedDatasource):
                     for k, v in sample.items()
                 }
             )
-            if len(rows) >= chunk_size:
+            if len(rows) >= WEBDATASET_READ_CHUNK_SIZE:
                 yield pd.DataFrame.from_records(rows)
                 rows = []
 

--- a/python/ray/data/tests/datasource/test_webdataset.py
+++ b/python/ray/data/tests/datasource/test_webdataset.py
@@ -7,6 +7,8 @@ import os
 import pickle
 import tarfile
 
+import numpy as np
+import pandas as pd
 import pytest
 import webdataset as wds
 
@@ -396,20 +398,52 @@ def test_custom_decoder_bypasses_unsafe_guard(ray_start_2_cpus, tmp_path):
 
 @pytest.mark.parametrize("num_samples", [1, 511, 512, 513, 1000])
 def test_read_webdataset_chunked_samples(ray_start_2_cpus, tmp_path, num_samples):
-    # Verify the chunked emission reads every sample with
-    # correct values and order, regardless of shard size.
     path = os.path.join(tmp_path, "data-000000.tar")
     with wds.TarWriter(path) as writer:
         for i in range(num_samples):
             writer.write({"__key__": f"{i:06d}", "cls": str(i).encode("utf-8")})
 
-    rows = ray.data.read_webdataset([path], suffixes=["cls"], decoder=None).take_all()
+    actual = (
+        ray.data.read_webdataset([path], suffixes=["cls"], decoder=None)
+        .to_pandas()
+        .sort_values("__key__")
+        .reset_index(drop=True)
+    )
+    expected = pd.DataFrame(
+        {
+            "__key__": [f"{i:06d}" for i in range(num_samples)],
+            "cls": [str(i).encode("utf-8") for i in range(num_samples)],
+        }
+    )
+    pd.testing.assert_frame_equal(actual[["__key__", "cls"]], expected)
 
-    assert len(rows) == num_samples
-    assert [row["__key__"] for row in rows] == [f"{i:06d}" for i in range(num_samples)]
-    assert [row["cls"] for row in rows] == [
-        str(i).encode("utf-8") for i in range(num_samples)
-    ]
+
+def test_read_webdataset_chunked_heterogeneous_keys(ray_start_2_cpus, tmp_path):
+    path = os.path.join(tmp_path, "data-000000.tar")
+    n = 6
+    with wds.TarWriter(path) as writer:
+        for i in range(n):
+            sample = {"__key__": f"{i:06d}", "cls": str(i).encode("utf-8")}
+            if i % 2 == 0:
+                sample["aux"] = str(i * 10).encode("utf-8")
+            writer.write(sample)
+
+    actual = (
+        ray.data.read_webdataset([path], suffixes=["cls", "aux"], decoder=None)
+        .to_pandas()
+        .sort_values("__key__")
+        .reset_index(drop=True)
+    )
+    expected = pd.DataFrame(
+        {
+            "__key__": [f"{i:06d}" for i in range(n)],
+            "cls": [str(i).encode("utf-8") for i in range(n)],
+            "aux": [
+                str(i * 10).encode("utf-8") if i % 2 == 0 else np.nan for i in range(n)
+            ],
+        }
+    )
+    pd.testing.assert_frame_equal(actual[["__key__", "cls", "aux"]], expected)
 
 
 if __name__ == "__main__":

--- a/python/ray/data/tests/datasource/test_webdataset.py
+++ b/python/ray/data/tests/datasource/test_webdataset.py
@@ -394,6 +394,24 @@ def test_custom_decoder_bypasses_unsafe_guard(ray_start_2_cpus, tmp_path):
     assert rows[0]["pkl"] == {"key": "value"}
 
 
+@pytest.mark.parametrize("num_samples", [1, 511, 512, 513, 1000])
+def test_read_webdataset_chunked_samples(ray_start_2_cpus, tmp_path, num_samples):
+    # Verify the chunked emission reads every sample with
+    # correct values and order, regardless of shard size.
+    path = os.path.join(tmp_path, "data-000000.tar")
+    with wds.TarWriter(path) as writer:
+        for i in range(num_samples):
+            writer.write({"__key__": f"{i:06d}", "cls": str(i).encode("utf-8")})
+
+    rows = ray.data.read_webdataset([path], suffixes=["cls"], decoder=None).take_all()
+
+    assert len(rows) == num_samples
+    assert [row["__key__"] for row in rows] == [f"{i:06d}" for i in range(num_samples)]
+    assert [row["cls"] for row in rows] == [
+        str(i).encode("utf-8") for i in range(num_samples)
+    ]
+
+
 if __name__ == "__main__":
     import sys
 


### PR DESCRIPTION
## Description
`WebDatasetDatasource._read_stream` emits one single-row DataFrame per sample, which means the output buffer runs `PandasBlockAccessor.size_bytes` once per sample. On large shards this dominates read-side CPU (~63% of the `ReadWebDataset` operator's CPU). This changes the behavior of readwebdataset and let it accumulates 512 samples per emitted DataFrame.

## Related issues
Closes #65350

## Additional information
Benchmark specs are specified in #65350 
- It was cross-validated with a reporter

Added a parametrized test (`test_read_webdataset_chunked_samples`) that verifies the output is identical to the original per-sample behavior (row count, values, and order) 
- test with different sample sizes (1 / 511 / 512 / 513 / 1000 samples).