### PR TITLE
[util] annotate Pool.close/terminate/join as returning None

### DIFF
--- a/python/ray/util/multiprocessing/pool.py
+++ b/python/ray/util/multiprocessing/pool.py
@@ -981,7 +981,7 @@ class Pool:
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.terminate()
 
-    def close(self):
+    def close(self) -> None:
         """Close the pool.
 
         Prevents any more tasks from being submitted on the pool but allows
@@ -995,7 +995,7 @@ class Pool:
         self._closed = True
         gc.collect()
 
-    def terminate(self):
+    def terminate(self) -> None:
         """Close the pool.
 
         Prevents any more tasks from being submitted on the pool and stops
@@ -1007,7 +1007,7 @@ class Pool:
         for actor, _ in self._actor_pool:
             ray.kill(actor)
 
-    def join(self):
+    def join(self) -> None:
         """Wait for the actors in a closed pool to exit.
 
         If the pool was closed using `close`, this will return once all


### PR DESCRIPTION
``ray`` ships a py.typed marker, so these unannotated methods are treated as untyped functions by type checkers. Any caller running mypy in strict mode gets

```
    error: Call to untyped function "close" in typed context  [no-untyped-call]
```

for the standard ``pool.close(); pool.join()`` teardown, which leaves downstream projects either sprinkling per-call ignores or disabling ``disallow_untyped_calls`` for the whole ``ray`` package. All three methods already return None on every path.
