### PR TITLE
[core] annotate cluster_resources/available_resources return types

### DIFF
--- a/python/ray/_private/state.py
+++ b/python/ray/_private/state.py
@@ -875,7 +875,7 @@ class GlobalState:
             worker_id, num_paused_threads_delta
         )
 
-    def cluster_resources(self):
+    def cluster_resources(self) -> Dict[str, float]:
         """Get the current total cluster resources.
 
         Note that this information can grow stale as nodes are added to or
@@ -935,7 +935,7 @@ class GlobalState:
 
         return total_resources_by_node
 
-    def available_resources(self):
+    def available_resources(self) -> Dict[str, float]:
         """Get the current available cluster resources.
 
         This is different from `cluster_resources` in that this will return
@@ -1216,7 +1216,7 @@ def object_transfer_timeline(filename: Optional[str] = None):
 
 @DeveloperAPI
 @client_mode_hook
-def cluster_resources():
+def cluster_resources() -> Dict[str, float]:
     """Get the current total cluster resources.
 
     Note that this information can grow stale as nodes are added to or removed
@@ -1231,7 +1231,7 @@ def cluster_resources():
 
 @DeveloperAPI
 @client_mode_hook
-def available_resources():
+def available_resources() -> Dict[str, float]:
     """Get the current available cluster resources.
 
     This is different from `cluster_resources` in that this will return idle


### PR DESCRIPTION
Both are ``@PublicAPI``/``@DeveloperAPI`` entry points re-exported as ``ray.cluster_resources`` and ``ray.available_resources``, and both are documented as returning 'a dictionary mapping resource name to the total quantity of that resource'. Because they carry no annotation and ``ray`` ships py.typed, a strict-mode caller gets

```
    error: Call to untyped function "cluster_resources" in typed context
```

and the result is ``Any``, so ``ray.cluster_resources()["CPU"] >= 2`` is unchecked. The quantities are accumulated as numbers and the GCS reports fractional resources, hence ``float``.
