### PR TITLE
[cherry-pick][2.58.0][Fix][Core] Report shutdown from `check_signals` instead of exiting the process (#65184)

### DIFF
--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -2806,6 +2806,7 @@ cdef c_bool kill_main_task(const CTaskID &task_id) nogil:
 
 
 cdef CRayStatus check_signals() nogil:
+    cdef optional[c_bool] should_interrupt
     with gil:
         # The Python exceptions are not handled if it is raised from cdef,
         # so we have to handle it here.
@@ -2839,7 +2840,15 @@ cdef CRayStatus check_signals() nogil:
         # signal to worker threads (CancelActorTaskOnExecutor for non-async actors).
         # Unblock nogil backpressure waits. Uses job/task guards so periodic io threads
         # do not call GetCurrentTaskID() without a job (WorkerContext CHECK).
-        if CCoreWorkerProcess.GetCoreWorker().ShouldInterruptTaskForCancellation():
+        #
+        # Empty means the core worker is gone, which background threads polling here run
+        # into while ray.shutdown() clears it. Report that the same way the
+        # sys.is_finalizing() branch above does and let the caller stop; reaching the core
+        # worker through GetCoreWorker() instead would exit the process outright.
+        should_interrupt = CCoreWorkerProcess.ShouldInterruptTaskForCancellation()
+        if not should_interrupt.has_value():
+            return CRayStatus.IntentionalSystemExit(b"The core worker is shut down.")
+        if should_interrupt.value():
             return CRayStatus.Interrupted(b"")
 
     return CRayStatus.OK()

--- a/python/ray/includes/libcoreworker.pxd
+++ b/python/ray/includes/libcoreworker.pxd
@@ -500,6 +500,9 @@ cdef extern from "ray/core_worker/core_worker.h" nogil:
         CCoreWorker &GetCoreWorker()
 
         @staticmethod
+        optional[c_bool] ShouldInterruptTaskForCancellation()
+
+        @staticmethod
         void Shutdown()
 
         @staticmethod

--- a/src/ray/core_worker/core_worker_process.cc
+++ b/src/ray/core_worker/core_worker_process.cc
@@ -135,6 +135,13 @@ std::shared_ptr<CoreWorker> CoreWorkerProcess::TryGetWorker() {
   return core_worker_process->TryGetCoreWorker();
 }
 
+std::optional<bool> CoreWorkerProcess::ShouldInterruptTaskForCancellation() {
+  if (core_worker_process == nullptr) {
+    return std::nullopt;
+  }
+  return core_worker_process->ShouldInterruptTaskForCancellation();
+}
+
 std::shared_ptr<CoreWorker> CoreWorkerProcessImpl::CreateCoreWorker(
     CoreWorkerOptions options, const WorkerID &worker_id) {
   /// Event loop where the IO events are handled. e.g. async GCS operations.
@@ -1073,6 +1080,18 @@ void CoreWorkerProcessImpl::ShutdownDriver() {
 std::shared_ptr<CoreWorker> CoreWorkerProcessImpl::TryGetCoreWorker() const {
   const auto read_locked = core_worker_.LockForRead();
   return read_locked.Get();
+}
+
+std::optional<bool> CoreWorkerProcessImpl::ShouldInterruptTaskForCancellation() const {
+  const auto read_locked = core_worker_.LockForRead();
+  // Bind by reference. Copying the shared_ptr would let a caller that outlives
+  // ShutdownDriver() become the last owner and run ~CoreWorker on its own thread, which
+  // deadlocks when ~MutableObjectProvider joins that same thread.
+  const auto &worker = read_locked.Get();
+  if (worker == nullptr) {
+    return std::nullopt;
+  }
+  return worker->ShouldInterruptTaskForCancellation();
 }
 
 std::shared_ptr<CoreWorker> CoreWorkerProcessImpl::GetCoreWorker() const {

--- a/src/ray/core_worker/core_worker_process.h
+++ b/src/ray/core_worker/core_worker_process.h
@@ -16,6 +16,7 @@
 
 #include <boost/thread.hpp>
 #include <memory>
+#include <optional>
 #include <string>
 
 #include "ray/asio/asio_util.h"
@@ -95,6 +96,13 @@ class CoreWorkerProcess {
   /// \return The `CoreWorker` instance.
   static std::shared_ptr<CoreWorker> TryGetWorker();
 
+  /// Whether a running task has been marked for cancellation and should be interrupted.
+  /// Empty once the core worker is gone, so that background threads polling during
+  /// shutdown can tell that case apart in one read instead of exiting the process the way
+  /// GetCoreWorker() does. No reference to the CoreWorker escapes, which keeps a caller
+  /// from becoming its last owner.
+  static std::optional<bool> ShouldInterruptTaskForCancellation();
+
   /// Whether the current process has been initialized for core worker.
   static bool IsInitialized();
 
@@ -136,6 +144,9 @@ class CoreWorkerProcessImpl {
 
   /// Try to get core worker. Returns nullptr if core worker doesn't exist.
   std::shared_ptr<CoreWorker> TryGetCoreWorker() const;
+
+  /// Whether a running task should be interrupted. Empty if core worker doesn't exist.
+  std::optional<bool> ShouldInterruptTaskForCancellation() const;
 
   std::shared_ptr<CoreWorker> CreateCoreWorker(CoreWorkerOptions options,
                                                const WorkerID &worker_id);

--- a/src/ray/core_worker/experimental_mutable_object_provider.cc
+++ b/src/ray/core_worker/experimental_mutable_object_provider.cc
@@ -225,13 +225,25 @@ void MutableObjectProvider::PollWriterClosure(
   // The corresponding ReadRelease() will be automatically called when
   // `object` goes out of scope.
   Status status = object_manager_->ReadAcquire(writer_object_id, object);
-  // Check if the thread returned from ReadAcquire() because the process is exiting, not
-  // because there is something to read.
-  if (status.code() == StatusCode::ChannelError) {
-    // The process is exiting.
+  if (!status.ok()) {
+    // ChannelError is how ~MutableObjectProvider ends this thread. IntentionalSystemExit
+    // and Interrupted come from check_signals once the process is going away, during
+    // either ray.shutdown() or interpreter finalization. None of those leaves a value to
+    // push, so stop polling. Anything else is unexpected, and stopping is silent from a
+    // reader's point of view, so say so loudly enough to be found.
+    const bool expected = status.code() == StatusCode::ChannelError ||
+                          status.code() == StatusCode::IntentionalSystemExit ||
+                          status.code() == StatusCode::Interrupted;
+    if (expected) {
+      RAY_LOG(DEBUG).WithField(writer_object_id) << "Writer poll stopped: " << status;
+    } else {
+      RAY_LOG(WARNING).WithField(writer_object_id)
+          << "Writer poll stopped on an unexpected status, readers of this channel will "
+             "not receive further values: "
+          << status;
+    }
     return;
   }
-  RAY_CHECK_EQ(static_cast<int>(status.code()), static_cast<int>(StatusCode::OK));
 
   RAY_CHECK(object->GetData());
   RAY_CHECK(object->GetMetadata());


### PR DESCRIPTION
Cherry pick from https://github.com/ray-project/ray/pull/65184

## Description

`//python/ray/tests:test_channel` failed in about half of all CI runs while every test inside it passed. The target's output ends with a test printing `PASSED`, immediately followed by `The core worker has already been shutdown` from `core_worker_process.cc`, and then stops. Nothing hangs: those tests take about 11 seconds against a 180s timeout.

`check_signals()` in `python/ray/_raylet.pyx` reached the core worker through `CoreWorkerProcess::GetCoreWorker()`, which calls `QuickExit()` once the core worker is gone, even though shutdown is a normal state:

<img width="881" height="619" alt="check-signals-shutdown-race" src="https://github.com/user-attachments/assets/2b7e0a1f-42a6-467f-b5db-6921227b4ac6" />

A poll in that window kills the driver just after a test has passed, and `_Exit()` takes pytest's summary and the `failed_test_logs` artifact with it, which is why the target looked like it was hanging.

`check_signals` now reports the shutdown rather than exiting, returning `IntentionalSystemExit` the way its own `sys.is_finalizing()` branch already does for the same class of event.
`CoreWorkerProcess::ShouldInterruptTaskForCancellation()` now returns `std::optional<bool>`, empty when the core worker is gone, so both facts come back from one read under the lock that already guards the pointer. It hands out no `shared_ptr` to the `CoreWorker`, which matters because a caller holding the last reference would run `~CoreWorker`, and that joins the very thread it was running on.

Returning a non-OK status needed one more change.
`MutableObjectProvider::PollWriterClosure` accepted only `OK` or `ChannelError` and `RAY_CHECK`ed anything else, so it now stops polling on any non-OK status. That `RAY_CHECK` was also a live crash before this PR. `check_signals` returns `IntentionalSystemExit` while the interpreter is finalizing, and since that is neither `OK` nor `ChannelError`, a channel writer polling at that moment aborted the process.

Other `check_signals` callers see the change too: a blocking call that races `ray.shutdown()` now stops with `SystemExit` instead of having the process exit underneath it.

## Related issues

N/A

## Additional information

A/B tested on CI by running all core tests 25 times:

- Without the changes in this PR (9/25 `test_channel` failed):
  - Code: https://github.com/ray-project/ray/pull/65186
  - Run: https://buildkite.com/ray-project/premerge/builds/71411
- With the changes in this PR (0/25 `test_channel` failed):
  - Code: https://github.com/ray-project/ray/pull/65185
  - Run: https://buildkite.com/ray-project/premerge/builds/71412