### PR TITLE
[TPU] Add subslice_index to subslice_placement_group

### DIFF
--- a/python/ray/tests/test_tpu.py
+++ b/python/ray/tests/test_tpu.py
@@ -1945,6 +1945,77 @@ def test_subslice_auto_select_skips_busy_first_subslice(mock_4x4_pgs):
     sg.shutdown()
 
 
+def test_subslice_select_specific_index_success(mock_4x4_pgs):
+    """Specifying subslice_index selects that specific subslice even if others are idle."""
+    mock_head_pg, mock_worker_pg = mock_4x4_pgs
+    slice_name = "test-slice-specific-index"
+    dummy_nodes = _make_dummy_nodes(slice_name, "4x4", 4)
+
+    # Pre-populate cache so no discovery is needed.
+    ray.util.tpu._tpu_subslice_cache[slice_name] = _SUBSLICE_2X4_LABELS
+
+    # All workers idle.
+    avail = {
+        "node_0": {"TPU": 4},
+        "node_1": {"TPU": 4},
+        "node_2": {"TPU": 4},
+        "node_3": {"TPU": 4},
+    }
+
+    with (
+        patch("ray.util.tpu.placement_group", return_value=mock_worker_pg),
+        patch("ray.nodes", return_value=dummy_nodes),
+        patch(
+            "ray._private.state.available_resources_per_node",
+            return_value=avail,
+        ),
+    ):
+        sg = ray.util.tpu.subslice_placement_group(
+            subslice_topology="2x4",
+            accelerator_version="v6e",
+            chips_per_vm=4,
+            subslice_index=1,
+        )
+
+    assert sg.subslice_index == 1
+    assert sg.num_hosts == 2
+    sg.shutdown()
+
+
+def test_subslice_select_specific_index_busy(mock_4x4_pgs):
+    """Specifying subslice_index fails if that specific subslice is busy, even if others are idle."""
+    mock_head_pg, mock_worker_pg = mock_4x4_pgs
+    slice_name = "test-slice-specific-index-busy"
+    dummy_nodes = _make_dummy_nodes(slice_name, "4x4", 4)
+
+    # Pre-populate cache so no discovery is needed.
+    ray.util.tpu._tpu_subslice_cache[slice_name] = _SUBSLICE_2X4_LABELS
+
+    # Workers 2 and 3 (subslice 1) busy; workers 0 and 1 (subslice 0) idle.
+    avail = {
+        "node_0": {"TPU": 4},
+        "node_1": {"TPU": 4},
+        "node_2": {"TPU": 0},
+        "node_3": {"TPU": 0},
+    }
+
+    with (
+        patch("ray.util.tpu.placement_group", return_value=mock_worker_pg),
+        patch("ray.nodes", return_value=dummy_nodes),
+        patch(
+            "ray._private.state.available_resources_per_node",
+            return_value=avail,
+        ),
+    ):
+        with pytest.raises(RuntimeError, match="No subslice of '2x4' is schedulable"):
+            ray.util.tpu.subslice_placement_group(
+                subslice_topology="2x4",
+                accelerator_version="v6e",
+                chips_per_vm=4,
+                subslice_index=1,
+            )
+
+
 def test_subslice_release_head_pgs_and_shutdown():
     """Test that release_head_pgs and shutdown are idempotent."""
     from ray.util.placement_group import PlacementGroup

--- a/python/ray/util/tpu.py
+++ b/python/ray/util/tpu.py
@@ -1676,6 +1676,7 @@ def _find_available_subslice(
     worker_labels: Dict[str, Dict[str, str]],
     avail: Dict[str, Dict[str, float]],
     slice_worker_to_node: Dict[Tuple[str, str], Any],
+    subslice_index: Optional[int] = None,
 ) -> Tuple[Optional[List[str]], Optional[int]]:
     """Find an idle subslice of *subslice_topology* within *slice_name*.
 
@@ -1691,6 +1692,8 @@ def _find_available_subslice(
     for worker_id, labels in worker_labels.items():
         idx = labels.get(label_key)
         if idx is not None:
+            if subslice_index is not None and int(idx) != subslice_index:
+                continue
             subslice_indices.setdefault(idx, []).append(worker_id)
 
     if not subslice_indices:
@@ -1989,6 +1992,7 @@ def _find_available_cached_subslice(
     nodes: List[Dict[str, Any]],
     avail: Dict[str, Dict[str, float]],
     slice_worker_to_node: Dict[Tuple[str, str], Any],
+    subslice_index: Optional[int] = None,
 ) -> Optional[Tuple[List[str], int, str, str, Dict[str, Dict[str, str]]]]:
     """Return the first idle subslice across all cached slices of any valid
     parent topology, or ``None``.
@@ -2007,6 +2011,7 @@ def _find_available_cached_subslice(
                 worker_labels,
                 avail,
                 slice_worker_to_node,
+                subslice_index,
             )
             if worker_ids is not None:
                 return worker_ids, idx, slice_name, parent_topology, worker_labels
@@ -2162,6 +2167,7 @@ def subslice_placement_group(
     head_reservation_timeout_s: Optional[
         float
     ] = DEFAULT_TPU_HEAD_RESERVATION_TIMEOUT_S,
+    subslice_index: Optional[int] = None,
 ) -> SubslicePlacementGroup:
     """Asynchronously creates a PlacementGroup for a TPU subslice.
 
@@ -2188,6 +2194,10 @@ def subslice_placement_group(
         head_reservation_timeout_s: Maximum seconds to wait for TPU head
             placement groups. Defaults to
             ``DEFAULT_TPU_HEAD_RESERVATION_TIMEOUT_S``.
+        subslice_index: Optional index of the subslice to select. If specified,
+            only the subslice at this index within the physical slice will be
+            considered. If that subslice is busy, the request will fail even if
+            other subslices are idle.
 
     Returns:
         A :class:`SubslicePlacementGroup` handle.
@@ -2242,7 +2252,12 @@ def subslice_placement_group(
         # search and the undiscovered-parent check observe persisted slices.
         _refresh_cache_from_kv(parent_topologies, nodes)
         cached_subslice = _find_available_cached_subslice(
-            parent_topologies, subslice_topology, nodes, avail, slice_worker_to_node
+            parent_topologies,
+            subslice_topology,
+            nodes,
+            avail,
+            slice_worker_to_node,
+            subslice_index,
         )
         discoverable = _find_undiscovered_idle_slice(
             parent_topologies, nodes, avail, version


### PR DESCRIPTION


## Description

When requesting multiple subslices simultaneously, it can be helpful to allow selecting specific subslices to guarantee a spread of jobs. This change adds an optional subslice_index parameter to the subslice_placement_group builder which restricts placement group selection.

## Related issues

Follow on to #64578
## Additional information
n/a