### PR TITLE
[jobs]: return structured 503 when job logs are unavailable

### DIFF
--- a/doc/source/cluster/running-applications/job-submission/openapi.yml
+++ b/doc/source/cluster/running-applications/job-submission/openapi.yml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: Ray Jobs API
-  version: 4.0.0
+  version: 5.0.0
   description: |
     This is the specification for the Ray Jobs REST API.
     See the Ray Jobs documentation for details:
@@ -253,6 +253,28 @@ paths:
               schema:
                 description: The error message.
                 type: string
+        503:
+          summary: Job Logs Unavailable
+          description: |
+            The job exists, but its node-local logs are unavailable because the
+            driver agent cannot be reached.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error_code:
+                    type: string
+                    enum:
+                      - JOB_LOGS_UNAVAILABLE
+                  message:
+                    type: string
+                  submission_id:
+                    type: string
+                required:
+                  - error_code
+                  - message
+                  - submission_id
         404:
           summary: Job Not Found
           description: |

--- a/python/ray/dashboard/modules/job/job_head.py
+++ b/python/ray/dashboard/modules/job/job_head.py
@@ -582,7 +582,7 @@ class JobHead(SubprocessModule):
                 text=json.dumps(dataclasses.asdict(payload)),
                 content_type="application/json",
             )
-        except (aiohttp.ClientConnectionError, asyncio.TimeoutError) as error:
+        except (aiohttp.ClientError, asyncio.TimeoutError) as error:
             logger.info(
                 "Job logs are unavailable because the driver agent cannot be reached.",
                 exc_info=error,

--- a/python/ray/dashboard/modules/job/job_head.py
+++ b/python/ray/dashboard/modules/job/job_head.py
@@ -9,6 +9,7 @@ import traceback
 from datetime import datetime
 from typing import AsyncIterator, Dict, Optional, Tuple
 
+import aiohttp
 import aiohttp.web
 from aiohttp.client import ClientResponse
 from aiohttp.web import Request, Response, StreamResponse
@@ -57,6 +58,8 @@ from ray.dashboard.utils import get_head_node_id
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
+
+JOB_LOGS_UNAVAILABLE_ERROR_CODE = "JOB_LOGS_UNAVAILABLE"
 
 
 class RayActivityStatus(str, enum.Enum):
@@ -568,6 +571,8 @@ class JobHead(SubprocessModule):
 
         try:
             job_agent_client = self.get_job_driver_agent_client(job)
+            if job_agent_client and not await self._is_job_driver_agent_registered(job):
+                return self._job_logs_unavailable_response(job.submission_id)
             payload = (
                 await job_agent_client.get_job_logs_internal(job.submission_id)
                 if job_agent_client
@@ -577,11 +582,40 @@ class JobHead(SubprocessModule):
                 text=json.dumps(dataclasses.asdict(payload)),
                 content_type="application/json",
             )
+        except (aiohttp.ClientConnectionError, asyncio.TimeoutError) as error:
+            logger.info(
+                "Job logs are unavailable because the driver agent cannot be reached.",
+                exc_info=error,
+            )
+            return self._job_logs_unavailable_response(job.submission_id)
         except Exception:
             return Response(
                 text=traceback.format_exc(),
                 status=aiohttp.web.HTTPInternalServerError.status_code,
             )
+
+    async def _is_job_driver_agent_registered(self, job: JobDetails) -> bool:
+        if job.driver_node_id is None:
+            return False
+        try:
+            await self._fetch_agent_info(NodeID.from_hex(job.driver_node_id))
+            return True
+        except KeyError:
+            return False
+
+    @staticmethod
+    def _job_logs_unavailable_response(submission_id: str) -> Response:
+        return aiohttp.web.json_response(
+            {
+                "error_code": JOB_LOGS_UNAVAILABLE_ERROR_CODE,
+                "message": (
+                    f"Logs for job {submission_id} are unavailable because "
+                    "the driver agent cannot be reached."
+                ),
+                "submission_id": submission_id,
+            },
+            status=aiohttp.web.HTTPServiceUnavailable.status_code,
+        )
 
     @routes.get(
         "/api/jobs/{job_or_submission_id}/logs/tail", resp_type=ResponseType.WEBSOCKET

--- a/python/ray/dashboard/modules/job/tests/test_http_job_server.py
+++ b/python/ray/dashboard/modules/job/tests/test_http_job_server.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import logging
 import os
@@ -8,13 +9,15 @@ import tempfile
 import time
 from pathlib import Path
 from typing import Optional
-from unittest.mock import patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
+import aiohttp
 import pytest
 import requests
 import yaml
 
 import ray
+from ray import NodeID
 from ray._common.test_utils import wait_for_condition
 from ray._private.runtime_env.packaging import (
     create_package,
@@ -27,8 +30,12 @@ from ray._private.test_utils import (
     wait_until_server_available,
 )
 from ray.dashboard.modules.dashboard_sdk import ClusterInfo, parse_cluster_info
-from ray.dashboard.modules.job.common import uri_to_http_components
-from ray.dashboard.modules.job.pydantic_models import JobDetails
+from ray.dashboard.modules.job.common import JobLogsResponse, uri_to_http_components
+from ray.dashboard.modules.job.job_head import (
+    JOB_LOGS_UNAVAILABLE_ERROR_CODE,
+    JobHead,
+)
+from ray.dashboard.modules.job.pydantic_models import JobDetails, JobType
 from ray.dashboard.modules.job.tests.test_cli_integration import set_env_var
 from ray.dashboard.modules.version import CURRENT_VERSION
 from ray.dashboard.tests.conftest import *  # noqa
@@ -606,6 +613,111 @@ def test_submit_still_accepts_job_id_or_submission_id(job_sdk_client):
     )
 
     wait_for_condition(_check_job_succeeded, client=client, job_id="raysubmit_23456")
+
+
+@pytest.fixture
+def job_head_with_agent():
+    node_id = NodeID.from_random().hex()
+    job = JobDetails(
+        type=JobType.SUBMISSION,
+        submission_id="test-job",
+        status=JobStatus.SUCCEEDED,
+        entrypoint="echo hello",
+        driver_agent_http_address="http://127.0.0.1:52365",
+        driver_node_id=node_id,
+    )
+    agent = MagicMock()
+    agent.get_job_logs_internal = AsyncMock()
+    job_head = object.__new__(JobHead)
+    job_head._gcs_client = MagicMock()
+    job_head._job_info_client = MagicMock()
+    job_head._agents = {node_id: agent}
+    job_head._fetch_agent_info = AsyncMock(return_value=("127.0.0.1", 52365, 52366))
+    return job_head, job, agent
+
+
+@pytest.mark.asyncio
+async def test_get_job_logs_from_live_agent(job_head_with_agent):
+    job_head, job, agent = job_head_with_agent
+    agent.get_job_logs_internal.return_value = JobLogsResponse(logs="hello\n")
+    request = MagicMock(match_info={"job_or_submission_id": job.submission_id})
+
+    with patch(
+        "ray.dashboard.modules.job.job_head.find_job_by_ids",
+        new=AsyncMock(return_value=job),
+    ):
+        response = await job_head.get_job_logs(request)
+
+    assert response.status == 200
+    assert json.loads(response.text) == {"logs": "hello\n"}
+
+
+@pytest.mark.asyncio
+async def test_get_job_logs_when_driver_node_is_missing(job_head_with_agent):
+    job_head, job, agent = job_head_with_agent
+    job_head._fetch_agent_info.side_effect = KeyError("agent is not registered")
+    request = MagicMock(match_info={"job_or_submission_id": job.submission_id})
+
+    with patch(
+        "ray.dashboard.modules.job.job_head.find_job_by_ids",
+        new=AsyncMock(return_value=job),
+    ):
+        response = await job_head.get_job_logs(request)
+
+    assert response.status == 503
+    assert json.loads(response.text) == {
+        "error_code": JOB_LOGS_UNAVAILABLE_ERROR_CODE,
+        "message": (
+            "Logs for job test-job are unavailable because "
+            "the driver agent cannot be reached."
+        ),
+        "submission_id": "test-job",
+    }
+    agent.get_job_logs_internal.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "error",
+    [
+        pytest.param(
+            aiohttp.ClientConnectionError("Connection refused"),
+            id="connection-refused",
+        ),
+        pytest.param(asyncio.TimeoutError(), id="timeout"),
+    ],
+)
+async def test_get_job_logs_when_driver_agent_is_unreachable(
+    job_head_with_agent, error
+):
+    job_head, job, agent = job_head_with_agent
+    agent.get_job_logs_internal.side_effect = error
+    request = MagicMock(match_info={"job_or_submission_id": job.submission_id})
+
+    with patch(
+        "ray.dashboard.modules.job.job_head.find_job_by_ids",
+        new=AsyncMock(return_value=job),
+    ):
+        response = await job_head.get_job_logs(request)
+
+    assert response.status == 503
+    assert response.content_type == "application/json"
+    assert json.loads(response.text)["error_code"] == JOB_LOGS_UNAVAILABLE_ERROR_CODE
+
+
+@pytest.mark.asyncio
+async def test_get_job_logs_unknown_job_preserves_404(job_head_with_agent):
+    job_head, _, _ = job_head_with_agent
+    request = MagicMock(match_info={"job_or_submission_id": "unknown-job"})
+
+    with patch(
+        "ray.dashboard.modules.job.job_head.find_job_by_ids",
+        new=AsyncMock(return_value=None),
+    ):
+        response = await job_head.get_job_logs(request)
+
+    assert response.status == 404
+    assert response.text == "Job unknown-job does not exist"
 
 
 def test_missing_resources(job_sdk_client):

--- a/python/ray/dashboard/modules/job/tests/test_sdk.py
+++ b/python/ray/dashboard/modules/job/tests/test_sdk.py
@@ -31,6 +31,7 @@ from ray.dashboard.modules.dashboard_sdk import (
     ClusterInfo,
     parse_cluster_info,
 )
+from ray.dashboard.modules.job.job_head import JOB_LOGS_UNAVAILABLE_ERROR_CODE
 from ray.dashboard.modules.job.pydantic_models import JobType
 from ray.dashboard.modules.job.sdk import JobStatus, JobSubmissionClient
 from ray.dashboard.tests.conftest import *  # noqa
@@ -295,6 +296,50 @@ def test_jobs_run_on_head_by_default_E2E(ray_start_cluster_head_with_env_vars):
     assert (num_ids > 1) if allow_driver_on_worker_nodes else (num_ids == 1), [
         id[:5] for id in driver_node_ids
     ]
+
+
+@pytest.mark.parametrize(
+    "ray_start_cluster_head",
+    [
+        {
+            "include_dashboard": True,
+            "num_cpus": 0,
+            "dashboard_agent_listen_port": 52465,
+        }
+    ],
+    indirect=True,
+)
+def test_job_logs_after_driver_node_removed(ray_start_cluster_head):
+    cluster = ray_start_cluster_head
+    worker_node = cluster.add_node(num_cpus=1, dashboard_agent_listen_port=52466)
+    assert wait_until_server_available(cluster.webui_url)
+    client = JobSubmissionClient(format_web_url(cluster.webui_url))
+    gcs_client = GcsClient(address=cluster.gcs_address)
+    wait_for_condition(lambda: get_register_agents_number(gcs_client) == 2, timeout=20)
+
+    job_id = client.submit_job(
+        entrypoint="echo worker-log",
+        entrypoint_num_cpus=1,
+    )
+    wait_for_condition(_check_job_succeeded, client=client, job_id=job_id, timeout=30)
+    assert "worker-log" in client.get_job_logs(job_id)
+
+    cluster.remove_node(worker_node, allow_graceful=True)
+    wait_for_condition(lambda: get_register_agents_number(gcs_client) == 1, timeout=20)
+
+    assert client.get_job_status(job_id) == JobStatus.SUCCEEDED
+    response = client._do_request("GET", f"/api/jobs/{job_id}/logs")
+    assert response.status_code == 503
+    assert response.json() == {
+        "error_code": JOB_LOGS_UNAVAILABLE_ERROR_CODE,
+        "message": (
+            f"Logs for job {job_id} are unavailable because "
+            "the driver agent cannot be reached."
+        ),
+        "submission_id": job_id,
+    }
+    with pytest.raises(RuntimeError, match=JOB_LOGS_UNAVAILABLE_ERROR_CODE):
+        client.get_job_logs(job_id)
 
 
 @pytest.fixture

--- a/python/ray/dashboard/modules/version.py
+++ b/python/ray/dashboard/modules/version.py
@@ -7,7 +7,8 @@ from dataclasses import dataclass
 # Version 2 -> 3: - Added optional fields entrypoint_num_cpus, entrypoint_num_gpus
 #                   and entrypoint_resources to submit_job sdk/cli/api.
 # Version 3 -> 4: - Added DELETE endpoint for deleting jobs.
-CURRENT_VERSION = "4"
+# Version 4 -> 5: - Added a structured 503 response for unavailable job logs.
+CURRENT_VERSION = "5"
 
 
 @dataclass


### PR DESCRIPTION
## Summary
- return a structured `503 Service Unavailable` when a submission job still exists but its driver agent is no longer registered or reachable
- preserve successful log retrieval, unknown-job `404` behavior, and the public SDK's existing `RuntimeError` contract
- document the JSON error response and bump the Jobs API version

The response does not imply that node-local logs are persisted or recoverable. This is a draft pending maintainer confirmation that `503` is the preferred API contract.

Fixes #65402

## Test plan
- [x] `pytest -q python/ray/dashboard/modules/job/tests/test_http_job_server.py -k 'get_job_logs_from_live_agent or get_job_logs_when_driver_node_is_missing or get_job_logs_when_driver_agent_is_unreachable or get_job_logs_unknown_job_preserves_404'`
- [x] `pytest -q python/ray/dashboard/modules/job/tests/test_sdk.py -k job_logs_after_driver_node_removed`
- [x] `pytest -vv python/ray/dashboard/modules/job/tests/test_job_agent.py -k job_log_in_multiple_node --maxfail=1`
- [x] `ruff check` and `ruff format --check` on changed Python files
- [x] Python compilation and OpenAPI YAML parsing
- [x] Upstream [microcheck](https://buildkite.com/ray-project/microcheck/builds/51960) passed.
- [ ] The two-node E2E was not independently rerun locally because this checkout lacks compiled `ray._raylet`. The public microcheck summary does not expose individual job execution, so the PR remains draft pending CI or maintainer confirmation that it ran.