### PR TITLE
[Data] Avoid scaling GPU node shapes for CPU-only autoscaling pressure

### DIFF
--- a/python/ray/data/_internal/cluster_autoscaler/default_cluster_autoscaler_v2.py
+++ b/python/ray/data/_internal/cluster_autoscaler/default_cluster_autoscaler_v2.py
@@ -18,6 +18,7 @@ from .default_autoscaling_coordinator import (
     DefaultAutoscalingCoordinator,
 )
 from .resource_utilization_gauge import (
+    ClusterUtil,
     ResourceUtilizationGauge,
     RollingLogicalUtilizationGauge,
 )
@@ -159,6 +160,38 @@ def _get_node_resource_spec_and_count(
         nodes_resource_spec_count[node_resource_spec] += 1
 
     return nodes_resource_spec_count
+
+
+def _select_node_specs_for_scale_up(
+    node_resource_spec_count: Dict[_NodeResourceSpec, int],
+    util: ClusterUtil,
+    threshold: float,
+) -> List[_NodeResourceSpec]:
+    """Select node shapes whose resources match the scale-up signal.
+
+    Heterogeneous clusters often have both CPU-only nodes and accelerator nodes.
+    If CPU or memory pressure is the only signal, requesting accelerator nodes can
+    be very expensive and may not help the bottleneck. Prefer CPU-only shapes for
+    CPU/memory pressure and accelerator shapes for GPU pressure. If the heuristic
+    finds no matching shape, fall back to all shapes to preserve scale-up behavior
+    for homogeneous clusters.
+    """
+    cpu_or_memory_hot = (
+        util.cpu >= threshold
+        or util.memory >= threshold
+        or util.object_store_memory >= threshold
+    )
+    gpu_hot = util.gpu >= threshold
+
+    selected = []
+    for node_resource_spec in node_resource_spec_count:
+        if node_resource_spec.gpu > 0:
+            if gpu_hot:
+                selected.append(node_resource_spec)
+        elif cpu_or_memory_hot:
+            selected.append(node_resource_spec)
+
+    return selected or list(node_resource_spec_count)
 
 
 class DefaultClusterAutoscalerV2(ClusterAutoscaler):
@@ -314,18 +347,21 @@ class DefaultClusterAutoscalerV2(ClusterAutoscaler):
 
         # We separate active bundles (existing nodes) from pending bundles (scale-up delta)
         # to ensure existing nodes' resources are never crowded out by scale-up requests.
-        # TODO(hchen): We scale up all nodes by the same delta for now.
-        # We may want to distinguish different node types based on their individual
-        # utilization.
         active_bundles = []
         pending_bundles = []
         node_resource_spec_count = self._get_node_counts()
+        node_specs_to_scale = _select_node_specs_for_scale_up(
+            node_resource_spec_count,
+            util,
+            self._cluster_scaling_up_util_threshold,
+        )
         for node_resource_spec, count in node_resource_spec_count.items():
             bundle = node_resource_spec.to_bundle()
             # Bundles for existing nodes -> active (must include)
             active_bundles.extend([bundle] * count)
             # Bundles for scale-up delta -> pending (best-effort)
-            pending_bundles.extend([bundle] * self._cluster_scaling_up_delta)
+            if node_resource_spec in node_specs_to_scale:
+                pending_bundles.extend([bundle] * self._cluster_scaling_up_delta)
 
         # Cap the resource request to respect user-configured limits.
         # Active bundles (existing nodes) are always included; pending bundles
@@ -351,7 +387,7 @@ class DefaultClusterAutoscalerV2(ClusterAutoscaler):
             f"CPU={current_utilization.cpu:.0%}, GPU={current_utilization.gpu:.0%}, "
             f"memory={current_utilization.memory:.0%}, "
             f"object_store_memory={current_utilization.object_store_memory:.0%}. "
-            f"Requesting {self._cluster_scaling_up_delta} node(s) of each shape:"
+            f"Requesting {self._cluster_scaling_up_delta} node(s) of selected shape(s):"
         )
 
         current_node_counts = Counter(

--- a/python/ray/data/_internal/cluster_autoscaler/default_cluster_autoscaler_v2.py
+++ b/python/ray/data/_internal/cluster_autoscaler/default_cluster_autoscaler_v2.py
@@ -398,6 +398,8 @@ class DefaultClusterAutoscalerV2(ClusterAutoscaler):
         )
         for node_spec, requested_count in requested_node_counts.items():
             current_count = current_node_counts.get(node_spec, 0)
+            if requested_count <= current_count:
+                continue
             message += f" [{node_spec}: {current_count} -> {requested_count}]"
 
         if self.RAY_DATA_DISABLE_AUTOSCALER_LOGGING or not self._autoscaling_enabled:

--- a/python/ray/data/tests/test_default_cluster_autoscaler_v2.py
+++ b/python/ray/data/tests/test_default_cluster_autoscaler_v2.py
@@ -11,6 +11,7 @@ from ray.data._internal.cluster_autoscaler.default_cluster_autoscaler_v2 import 
     DefaultClusterAutoscalerV2,
     _get_node_resource_spec_and_count,
     _NodeResourceSpec,
+    _select_node_specs_for_scale_up,
 )
 from ray.data._internal.cluster_autoscaler.fake_autoscaling_coordinator import (
     FakeAutoscalingCoordinator,
@@ -208,8 +209,16 @@ class TestClusterAutoscaling:
         if not should_scale_up:
             assert resources_reserved == ExecutionResources.zero()
         else:
-            expected_num_resource_spec1_requested = 2 + scale_up_delta
-            expected_num_resource_spec2_requested = 1 + scale_up_delta
+            cpu_or_memory_hot = (
+                cpu_util >= scale_up_threshold or mem_util >= scale_up_threshold
+            )
+            gpu_hot = gpu_util >= scale_up_threshold
+            expected_num_resource_spec1_requested = 2 + (
+                scale_up_delta if cpu_or_memory_hot else 0
+            )
+            expected_num_resource_spec2_requested = 1 + (
+                scale_up_delta if gpu_hot else 0
+            )
             expected_resources = ExecutionResources(
                 cpu=(
                     resource_spec1.cpu * expected_num_resource_spec1_requested
@@ -226,6 +235,63 @@ class TestClusterAutoscaling:
             )
 
             assert resources_reserved == expected_resources
+
+    def test_cpu_pressure_does_not_scale_gpu_nodes_when_cpu_nodes_exist(self):
+        """CPU-only pressure should not request accelerator nodes in a mixed cluster.
+
+        This covers the failure mode from ray-project/ray#56431 where Ray Data
+        batch inference with vLLM could ask for more GPU nodes while the observed
+        pressure was CPU-only.
+        """
+        scale_up_threshold = 0.75
+        scale_up_delta = 1
+        cpu_node_spec = _NodeResourceSpec.of(cpu=32, gpu=0, mem=16 * GiB)
+        gpu_node_spec = _NodeResourceSpec.of(cpu=1, gpu=8, mem=64 * GiB)
+
+        autoscaler = DefaultClusterAutoscalerV2(
+            resource_manager=MagicMock(),
+            resource_limits=ExecutionResources.inf(),
+            execution_id="test_cpu_only_pressure_mixed_cluster",
+            cluster_scaling_up_delta=scale_up_delta,
+            resource_utilization_calculator=StubUtilizationGauge(
+                ExecutionResources(
+                    cpu=0.95,
+                    gpu=0.1,
+                    memory=0.1,
+                    object_store_memory=0.1,
+                )
+            ),
+            cluster_scaling_up_util_threshold=scale_up_threshold,
+            min_gap_between_autoscaling_requests_s=0,
+            autoscaling_coordinator=FakeAutoscalingCoordinator(),
+            get_node_counts=lambda: {
+                cpu_node_spec: 10,
+                gpu_node_spec: 2,
+            },
+        )
+
+        autoscaler.try_trigger_scaling()
+
+        resources_reserved = autoscaler.get_total_resources()
+        assert resources_reserved.cpu == (
+            cpu_node_spec.cpu * (10 + scale_up_delta) + gpu_node_spec.cpu * 2
+        )
+        assert resources_reserved.gpu == gpu_node_spec.gpu * 2
+        assert resources_reserved.memory == (
+            cpu_node_spec.mem * (10 + scale_up_delta) + gpu_node_spec.mem * 2
+        )
+
+    def test_cpu_pressure_scales_gpu_nodes_if_no_cpu_node_type_exists(self):
+        """Fallback preserves scale-up behavior for GPU-only clusters."""
+        gpu_node_spec = _NodeResourceSpec.of(cpu=1, gpu=8, mem=64 * GiB)
+
+        selected = _select_node_specs_for_scale_up(
+            {gpu_node_spec: 2},
+            ExecutionResources(cpu=0.95, gpu=0.1, memory=0.1, object_store_memory=0.1),
+            threshold=0.75,
+        )
+
+        assert selected == [gpu_node_spec]
 
     def test_get_node_resource_spec_and_count_from_zero(self):
         """Test that get_node_resource_spec_and_count can discover node types
@@ -860,7 +926,7 @@ class TestClusterAutoscaling:
         expected_message = (
             "The utilization of one or more logical resource is higher than the "
             "specified threshold of 75%: CPU=100%, GPU=100%, memory=0%, "
-            "object_store_memory=100%. Requesting 1 node(s) of each shape: "
+            "object_store_memory=100%. Requesting 1 node(s) of selected shape(s): "
             "[{CPU: 1, GPU: 0, memory: 8.0GiB}: 1 -> 2]"
         )
         log_messages = [record.message for record in caplog.records]

--- a/python/ray/data/tests/test_default_cluster_autoscaler_v2.py
+++ b/python/ray/data/tests/test_default_cluster_autoscaler_v2.py
@@ -236,7 +236,9 @@ class TestClusterAutoscaling:
 
             assert resources_reserved == expected_resources
 
-    def test_cpu_pressure_does_not_scale_gpu_nodes_when_cpu_nodes_exist(self):
+    def test_cpu_pressure_does_not_scale_gpu_nodes_when_cpu_nodes_exist(
+        self, propagate_logs, caplog
+    ):
         """CPU-only pressure should not request accelerator nodes in a mixed cluster.
 
         This covers the failure mode from ray-project/ray#56431 where Ray Data
@@ -248,29 +250,31 @@ class TestClusterAutoscaling:
         cpu_node_spec = _NodeResourceSpec.of(cpu=32, gpu=0, mem=16 * GiB)
         gpu_node_spec = _NodeResourceSpec.of(cpu=1, gpu=8, mem=64 * GiB)
 
-        autoscaler = DefaultClusterAutoscalerV2(
-            resource_manager=MagicMock(),
-            resource_limits=ExecutionResources.inf(),
-            execution_id="test_cpu_only_pressure_mixed_cluster",
-            cluster_scaling_up_delta=scale_up_delta,
-            resource_utilization_calculator=StubUtilizationGauge(
-                ExecutionResources(
-                    cpu=0.95,
-                    gpu=0.1,
-                    memory=0.1,
-                    object_store_memory=0.1,
-                )
-            ),
-            cluster_scaling_up_util_threshold=scale_up_threshold,
-            min_gap_between_autoscaling_requests_s=0,
-            autoscaling_coordinator=FakeAutoscalingCoordinator(),
-            get_node_counts=lambda: {
-                cpu_node_spec: 10,
-                gpu_node_spec: 2,
-            },
-        )
+        with patch(_IS_AUTOSCALING_ENABLED_PATH, return_value=True):
+            autoscaler = DefaultClusterAutoscalerV2(
+                resource_manager=MagicMock(),
+                resource_limits=ExecutionResources.inf(),
+                execution_id="test_cpu_only_pressure_mixed_cluster",
+                cluster_scaling_up_delta=scale_up_delta,
+                resource_utilization_calculator=StubUtilizationGauge(
+                    ExecutionResources(
+                        cpu=0.95,
+                        gpu=0.1,
+                        memory=0.1,
+                        object_store_memory=0.1,
+                    )
+                ),
+                cluster_scaling_up_util_threshold=scale_up_threshold,
+                min_gap_between_autoscaling_requests_s=0,
+                autoscaling_coordinator=FakeAutoscalingCoordinator(),
+                get_node_counts=lambda: {
+                    cpu_node_spec: 10,
+                    gpu_node_spec: 2,
+                },
+            )
 
-        autoscaler.try_trigger_scaling()
+        with caplog.at_level(logging.INFO):
+            autoscaler.try_trigger_scaling()
 
         resources_reserved = autoscaler.get_total_resources()
         assert resources_reserved.cpu == (
@@ -279,6 +283,15 @@ class TestClusterAutoscaling:
         assert resources_reserved.gpu == gpu_node_spec.gpu * 2
         assert resources_reserved.memory == (
             cpu_node_spec.mem * (10 + scale_up_delta) + gpu_node_spec.mem * 2
+        )
+        log_messages = [record.message for record in caplog.records]
+        assert any(
+            "[{CPU: 32, GPU: 0, memory: 16.0GiB}: 10 -> 11]" in message
+            for message in log_messages
+        )
+        assert all(
+            "[{CPU: 1, GPU: 8, memory: 64.0GiB}: 2 -> 2]" not in message
+            for message in log_messages
         )
 
     def test_cpu_pressure_scales_gpu_nodes_if_no_cpu_node_type_exists(self):


### PR DESCRIPTION
## Description

Ray Data's `DefaultClusterAutoscalerV2` decides to scale up when one of its existing cluster utilization values is above the scale-up threshold. Those values are CPU, GPU, memory, and object store memory.

Before this PR, once that check said "scale up", Ray Data added pending scale-up bundles for every known worker node shape. In a mixed CPU/GPU cluster, CPU-only pressure could therefore request another GPU node shape even when GPU utilization was low.

This PR keeps the same scale-up signal and threshold. The only change is which node shapes get pending scale-up bundles:

- If CPU, memory, or object store memory is high, add pending bundles for CPU-only node shapes.
- If GPU is high, add pending bundles for GPU node shapes.
- If no matching node shape exists, fall back to the previous behavior so scale-up still works.

This addresses the GPU-node spillover described in #56431. It does not try to fully solve why CPU pressure may stay high.

Duplicate/work-in-flight checks:

- No open PRs found referencing #56431.
- No open PRs found for `DefaultClusterAutoscalerV2`.
- Searched related Ray Data/vLLM autoscaling issues. #56431 and #49589 are the closest matches, but this PR is scoped to GPU-node scale-up caused by CPU-only pressure.

## Related issues

Related to #56431 and #49589.

## Additional information

AI assistance was used.

Tested:

- Negative-control behavior on current `origin/master` at the time of development: CPU-only pressure in a mixed CPU/GPU cluster requested GPU capacity `16 -> 24`.
- Fixed behavior: the same CPU-only pressure keeps GPU capacity at `16` while still requesting one more CPU node shape.
- The regression test also checks that the scale-up log lists the CPU node shape increase and does not list the unchanged GPU node shape.
- After merging latest `origin/master` into this branch, reran:
- `PYTHONPATH=python python -m pytest -q python/ray/data/tests/test_default_cluster_autoscaler_v2.py`: `34 passed`
- `ruff check python/ray/data/_internal/cluster_autoscaler/default_cluster_autoscaler_v2.py python/ray/data/tests/test_default_cluster_autoscaler_v2.py`: passed
- `ruff check --select I python/ray/data/_internal/cluster_autoscaler/default_cluster_autoscaler_v2.py python/ray/data/tests/test_default_cluster_autoscaler_v2.py`: passed
- `black --check python/ray/data/_internal/cluster_autoscaler/default_cluster_autoscaler_v2.py python/ray/data/tests/test_default_cluster_autoscaler_v2.py`: passed
- Local Ray build and `ray._raylet` import check: passed
