### PR TITLE
[Data] Rename Shuffle strategy from `hash_shuffle_v2` to `shuffle_v2`

### DIFF
--- a/python/ray/data/_internal/planner/plan_all_to_all_op.py
+++ b/python/ray/data/_internal/planner/plan_all_to_all_op.py
@@ -308,7 +308,7 @@ def plan_all_to_all_op(
                 return _plan_gpu_shuffle_repartition(
                     data_context, op, input_physical_dag
                 )
-            elif data_context.shuffle_strategy == ShuffleStrategy.HASH_SHUFFLE_V2:
+            elif data_context.shuffle_strategy == ShuffleStrategy.SHUFFLE_V2:
                 return _plan_hash_shuffle_repartition_v2(
                     data_context, op, input_physical_dag
                 )
@@ -320,7 +320,7 @@ def plan_all_to_all_op(
                 raise ValueError(
                     "Key-based repartitioning only supported for "
                     f"`DataContext.shuffle_strategy=HASH_SHUFFLE`, "
-                    f"`DataContext.shuffle_strategy=HASH_SHUFFLE_V2` or "
+                    f"`DataContext.shuffle_strategy=SHUFFLE_V2` or "
                     f"`DataContext.shuffle_strategy=GPU_SHUFFLE` "
                     f"(got {data_context.shuffle_strategy})"
                 )
@@ -352,7 +352,7 @@ def plan_all_to_all_op(
     elif isinstance(op, Aggregate):
         if data_context.shuffle_strategy == ShuffleStrategy.GPU_SHUFFLE:
             return _plan_gpu_shuffle_aggregate(data_context, op, input_physical_dag)
-        elif data_context.shuffle_strategy == ShuffleStrategy.HASH_SHUFFLE_V2:
+        elif data_context.shuffle_strategy == ShuffleStrategy.SHUFFLE_V2:
             return _plan_hash_shuffle_aggregate_v2(data_context, op, input_physical_dag)
         elif data_context.shuffle_strategy == ShuffleStrategy.HASH_SHUFFLE:
             return _plan_hash_shuffle_aggregate(data_context, op, input_physical_dag)

--- a/python/ray/data/_internal/planner/planner.py
+++ b/python/ray/data/_internal/planner/planner.py
@@ -195,7 +195,7 @@ def plan_join_op(
     data_context: DataContext,
 ) -> PhysicalOperator:
     assert len(physical_children) == 2
-    if data_context.shuffle_strategy == ShuffleStrategy.HASH_SHUFFLE_V2:
+    if data_context.shuffle_strategy == ShuffleStrategy.SHUFFLE_V2:
         return _plan_join_shuffle_v2(logical_op, physical_children, data_context)
     return JoinOperator(
         data_context=data_context,

--- a/python/ray/data/context.py
+++ b/python/ray/data/context.py
@@ -30,6 +30,13 @@ _default_context: "Optional[DataContext]" = None
 _context_lock = threading.Lock()
 
 
+# Deprecated value of ``ShuffleStrategy.SHUFFLE_V2``, still accepted when
+# constructing the enum from a string (i.e. by
+# ``RAY_DATA_DEFAULT_SHUFFLE_STRATEGY`` or when assigning
+# ``DataContext.shuffle_strategy``).
+_DEPRECATED_SHUFFLE_V2_VALUE = "hash_shuffle_v2"
+
+
 @DeveloperAPI(stability="alpha")
 class ShuffleStrategy(str, enum.Enum):
     """Shuffle strategy determines shuffling algorithm employed by operations
@@ -38,8 +45,28 @@ class ShuffleStrategy(str, enum.Enum):
     SORT_SHUFFLE_PULL_BASED = "sort_shuffle_pull_based"
     SORT_SHUFFLE_PUSH_BASED = "sort_shuffle_push_based"
     HASH_SHUFFLE = "hash_shuffle"
-    HASH_SHUFFLE_V2 = "hash_shuffle_v2"
+    SHUFFLE_V2 = "shuffle_v2"
     GPU_SHUFFLE = "gpu_shuffle"
+
+    # Deprecated alias of ``SHUFFLE_V2`` (this strategy is no longer specific
+    # to hash-partitioning). Enum members sharing a value are aliases of each
+    # other, hence this resolves to ``SHUFFLE_V2`` itself and is excluded from
+    # iteration over the strategies.
+    HASH_SHUFFLE_V2 = "shuffle_v2"
+
+    @classmethod
+    def _missing_(cls, value):
+        if value == _DEPRECATED_SHUFFLE_V2_VALUE:
+            warnings.warn(
+                f"`{_DEPRECATED_SHUFFLE_V2_VALUE}` shuffle strategy is deprecated, "
+                f"please use `{cls.SHUFFLE_V2.value}` instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+
+            return cls.SHUFFLE_V2
+
+        return None
 
 
 # We chose 128MiB for default: With streaming execution and num_cpus many concurrent
@@ -518,14 +545,17 @@ def _deduce_default_shuffle_algorithm() -> ShuffleStrategy:
 
         return ShuffleStrategy.SORT_SHUFFLE_PUSH_BASED
     else:
-        vs = [s for s in ShuffleStrategy]  # noqa: C416
+        try:
+            # NOTE: This also resolves deprecated aliases (like `hash_shuffle_v2`)
+            #       to their current strategy
+            return ShuffleStrategy(DEFAULT_SHUFFLE_STRATEGY)
+        except ValueError:
+            vs = [s.value for s in ShuffleStrategy]
 
-        assert DEFAULT_SHUFFLE_STRATEGY in vs, (
-            f"RAY_DATA_DEFAULT_SHUFFLE_STRATEGY has to be one of the [{','.join(vs)}] "
-            f"(got {DEFAULT_SHUFFLE_STRATEGY})"
-        )
-
-        return DEFAULT_SHUFFLE_STRATEGY
+            raise ValueError(
+                f"RAY_DATA_DEFAULT_SHUFFLE_STRATEGY has to be one of the "
+                f"[{','.join(vs)}] (got {DEFAULT_SHUFFLE_STRATEGY})"
+            ) from None
 
 
 def _default_fixed_shape_tensor_format():
@@ -733,7 +763,7 @@ class DataContext:
             timeout, fetching each batch in a single blocking call.
         shuffle_input_batch_bytes: Target batch size in bytes for coalescing
             shuffle input blocks before partitioning. Currently only applies
-            to the ``HASH_SHUFFLE_V2`` shuffle strategy; other shuffle
+            to the ``SHUFFLE_V2`` shuffle strategy; other shuffle
             strategies ignore it. Input blocks are buffered per node and
             processed as a batch once this size is reached; remaining
             buffered blocks are flushed when input is exhausted. Lower values
@@ -844,7 +874,7 @@ class DataContext:
     hash_shuffle_reduce_get_timeout_s: float = DEFAULT_HASH_SHUFFLE_REDUCE_GET_TIMEOUT_S
 
     # Target batch size (bytes) for coalescing shuffle input blocks before
-    # partitioning (currently hash_shuffle_v2 only); blocks are buffered per
+    # partitioning (currently shuffle_v2 only); blocks are buffered per
     # node until this size is reached. 0 disables batching.
     shuffle_input_batch_bytes: int = DEFAULT_SHUFFLE_INPUT_BATCH_BYTES
 
@@ -1226,8 +1256,10 @@ class DataContext:
         return self._shuffle_strategy
 
     @shuffle_strategy.setter
-    def shuffle_strategy(self, value: ShuffleStrategy) -> None:
-        self._shuffle_strategy = value
+    def shuffle_strategy(self, value: Union[ShuffleStrategy, str]) -> None:
+        # NOTE: Coercing to the enum resolves deprecated aliases (like
+        #       `hash_shuffle_v2`) to their current strategy
+        self._shuffle_strategy = ShuffleStrategy(value)
 
     @property
     def execution_callback_classes(self) -> List[Type["ExecutionCallback"]]:

--- a/python/ray/data/grouped_data.py
+++ b/python/ray/data/grouped_data.py
@@ -230,7 +230,7 @@ class GroupedData:
             shuffled_ds = self._dataset.repartition(1)
         elif self._dataset.context.shuffle_strategy in (
             ShuffleStrategy.HASH_SHUFFLE,
-            ShuffleStrategy.HASH_SHUFFLE_V2,
+            ShuffleStrategy.SHUFFLE_V2,
             ShuffleStrategy.GPU_SHUFFLE,
         ):
             num_partitions = (

--- a/python/ray/data/tests/conftest.py
+++ b/python/ray/data/tests/conftest.py
@@ -342,7 +342,7 @@ def configure_shuffle_method(request):
     #       parallelism
     if shuffle_strategy in [
         ShuffleStrategy.HASH_SHUFFLE,
-        ShuffleStrategy.HASH_SHUFFLE_V2,
+        ShuffleStrategy.SHUFFLE_V2,
         ShuffleStrategy.GPU_SHUFFLE,
     ]:
         ctx.default_hash_shuffle_parallelism = 8

--- a/python/ray/data/tests/test_context.py
+++ b/python/ray/data/tests/test_context.py
@@ -1,6 +1,7 @@
 import pytest
 
 import ray
+from ray.data.context import ShuffleStrategy
 from ray.util.annotations import RayDeprecationWarning
 
 
@@ -53,8 +54,6 @@ def test_data_context_current_context_manager():
 
 def test_hash_shuffle_v2_strategy_alias():
     """`hash_shuffle_v2` remains a deprecated alias of `shuffle_v2`."""
-
-    from ray.data.context import ShuffleStrategy
 
     assert ShuffleStrategy.SHUFFLE_V2.value == "shuffle_v2"
     assert ShuffleStrategy.HASH_SHUFFLE_V2 is ShuffleStrategy.SHUFFLE_V2

--- a/python/ray/data/tests/test_context.py
+++ b/python/ray/data/tests/test_context.py
@@ -51,6 +51,23 @@ def test_data_context_current_context_manager():
     assert DataContext.get_current() is original
 
 
+def test_hash_shuffle_v2_strategy_alias():
+    """`hash_shuffle_v2` remains a deprecated alias of `shuffle_v2`."""
+
+    from ray.data.context import ShuffleStrategy
+
+    assert ShuffleStrategy.SHUFFLE_V2.value == "shuffle_v2"
+    assert ShuffleStrategy.HASH_SHUFFLE_V2 is ShuffleStrategy.SHUFFLE_V2
+    assert "hash_shuffle_v2" not in [s.value for s in ShuffleStrategy]
+
+    # Deprecated value resolves to the current strategy
+    with pytest.warns(DeprecationWarning, match="hash_shuffle_v2"):
+        assert ShuffleStrategy("hash_shuffle_v2") is ShuffleStrategy.SHUFFLE_V2
+
+    with pytest.raises(ValueError):
+        ShuffleStrategy("not_a_shuffle_strategy")
+
+
 if __name__ == "__main__":
     import sys
 

--- a/python/ray/data/tests/test_gpu_shuffle.py
+++ b/python/ray/data/tests/test_gpu_shuffle.py
@@ -634,7 +634,7 @@ class TestPlanAllToAllOpRouting:
         )
 
         ctx = DataContext()
-        ctx._shuffle_strategy = ShuffleStrategy.HASH_SHUFFLE_V2
+        ctx._shuffle_strategy = ShuffleStrategy.SHUFFLE_V2
 
         logical_op = self._make_repartition_op(keys=["user_id"], num_outputs=8)
         input_physical_op = _make_input_op_mock()

--- a/python/ray/data/tests/test_groupby_e2e.py
+++ b/python/ray/data/tests/test_groupby_e2e.py
@@ -591,7 +591,7 @@ def test_groupby_arrow_multi_agg(
         (
             ds_format == "pandas"
             and configure_shuffle_method
-            in (ShuffleStrategy.HASH_SHUFFLE, ShuffleStrategy.HASH_SHUFFLE_V2)
+            in (ShuffleStrategy.HASH_SHUFFLE, ShuffleStrategy.SHUFFLE_V2)
         )
     )
 

--- a/python/ray/data/tests/test_hash_shuffle_v2.py
+++ b/python/ray/data/tests/test_hash_shuffle_v2.py
@@ -53,9 +53,9 @@ def _assert_keys_colocated(per_block):
 
 
 @pytest.fixture(autouse=True)
-def data_context_hash_shuffle_v2(restore_data_context):
+def data_context_shuffle_v2(restore_data_context):
     ctx = restore_data_context
-    ctx.shuffle_strategy = ShuffleStrategy.HASH_SHUFFLE_V2
+    ctx.shuffle_strategy = ShuffleStrategy.SHUFFLE_V2
 
 
 @pytest.mark.parametrize("num_partitions", [1, 4, 8])
@@ -337,7 +337,7 @@ def test_shuffle_reduce_task_uses_operator_name():
 # --- Multi-input reduce -------------------------------------------------------
 # TODO: move these multi-input ShuffleReduceOp tests (and the _get_shard_batch
 # shuffle_tasks tests above) into a dedicated operator/task-level test file --
-# they aren't specific to hash-shuffle-v2.
+# they aren't specific to shuffle-v2.
 def _ipc_shard_bundle(partition_id, table):
     """One partition's shard as a ShuffleMapOp emits it: an IPC-encoded buffer
     stamped with the partition id."""

--- a/python/ray/data/tests/test_join.py
+++ b/python/ray/data/tests/test_join.py
@@ -17,7 +17,7 @@ from ray.tests.conftest import *  # noqa
 
 @pytest.fixture(
     autouse=True,
-    params=[ShuffleStrategy.HASH_SHUFFLE, ShuffleStrategy.HASH_SHUFFLE_V2],
+    params=[ShuffleStrategy.HASH_SHUFFLE, ShuffleStrategy.SHUFFLE_V2],
     ids=["shufflev1", "shufflev2"],
 )
 def hash_shuffle_version(request, restore_data_context):

--- a/python/ray/data/tests/test_no_progress_guard.py
+++ b/python/ray/data/tests/test_no_progress_guard.py
@@ -49,7 +49,7 @@ def test_legacy_shuffle_operators_disable_the_guard(
     restore_data_context,  # noqa: F811
 ):
     # Only the V2 hash shuffle implementation is supported by the guard.
-    expected_enabled = shuffle_strategy is ShuffleStrategy.HASH_SHUFFLE_V2
+    expected_enabled = shuffle_strategy is ShuffleStrategy.SHUFFLE_V2
     DataContext.get_current().shuffle_strategy = shuffle_strategy
 
     ds = ray.data.range(1).groupby("id").count()

--- a/python/ray/data/tests/test_operator_fusion.py
+++ b/python/ray/data/tests/test_operator_fusion.py
@@ -561,7 +561,7 @@ def test_fuse_map_into_shuffle_reduce(
     ray_start_regular_shared_2_cpus, restore_data_context
 ):
     ctx = DataContext.get_current()
-    ctx.shuffle_strategy = ShuffleStrategy.HASH_SHUFFLE_V2
+    ctx.shuffle_strategy = ShuffleStrategy.SHUFFLE_V2
 
     ds = ray.data.range(100).repartition(4, keys=["id"]).map_batches(lambda b: b)
     dag = get_execution_plan(ds._logical_plan)[0].dag
@@ -584,7 +584,7 @@ def test_fused_shuffle_reduce_preserves_operator_config(
     back to the 2x default) and should_emit_empty_partitions.
     """
     ctx = DataContext.get_current()
-    ctx.shuffle_strategy = ShuffleStrategy.HASH_SHUFFLE_V2
+    ctx.shuffle_strategy = ShuffleStrategy.SHUFFLE_V2
 
     ds = (
         ray.data.range(100)
@@ -604,7 +604,7 @@ def test_map_not_fused_into_shuffle_reduce_with_downstream_limit(
     ray_start_regular_shared_2_cpus, restore_data_context
 ):
     ctx = DataContext.get_current()
-    ctx.shuffle_strategy = ShuffleStrategy.HASH_SHUFFLE_V2
+    ctx.shuffle_strategy = ShuffleStrategy.SHUFFLE_V2
 
     ds = (
         ray.data.range(100)
@@ -628,7 +628,7 @@ def test_concurrency_capped_map_not_fused_into_shuffle_reduce(
     ray_start_regular_shared_2_cpus, restore_data_context
 ):
     ctx = DataContext.get_current()
-    ctx.shuffle_strategy = ShuffleStrategy.HASH_SHUFFLE_V2
+    ctx.shuffle_strategy = ShuffleStrategy.SHUFFLE_V2
 
     ds = (
         ray.data.range(100)
@@ -649,7 +649,7 @@ def test_non_file_datasink_write_not_fused_into_shuffle_reduce(
     from ray.data.datasource.datasink import Datasink
 
     ctx = DataContext.get_current()
-    ctx.shuffle_strategy = ShuffleStrategy.HASH_SHUFFLE_V2
+    ctx.shuffle_strategy = ShuffleStrategy.SHUFFLE_V2
 
     class _NoopDatasink(Datasink):
         def write(self, blocks, ctx):

--- a/python/ray/data/tests/test_shuffle_diagnostics.py
+++ b/python/ray/data/tests/test_shuffle_diagnostics.py
@@ -22,7 +22,7 @@ def test_debug_limit_shuffle_execution_to_num_blocks(
 ):
     if configure_shuffle_method in (
         ShuffleStrategy.HASH_SHUFFLE,
-        ShuffleStrategy.HASH_SHUFFLE_V2,
+        ShuffleStrategy.SHUFFLE_V2,
     ):
         pytest.skip("Not supported by hash-shuffle")
 

--- a/release/release_data_tests.yaml
+++ b/release/release_data_tests.yaml
@@ -268,7 +268,7 @@
   matrix:
     setup:
       scaling: [fixed_size, autoscaling]
-      shuffle_strategy: [hash_shuffle_v2]
+      shuffle_strategy: [shuffle_v2]
       columns:
         - "column08 column13 column14"   # 84 groups
         - "column02 column14"  # 7M groups
@@ -319,7 +319,7 @@
   matrix:
     setup:
       scaling: [fixed_size, autoscaling]
-      shuffle_strategy: [hash_shuffle_v2]
+      shuffle_strategy: [shuffle_v2]
       columns:
         - "column02 column14"  # 7M groups
 
@@ -345,7 +345,7 @@
   matrix:
     setup:
       scaling: [fixed_size, autoscaling]
-      shuffle_strategy: [hash_shuffle_v2]
+      shuffle_strategy: [shuffle_v2]
       columns:
         - "column08 column13 column14"   # 84 groups
 
@@ -415,7 +415,7 @@
       --join_type {{join_type}}
       --num_partitions 50
 
-- name: "joins_{{dataset}}_{{join_type}}_hash_shuffle_v2"
+- name: "joins_{{dataset}}_{{join_type}}_shuffle_v2"
   python: "3.10"
   cluster:
     anyscale_sdk_2026: true
@@ -424,7 +424,7 @@
         - RAY_DATA_DEBUG_RESOURCE_MANAGER=1
         - RAYTEST_FAIL_ON_WORKER_OOM=1
         - RAYTEST_FAIL_ON_DEAD_NODES=1
-        - RAY_DATA_DEFAULT_SHUFFLE_STRATEGY=hash_shuffle_v2
+        - RAY_DATA_DEFAULT_SHUFFLE_STRATEGY=shuffle_v2
         - RAY_max_direct_call_object_size=8192
     cluster_compute: fixed_size_all_to_all_compute.yaml
 
@@ -1327,7 +1327,7 @@
   matrix:
     setup:
       scaling: [fixed_size, autoscaling]
-      shuffle_strategy: [hash_shuffle_v2]
+      shuffle_strategy: [shuffle_v2]
 
   cluster:
     anyscale_sdk_2026: true
@@ -1394,7 +1394,7 @@
     setup:
       query: [q2, q3, q4, q5, q6, q7, q9, q10, q11, q12, q14, q17, q18, q20]
       scaling: [fixed_size, autoscaling]
-      shuffle_strategy: [hash_shuffle_v2]
+      shuffle_strategy: [shuffle_v2]
 
   cluster:
     anyscale_sdk_2026: true
@@ -1432,7 +1432,7 @@
   matrix:
     setup:
       query: [q8, q13, q15, q21, q22]
-      shuffle_strategy: [hash_shuffle_v2]
+      shuffle_strategy: [shuffle_v2]
 
   cluster:
     anyscale_sdk_2026: true
@@ -1470,7 +1470,7 @@
   matrix:
     setup:
       query: [q8, q13, q15, q21, q22]
-      shuffle_strategy: [hash_shuffle_v2]
+      shuffle_strategy: [shuffle_v2]
 
   cluster:
     anyscale_sdk_2026: true


### PR DESCRIPTION
## Description
As title, this is because in next release we will make other partition functions (e.g. range partition form `sort` / `random_shuffle`) also based on the so-called "hash shuffle v2", therefore for the accuracy we rename the strategy from `hash_shuffle_v2` to `shuffle_v2` while keeping `hash_shuffle_v2` as alias to `shuffle_v2` but will deprecate in the future.

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
