### PR TITLE
[core][sandbox] Enable nestable cgroups in sandbox CI tests

### DIFF
--- a/python/ray/experimental/sandbox/tests/conftest.py
+++ b/python/ray/experimental/sandbox/tests/conftest.py
@@ -1,6 +1,7 @@
 import os
 import platform
 import shutil
+import sys
 import tempfile
 import urllib.request
 from pathlib import Path
@@ -13,6 +14,41 @@ from ray._private.test_utils import sandbox_test_enabled
 
 _MOUNT_FILE_PATH = "/proc/mounts"
 _ROOT_CGROUP = Path("/sys/fs/cgroup")
+_ARTIFACT_DIR = Path("/artifact-mount")
+_STATUS_FILE = _ARTIFACT_DIR / "sandbox-cgroup-status.txt"
+
+
+def _artifact_status_path() -> Optional[Path]:
+    if _ARTIFACT_DIR.is_dir() and os.access(_ARTIFACT_DIR, os.W_OK):
+        return _STATUS_FILE
+    return None
+
+
+def _write_artifact_status(lines: list[str], *, append: bool = False) -> None:
+    """Write sandbox cgroup diagnostics for Buildkite artifact upload."""
+    path = _artifact_status_path()
+    if path is None:
+        return
+    mode = "a" if append else "w"
+    with open(path, mode, encoding="utf-8") as status_file:
+        for line in lines:
+            status_file.write(line.rstrip() + "\n")
+        status_file.flush()
+
+
+def _write_artifact_section(lines: list[str]) -> None:
+    path = _artifact_status_path()
+    if path is None:
+        return
+    section = [f"=== {Path(sys.argv[0]).stem} ===", *lines]
+    _write_artifact_status(section, append=path.exists())
+
+
+def _read_subtree_control(path: Path) -> str:
+    subtree = path / "cgroup.subtree_control"
+    if not subtree.exists():
+        return ""
+    return subtree.read_text(encoding="utf-8").strip()
 
 
 def _move_procs(src: Path, dst: Path) -> None:
@@ -33,7 +69,7 @@ def _move_procs(src: Path, dst: Path) -> None:
 
 
 def _try_enable_cgroup_nesting() -> Tuple[
-    bool, Optional[Path], Optional[Path], Optional[Path]
+    bool, Optional[Path], Optional[Path], Optional[Path], str
 ]:
     """Mirror resource isolation integration setup for a nestable cgroup domain.
 
@@ -45,13 +81,12 @@ def _try_enable_cgroup_nesting() -> Tuple[
                  TEST_CGROUP   LEAF_CGROUP
 
     Moves processes ROOT -> LEAF, then enables cpu/memory on ROOT/BASE/TEST.
-    Returns (success, base, test, leaf).
+    Returns (success, base, test, leaf, status_message).
     """
     if platform.system() != "Linux":
-        return False, None, None, None
+        return False, None, None, None, "not Linux"
     if not _ROOT_CGROUP.is_dir() or not os.access(_ROOT_CGROUP, os.W_OK):
-        print(f"Sandbox tests: {_ROOT_CGROUP} is not writable")
-        return False, None, None, None
+        return False, None, None, None, f"{_ROOT_CGROUP} is not writable"
 
     try:
         with open(_MOUNT_FILE_PATH, "r") as mount_file:
@@ -59,17 +94,19 @@ def _try_enable_cgroup_nesting() -> Tuple[
         found_cgroup_v1 = any("cgroup r" in line.strip() for line in lines)
         found_cgroup_v2 = any("cgroup2 rw" in line.strip() for line in lines)
         if not found_cgroup_v2 or found_cgroup_v1:
-            print("Sandbox tests: need cgroup v2 unified rw mount")
-            return False, None, None, None
+            return False, None, None, None, "need cgroup v2 unified rw mount"
 
         with open(_ROOT_CGROUP / "cgroup.controllers", "r") as controllers_file:
             available = set(controllers_file.readline().strip().split())
         if not {"cpu", "memory"}.issubset(available):
-            print(
-                "Sandbox tests: cpu/memory controllers unavailable in "
-                f"{_ROOT_CGROUP}/cgroup.controllers (have {sorted(available)})"
+            return (
+                False,
+                None,
+                None,
+                None,
+                "cpu/memory controllers unavailable in "
+                f"{_ROOT_CGROUP}/cgroup.controllers (have {sorted(available)})",
             )
-            return False, None, None, None
 
         base = _ROOT_CGROUP / ("testing_" + get_random_alphanumeric_string(5))
         test = base / "test"
@@ -85,10 +122,9 @@ def _try_enable_cgroup_nesting() -> Tuple[
                 subtree.write("+cpu +memory")
                 subtree.flush()
 
-        return True, base, test, leaf
+        return True, base, test, leaf, "enabled"
     except Exception as e:
-        print(f"Sandbox tests: cgroup nesting setup failed: {e}")
-        return False, None, None, None
+        return False, None, None, None, f"cgroup nesting setup failed: {e}"
 
 
 def _cleanup_cgroup_nesting(
@@ -118,33 +154,65 @@ def pytest_runtest_setup(item):
         pytest.skip("Sandbox tests are only run when TEST_SANDBOX=1")
 
 
+@pytest.hookimpl(hookwrapper=True)
+def pytest_runtest_makereport(item, call):
+    outcome = yield
+    report = outcome.get_result()
+    if not sandbox_test_enabled() or call.when != "call":
+        return
+    if "cgroup_limits" not in item.nodeid:
+        return
+    if report.passed:
+        _write_artifact_status(["cgroup_limits_probe=passed"], append=True)
+    elif report.skipped:
+        _write_artifact_status(["cgroup_limits_probe=skipped"], append=True)
+    elif report.failed:
+        _write_artifact_status(["cgroup_limits_probe=failed"], append=True)
+
+
+def pytest_sessionfinish(session, exitstatus):
+    if not sandbox_test_enabled():
+        return
+    _write_artifact_status([f"pytest_exitstatus={exitstatus}"], append=True)
+
+
 @pytest.fixture(scope="session", autouse=True)
 def configure_cgroups_and_runsc():
     """Install runsc and enable nestable cgroups like resource isolation tests.
 
     Privileged CI containers are a cgroup v2 leaf. We use the same Python setup
     as test_resource_isolation_integration.py so runsc can create child cgroups
-    without --ignore-cgroups. Falls back to RAY_SANDBOX_IGNORE_CGROUPS=1 when
-    setup is unavailable.
+    without --ignore-cgroups.
     """
     if not sandbox_test_enabled():
         return
 
-    using_cgroups, base, test, leaf = _try_enable_cgroup_nesting()
-    if using_cgroups:
-        os.environ.pop("RAY_SANDBOX_IGNORE_CGROUPS", None)
-        print(
-            "Sandbox tests: cgroup nesting enabled "
-            "(RAY_SANDBOX_IGNORE_CGROUPS unset)"
+    using_cgroups, base, test, leaf, status_message = _try_enable_cgroup_nesting()
+    if not using_cgroups:
+        _write_artifact_section(
+            [
+                "cgroup_nesting=failed",
+                f"reason={status_message}",
+            ]
         )
-    else:
-        os.environ["RAY_SANDBOX_IGNORE_CGROUPS"] = "1"
-        print(
-            "Sandbox tests: using RAY_SANDBOX_IGNORE_CGROUPS=1 "
-            "(cgroup nesting unavailable)"
+        pytest.skip(
+            "Sandbox tests require nestable cgroup v2 (privileged Linux CI container): "
+            f"{status_message}"
         )
 
+    _write_artifact_section(
+        [
+            "cgroup_nesting=enabled",
+            f"cgroup_base={base}",
+            f"root_subtree_control={_read_subtree_control(_ROOT_CGROUP)}",
+            f"base_subtree_control={_read_subtree_control(base)}",
+        ]
+    )
+    print("Sandbox tests: cgroup nesting enabled")
+
+    runsc_source = "preinstalled"
     if not shutil.which("runsc"):
+        runsc_source = "downloaded"
         temp_bin = tempfile.mkdtemp()
         os.chmod(temp_bin, 0o755)
         runsc_path = os.path.join(temp_bin, "runsc")
@@ -162,7 +230,22 @@ def configure_cgroups_and_runsc():
             os.chmod(runsc_path, 0o755)
             os.environ["PATH"] = f"{temp_bin}:{os.environ.get('PATH', '')}"
         except Exception as e:
+            _write_artifact_status(
+                [
+                    "runsc_install=failed",
+                    f"runsc_error={e}",
+                ],
+                append=True,
+            )
             pytest.skip(f"Failed to install runsc for sandbox tests: {e}")
+
+    _write_artifact_status(
+        [
+            f"runsc={shutil.which('runsc')}",
+            f"runsc_source={runsc_source}",
+        ],
+        append=True,
+    )
 
     yield
 

--- a/python/ray/experimental/sandbox/tests/conftest.py
+++ b/python/ray/experimental/sandbox/tests/conftest.py
@@ -3,24 +3,146 @@ import platform
 import shutil
 import tempfile
 import urllib.request
+from pathlib import Path
+from typing import Optional, Tuple
 
 import pytest
 
+from ray._common.utils import get_random_alphanumeric_string
 from ray._private.test_utils import sandbox_test_enabled
+
+_MOUNT_FILE_PATH = "/proc/mounts"
+_ROOT_CGROUP = Path("/sys/fs/cgroup")
+
+
+def _move_procs(src: Path, dst: Path) -> None:
+    """Move PIDs listed in src/cgroup.procs into dst/cgroup.procs."""
+    with open(src / "cgroup.procs", "r") as src_file, open(
+        dst / "cgroup.procs", "w"
+    ) as dst_file:
+        for line in src_file.readlines():
+            pid = line.strip()
+            if not pid:
+                continue
+            try:
+                dst_file.write(pid)
+                dst_file.flush()
+            except OSError:
+                # PID may have exited between read and write.
+                pass
+
+
+def _try_enable_cgroup_nesting() -> Tuple[
+    bool, Optional[Path], Optional[Path], Optional[Path]
+]:
+    """Mirror resource isolation integration setup for a nestable cgroup domain.
+
+    Creates:
+                        ROOT_CGROUP
+                             |
+                        BASE_CGROUP
+                       /           \\
+                 TEST_CGROUP   LEAF_CGROUP
+
+    Moves processes ROOT -> LEAF, then enables cpu/memory on ROOT/BASE/TEST.
+    Returns (success, base, test, leaf).
+    """
+    if platform.system() != "Linux":
+        return False, None, None, None
+    if not _ROOT_CGROUP.is_dir() or not os.access(_ROOT_CGROUP, os.W_OK):
+        print(f"Sandbox tests: {_ROOT_CGROUP} is not writable")
+        return False, None, None, None
+
+    try:
+        with open(_MOUNT_FILE_PATH, "r") as mount_file:
+            lines = mount_file.readlines()
+        found_cgroup_v1 = any("cgroup r" in line.strip() for line in lines)
+        found_cgroup_v2 = any("cgroup2 rw" in line.strip() for line in lines)
+        if not found_cgroup_v2 or found_cgroup_v1:
+            print("Sandbox tests: need cgroup v2 unified rw mount")
+            return False, None, None, None
+
+        with open(_ROOT_CGROUP / "cgroup.controllers", "r") as controllers_file:
+            available = set(controllers_file.readline().strip().split())
+        if not {"cpu", "memory"}.issubset(available):
+            print(
+                "Sandbox tests: cpu/memory controllers unavailable in "
+                f"{_ROOT_CGROUP}/cgroup.controllers (have {sorted(available)})"
+            )
+            return False, None, None, None
+
+        base = _ROOT_CGROUP / ("testing_" + get_random_alphanumeric_string(5))
+        test = base / "test"
+        leaf = base / "leaf"
+        os.mkdir(base)
+        os.mkdir(test)
+        os.mkdir(leaf)
+
+        _move_procs(_ROOT_CGROUP, leaf)
+
+        for path in (_ROOT_CGROUP, base, test):
+            with open(path / "cgroup.subtree_control", "w") as subtree:
+                subtree.write("+cpu +memory")
+                subtree.flush()
+
+        return True, base, test, leaf
+    except Exception as e:
+        print(f"Sandbox tests: cgroup nesting setup failed: {e}")
+        return False, None, None, None
+
+
+def _cleanup_cgroup_nesting(
+    base: Optional[Path], test: Optional[Path], leaf: Optional[Path]
+) -> None:
+    """Best-effort teardown matching resource isolation cleanup order."""
+    if base is None or test is None or leaf is None:
+        return
+    try:
+        for path in (test, base, _ROOT_CGROUP):
+            subtree = path / "cgroup.subtree_control"
+            if subtree.exists():
+                with open(subtree, "w") as subtree_file:
+                    subtree_file.write("-cpu -memory")
+                    subtree_file.flush()
+        if leaf.exists():
+            _move_procs(leaf, _ROOT_CGROUP)
+        for path in (test, leaf, base):
+            if path.exists():
+                path.rmdir()
+    except Exception as e:
+        print(f"Sandbox tests: cgroup nesting teardown failed: {e}")
 
 
 def pytest_runtest_setup(item):
     if not sandbox_test_enabled():
         pytest.skip("Sandbox tests are only run when TEST_SANDBOX=1")
-    os.environ["RAY_SANDBOX_IGNORE_CGROUPS"] = "1"
 
 
 @pytest.fixture(scope="session", autouse=True)
-def ensure_runsc():
+def configure_cgroups_and_runsc():
+    """Install runsc and enable nestable cgroups like resource isolation tests.
+
+    Privileged CI containers are a cgroup v2 leaf. We use the same Python setup
+    as test_resource_isolation_integration.py so runsc can create child cgroups
+    without --ignore-cgroups. Falls back to RAY_SANDBOX_IGNORE_CGROUPS=1 when
+    setup is unavailable.
+    """
     if not sandbox_test_enabled():
         return
 
-    os.environ["RAY_SANDBOX_IGNORE_CGROUPS"] = "1"
+    using_cgroups, base, test, leaf = _try_enable_cgroup_nesting()
+    if using_cgroups:
+        os.environ.pop("RAY_SANDBOX_IGNORE_CGROUPS", None)
+        print(
+            "Sandbox tests: cgroup nesting enabled "
+            "(RAY_SANDBOX_IGNORE_CGROUPS unset)"
+        )
+    else:
+        os.environ["RAY_SANDBOX_IGNORE_CGROUPS"] = "1"
+        print(
+            "Sandbox tests: using RAY_SANDBOX_IGNORE_CGROUPS=1 "
+            "(cgroup nesting unavailable)"
+        )
 
     if not shutil.which("runsc"):
         temp_bin = tempfile.mkdtemp()
@@ -31,10 +153,18 @@ def ensure_runsc():
             if platform.machine().lower() in ("aarch64", "arm64")
             else "x86_64"
         )
-        url = f"https://storage.googleapis.com/gvisor/releases/release/latest/{arch}/runsc"
+        url = (
+            "https://storage.googleapis.com/gvisor/releases/release/latest/"
+            f"{arch}/runsc"
+        )
         try:
             urllib.request.urlretrieve(url, runsc_path)
             os.chmod(runsc_path, 0o755)
             os.environ["PATH"] = f"{temp_bin}:{os.environ.get('PATH', '')}"
         except Exception as e:
             pytest.skip(f"Failed to install runsc for sandbox tests: {e}")
+
+    yield
+
+    if using_cgroups:
+        _cleanup_cgroup_nesting(base, test, leaf)

--- a/python/ray/experimental/sandbox/tests/test_gvisor_backend.py
+++ b/python/ray/experimental/sandbox/tests/test_gvisor_backend.py
@@ -198,34 +198,14 @@ def test_gvisor_backend_readonly_rootfs():
         backend.delete_sandbox(sandbox_id)
 
 
-def test_gvisor_backend_ignore_cgroups_flag():
-    backend = GVisorSandboxBackend()
-    cfg_default = GVisorSandboxConfig(image="busybox:latest")
-    orig_env = os.environ.pop("RAY_SANDBOX_IGNORE_CGROUPS", None)
-    try:
-        args_default = backend._runsc_base_args(cfg_default)
-        assert "--ignore-cgroups" not in args_default
-
-        cfg_ignored = GVisorSandboxConfig(image="busybox:latest", _ignore_cgroups=True)
-        args_ignored = backend._runsc_base_args(cfg_ignored)
-        assert "--ignore-cgroups" in args_ignored
-    finally:
-        if orig_env is not None:
-            os.environ["RAY_SANDBOX_IGNORE_CGROUPS"] = orig_env
-
-
-def test_gvisor_backend_create_without_ignore_cgroups_when_nested():
-    """When cgroup nesting is available, create a sandbox without --ignore-cgroups."""
-    if os.environ.get("RAY_SANDBOX_IGNORE_CGROUPS") == "1":
-        pytest.skip("cgroup nesting unavailable; ignoring cgroups for this suite")
-
+def test_gvisor_backend_create_with_cgroup_limits():
+    """Create a sandbox with CPU/memory limits using nested cgroups."""
     backend = GVisorSandboxBackend()
     cfg = GVisorSandboxConfig(
         image="busybox:latest",
         workdir="/workspace",
         cpu=0.5,
         memory="128Mi",
-        _ignore_cgroups=False,
     )
     assert "--ignore-cgroups" not in backend._runsc_base_args(cfg)
 

--- a/python/ray/experimental/sandbox/tests/test_gvisor_backend.py
+++ b/python/ray/experimental/sandbox/tests/test_gvisor_backend.py
@@ -214,5 +214,30 @@ def test_gvisor_backend_ignore_cgroups_flag():
             os.environ["RAY_SANDBOX_IGNORE_CGROUPS"] = orig_env
 
 
+def test_gvisor_backend_create_without_ignore_cgroups_when_nested():
+    """When cgroup nesting is available, create a sandbox without --ignore-cgroups."""
+    if os.environ.get("RAY_SANDBOX_IGNORE_CGROUPS") == "1":
+        pytest.skip("cgroup nesting unavailable; ignoring cgroups for this suite")
+
+    backend = GVisorSandboxBackend()
+    cfg = GVisorSandboxConfig(
+        image="busybox:latest",
+        workdir="/workspace",
+        cpu=0.5,
+        memory="128Mi",
+        _ignore_cgroups=False,
+    )
+    assert "--ignore-cgroups" not in backend._runsc_base_args(cfg)
+
+    sandbox_id = backend.create_sandbox(cfg)
+    try:
+        assert backend.get_status(sandbox_id) == SandboxStatus.RUNNING
+        res = backend.exec_command(sandbox_id, "echo nested-cgroup-ok")
+        assert res.exit_code == 0
+        assert "nested-cgroup-ok" in res.stdout
+    finally:
+        backend.delete_sandbox(sandbox_id)
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main(["-v", __file__]))

--- a/python/ray/experimental/sandbox/tests/test_sandbox_config.py
+++ b/python/ray/experimental/sandbox/tests/test_sandbox_config.py
@@ -19,7 +19,6 @@ def test_default_sandbox_config():
     assert config.rootless is True
     assert config.network == "none"
     assert config.readonly is True
-    assert config._ignore_cgroups is False
 
     # SandboxConfig requires image
     with pytest.raises(TypeError):
@@ -39,14 +38,12 @@ def test_gvisor_sandbox_config():
         memory="4Gi",
         env={"TEST_VAR": "value"},
         readonly=False,
-        _ignore_cgroups=True,
     )
     assert config.image == "ubuntu:22.04"
     assert config.cpu == 2.0
     assert config.memory == "4Gi"
     assert config.env == {"TEST_VAR": "value"}
     assert config.readonly is False
-    assert config._ignore_cgroups is True
 
 
 def test_parse_memory_bytes():


### PR DESCRIPTION
Privileged Docker leaves the suite in a cgroup v2 leaf, so runsc hit EBUSY on subtree_control and needed --ignore-cgroups. Reuse the same Python nesting setup as resource isolation tests, and only fall back to ignore-cgroups when that setup is unavailable.

Draft PR, to test whether this workaround passes buildkite CI tests or not
