### PR TITLE
[dashboard] Safely skip unsupported process GPU utilization API

### DIFF
--- a/doc/source/ray-observability/reference/system-metrics.rst
+++ b/doc/source/ray-observability/reference/system-metrics.rst
@@ -21,6 +21,15 @@ Ray exports a number of system metrics, which provide introspection into the sta
   - `recommended`: Drop high-cardinality labels. Ray internally determines specific labels; currently this includes only `WorkerId`. (This is the default behavior since Ray 2.53.)
   - `low`: Same as `recommended`, but also drops the Name label for tasks and actors.
 
+.. note::
+
+  Ray uses an optional NVML API to collect per-process GPU SM utilization. If an
+  NVML-compatible library doesn't safely support this API, set
+  ``RAY_SKIP_PROCESS_UTIL_API=true`` on each affected Ray node. Ray continues to
+  report GPU process IDs, allocated GPU memory, and device-level utilization,
+  memory, power, and temperature metrics. Only per-process GPU utilization is
+  unavailable.
+
 .. list-table:: Ray System Metrics
    :header-rows: 1
 

--- a/doc/source/ray-observability/reference/system-metrics.rst
+++ b/doc/source/ray-observability/reference/system-metrics.rst
@@ -23,9 +23,18 @@ Ray exports a number of system metrics, which provide introspection into the sta
 
 .. note::
 
-  Ray uses an optional NVML API to collect per-process GPU SM utilization. If an
-  NVML-compatible library doesn't safely support this API, set
-  ``RAY_SKIP_PROCESS_UTIL_API=true`` on each affected Ray node. Ray continues to
+  Ray uses an optional NVML API to collect per-process GPU SM utilization. Ray
+  automatically skips this API for devices whose name matches a known PPU
+  device-name pattern (for example, ``PPU-ZW810``). For other NVML-compatible
+  libraries that don't safely support this API, set
+  ``RAY_SKIP_PROCESS_UTIL_API=true`` on each affected Ray node.
+  To skip specific device names, use the comma-separated
+  ``RAY_SKIP_PROCESS_UTIL_API_DEVICE_NAMES`` environment variable (names are
+  matched case-insensitively and exactly).
+
+  These variables must be set in the Ray node and Dashboard Reporter process
+  environment before ``ray start`` (for example, in the Pod environment when
+  using KubeRay). They are not applied through ``runtime_env``. Ray continues to
   report GPU process IDs, allocated GPU memory, and device-level utilization,
   memory, power, and temperature metrics. Only per-process GPU utilization is
   unavailable.

--- a/python/ray/dashboard/modules/reporter/gpu_providers.py
+++ b/python/ray/dashboard/modules/reporter/gpu_providers.py
@@ -7,9 +7,11 @@ This module provides an object-oriented interface for different GPU providers
 import abc
 import enum
 import logging
+import os
+import re
 import subprocess
 import time
-from typing import Dict, List, Optional, TypedDict, Union
+from typing import Dict, List, Optional, Set, TypedDict, Union
 
 try:
     from typing import NotRequired
@@ -22,6 +24,8 @@ logger = logging.getLogger(__name__)
 
 # Constants
 MB = 1024 * 1024
+RAY_SKIP_PROCESS_UTIL_API = "RAY_SKIP_PROCESS_UTIL_API"
+_PPU_NAME_RE = re.compile(r"\bPPU\b", re.IGNORECASE)
 
 # Types
 Percentage = int
@@ -119,6 +123,13 @@ class NvidiaGpuProvider(GpuProvider):
         self._pynvml = None
         # Maintain per-GPU sampling timestamps when using process utilization API
         self._gpu_process_last_sample_ts: Dict[int, int] = {}
+        self._force_skip_process_util_api = os.environ.get(
+            RAY_SKIP_PROCESS_UTIL_API, ""
+        ).lower() in ("1", "true")
+        self._skip_process_util_gpu_indices: Set[int] = set()
+        self._ppu_detection_done = False
+        self._detected_gpu_count: Optional[int] = None
+        self._force_fallback_this_cycle = False
 
     def get_provider_name(self) -> GpuProviderType:
         return GpuProviderType.NVIDIA
@@ -166,15 +177,57 @@ class NvidiaGpuProvider(GpuProvider):
 
         return self._get_pynvml_gpu_usage()
 
+    def _detect_ppu_devices(self, num_gpus: int) -> None:
+        """Detect devices that cannot safely use the process utilization API."""
+        self._force_fallback_this_cycle = False
+
+        if self._force_skip_process_util_api:
+            return
+
+        if self._ppu_detection_done and self._detected_gpu_count == num_gpus:
+            return
+
+        detected_indices: Set[int] = set()
+        try:
+            for gpu_index in range(num_gpus):
+                gpu_handle = self._pynvml.nvmlDeviceGetHandleByIndex(gpu_index)
+                gpu_name = self._decode(self._pynvml.nvmlDeviceGetName(gpu_handle))
+                if _PPU_NAME_RE.search(gpu_name):
+                    detected_indices.add(gpu_index)
+        except Exception as e:
+            self._ppu_detection_done = False
+            self._detected_gpu_count = None
+            self._force_fallback_this_cycle = True
+            if log_once("gpu_process_utilization_device_detection"):
+                logger.info(
+                    "Failed to detect devices that support GPU process SM "
+                    "utilization; skipping the process utilization API for this "
+                    f"collection cycle: {e}"
+                )
+            return
+
+        self._skip_process_util_gpu_indices = detected_indices
+        self._ppu_detection_done = True
+        self._detected_gpu_count = num_gpus
+
     def _get_pynvml_gpu_usage(self) -> List[GpuUtilizationInfo]:
         if not self._initialized:
             if not self._initialize():
                 return []
 
         gpu_utilizations = []
+        self._force_fallback_this_cycle = False
 
         try:
-            num_gpus = self._pynvml.nvmlDeviceGetCount()
+            try:
+                num_gpus = self._pynvml.nvmlDeviceGetCount()
+            except Exception:
+                self._ppu_detection_done = False
+                self._detected_gpu_count = None
+                self._force_fallback_this_cycle = True
+                raise
+
+            self._detect_ppu_devices(num_gpus)
 
             for i in range(num_gpus):
                 gpu_handle = self._pynvml.nvmlDeviceGetHandleByIndex(i)
@@ -352,34 +405,43 @@ class NvidiaGpuProvider(GpuProvider):
                         f"and `nvmlDeviceGetGraphicsRunningProcesses` APIs: {e}"
                     )
 
-            # Use a newer API (driver 550+) to get per-process SM utilization, but the user
-            # may not always have the access to the newest API.
-            try:
-                current_ts_ms = int(time.time() * 1000)
-                last_ts_ms = self._gpu_process_last_sample_ts.get(gpu_index, 0)
-                nv_processes = self._pynvml.nvmlDeviceGetProcessesUtilizationInfo(
-                    gpu_handle, last_ts_ms
-                )
-                self._gpu_process_last_sample_ts[gpu_index] = current_ts_ms
-
-                for nv_process in nv_processes:
-                    pid = int(nv_process.pid)
-                    if pid not in processes_pids:
-                        # Note that it's pretty unlikely that nvmlDeviceGetProcessesUtilizationInfo
-                        # will include a process that nvmlDeviceGetComputeRunningProcesses +
-                        # nvmlDeviceGetGraphicsRunningProcesses didn't find, but doing this just in case.
-                        processes_pids[pid] = ProcessGPUInfo(
-                            pid=pid,
-                            gpu_memory_usage=0,
-                            gpu_utilization=int(nv_process.smUtil),
-                        )
-                    else:
-                        processes_pids[pid]["gpu_utilization"] = int(nv_process.smUtil)
-            except self._pynvml.NVMLError as e:
-                if log_once("gpu_process_sm_utilization"):
-                    logger.info(
-                        f"Failed to retrieve GPU process SM utilization using `nvmlDeviceGetProcessesUtilizationInfo`, error: {e}"
+            skip_process_util = (
+                self._force_skip_process_util_api
+                or self._force_fallback_this_cycle
+                or gpu_index in self._skip_process_util_gpu_indices
+            )
+            if not skip_process_util:
+                # Use a newer API (driver 550+) to get per-process SM utilization,
+                # but the user may not always have access to the newest API.
+                try:
+                    current_ts_ms = int(time.time() * 1000)
+                    last_ts_ms = self._gpu_process_last_sample_ts.get(gpu_index, 0)
+                    nv_processes = self._pynvml.nvmlDeviceGetProcessesUtilizationInfo(
+                        gpu_handle, last_ts_ms
                     )
+                    self._gpu_process_last_sample_ts[gpu_index] = current_ts_ms
+
+                    for nv_process in nv_processes:
+                        pid = int(nv_process.pid)
+                        if pid not in processes_pids:
+                            # This API may include a process that the compute and
+                            # graphics running-process APIs did not find.
+                            processes_pids[pid] = ProcessGPUInfo(
+                                pid=pid,
+                                gpu_memory_usage=0,
+                                gpu_utilization=int(nv_process.smUtil),
+                            )
+                        else:
+                            processes_pids[pid]["gpu_utilization"] = int(
+                                nv_process.smUtil
+                            )
+                except self._pynvml.NVMLError as e:
+                    if log_once("gpu_process_sm_utilization"):
+                        logger.info(
+                            "Failed to retrieve GPU process SM utilization using "
+                            "`nvmlDeviceGetProcessesUtilizationInfo`, "
+                            f"error: {e}"
+                        )
 
             # Optional: power (milliwatts) and temperature (Celsius)
             power_mw = None

--- a/python/ray/dashboard/modules/reporter/gpu_providers.py
+++ b/python/ray/dashboard/modules/reporter/gpu_providers.py
@@ -11,13 +11,14 @@ import os
 import re
 import subprocess
 import time
-from typing import Dict, List, Optional, Set, TypedDict, Union
+from typing import Dict, List, Optional, Set, Tuple, TypedDict, Union
 
 try:
     from typing import NotRequired
 except ImportError:
     from typing_extensions import NotRequired
 
+from ray._common.utils import env_bool
 from ray.util.debug import log_once
 
 logger = logging.getLogger(__name__)
@@ -25,7 +26,15 @@ logger = logging.getLogger(__name__)
 # Constants
 MB = 1024 * 1024
 RAY_SKIP_PROCESS_UTIL_API = "RAY_SKIP_PROCESS_UTIL_API"
-_PPU_NAME_RE = re.compile(r"\bPPU\b", re.IGNORECASE)
+RAY_SKIP_PROCESS_UTIL_API_DEVICE_NAMES = "RAY_SKIP_PROCESS_UTIL_API_DEVICE_NAMES"
+# PPU-compatible devices may append a model identifier directly to the prefix
+# (for example, PPU-ZW810, PPU810, or PPUZW910). Keep the leading boundary so
+# unrelated names such as XPPU are not classified as unsafe, and require at
+# least two suffix characters to preserve the standalone-name guard for PPU2.
+_UNSAFE_PROCESS_UTIL_NAME_PATTERNS = (
+    re.compile(r"(?<!\w)PPU(?:\b|[-_]?[A-Za-z0-9][A-Za-z0-9_-]+)", re.IGNORECASE),
+)
+_PROCESS_UTIL_DETECTION_LOG_INTERVAL_S = 60.0
 
 # Types
 Percentage = int
@@ -123,13 +132,22 @@ class NvidiaGpuProvider(GpuProvider):
         self._pynvml = None
         # Maintain per-GPU sampling timestamps when using process utilization API
         self._gpu_process_last_sample_ts: Dict[int, int] = {}
-        self._force_skip_process_util_api = os.environ.get(
-            RAY_SKIP_PROCESS_UTIL_API, ""
-        ).lower() in ("1", "true")
+        self._force_skip_process_util_api = env_bool(RAY_SKIP_PROCESS_UTIL_API, False)
+        self._skip_process_util_device_names = {
+            name.strip().casefold()
+            for name in os.environ.get(
+                RAY_SKIP_PROCESS_UTIL_API_DEVICE_NAMES, ""
+            ).split(",")
+            if name.strip()
+        }
         self._skip_process_util_gpu_indices: Set[int] = set()
+        self._logged_skip_process_util_devices: Set[Tuple[int, str]] = set()
+        self._process_util_override_logged = False
         self._ppu_detection_done = False
         self._detected_gpu_count: Optional[int] = None
         self._force_fallback_this_cycle = False
+        self._process_util_detection_failure_count = 0
+        self._last_process_util_detection_failure_log_ts = 0.0
 
     def get_provider_name(self) -> GpuProviderType:
         return GpuProviderType.NVIDIA
@@ -179,36 +197,71 @@ class NvidiaGpuProvider(GpuProvider):
 
     def _detect_ppu_devices(self, num_gpus: int) -> None:
         """Detect devices that cannot safely use the process utilization API."""
-        self._force_fallback_this_cycle = False
-
         if self._force_skip_process_util_api:
+            if not self._process_util_override_logged:
+                logger.info(
+                    "Skipping nvmlDeviceGetProcessesUtilizationInfo for all NVIDIA "
+                    "devices because %s=true",
+                    RAY_SKIP_PROCESS_UTIL_API,
+                )
+                self._process_util_override_logged = True
             return
 
         if self._ppu_detection_done and self._detected_gpu_count == num_gpus:
             return
 
         detected_indices: Set[int] = set()
+        detected_names: Dict[int, str] = {}
         try:
             for gpu_index in range(num_gpus):
                 gpu_handle = self._pynvml.nvmlDeviceGetHandleByIndex(gpu_index)
                 gpu_name = self._decode(self._pynvml.nvmlDeviceGetName(gpu_handle))
-                if _PPU_NAME_RE.search(gpu_name):
+                if gpu_name.casefold() in self._skip_process_util_device_names or any(
+                    pattern.search(gpu_name)
+                    for pattern in _UNSAFE_PROCESS_UTIL_NAME_PATTERNS
+                ):
                     detected_indices.add(gpu_index)
+                    detected_names[gpu_index] = gpu_name
         except Exception as e:
+            # Fail closed: a partial classification could leave an unprobed,
+            # unsafe device exposed to the process utilization API.
             self._ppu_detection_done = False
             self._detected_gpu_count = None
+            self._skip_process_util_gpu_indices.clear()
             self._force_fallback_this_cycle = True
-            if log_once("gpu_process_utilization_device_detection"):
-                logger.info(
+            self._process_util_detection_failure_count += 1
+            now = time.monotonic()
+            if (
+                self._process_util_detection_failure_count == 1
+                or now - self._last_process_util_detection_failure_log_ts
+                >= _PROCESS_UTIL_DETECTION_LOG_INTERVAL_S
+            ):
+                logger.warning(
                     "Failed to detect devices that support GPU process SM "
                     "utilization; skipping the process utilization API for this "
-                    f"collection cycle: {e}"
+                    "collection cycle and retrying: %s",
+                    e,
                 )
+                self._last_process_util_detection_failure_log_ts = now
             return
 
         self._skip_process_util_gpu_indices = detected_indices
         self._ppu_detection_done = True
         self._detected_gpu_count = num_gpus
+        self._process_util_detection_failure_count = 0
+        self._last_process_util_detection_failure_log_ts = 0.0
+
+        for gpu_index, gpu_name in detected_names.items():
+            device_key = (gpu_index, gpu_name)
+            if device_key not in self._logged_skip_process_util_devices:
+                logger.info(
+                    "Skipping nvmlDeviceGetProcessesUtilizationInfo for device %r "
+                    "(index %d): per-process utilization API is known to be "
+                    "unsafe on this device",
+                    gpu_name,
+                    gpu_index,
+                )
+                self._logged_skip_process_util_devices.add(device_key)
 
     def _get_pynvml_gpu_usage(self) -> List[GpuUtilizationInfo]:
         if not self._initialized:
@@ -224,7 +277,6 @@ class NvidiaGpuProvider(GpuProvider):
             except Exception:
                 self._ppu_detection_done = False
                 self._detected_gpu_count = None
-                self._force_fallback_this_cycle = True
                 raise
 
             self._detect_ppu_devices(num_gpus)

--- a/python/ray/dashboard/modules/reporter/tests/test_gpu_providers.py
+++ b/python/ray/dashboard/modules/reporter/tests/test_gpu_providers.py
@@ -7,6 +7,7 @@ from unittest.mock import Mock, call, patch
 from ray.dashboard.modules.reporter.gpu_providers import (
     MB,
     RAY_SKIP_PROCESS_UTIL_API,
+    RAY_SKIP_PROCESS_UTIL_API_DEVICE_NAMES,
     AmdGpuProvider,
     GpuMetricProvider,
     GpuProvider,
@@ -280,7 +281,10 @@ class TestNvidiaGpuProvider(unittest.TestCase):
             mock_pynvml, ["MetaX ppu Accelerator", "NVIDIA H100"]
         )
 
-        result = self.provider.get_gpu_utilization()
+        with self.assertLogs(
+            "ray.dashboard.modules.reporter.gpu_providers", level="INFO"
+        ) as logs:
+            result = self.provider.get_gpu_utilization()
 
         self.assertEqual(self.provider._skip_process_util_gpu_indices, {0})
         self.assertEqual(
@@ -289,7 +293,13 @@ class TestNvidiaGpuProvider(unittest.TestCase):
         )
         self.assertEqual(result[0]["processes_pids"][1000]["gpu_memory_usage"], 128)
         self.assertIsNone(result[0]["processes_pids"][1000]["gpu_utilization"])
+        self.assertEqual(result[0]["memory_used"], 256)
+        self.assertEqual(result[0]["power_mw"], 100000)
+        self.assertEqual(result[0]["temperature_c"], 50)
         self.assertEqual(result[1]["processes_pids"][1001]["gpu_utilization"], 41)
+        self.assertTrue(
+            any("MetaX ppu Accelerator" in message for message in logs.output)
+        )
 
     @patch("ray._private.thirdparty.pynvml", create=True)
     def test_process_utilization_skipped_for_nonzero_ppu_device(self, mock_pynvml):
@@ -309,19 +319,47 @@ class TestNvidiaGpuProvider(unittest.TestCase):
         self.assertIsNone(result[1]["processes_pids"][1001]["gpu_utilization"])
 
     @patch("ray._private.thirdparty.pynvml", create=True)
-    def test_ppu_detection_requires_standalone_name(self, mock_pynvml):
-        """Test that PPU is matched as a standalone token only."""
+    def test_ppu_detection_matches_ppu_device_name_patterns(self, mock_pynvml):
+        """Test PPU model suffixes while preserving standalone-name matching."""
         handles = self._configure_nvidia_collection(
-            mock_pynvml, ["XPPU Accelerator", "PPU2 Accelerator"]
+            mock_pynvml,
+            [
+                "XPPU Accelerator",
+                "PPU2 Accelerator",
+                "PPU-ZW810",
+                "PPU810",
+                "PPUZW910",
+            ],
         )
 
         self.provider.get_gpu_utilization()
 
-        self.assertEqual(self.provider._skip_process_util_gpu_indices, set())
+        self.assertEqual(self.provider._skip_process_util_gpu_indices, {2, 3, 4})
         self.assertEqual(
             mock_pynvml.nvmlDeviceGetProcessesUtilizationInfo.call_args_list,
             [call(handles[0], 0), call(handles[1], 0)],
         )
+
+    @patch("ray._private.thirdparty.pynvml", create=True)
+    def test_process_utilization_skipped_for_configured_device_name(self, mock_pynvml):
+        """Test that operators can skip an unsafe device by its exact name."""
+        with patch.dict(
+            os.environ,
+            {RAY_SKIP_PROCESS_UTIL_API_DEVICE_NAMES: "vendor accelerator,Other"},
+        ):
+            self.provider = NvidiaGpuProvider()
+        handles = self._configure_nvidia_collection(
+            mock_pynvml, ["Vendor Accelerator", "NVIDIA H100"]
+        )
+
+        result = self.provider.get_gpu_utilization()
+
+        self.assertEqual(self.provider._skip_process_util_gpu_indices, {0})
+        self.assertEqual(
+            mock_pynvml.nvmlDeviceGetProcessesUtilizationInfo.call_args_list,
+            [call(handles[1], 0)],
+        )
+        self.assertIsNone(result[0]["processes_pids"][1000]["gpu_utilization"])
 
     @patch("ray._private.thirdparty.pynvml", create=True)
     def test_ppu_detection_failure_falls_back_and_retries(self, mock_pynvml):
@@ -365,6 +403,27 @@ class TestNvidiaGpuProvider(unittest.TestCase):
         )
 
     @patch("ray._private.thirdparty.pynvml", create=True)
+    def test_ppu_detection_failure_falls_back_on_every_cycle(self, mock_pynvml):
+        """Test that repeated detection failures never call the unsafe API."""
+        handles = self._configure_nvidia_collection(
+            mock_pynvml, ["NVIDIA H100", "NVIDIA H200"]
+        )
+
+        def get_name(handle):
+            if handle == handles[1]:
+                raise mock_pynvml.NVMLError("persistent name query failure")
+            return b"NVIDIA H100"
+
+        mock_pynvml.nvmlDeviceGetName.side_effect = get_name
+
+        with patch.object(self.provider, "_shutdown"):
+            self.provider.get_gpu_utilization()
+            self.provider.get_gpu_utilization()
+
+        self.assertEqual(self.provider._process_util_detection_failure_count, 2)
+        mock_pynvml.nvmlDeviceGetProcessesUtilizationInfo.assert_not_called()
+
+    @patch("ray._private.thirdparty.pynvml", create=True)
     def test_ppu_detection_cache_invalidated_by_gpu_count(self, mock_pynvml):
         """Test that a GPU count change triggers full detection again."""
         self._configure_nvidia_collection(
@@ -388,14 +447,47 @@ class TestNvidiaGpuProvider(unittest.TestCase):
             self.provider = NvidiaGpuProvider()
         self._configure_nvidia_collection(mock_pynvml, ["NVIDIA H100"])
 
-        result = self.provider.get_gpu_utilization()
+        with self.assertLogs(
+            "ray.dashboard.modules.reporter.gpu_providers", level="INFO"
+        ) as logs:
+            result = self.provider.get_gpu_utilization()
 
         self.assertTrue(self.provider._force_skip_process_util_api)
         self.assertFalse(self.provider._ppu_detection_done)
+        # The only name lookup is the one needed to populate the GPU info.
         self.assertEqual(mock_pynvml.nvmlDeviceGetName.call_count, 1)
         mock_pynvml.nvmlDeviceGetProcessesUtilizationInfo.assert_not_called()
         self.assertEqual(result[0]["processes_pids"][1000]["gpu_memory_usage"], 128)
         self.assertIsNone(result[0]["processes_pids"][1000]["gpu_utilization"])
+        self.assertTrue(
+            any(RAY_SKIP_PROCESS_UTIL_API in message for message in logs.output)
+        )
+
+    @patch("ray._private.thirdparty.pynvml", create=True)
+    def test_process_utilization_operator_override_values(self, mock_pynvml):
+        """Test accepted and rejected values for the operator override."""
+        for value, expected in (
+            ("true", True),
+            ("1", True),
+            ("false", False),
+            ("0", False),
+        ):
+            with self.subTest(value=value):
+                with patch.dict(os.environ, {RAY_SKIP_PROCESS_UTIL_API: value}):
+                    self.provider = NvidiaGpuProvider()
+                self._configure_nvidia_collection(mock_pynvml, ["NVIDIA H100"])
+
+                self.provider.get_gpu_utilization()
+
+                self.assertEqual(self.provider._force_skip_process_util_api, expected)
+                process_utilization_api = (
+                    mock_pynvml.nvmlDeviceGetProcessesUtilizationInfo
+                )
+                if expected:
+                    process_utilization_api.assert_not_called()
+                else:
+                    process_utilization_api.assert_called_once()
+                mock_pynvml.reset_mock()
 
     @patch("ray._private.thirdparty.pynvml", create=True)
     def test_get_gpu_utilization_success(self, mock_pynvml):

--- a/python/ray/dashboard/modules/reporter/tests/test_gpu_providers.py
+++ b/python/ray/dashboard/modules/reporter/tests/test_gpu_providers.py
@@ -1,10 +1,12 @@
 """Unit tests for GPU providers."""
 
+import os
 import unittest
-from unittest.mock import Mock, patch
+from unittest.mock import Mock, call, patch
 
 from ray.dashboard.modules.reporter.gpu_providers import (
     MB,
+    RAY_SKIP_PROCESS_UTIL_API,
     AmdGpuProvider,
     GpuMetricProvider,
     GpuProvider,
@@ -111,6 +113,51 @@ class TestNvidiaGpuProvider(unittest.TestCase):
     def setUp(self):
         """Set up test fixtures."""
         self.provider = NvidiaGpuProvider()
+
+    def _configure_nvidia_collection(self, mock_pynvml, gpu_names):
+        class MockNVMLError(Exception):
+            pass
+
+        handles = [f"gpu-{index}" for index in range(len(gpu_names))]
+        gpu_indices = {handle: index for index, handle in enumerate(handles)}
+
+        mock_pynvml.NVMLError = MockNVMLError
+        mock_pynvml.NVML_TEMPERATURE_GPU = 0
+        mock_pynvml.nvmlDeviceGetCount.return_value = len(gpu_names)
+        mock_pynvml.nvmlDeviceGetHandleByIndex.side_effect = handles.__getitem__
+        mock_pynvml.nvmlDeviceGetName.side_effect = lambda handle: gpu_names[
+            gpu_indices[handle]
+        ].encode()
+        mock_pynvml.nvmlDeviceGetUUID.side_effect = (
+            lambda handle: f"GPU-{gpu_indices[handle]}".encode()
+        )
+        mock_pynvml.nvmlDeviceGetMigMode.return_value = (False, False)
+        mock_pynvml.nvmlDeviceGetMemoryInfo.side_effect = lambda handle: Mock(
+            used=(gpu_indices[handle] + 1) * 256 * MB,
+            total=16 * 1024 * MB,
+        )
+        mock_pynvml.nvmlDeviceGetUtilizationRates.return_value = Mock(gpu=75)
+        mock_pynvml.nvmlDeviceGetComputeRunningProcesses.side_effect = lambda handle: [
+            Mock(
+                pid=1000 + gpu_indices[handle],
+                usedGpuMemory=(gpu_indices[handle] + 1) * 128 * MB,
+            )
+        ]
+        mock_pynvml.nvmlDeviceGetGraphicsRunningProcesses.return_value = []
+        mock_pynvml.nvmlDeviceGetProcessesUtilizationInfo.side_effect = (
+            lambda handle, _: [
+                Mock(
+                    pid=1000 + gpu_indices[handle],
+                    smUtil=40 + gpu_indices[handle],
+                )
+            ]
+        )
+        mock_pynvml.nvmlDeviceGetPowerUsage.return_value = 100000
+        mock_pynvml.nvmlDeviceGetTemperature.return_value = 50
+
+        self.provider._pynvml = mock_pynvml
+        self.provider._initialized = True
+        return handles
 
     def test_get_provider_name(self):
         """Test provider name."""
@@ -227,6 +274,130 @@ class TestNvidiaGpuProvider(unittest.TestCase):
         mock_pynvml.nvmlShutdown.assert_not_called()
 
     @patch("ray._private.thirdparty.pynvml", create=True)
+    def test_process_utilization_skipped_only_for_ppu_device(self, mock_pynvml):
+        """Test that PPU devices are skipped without degrading NVIDIA GPUs."""
+        handles = self._configure_nvidia_collection(
+            mock_pynvml, ["MetaX ppu Accelerator", "NVIDIA H100"]
+        )
+
+        result = self.provider.get_gpu_utilization()
+
+        self.assertEqual(self.provider._skip_process_util_gpu_indices, {0})
+        self.assertEqual(
+            mock_pynvml.nvmlDeviceGetProcessesUtilizationInfo.call_args_list,
+            [call(handles[1], 0)],
+        )
+        self.assertEqual(result[0]["processes_pids"][1000]["gpu_memory_usage"], 128)
+        self.assertIsNone(result[0]["processes_pids"][1000]["gpu_utilization"])
+        self.assertEqual(result[1]["processes_pids"][1001]["gpu_utilization"], 41)
+
+    @patch("ray._private.thirdparty.pynvml", create=True)
+    def test_process_utilization_skipped_for_nonzero_ppu_device(self, mock_pynvml):
+        """Test that a nonzero PPU index is skipped independently."""
+        handles = self._configure_nvidia_collection(
+            mock_pynvml, ["NVIDIA H100", "MetaX PPU Accelerator"]
+        )
+
+        result = self.provider.get_gpu_utilization()
+
+        self.assertEqual(self.provider._skip_process_util_gpu_indices, {1})
+        self.assertEqual(
+            mock_pynvml.nvmlDeviceGetProcessesUtilizationInfo.call_args_list,
+            [call(handles[0], 0)],
+        )
+        self.assertEqual(result[0]["processes_pids"][1000]["gpu_utilization"], 40)
+        self.assertIsNone(result[1]["processes_pids"][1001]["gpu_utilization"])
+
+    @patch("ray._private.thirdparty.pynvml", create=True)
+    def test_ppu_detection_requires_standalone_name(self, mock_pynvml):
+        """Test that PPU is matched as a standalone token only."""
+        handles = self._configure_nvidia_collection(
+            mock_pynvml, ["XPPU Accelerator", "PPU2 Accelerator"]
+        )
+
+        self.provider.get_gpu_utilization()
+
+        self.assertEqual(self.provider._skip_process_util_gpu_indices, set())
+        self.assertEqual(
+            mock_pynvml.nvmlDeviceGetProcessesUtilizationInfo.call_args_list,
+            [call(handles[0], 0), call(handles[1], 0)],
+        )
+
+    @patch("ray._private.thirdparty.pynvml", create=True)
+    def test_ppu_detection_failure_falls_back_and_retries(self, mock_pynvml):
+        """Test that detection failure skips one cycle and is retried."""
+        handles = self._configure_nvidia_collection(
+            mock_pynvml, ["NVIDIA H100", "NVIDIA H200"]
+        )
+        name_call_counts = {handle: 0 for handle in handles}
+
+        def get_name(handle):
+            name_call_counts[handle] += 1
+            if handle == handles[1] and name_call_counts[handle] == 1:
+                raise mock_pynvml.NVMLError("temporary name query failure")
+            return f"NVIDIA GPU {handle}".encode()
+
+        mock_pynvml.nvmlDeviceGetName.side_effect = get_name
+
+        with patch.object(self.provider, "_shutdown"):
+            first_result = self.provider.get_gpu_utilization()
+
+            self.assertTrue(self.provider._force_fallback_this_cycle)
+            self.assertFalse(self.provider._ppu_detection_done)
+            mock_pynvml.nvmlDeviceGetProcessesUtilizationInfo.assert_not_called()
+            self.assertEqual(
+                first_result[0]["processes_pids"][1000]["gpu_memory_usage"], 128
+            )
+            self.assertIsNone(
+                first_result[0]["processes_pids"][1000]["gpu_utilization"]
+            )
+
+            second_result = self.provider.get_gpu_utilization()
+
+        self.assertFalse(self.provider._force_fallback_this_cycle)
+        self.assertTrue(self.provider._ppu_detection_done)
+        self.assertEqual(
+            mock_pynvml.nvmlDeviceGetProcessesUtilizationInfo.call_args_list,
+            [call(handles[0], 0), call(handles[1], 0)],
+        )
+        self.assertEqual(
+            second_result[0]["processes_pids"][1000]["gpu_utilization"], 40
+        )
+
+    @patch("ray._private.thirdparty.pynvml", create=True)
+    def test_ppu_detection_cache_invalidated_by_gpu_count(self, mock_pynvml):
+        """Test that a GPU count change triggers full detection again."""
+        self._configure_nvidia_collection(
+            mock_pynvml, ["NVIDIA H100", "NVIDIA H200", "MetaX PPU"]
+        )
+
+        self.provider._detect_ppu_devices(2)
+        self.assertEqual(mock_pynvml.nvmlDeviceGetName.call_count, 2)
+
+        self.provider._detect_ppu_devices(2)
+        self.assertEqual(mock_pynvml.nvmlDeviceGetName.call_count, 2)
+
+        self.provider._detect_ppu_devices(3)
+        self.assertEqual(mock_pynvml.nvmlDeviceGetName.call_count, 5)
+        self.assertEqual(self.provider._skip_process_util_gpu_indices, {2})
+
+    @patch("ray._private.thirdparty.pynvml", create=True)
+    def test_process_utilization_operator_override(self, mock_pynvml):
+        """Test that the operator override skips only process utilization."""
+        with patch.dict(os.environ, {RAY_SKIP_PROCESS_UTIL_API: "true"}):
+            self.provider = NvidiaGpuProvider()
+        self._configure_nvidia_collection(mock_pynvml, ["NVIDIA H100"])
+
+        result = self.provider.get_gpu_utilization()
+
+        self.assertTrue(self.provider._force_skip_process_util_api)
+        self.assertFalse(self.provider._ppu_detection_done)
+        self.assertEqual(mock_pynvml.nvmlDeviceGetName.call_count, 1)
+        mock_pynvml.nvmlDeviceGetProcessesUtilizationInfo.assert_not_called()
+        self.assertEqual(result[0]["processes_pids"][1000]["gpu_memory_usage"], 128)
+        self.assertIsNone(result[0]["processes_pids"][1000]["gpu_utilization"])
+
+    @patch("ray._private.thirdparty.pynvml", create=True)
     def test_get_gpu_utilization_success(self, mock_pynvml):
         """Test successful GPU utilization retrieval."""
         # Mock GPU device
@@ -242,14 +413,22 @@ class TestNvidiaGpuProvider(unittest.TestCase):
         mock_process.pid = 1234
         mock_process.usedGpuMemory = 256 * MB
 
+        mock_process_utilization = Mock()
+        mock_process_utilization.pid = 1234
+        mock_process_utilization.smUtil = 35
+
         # Configure mocks
         mock_pynvml.nvmlInit.return_value = None
+        mock_pynvml.nvmlDeviceGetMigMode.return_value = (False, False)
         mock_pynvml.nvmlDeviceGetCount.return_value = 1
         mock_pynvml.nvmlDeviceGetHandleByIndex.return_value = mock_handle
         mock_pynvml.nvmlDeviceGetMemoryInfo.return_value = mock_memory_info
         mock_pynvml.nvmlDeviceGetUtilizationRates.return_value = mock_utilization_info
         mock_pynvml.nvmlDeviceGetComputeRunningProcesses.return_value = [mock_process]
         mock_pynvml.nvmlDeviceGetGraphicsRunningProcesses.return_value = []
+        mock_pynvml.nvmlDeviceGetProcessesUtilizationInfo.return_value = [
+            mock_process_utilization
+        ]
         mock_pynvml.nvmlDeviceGetName.return_value = b"NVIDIA GeForce RTX 3080"
         mock_pynvml.nvmlDeviceGetUUID.return_value = (
             b"GPU-12345678-1234-1234-1234-123456789abc"
@@ -274,6 +453,7 @@ class TestNvidiaGpuProvider(unittest.TestCase):
         self.assertEqual(len(gpu_info["processes_pids"]), 1)
         self.assertEqual(gpu_info["processes_pids"][1234]["pid"], 1234)
         self.assertEqual(gpu_info["processes_pids"][1234]["gpu_memory_usage"], 256)
+        self.assertEqual(gpu_info["processes_pids"][1234]["gpu_utilization"], 35)
 
     @patch("ray._private.thirdparty.pynvml", create=True)
     def test_get_gpu_utilization_with_errors(self, mock_pynvml):


### PR DESCRIPTION
## Description

Some third-party NVML-compatible libraries export
'nvmlDeviceGetProcessesUtilizationInfo' but terminate the calling process when
the API is invoked. Because this happens in native code, Python exception
handling cannot prevent the Reporter Agent from exiting.

## What changed

- Detect incompatible PPU devices before calling the process utilization API.
- Use case-insensitive 'PPU' prefix matching with a leading identifier boundary.
- Skip the API per GPU index so compatible NVIDIA GPUs on mixed nodes continue reporting per-process SM utilization.
- Fail closed for the current collection cycle when device detection fails, and retry detection on the next cycle.
- Add RAY_SKIP_PROCESS_UTIL_API=true as a node-wide operator escape hatch.
- Preserve process IDs, allocated GPU memory, and device-level metrics when process utilization is skipped.
- Document the escape hatch and its metric impact.

## Related issues

Fixes #65414


## Additional information

### What is a PPU?

PPU refers to **Alibaba Cloud PPU (Parallel Processing Unit)** — specifically the **PPU-Z** series (e.g. `PPU-ZW810`) — a non-NVIDIA AI accelerator for large-scale model training and inference. It exposes CUDA- and NVML-compatible interfaces so that existing GPU software stacks can run on it. See https://www.aliyun.com/ppu.

### What device and which "third-party NVML-compatible library"?

| Item | Details |
| --- | --- |
| Device | `PPU-ZW810` (reported by `nvmlDeviceGetName()` / `nvidia-smi`; 96 GB, 98304 MiB) |
| Accelerator SDK/driver | PPU SDK `2.0.0-715aa1`; `ppu-smi 1.22`; driver `1.5.3-5239a4`; HGGC `13.0` (the vendor's compute stack, analogous to the NVIDIA driver) |
| NVML implementation | The vendor's NVML-compatible shim `libnvidia-ml.so.1`, shipped with the PPU SDK at `/usr/local/PPU_SDK/CUDA_SDK/targets/x86_64-linux/lib/` — a drop-in replacement for NVIDIA's NVML, layered over the vendor's native `hgml` API |
| Ray | `2.56.0` (installed via pip; `/opt/conda/lib/python3.12/site-packages/ray/`) |


So "third-party NVML-compatible library" = the PPU vendor's `libnvidia-ml.so.1` shim, not NVIDIA's library.

### Steps to reproduce

**1. Minimal reproduction (no Ray code involved — plain ctypes against the vendor shim):**

```python
import ctypes

nvml = ctypes.CDLL("libnvidia-ml.so.1")

handle = ctypes.c_void_p()
nvml.nvmlInit_v2()
nvml.nvmlDeviceGetHandleByIndex_v2(0, ctypes.byref(handle))

buf = ctypes.create_string_buffer(96)
nvml.nvmlDeviceGetName(handle, buf, 96)
print("device:", buf.value.decode(), flush=True)


# Matches nvml.h:
#   nvmlReturn_t nvmlDeviceGetProcessesUtilizationInfo(
#       nvmlDevice_t device, nvmlProcessesUtilizationInfo_t *procesesUtilInfo);
class nvmlProcessUtilizationInfo_v1_t(ctypes.Structure):
    _fields_ = [
        ("timeStamp", ctypes.c_ulonglong),
        ("pid", ctypes.c_uint),
        ("smUtil", ctypes.c_uint),
        ("memUtil", ctypes.c_uint),
        ("encUtil", ctypes.c_uint),
        ("decUtil", ctypes.c_uint),
        ("jpgUtil", ctypes.c_uint),
        ("ofaUtil", ctypes.c_uint),
    ]


class nvmlProcessesUtilizationInfo_v1_t(ctypes.Structure):
    _fields_ = [
        ("version", ctypes.c_uint),
        ("processSamplesCount", ctypes.c_uint),
        ("lastSeenTimeStamp", ctypes.c_ulonglong),
        ("procUtilArray", ctypes.POINTER(nvmlProcessUtilizationInfo_v1_t)),
    ]


# Well-formed call: correct struct version, valid caller-allocated buffer.
# version = NVML_STRUCT_VERSION(ProcessesUtilizationInfo, 1) = sizeof(struct) | (1 << 24)
samples = (nvmlProcessUtilizationInfo_v1_t * 64)()
info = nvmlProcessesUtilizationInfo_v1_t(
    version=ctypes.sizeof(nvmlProcessesUtilizationInfo_v1_t) | (1 << 24),
    processSamplesCount=64,
    lastSeenTimeStamp=0,
    procUtilArray=samples,
)
nvml.nvmlDeviceGetProcessesUtilizationInfo(handle, ctypes.byref(info))

print("unreachable")
```

```text
$ LD_LIBRARY_PATH=/usr/local/PPU_SDK/CUDA_SDK/targets/x86_64-linux/lib python3 repro.py
device: PPU-ZW810
nvmlDeviceGetProcessesUtilizationInfo is not supported by HGGC.
$ echo $?
1
```

The process is terminated **in native code** with exit code `1`. No `pynvml.NVMLError` (or any Python exception) is raised, so no `try/except` in Python can intercept it. The same happens via `ray._private.thirdparty.pynvml.nvmlDeviceGetProcessesUtilizationInfo(handle, 0)`. (Also verified with a NULL info pointer — the shim exits on the unsupported call itself, not on any pointer dereference.)

**2. Reproduction in Ray:**

1. Start a Ray node on a machine with this device and vendor runtime.
2. The Dashboard Reporter starts its periodic GPU metrics collection.
3. The Reporter calls `nvmlDeviceGetProcessesUtilizationInfo` (for per-process SM utilization).
4. The native library terminates the Reporter process.
5. Node metrics are no longer reported.

To confirm the process is hard-terminated rather than raising, I wrapped the reporter call in `try/except BaseException` with `faulthandler` enabled — a raised exception or a fault-induced crash would both produce a Python traceback; neither appears:

```python
# repro_ray.py
import faulthandler, traceback
faulthandler.enable()
from ray.dashboard.modules.reporter.gpu_providers import NvidiaGpuProvider

provider = NvidiaGpuProvider()
print("calling get_gpu_utilization() ...", flush=True)
try:
    result = provider.get_gpu_utilization()
except BaseException as e:                      # would catch NVMLError if raised
    print("Python exception caught:", repr(e))
    traceback.print_exc()
else:
    print("returned", len(result), "GPUs")      # never reached
print("end of script")                          # never reached
```

```text
$ LD_LIBRARY_PATH=/usr/local/PPU_SDK/CUDA_SDK/targets/x86_64-linux/lib python3 repro_ray.py
calling get_gpu_utilization() ...
nvmlDeviceGetProcessesUtilizationInfo is not supported by HGGC.
$ echo $?
1
```

The lines after `get_gpu_utilization()` never execute, `try/except BaseException` catches nothing, there is no traceback, and the exit code is `1`. This is why the existing `try/except` in the reporter cannot protect against it — the only safe option is to not call this optional API on affected devices.



## Validation

Duplicate-work check: searched open PRs for issue #65414 and for NVML process-utilization/PPU changes; only this PR addresses the issue.

Tests:

- `python -m pytest -q python/ray/dashboard/modules/reporter/tests/test_gpu_providers.py` (44 passed, 4 subtests passed)
- `pre-commit run --files python/ray/dashboard/modules/reporter/gpu_providers.py python/ray/dashboard/modules/reporter/tests/test_gpu_providers.py` (passed)

## AI assistance

AI assistance was used to help analyze, implement, test, and review this change.

