### PR TITLE
[core][rdt] nixl: allow pool to serve tensors on a different device

### DIFF
--- a/python/ray/experimental/rdt/nixl_tensor_transport.py
+++ b/python/ray/experimental/rdt/nixl_tensor_transport.py
@@ -316,15 +316,10 @@ class NixlTensorTransport(TensorTransportManager):
                         stream.synchronize()
 
                 nixl_agent = self.get_nixl_agent()
-                # Use the pool only when every tensor lives on the exact same
-                # device as the pool, AND no tensor already has an existing
-                # NIXL registration (via register_nixl_memory).
+                # Use the pool when no tensor already has an existing NIXL
+                # registration (via register_nixl_memory).
                 pool_eligible = (
                     self._memory_pool is not None
-                    and all(
-                        t.device == self._memory_pool.get_pool_tensor().device
-                        for t in rdt_object
-                    )
                     and not any(self._tensor_memory_registered(t) for t in rdt_object)
                 )
                 if pool_eligible:

--- a/python/ray/experimental/rdt/nixl_tensor_transport.py
+++ b/python/ray/experimental/rdt/nixl_tensor_transport.py
@@ -318,9 +318,18 @@ class NixlTensorTransport(TensorTransportManager):
                 nixl_agent = self.get_nixl_agent()
                 # Use the pool when no tensor already has an existing NIXL
                 # registration (via register_nixl_memory).
+                pool_device = (
+                    self._memory_pool.get_pool_tensor().device
+                    if self._memory_pool is not None
+                    else None
+                )
                 pool_eligible = (
                     self._memory_pool is not None
                     and not any(self._tensor_memory_registered(t) for t in rdt_object)
+                    and (
+                        pool_device.type == "cpu"
+                        or all(t.device == pool_device for t in rdt_object)
+                    )
                 )
                 if pool_eligible:
                     xfer_descs = self._allocate_pool_xfer_descs(rdt_object)

--- a/python/ray/tests/rdt/test_rdt_nixl.py
+++ b/python/ray/tests/rdt/test_rdt_nixl.py
@@ -811,16 +811,35 @@ def test_nixl_memory_pool_cpu_pool_gpu_tensor(ray_start_regular):
 
         @ray.method(tensor_transport="nixl")
         def echo(self, data):
+            # Guard against the argument silently landing on CPU.
+            assert data.device.type == "cuda"
             return data
 
-    # The pool lives on CPU while the source tensor is created on the actor's GPU.
-    src_actor = PoolActor.remote("cpu", 48)
-    dst_actor = GPUTestActor.remote()
+        def pool_device_type(self):
+            return (
+                get_tensor_transport_manager("NIXL")
+                ._memory_pool.get_pool_tensor()
+                .device.type
+            )
 
-    ref = src_actor.echo.remote(torch.tensor([1, 2, 3]).to("cuda"))
-    # The receiver should still get the tensor on the GPU, even though the
-    # sender used a CPU-based pool to stage the transfer.
-    assert ray.get(dst_actor.sum.remote(ref, "cuda")) == 6
+    # Pool holds exactly one small tensor (24 bytes).
+    src_actor = PoolActor.remote("cpu", 24)
+    dst_actor = GPUTestActor.remote()
+    assert ray.get(src_actor.pool_device_type.remote()) == "cpu"
+
+    # Transfer the first small tensor (using memory pool internally).
+    ref1 = src_actor.echo.remote(torch.tensor([1, 2, 3]).to("cuda"))
+    assert ray.get(dst_actor.sum.remote(ref1, "cuda")) == 6
+
+    # Second transfer: pool is full (ref1 still alive). The allocation raises
+    # NixlOutOfMemoryError, which surfaces as a RayTaskError, proving the
+    # pool (not direct registration) served ref1.
+    ref2 = src_actor.echo.remote(torch.tensor([4, 5, 6]).to("cuda"))
+    with pytest.raises(ray.exceptions.RayTaskError) as excinfo:
+        ray.get(dst_actor.sum.remote(ref2, "cuda"))
+    assert "NixlOutOfMemoryError" in str(excinfo.value) and "out of memory" in str(
+        excinfo.value
+    )
 
 
 @pytest.mark.parametrize("ray_start_regular", [{"num_gpus": 1}], indirect=True)

--- a/python/ray/tests/rdt/test_rdt_nixl.py
+++ b/python/ray/tests/rdt/test_rdt_nixl.py
@@ -795,6 +795,34 @@ def test_nixl_memory_pool(ray_start_regular, device):
     assert ray.get(dst_actor.sum.remote(ref4, device)) == 21
 
 
+@pytest.mark.parametrize("ray_start_regular", [{"num_gpus": 2}], indirect=True)
+def test_nixl_memory_pool_cpu_pool_gpu_tensor(ray_start_regular):
+    """
+    Test that a CPU-based memory pool can serve GPU source tensors, and that
+    the tensor still lands on the GPU on the receiver.
+    """
+
+    @ray.remote(num_gpus=1, num_cpus=0, enable_tensor_transport=True)
+    class PoolActor:
+        def __init__(self, pool_device, pool_size):
+            from ray.experimental import register_nixl_memory_pool
+
+            register_nixl_memory_pool(pool_size, torch.device(pool_device))
+
+        @ray.method(tensor_transport="nixl")
+        def echo(self, data):
+            return data
+
+    # The pool lives on CPU while the source tensor is created on the actor's GPU.
+    src_actor = PoolActor.remote("cpu", 48)
+    dst_actor = GPUTestActor.remote()
+
+    ref = src_actor.echo.remote(torch.tensor([1, 2, 3]).to("cuda"))
+    # The receiver should still get the tensor on the GPU, even though the
+    # sender used a CPU-based pool to stage the transfer.
+    assert ray.get(dst_actor.sum.remote(ref, "cuda")) == 6
+
+
 @pytest.mark.parametrize("ray_start_regular", [{"num_gpus": 1}], indirect=True)
 def test_nixl_memory_pool_view_deduplication(ray_start_regular):
     """


### PR DESCRIPTION
## Why

Fixes #64712.

The `pool_eligible` check in `NixlTensorTransport` rejected pools whose device differed from the source tensors. `MemoryPoolManager.allocate_for_tensors` already handles cross-device copies via `.copy_()`, so the constraint was unnecessary. Removing it lets a CPU memory pool back GPU tensor sends, which is useful when GPU memory is scarce and long-lived streaming pools are needed.

## Changes

- `nixl_tensor_transport.py`: remove `t.device == self._memory_pool.get_pool_tensor().device` from `pool_eligible`.

