### PR TITLE
[core] Enable TCP keepalive on GCS<->Redis connections

### DIFF
--- a/doc/source/cluster/kubernetes/user-guides/kuberay-gcs-ft.md
+++ b/doc/source/cluster/kubernetes/user-guides/kuberay-gcs-ft.md
@@ -356,6 +356,46 @@ Note that Redis does this eviction and it doesn't guarantee that
 Ray won't use the deleted keys.
 ```
 
+### 5. Tune TCP keepalive for the Redis connection
+
+The GCS enables TCP keepalive on its connections to the external Redis so that
+proxies, load balancers, NAT, or managed-service gateways on the network path
+don't silently remove idle flows, and so that a dead connection is detected
+instead of hanging until the next command. Set these environment variables on
+the head Pod to tune it:
+
+* `RAY_redis_tcp_keepalive_interval_seconds`: 30 by default. How long a
+  connection may sit idle before a keepalive probe, and the gap between probes.
+  Keep it **below the shortest idle timeout on the network path** to Redis
+  (cloud load balancers commonly use 60-350 seconds); otherwise keepalive only
+  detects removed flows instead of preventing their removal. Set it to `0` to
+  disable keepalive entirely and restore the previous socket behavior. Valid
+  values are `0` through `32767`.
+
+* `RAY_redis_tcp_keepalive_probes`: 3 by default. How many unanswered probes
+  declare the connection dead, so detection takes about
+  `interval * (1 + probes)` — roughly 2 minutes with the defaults. Valid values
+  are `1` through `127` when TCP keepalive is enabled.
+
+```{note}
+Both settings take full effect only on glibc Linux, which covers the official
+Ray images and wheels. On macOS the interval sets the idle time but the probe
+timing comes from the operating system, and on musl-based Linux (Alpine) the
+interval isn't applied either — the connection only gets `SO_KEEPALIVE`, whose
+kernel default idle time is two hours. If you build Ray against musl, don't rely
+on these settings to keep an idle flow alive; raise the kernel defaults through
+`net.ipv4.tcp_keepalive_time` and friends instead.
+```
+
+```{warning}
+Ray does not yet reconnect to Redis in place. When a connection is declared
+dead, the pending Redis operation exhausts its retry budget and the GCS process
+exits. Lowering `RAY_redis_tcp_keepalive_probes` or the interval shortens the
+window before that happens, so a transient network stall that the connection
+would otherwise have survived can terminate the GCS instead. Keep the detection
+window comfortably longer than any stall you expect to recover from.
+```
+
 ## Next steps
 
 * See {ref}`Ray Serve end-to-end fault tolerance documentation <serve-e2e-ft-guide-gcs>` for more information.

--- a/doc/source/cluster/kubernetes/user-guides/kuberay-gcs-ft.md
+++ b/doc/source/cluster/kubernetes/user-guides/kuberay-gcs-ft.md
@@ -358,39 +358,45 @@ Ray won't use the deleted keys.
 
 ### 5. Tune TCP keepalive for the Redis connection
 
-The GCS enables TCP keepalive on its connections to the external Redis so that
-proxies, load balancers, NAT, or managed-service gateways on the network path
-don't silently remove idle flows, and so that a dead connection is detected
-instead of hanging until the next command. Set these environment variables on
-the head Pod to tune it:
+The GCS enables TCP keepalive on its connections to external Redis to detect
+unresponsive idle connections. Probes can also preserve idle flows through
+network devices that count TCP keepalive as activity. Set these environment
+variables on the head Pod to tune it:
 
 * `RAY_redis_tcp_keepalive_interval_seconds`: 30 by default. How long a
   connection may sit idle before a keepalive probe, and the gap between probes.
   Keep it **below the shortest idle timeout on the network path** to Redis
-  (cloud load balancers commonly use 60-350 seconds); otherwise keepalive only
-  detects removed flows instead of preventing their removal. Set it to `0` to
+  (cloud load balancers commonly use 60-350 seconds). An interval above that
+  timeout can't preserve the flow; whether probes prevent removal also depends
+  on the device's policy. Set it to `0` to
   disable keepalive entirely and restore the previous socket behavior. Valid
   values are `0` through `32767`.
 
 * `RAY_redis_tcp_keepalive_probes`: 3 by default. How many unanswered probes
-  declare the connection dead, so detection takes about
-  `interval * (1 + probes)` — roughly 2 minutes with the defaults. Valid values
-  are `1` through `127` when TCP keepalive is enabled.
+  declare an idle, unresponsive connection dead. On Linux, when all settings
+  succeed, detection takes about `interval * (1 + probes)` — roughly 2 minutes
+  with the defaults. This isn't a timeout for commands with data awaiting
+  acknowledgment; TCP retransmission behavior also matters. Valid values are
+  `1` through `127` when TCP keepalive is enabled.
 
 ```{note}
-Both settings take full effect only on glibc Linux, which covers the official
-Ray images and wheels. On macOS the interval sets the idle time but the probe
-timing comes from the operating system, and on musl-based Linux (Alpine) the
-interval isn't applied either — the connection only gets `SO_KEEPALIVE`, whose
-kernel default idle time is two hours. If you build Ray against musl, don't rely
-on these settings to keep an idle flow alive; raise the kernel defaults through
-`net.ipv4.tcp_keepalive_time` and friends instead.
+Linux, including musl-based builds, applies idle time, probe interval, and probe
+count when the TCP socket options are available. On macOS only idle time is
+applied. Windows applies idle time and probe interval, with an OS-controlled
+probe count. Other platforms use OS timing defaults.
+
+Invalid configuration and failure to enable keepalive fail the connection
+attempt without retries. On POSIX, failure to tune a timing option instead logs
+a warning and continues with keepalive enabled. Successful options remain
+applied; rejected options retain their previous values. In that case, the
+requested detection window may not apply. Windows uses a combined enable/tune
+operation and any failure still fails the connection attempt.
 ```
 
 ```{warning}
-Ray does not yet reconnect to Redis in place. When a connection is declared
-dead, the pending Redis operation exhausts its retry budget and the GCS process
-exits. Lowering `RAY_redis_tcp_keepalive_probes` or the interval shortens the
+In Ray versions without in-place Redis reconnect support, a connection declared
+dead causes the pending Redis operation to exhaust its retry budget and the GCS
+process to exit. Lowering `RAY_redis_tcp_keepalive_probes` or the interval shortens the
 window before that happens, so a transient network stall that the connection
 would otherwise have survived can terminate the GCS instead. Keep the detection
 window comfortably longer than any stall you expect to recover from.

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -426,17 +426,20 @@ RAY_CONFIG(int64_t, redis_tcp_keepalive_interval_seconds, 30)
 ///
 /// This is deliberately decoupled from the probe interval: the interval must be
 /// short enough to keep an idle flow alive, while declaring a connection dead
-/// must be slow enough to ride out transient congestion. Until in-place
-/// reconnect lands (https://github.com/ray-project/ray/pull/65298), a connection
-/// declared dead escalates to a GCS crash once the request retry budget is
-/// exhausted, so the default is conservative (~2 minutes with the default
-/// interval).
+/// must be slow enough to ride out transient congestion. In versions without
+/// in-place Redis reconnect support, a connection declared dead escalates to a
+/// GCS crash once the request retry budget is exhausted. The default gives an
+/// idle, unresponsive connection roughly 2 minutes before detection.
+/// TODO: Reevaluate the detection window together with request and reconnect
+/// budgets after https://github.com/ray-project/ray/pull/65298. A 60-90 second
+/// window is a candidate to test, not a guaranteed recovery bound.
 ///
-/// Only glibc Linux honors this: hiredis sets TCP_KEEPIDLE/TCP_KEEPINTVL/
-/// TCP_KEEPCNT only under __GLIBC__, so on musl only SO_KEEPALIVE is applied
-/// (kernel defaults govern the timing), macOS applies the interval alone, and
-/// Windows uses a system-fixed probe count. Valid values are 1 through 127 when
-/// TCP keepalive is enabled.
+/// Linux (including musl) applies idle, interval, and count when the TCP socket
+/// options are available. macOS applies idle only; Windows uses a system-fixed
+/// probe count. Other platforms use OS timing defaults. On POSIX, rejected
+/// timing options warn and retain their previous values, so the requested
+/// detection window may not apply. Valid values are 1 through 127 when TCP
+/// keepalive is enabled.
 RAY_CONFIG(int64_t, redis_tcp_keepalive_probes, 3)
 
 /// Number of retries for a redis request failure.

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -412,6 +412,33 @@ RAY_CONFIG(bool, gcs_redis_payload_metrics_enabled, true)
 /// have permission to run it. Ray does not probe for support or fall back to DEL.
 RAY_CONFIG(bool, redis_namespace_cleanup_use_unlink, false)
 
+/// TCP keepalive probe interval for external Redis connections, in seconds.
+/// Idle GCS<->Redis flows can be silently removed by NAT, proxies, or managed
+/// service gateways; keepalive probes keep the flow entry alive and surface a
+/// dead peer instead of hanging on the next command. Keep this smaller than the
+/// shortest idle timeout on the network path. Set to 0 to disable TCP keepalive
+/// entirely. Valid values are 0 through 32767.
+RAY_CONFIG(int64_t, redis_tcp_keepalive_interval_seconds, 30)
+
+/// Number of unanswered TCP keepalive probes before an external Redis
+/// connection is declared dead, so detection takes roughly
+/// redis_tcp_keepalive_interval_seconds * (1 + this value).
+///
+/// This is deliberately decoupled from the probe interval: the interval must be
+/// short enough to keep an idle flow alive, while declaring a connection dead
+/// must be slow enough to ride out transient congestion. Until in-place
+/// reconnect lands (https://github.com/ray-project/ray/pull/65298), a connection
+/// declared dead escalates to a GCS crash once the request retry budget is
+/// exhausted, so the default is conservative (~2 minutes with the default
+/// interval).
+///
+/// Only glibc Linux honors this: hiredis sets TCP_KEEPIDLE/TCP_KEEPINTVL/
+/// TCP_KEEPCNT only under __GLIBC__, so on musl only SO_KEEPALIVE is applied
+/// (kernel defaults govern the timing), macOS applies the interval alone, and
+/// Windows uses a system-fixed probe count. Valid values are 1 through 127 when
+/// TCP keepalive is enabled.
+RAY_CONFIG(int64_t, redis_tcp_keepalive_probes, 3)
+
 /// Number of retries for a redis request failure.
 RAY_CONFIG(size_t, num_redis_request_retries, 5)
 

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -414,10 +414,10 @@ RAY_CONFIG(bool, redis_namespace_cleanup_use_unlink, false)
 
 /// TCP keepalive probe interval for external Redis connections, in seconds.
 /// Idle GCS<->Redis flows can be silently removed by NAT, proxies, or managed
-/// service gateways; keepalive probes keep the flow entry alive and surface a
-/// dead peer instead of hanging on the next command. Keep this smaller than the
-/// shortest idle timeout on the network path. Set to 0 to disable TCP keepalive
-/// entirely. Valid values are 0 through 32767.
+/// service gateways. Keepalive detects idle, unresponsive connections and can
+/// preserve flows through devices that count probes as activity. Keep this
+/// smaller than the shortest idle timeout on the network path. Set to 0 to
+/// disable TCP keepalive entirely. Valid values are 0 through 32767.
 RAY_CONFIG(int64_t, redis_tcp_keepalive_interval_seconds, 30)
 
 /// Number of unanswered TCP keepalive probes before an external Redis
@@ -430,9 +430,10 @@ RAY_CONFIG(int64_t, redis_tcp_keepalive_interval_seconds, 30)
 /// in-place Redis reconnect support, a connection declared dead escalates to a
 /// GCS crash once the request retry budget is exhausted. The default gives an
 /// idle, unresponsive connection roughly 2 minutes before detection.
-/// TODO: Reevaluate the detection window together with request and reconnect
-/// budgets after https://github.com/ray-project/ray/pull/65298. A 60-90 second
-/// window is a candidate to test, not a guaranteed recovery bound.
+/// TODO(https://github.com/ray-project/ray/issues/66074): Reevaluate the
+/// detection window together with request and reconnect budgets after in-place
+/// reconnect is available. A 60-90 second window is a candidate to test, not a
+/// guaranteed recovery bound.
 ///
 /// Linux (including musl) applies idle, interval, and count when the TCP socket
 /// options are available. macOS applies idle only; Windows uses a system-fixed

--- a/src/ray/gcs/store_client/BUILD.bazel
+++ b/src/ray/gcs/store_client/BUILD.bazel
@@ -23,6 +23,7 @@ ray_cc_library(
         "redis_async_context.h",
         "redis_context.h",
         "redis_store_client.h",
+        "redis_tcp_keepalive.h",
     ],
     deps = [
         ":store_client",

--- a/src/ray/gcs/store_client/redis_context.cc
+++ b/src/ray/gcs/store_client/redis_context.cc
@@ -14,9 +14,16 @@
 
 #include "ray/gcs/store_client/redis_context.h"
 
+#ifndef _WIN32
+#include <netinet/in.h>
+#include <netinet/tcp.h>
+#include <sys/socket.h>
+#endif
+
 #include <cerrno>
 #include <charconv>
 #include <cstddef>
+#include <cstring>
 #include <limits>
 #include <memory>
 #include <optional>
@@ -449,6 +456,137 @@ Status RestoreRedisTimeout(redisContext *context) {
   return Status::OK();
 }
 
+namespace {
+
+// hiredis' async context embeds the sync context; the socket lives in c.fd.
+redisContext *AsRedisContext(redisContext *context) { return context; }
+redisContext *AsRedisContext(redisAsyncContext *context) { return &context->c; }
+
+// Linux caps both TCP_KEEPIDLE and TCP_KEEPINTVL at 32767 seconds.
+constexpr int64_t kMaxRedisTcpKeepaliveIntervalSeconds = 32767;
+// Linux caps TCP_KEEPCNT at 127.
+constexpr int64_t kMaxRedisTcpKeepaliveProbes = 127;
+
+// Validates the keepalive configuration on its own, so a bad value fails before
+// any connection attempt instead of surfacing as a Redis connectivity error
+// after the connect-retry budget is spent.
+Status ValidateRedisTcpKeepaliveConfig() {
+  const int64_t interval = RayConfig::instance().redis_tcp_keepalive_interval_seconds();
+  if (interval < 0 || interval > kMaxRedisTcpKeepaliveIntervalSeconds) {
+    return Status::InvalidArgument(
+        absl::StrCat("redis_tcp_keepalive_interval_seconds must be in [0, ",
+                     kMaxRedisTcpKeepaliveIntervalSeconds,
+                     "], got ",
+                     interval,
+                     ". Set RAY_redis_tcp_keepalive_interval_seconds=0 to disable "
+                     "TCP keepalive."));
+  }
+  const int64_t probes = RayConfig::instance().redis_tcp_keepalive_probes();
+  if (interval > 0 && (probes < 1 || probes > kMaxRedisTcpKeepaliveProbes)) {
+    return Status::InvalidArgument(
+        absl::StrCat("redis_tcp_keepalive_probes must be in [1, ",
+                     kMaxRedisTcpKeepaliveProbes,
+                     "] when TCP keepalive is enabled, got ",
+                     probes,
+                     "."));
+  }
+  return Status::OK();
+}
+
+std::string DescribeRedisTcpKeepalivePolicy(int64_t interval, int64_t probes) {
+  if (interval == 0) {
+    return "disabled by configuration";
+  }
+  static_cast<void>(probes);
+#if defined(__linux__) && defined(__GLIBC__)
+  return absl::StrCat("idle=",
+                      interval,
+                      "s, probe interval=",
+                      interval,
+                      "s, probes=",
+                      probes,
+                      " (dead connection detected after ~",
+                      interval * (1 + probes),
+                      "s)");
+#elif defined(__APPLE__) && defined(__MACH__)
+  return absl::StrCat(
+      "idle=", interval, "s; probe interval and count are controlled by the OS");
+#elif defined(_WIN32)
+  return absl::StrCat("idle=",
+                      interval,
+                      "s, probe interval=",
+                      interval,
+                      "s; probe count is controlled by the OS");
+#else
+  return "SO_KEEPALIVE enabled; idle time, probe interval, and probe count are "
+         "controlled by the OS";
+#endif
+}
+
+// Applies the configured TCP keepalive policy to a freshly created hiredis
+// context. Called from exactly one place (ConnectWithoutRetries) so that every
+// external Redis socket - sync, async, Sentinel, Cluster-redirect, and cleanup
+// connections - receives the same policy before TLS, AUTH, or any command.
+//
+// Validation and socket-option failures are not RedisError statuses because
+// retrying the same policy cannot fix them. ConnectWithRetries surfaces them
+// immediately.
+Status ConfigureRedisTcpKeepalive(redisContext *context,
+                                  const std::string &address,
+                                  int port) {
+  RAY_RETURN_NOT_OK(ValidateRedisTcpKeepaliveConfig());
+  const int64_t interval = RayConfig::instance().redis_tcp_keepalive_interval_seconds();
+  if (interval == 0) {
+    RAY_LOG(INFO) << "TCP keepalive is disabled by configuration for the Redis "
+                     "connection to "
+                  << BuildAddress(address, port) << ".";
+    return Status::OK();
+  }
+  if (::redisEnableKeepAliveWithInterval(context, static_cast<int>(interval)) !=
+      REDIS_OK) {
+    return Status::IOError(
+        absl::StrCat("Failed to enable TCP keepalive on the Redis connection to ",
+                     BuildAddress(address, port),
+                     ": ",
+                     context->errstr,
+                     ". Set RAY_redis_tcp_keepalive_interval_seconds=0 to disable TCP "
+                     "keepalive if this platform cannot support it."));
+  }
+
+  // hiredis derives TCP_KEEPINTVL=interval/3 and TCP_KEEPCNT=3, which ties how
+  // fast a dead flow is detected (2*interval) to how often probes are sent.
+  // Those need opposite tuning: probes must be frequent enough to keep an idle
+  // flow alive, while declaring the connection dead must be slow enough to ride
+  // out transient congestion - which, until in-place reconnect lands, escalates
+  // to a GCS crash. Override both where the platform lets us.
+#if defined(__linux__) && defined(__GLIBC__)
+  const int probe_interval = static_cast<int>(interval);
+  const int probes = static_cast<int>(RayConfig::instance().redis_tcp_keepalive_probes());
+  const std::pair<int, int> options[] = {{TCP_KEEPINTVL, probe_interval},
+                                         {TCP_KEEPCNT, probes}};
+  for (const auto &[option, value] : options) {
+    if (::setsockopt(context->fd, IPPROTO_TCP, option, &value, sizeof(value)) != 0) {
+      const int saved_errno = errno;
+      return Status::IOError(absl::StrCat(
+          "Failed to configure TCP keepalive timing on the Redis connection to ",
+          BuildAddress(address, port),
+          ": ",
+          std::strerror(saved_errno),
+          ". Set RAY_redis_tcp_keepalive_interval_seconds=0 to disable TCP "
+          "keepalive."));
+    }
+  }
+#endif
+  RAY_LOG(INFO) << "Enabled TCP keepalive on the Redis connection to "
+                << BuildAddress(address, port) << ": "
+                << DescribeRedisTcpKeepalivePolicy(
+                       interval, RayConfig::instance().redis_tcp_keepalive_probes())
+                << ".";
+  return Status::OK();
+}
+
+}  // namespace
+
 Status AuthenticateRedis(redisContext *context,
                          const std::string &username,
                          const std::string &password,
@@ -501,7 +639,26 @@ Status AuthenticateRedis(redisAsyncContext *context,
 }
 
 void RedisAsyncContextDisconnectCallback(const redisAsyncContext *context, int status) {
-  RAY_LOG(DEBUG) << "Redis async context disconnected. Status: " << status;
+  if (status == REDIS_OK) {
+    // Deliberate disconnect (Disconnect()/teardown); keep quiet on shutdown.
+    RAY_LOG(DEBUG) << "Redis async context disconnected. Status: " << status;
+  } else {
+    // This is the first signal when an idle connection was silently removed by
+    // the network path. Copy the error fields before hiredis frees the context
+    // below. errno is not meaningful at this point (the failure happened
+    // earlier, inside hiredis); errstr already carries the strerror(errno)
+    // captured at the failure point.
+    const int err = context->c.err;
+    const std::string errstr =
+        context->c.errstr[0] != '\0' ? context->c.errstr : "unknown error";
+    RAY_LOG(WARNING) << "Redis async connection was closed unexpectedly (err = " << err
+                     << ", " << errstr << "). TCP keepalive policy: "
+                     << DescribeRedisTcpKeepalivePolicy(
+                            RayConfig::instance().redis_tcp_keepalive_interval_seconds(),
+                            RayConfig::instance().redis_tcp_keepalive_probes())
+                     << ". If this connection was idle, the network path may have "
+                        "removed the flow.";
+  }
   // Reset raw 'redisAsyncContext' to nullptr because hiredis will release this context.
   reinterpret_cast<RedisAsyncContext *>(context->data)->ResetRawRedisAsyncContext();
 }
@@ -523,6 +680,9 @@ ConnectWithoutRetries(const std::string &address,
   // as an output parameter and in the Status::RedisError,
   // because we're not sure whether we'll want to change what this returns.
   RedisContextType *newContext = connect_function(address.c_str(), port);
+  // Own the context right away so every failure path below frees it.
+  std::unique_ptr<RedisContextType, RedisContextDeleter> context_holder(
+      newContext, RedisContextDeleter());
   if (newContext == nullptr || (newContext)->err) {
     std::ostringstream oss;
     if (newContext == nullptr) {
@@ -533,9 +693,15 @@ ConnectWithoutRetries(const std::string &address,
     }
     return std::make_pair(Status::RedisError(oss.str()), nullptr);
   }
-  return std::make_pair(Status::OK(),
-                        std::unique_ptr<RedisContextType, RedisContextDeleter>(
-                            newContext, RedisContextDeleter()));
+  // Apply the TCP keepalive policy before the context is used for anything
+  // (TLS, AUTH, or the first command). For the async context the TCP handshake
+  // may not have completed yet; that is fine - the options apply to the
+  // socket, not the connection.
+  Status status = ConfigureRedisTcpKeepalive(AsRedisContext(newContext), address, port);
+  if (!status.ok()) {
+    return std::make_pair(status, nullptr);
+  }
+  return std::make_pair(Status::OK(), std::move(context_holder));
 }
 
 template <typename RedisContextType, typename RedisConnectFunctionType>
@@ -549,6 +715,14 @@ ConnectWithRetries(const std::string &address,
   auto resp = ConnectWithoutRetries<RedisContextType>(address, port, connect_function);
   auto status = resp.first;
   while (!status.ok()) {
+    if (!status.IsRedisError()) {
+      // Policy/configuration failures (e.g. TCP keepalive setup) are not
+      // transient; retrying cannot fix them. Surface them immediately instead
+      // of retrying for ~60s and then reporting Redis as unreachable.
+      RAY_LOG(ERROR) << "Giving up connecting to Redis due to a non-retryable error: "
+                     << status.ToString();
+      break;
+    }
     if (connection_attempts >= RayConfig::instance().redis_db_connect_retries()) {
       // Do not crash here. Return the failed status so callers (e.g. an
       // in-place reconnect) can decide how to recover. Existing callers still
@@ -834,6 +1008,10 @@ Status RedisContext::Connect(const std::string &address,
 
   RAY_CHECK(!context_);
   RAY_CHECK(!redis_async_context_);
+  // Reject a bad keepalive configuration before touching the network, so it
+  // surfaces as itself rather than as a Redis connectivity error after DNS
+  // resolution and the connect-retry budget.
+  RAY_RETURN_NOT_OK(ValidateRedisTcpKeepaliveConfig());
   // Fetch the ip address from the address. It might return multiple
   // addresses and only the first one will be used.
   // ResolveDNS may throw (boost resolver) when the name cannot be resolved

--- a/src/ray/gcs/store_client/redis_context.cc
+++ b/src/ray/gcs/store_client/redis_context.cc
@@ -14,12 +14,6 @@
 
 #include "ray/gcs/store_client/redis_context.h"
 
-#ifndef _WIN32
-#include <netinet/in.h>
-#include <netinet/tcp.h>
-#include <sys/socket.h>
-#endif
-
 #include <cerrno>
 #include <charconv>
 #include <cstddef>
@@ -34,6 +28,7 @@
 #include <vector>
 
 #include "ray/asio/asio_util.h"
+#include "ray/gcs/store_client/redis_tcp_keepalive.h"
 #include "ray/util/network_util.h"
 
 extern "C" {
@@ -498,14 +493,15 @@ std::string DescribeRedisTcpKeepalivePolicy(int64_t interval, int64_t probes) {
     return "disabled by configuration";
   }
   static_cast<void>(probes);
-#if defined(__linux__) && defined(__GLIBC__)
+#if defined(__linux__) && defined(TCP_KEEPIDLE) && defined(TCP_KEEPINTVL) && \
+    defined(TCP_KEEPCNT)
   return absl::StrCat("idle=",
                       interval,
                       "s, probe interval=",
                       interval,
                       "s, probes=",
                       probes,
-                      " (dead connection detected after ~",
+                      " (idle, unresponsive connection detected after ~",
                       interval * (1 + probes),
                       "s)");
 #elif defined(__APPLE__) && defined(__MACH__)
@@ -528,9 +524,9 @@ std::string DescribeRedisTcpKeepalivePolicy(int64_t interval, int64_t probes) {
 // external Redis socket - sync, async, Sentinel, Cluster-redirect, and cleanup
 // connections - receives the same policy before TLS, AUTH, or any command.
 //
-// Validation and socket-option failures are not RedisError statuses because
-// retrying the same policy cannot fix them. ConnectWithRetries surfaces them
-// immediately.
+// Validation and failures to enable keepalive are non-retryable. On POSIX,
+// tuning failures leave keepalive enabled and warn without rejecting a usable
+// connection. Windows retains hiredis' combined enable/tune operation.
 Status ConfigureRedisTcpKeepalive(redisContext *context,
                                   const std::string &address,
                                   int port) {
@@ -542,6 +538,7 @@ Status ConfigureRedisTcpKeepalive(redisContext *context,
                   << BuildAddress(address, port) << ".";
     return Status::OK();
   }
+#ifdef _WIN32
   if (::redisEnableKeepAliveWithInterval(context, static_cast<int>(interval)) !=
       REDIS_OK) {
     return Status::IOError(
@@ -553,28 +550,45 @@ Status ConfigureRedisTcpKeepalive(redisContext *context,
                      "keepalive if this platform cannot support it."));
   }
 
-  // hiredis derives TCP_KEEPINTVL=interval/3 and TCP_KEEPCNT=3, which ties how
-  // fast a dead flow is detected (2*interval) to how often probes are sent.
-  // Those need opposite tuning: probes must be frequent enough to keep an idle
-  // flow alive, while declaring the connection dead must be slow enough to ride
-  // out transient congestion - which, until in-place reconnect lands, escalates
-  // to a GCS crash. Override both where the platform lets us.
-#if defined(__linux__) && defined(__GLIBC__)
-  const int probe_interval = static_cast<int>(interval);
-  const int probes = static_cast<int>(RayConfig::instance().redis_tcp_keepalive_probes());
-  const std::pair<int, int> options[] = {{TCP_KEEPINTVL, probe_interval},
-                                         {TCP_KEEPCNT, probes}};
-  for (const auto &[option, value] : options) {
-    if (::setsockopt(context->fd, IPPROTO_TCP, option, &value, sizeof(value)) != 0) {
-      const int saved_errno = errno;
-      return Status::IOError(absl::StrCat(
-          "Failed to configure TCP keepalive timing on the Redis connection to ",
-          BuildAddress(address, port),
-          ": ",
-          std::strerror(saved_errno),
-          ". Set RAY_redis_tcp_keepalive_interval_seconds=0 to disable TCP "
-          "keepalive."));
-    }
+#else
+  // hiredis also tunes the timing, and marks context->err on any failure.
+  // Apply options directly so a rejected timing option cannot poison an
+  // otherwise usable hiredis context. This also applies Linux timing on musl.
+  Status enable_status = Status::OK();
+  const auto result = internal::SetRedisTcpKeepalive(
+      static_cast<int>(interval),
+      static_cast<int>(RayConfig::instance().redis_tcp_keepalive_probes()),
+      [&](int level, int option, const char *name, int value) {
+        if (::setsockopt(context->fd, level, option, &value, sizeof(value)) == 0) {
+          return true;
+        }
+        const int saved_errno = errno;
+        const auto error = absl::StrCat("Failed to set ",
+                                        name,
+                                        "=",
+                                        value,
+                                        " on the Redis connection to ",
+                                        BuildAddress(address, port),
+                                        " (errno=",
+                                        saved_errno,
+                                        "): ",
+                                        std::strerror(saved_errno));
+        if (level == SOL_SOCKET && option == SO_KEEPALIVE) {
+          enable_status = Status::IOError(absl::StrCat(
+              error,
+              ". Set RAY_redis_tcp_keepalive_interval_seconds=0 to disable TCP "
+              "keepalive if this platform cannot support it."));
+        } else {
+          RAY_LOG(WARNING) << error
+                           << ". TCP keepalive remains enabled; this option retains "
+                              "its previous value. The requested detection window "
+                              "may not apply. Continuing with the connection.";
+        }
+        return false;
+      });
+  RAY_RETURN_NOT_OK(enable_status);
+  if (result == internal::RedisTcpKeepaliveResult::kDegraded) {
+    return Status::OK();
   }
 #endif
   RAY_LOG(INFO) << "Enabled TCP keepalive on the Redis connection to "
@@ -643,21 +657,20 @@ void RedisAsyncContextDisconnectCallback(const redisAsyncContext *context, int s
     // Deliberate disconnect (Disconnect()/teardown); keep quiet on shutdown.
     RAY_LOG(DEBUG) << "Redis async context disconnected. Status: " << status;
   } else {
-    // This is the first signal when an idle connection was silently removed by
-    // the network path. Copy the error fields before hiredis frees the context
-    // below. errno is not meaningful at this point (the failure happened
+    // Copy the error fields before hiredis frees the context below.
+    // errno is not meaningful at this point (the failure happened
     // earlier, inside hiredis); errstr already carries the strerror(errno)
     // captured at the failure point.
     const int err = context->c.err;
     const std::string errstr =
         context->c.errstr[0] != '\0' ? context->c.errstr : "unknown error";
     RAY_LOG(WARNING) << "Redis async connection was closed unexpectedly (err = " << err
-                     << ", " << errstr << "). TCP keepalive policy: "
-                     << DescribeRedisTcpKeepalivePolicy(
-                            RayConfig::instance().redis_tcp_keepalive_interval_seconds(),
-                            RayConfig::instance().redis_tcp_keepalive_probes())
-                     << ". If this connection was idle, the network path may have "
-                        "removed the flow.";
+                     << ", " << errstr
+                     << "). Current TCP keepalive configuration: interval="
+                     << RayConfig::instance().redis_tcp_keepalive_interval_seconds()
+                     << "s, probes=" << RayConfig::instance().redis_tcp_keepalive_probes()
+                     << ". Applied socket settings may differ; see connection setup "
+                        "logs.";
   }
   // Reset raw 'redisAsyncContext' to nullptr because hiredis will release this context.
   reinterpret_cast<RedisAsyncContext *>(context->data)->ResetRawRedisAsyncContext();

--- a/src/ray/gcs/store_client/redis_tcp_keepalive.h
+++ b/src/ray/gcs/store_client/redis_tcp_keepalive.h
@@ -1,0 +1,68 @@
+// Copyright 2026 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#ifndef _WIN32
+#include <netinet/in.h>
+#include <netinet/tcp.h>
+#include <sys/socket.h>
+
+namespace ray::gcs::internal {
+
+enum class RedisTcpKeepaliveResult { kEnabled, kDegraded, kFailed };
+
+// interval and probes have already been validated, and interval is positive.
+// set_option(level, option, name, value) applies one socket option and reports
+// whether it succeeded. Keeping the syscall at the call site lets tests reject
+// individual options on real sockets without a process-wide syscall hook.
+template <typename SetOption>
+RedisTcpKeepaliveResult SetRedisTcpKeepalive(int interval,
+                                             int probes,
+                                             const SetOption &set_option) {
+  if (!set_option(SOL_SOCKET, SO_KEEPALIVE, "SO_KEEPALIVE", 1)) {
+    return RedisTcpKeepaliveResult::kFailed;
+  }
+
+  auto result = RedisTcpKeepaliveResult::kEnabled;
+  static_cast<void>(interval);
+  static_cast<void>(probes);
+#if (defined(__linux__) && defined(TCP_KEEPIDLE) && defined(TCP_KEEPINTVL) && \
+     defined(TCP_KEEPCNT)) ||                                                 \
+    (defined(__APPLE__) && defined(__MACH__))
+  const struct {
+    int option;
+    const char *name;
+    int value;
+  } options[] = {
+#if defined(__linux__)
+    {TCP_KEEPIDLE, "TCP_KEEPIDLE", interval},
+    {TCP_KEEPINTVL, "TCP_KEEPINTVL", interval},
+    {TCP_KEEPCNT, "TCP_KEEPCNT", probes},
+#else
+    {TCP_KEEPALIVE, "TCP_KEEPALIVE", interval},
+#endif
+  };
+  for (const auto &[option, name, value] : options) {
+    if (!set_option(IPPROTO_TCP, option, name, value)) {
+      // Keep the successfully applied options and attempt the remaining ones.
+      result = RedisTcpKeepaliveResult::kDegraded;
+    }
+  }
+#endif
+  return result;
+}
+
+}  // namespace ray::gcs::internal
+#endif  // !_WIN32

--- a/src/ray/gcs/store_client/tests/BUILD.bazel
+++ b/src/ray/gcs/store_client/tests/BUILD.bazel
@@ -224,14 +224,10 @@ ray_cc_test(
         "TEST_REDIS_SERVER_EXEC_PATH": "$(rootpath //:redis-server)",
         "TEST_REDIS_CLIENT_EXEC_PATH": "$(rootpath //:redis-cli)",
     },
-    # Wrap calls from both Ray and hiredis to exercise connection setup failures.
+    # Export the test interposer so calls from dynamic Ray libraries resolve to it.
     linkopts = select({
-        "@platforms//os:linux": ["-Wl,--wrap=setsockopt"],
+        "@platforms//os:linux": ["-Wl,--export-dynamic-symbol=setsockopt"],
         "//conditions:default": [],
-    }),
-    linkstatic = select({
-        "@platforms//os:linux": True,
-        "//conditions:default": False,
     }),
     tags = ["team:core"],
     deps = [

--- a/src/ray/gcs/store_client/tests/BUILD.bazel
+++ b/src/ray/gcs/store_client/tests/BUILD.bazel
@@ -224,6 +224,15 @@ ray_cc_test(
         "TEST_REDIS_SERVER_EXEC_PATH": "$(rootpath //:redis-server)",
         "TEST_REDIS_CLIENT_EXEC_PATH": "$(rootpath //:redis-cli)",
     },
+    # Wrap calls from both Ray and hiredis to exercise connection setup failures.
+    linkopts = select({
+        "@platforms//os:linux": ["-Wl,--wrap=setsockopt"],
+        "//conditions:default": [],
+    }),
+    linkstatic = select({
+        "@platforms//os:linux": True,
+        "//conditions:default": False,
+    }),
     tags = ["team:core"],
     deps = [
         "//src/ray/common:test_utils",

--- a/src/ray/gcs/store_client/tests/BUILD.bazel
+++ b/src/ray/gcs/store_client/tests/BUILD.bazel
@@ -216,8 +216,17 @@ ray_cc_test(
     name = "redis_context_test",
     size = "small",
     srcs = ["redis_context_test.cc"],
+    data = [
+        "//:redis-cli",
+        "//:redis-server",
+    ],
+    env = {
+        "TEST_REDIS_SERVER_EXEC_PATH": "$(rootpath //:redis-server)",
+        "TEST_REDIS_CLIENT_EXEC_PATH": "$(rootpath //:redis-cli)",
+    },
     tags = ["team:core"],
     deps = [
+        "//src/ray/common:test_utils",
         "//src/ray/gcs/store_client:redis_store_client",
     ],
 )

--- a/src/ray/gcs/store_client/tests/redis_context_test.cc
+++ b/src/ray/gcs/store_client/tests/redis_context_test.cc
@@ -14,14 +14,59 @@
 
 #include "ray/gcs/store_client/redis_context.h"
 
+#ifndef _WIN32
+#include <netinet/in.h>
+#include <netinet/tcp.h>
+#include <sys/socket.h>
+#endif
+
+#include <cerrno>
+#include <cstring>
+#include <string>
+#include <vector>
+
 #include "gtest/gtest.h"
 #include "ray/asio/instrumented_io_context.h"
 #include "ray/common/ray_config.h"
 #include "ray/common/status.h"
+#include "ray/common/test_utils.h"
 #include "ray/util/clock.h"
 
 namespace ray {
 namespace gcs {
+
+class RedisContextConfigTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    saved_interval_seconds_ =
+        RayConfig::instance().redis_tcp_keepalive_interval_seconds();
+    saved_probes_ = RayConfig::instance().redis_tcp_keepalive_probes();
+    saved_connect_retries_ = RayConfig::instance().redis_db_connect_retries();
+    saved_connect_wait_ms_ = RayConfig::instance().redis_db_connect_wait_milliseconds();
+  }
+
+  void TearDown() override {
+    RayConfig::instance().redis_tcp_keepalive_interval_seconds() =
+        saved_interval_seconds_;
+    RayConfig::instance().redis_tcp_keepalive_probes() = saved_probes_;
+    RayConfig::instance().redis_db_connect_retries() = saved_connect_retries_;
+    RayConfig::instance().redis_db_connect_wait_milliseconds() = saved_connect_wait_ms_;
+  }
+
+  Status ConnectToUnusedPort(RedisContext &context) {
+    return context.Connect("127.0.0.1",
+                           /*port=*/1,
+                           /*username=*/"",
+                           /*password=*/"",
+                           /*enable_ssl=*/false);
+  }
+
+ private:
+  int64_t saved_interval_seconds_ = 0;
+  int64_t saved_probes_ = 0;
+  int64_t saved_connect_retries_ = 0;
+  int64_t saved_connect_wait_ms_ = 0;
+};
 
 // Regression test for the GCS crash on Redis connection loss
 // (https://github.com/ray-project/ray/issues/53475).
@@ -33,25 +78,156 @@ namespace gcs {
 // Status when the endpoint is unreachable, instead of crashing the process.
 // (Existing callers still RAY_CHECK_OK the result, so boot-time behavior is
 // unchanged.)
-TEST(RedisContextConnectTest, ConnectToUnreachableEndpointReturnsErrorInsteadOfCrashing) {
+TEST_F(RedisContextConfigTest,
+       ConnectToUnreachableEndpointReturnsErrorInsteadOfCrashing) {
   // Fail fast: try once and give up instead of retrying for ~60s.
-  RayConfig::instance().initialize(R"({"redis_db_connect_retries": 0})");
+  RayConfig::instance().redis_db_connect_retries() = 0;
+  RayConfig::instance().redis_tcp_keepalive_interval_seconds() = 30;
+  RayConfig::instance().redis_tcp_keepalive_probes() = 3;
 
   instrumented_io_context io_service{/*enable_lag_probe=*/false,
                                      /*running_on_single_thread=*/true};
   Clock clock;
   RedisContext context(io_service, clock);
 
-  // Port 1 has nothing listening on it, so the TCP connection is refused.
-  const Status status = context.Connect("127.0.0.1",
-                                        /*port=*/1,
-                                        /*username=*/"",
-                                        /*password=*/"",
-                                        /*enable_ssl=*/false);
+  const Status status = ConnectToUnusedPort(context);
 
   ASSERT_FALSE(status.ok());
   ASSERT_TRUE(status.IsRedisError()) << status.ToString();
 }
+
+// Validate before DNS or TCP connect so configuration errors are never masked
+// by an unreachable Redis endpoint or delayed by connection retries.
+TEST_F(RedisContextConfigTest, InvalidKeepaliveIntervalsAreRejectedBeforeConnecting) {
+  RayConfig::instance().redis_tcp_keepalive_probes() = 3;
+  RayConfig::instance().redis_db_connect_retries() = 0;
+
+  for (const int64_t invalid_interval : {-1, 32768}) {
+    SCOPED_TRACE(invalid_interval);
+    RayConfig::instance().redis_tcp_keepalive_interval_seconds() = invalid_interval;
+
+    instrumented_io_context io_service{/*enable_lag_probe=*/false,
+                                       /*running_on_single_thread=*/true};
+    Clock clock;
+    RedisContext context(io_service, clock);
+    const Status status = ConnectToUnusedPort(context);
+
+    ASSERT_FALSE(status.ok());
+    EXPECT_TRUE(status.IsInvalidArgument()) << status.ToString();
+    EXPECT_NE(status.message().find("redis_tcp_keepalive_interval_seconds"),
+              std::string::npos)
+        << status.ToString();
+    EXPECT_NE(status.message().find(std::to_string(invalid_interval)), std::string::npos)
+        << status.ToString();
+  }
+}
+
+TEST_F(RedisContextConfigTest, InvalidKeepaliveProbeCountsAreRejectedBeforeConnecting) {
+  RayConfig::instance().redis_tcp_keepalive_interval_seconds() = 30;
+  RayConfig::instance().redis_db_connect_retries() = 0;
+
+  for (const int64_t invalid_probes : {0, 128}) {
+    SCOPED_TRACE(invalid_probes);
+    RayConfig::instance().redis_tcp_keepalive_probes() = invalid_probes;
+
+    instrumented_io_context io_service{/*enable_lag_probe=*/false,
+                                       /*running_on_single_thread=*/true};
+    Clock clock;
+    RedisContext context(io_service, clock);
+    const Status status = ConnectToUnusedPort(context);
+
+    ASSERT_FALSE(status.ok());
+    EXPECT_TRUE(status.IsInvalidArgument()) << status.ToString();
+    EXPECT_NE(status.message().find("redis_tcp_keepalive_probes"), std::string::npos)
+        << status.ToString();
+    EXPECT_NE(status.message().find(std::to_string(invalid_probes)), std::string::npos)
+        << status.ToString();
+  }
+}
+
+// The keepalive tests assert on the real sockets hiredis created, via
+// getsockopt(), against a live local Redis. Windows is excluded because its
+// socket option API differs.
+#ifndef _WIN32
+
+namespace {
+
+int GetIntSockOpt(int fd, int level, int optname) {
+  int value = -1;
+  socklen_t len = sizeof(value);
+  EXPECT_EQ(getsockopt(fd, level, optname, &value, &len), 0) << strerror(errno);
+  return value;
+}
+
+}  // namespace
+
+class RedisContextKeepaliveTest : public RedisContextConfigTest {
+ public:
+  static void SetUpTestCase() { TestSetupUtil::StartUpRedisServers(std::vector<int>()); }
+
+  static void TearDownTestCase() { TestSetupUtil::ShutDownRedisServers(); }
+
+ protected:
+  Status ConnectToLocalRedis(RedisContext &context) {
+    return context.Connect("127.0.0.1",
+                           TEST_REDIS_SERVER_PORTS.front(),
+                           /*username=*/"",
+                           /*password=*/"",
+                           /*enable_ssl=*/false);
+  }
+};
+
+// Both the sync and the async hiredis sockets must carry the configured
+// policy at the largest values accepted by Linux.
+TEST_F(RedisContextKeepaliveTest, AppliesMaximumPolicyToSyncAndAsyncSockets) {
+  RayConfig::instance().redis_tcp_keepalive_interval_seconds() = 32767;
+  RayConfig::instance().redis_tcp_keepalive_probes() = 127;
+
+  instrumented_io_context io_service{/*enable_lag_probe=*/false,
+                                     /*running_on_single_thread=*/true};
+  Clock clock;
+  RedisContext context(io_service, clock);
+  const Status status = ConnectToLocalRedis(context);
+  ASSERT_TRUE(status.ok()) << status.ToString();
+
+  const int sync_fd = context.sync_context()->fd;
+  const int async_fd = context.async_context().GetRawRedisAsyncContext()->c.fd;
+  for (const int fd : {sync_fd, async_fd}) {
+    EXPECT_EQ(GetIntSockOpt(fd, SOL_SOCKET, SO_KEEPALIVE), 1) << "fd: " << fd;
+#if defined(__linux__) && defined(__GLIBC__)
+    EXPECT_EQ(GetIntSockOpt(fd, IPPROTO_TCP, TCP_KEEPIDLE), 32767) << "fd: " << fd;
+    // Ray overrides hiredis' derived values (interval/3, 3 probes) so that
+    // probe cadence and time-to-declare-dead can be tuned independently.
+    EXPECT_EQ(GetIntSockOpt(fd, IPPROTO_TCP, TCP_KEEPINTVL), 32767) << "fd: " << fd;
+    EXPECT_EQ(GetIntSockOpt(fd, IPPROTO_TCP, TCP_KEEPCNT), 127) << "fd: " << fd;
+#elif defined(__APPLE__) && defined(__MACH__)
+    EXPECT_EQ(GetIntSockOpt(fd, IPPROTO_TCP, TCP_KEEPALIVE), 32767) << "fd: " << fd;
+#endif
+  }
+}
+
+// Regression guard for the escape hatch: interval 0 must leave the sockets
+// exactly as they were before this feature existed.
+TEST_F(RedisContextKeepaliveTest, IntervalZeroLeavesKeepaliveDisabled) {
+  RayConfig::instance().redis_tcp_keepalive_interval_seconds() = 0;
+  // Probes are not validated or applied when keepalive is off.
+  RayConfig::instance().redis_tcp_keepalive_probes() = 0;
+
+  instrumented_io_context io_service{/*enable_lag_probe=*/false,
+                                     /*running_on_single_thread=*/true};
+  Clock clock;
+  RedisContext context(io_service, clock);
+  const Status status = ConnectToLocalRedis(context);
+  ASSERT_TRUE(status.ok()) << status.ToString();
+
+  const int sync_fd = context.sync_context()->fd;
+  const int async_fd = context.async_context().GetRawRedisAsyncContext()->c.fd;
+  for (const int fd : {sync_fd, async_fd}) {
+    EXPECT_EQ(GetIntSockOpt(fd, SOL_SOCKET, SO_KEEPALIVE), 0) << "fd: " << fd;
+  }
+}
+
+#endif  // !defined(_WIN32)
 
 }  // namespace gcs
 }  // namespace ray

--- a/src/ray/gcs/store_client/tests/redis_context_test.cc
+++ b/src/ray/gcs/store_client/tests/redis_context_test.cc
@@ -23,7 +23,10 @@
 #include <cerrno>
 #include <chrono>
 #include <cstring>
+#include <functional>
+#include <map>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "gtest/gtest.h"
@@ -33,6 +36,44 @@
 #include "ray/common/test_utils.h"
 #include "ray/gcs/store_client/redis_tcp_keepalive.h"
 #include "ray/util/clock.h"
+
+#ifdef __linux__
+namespace {
+
+// Only this test binary wraps setsockopt. The override is scoped to the thread
+// calling Connect; unrelated options and calls outside that scope reach libc.
+thread_local const std::function<bool(int, int, int)> *setsockopt_failure = nullptr;
+
+class ScopedSetsockoptFailure {
+ public:
+  explicit ScopedSetsockoptFailure(std::function<bool(int, int, int)> failure)
+      : failure_(std::move(failure)),
+        previous_(std::exchange(setsockopt_failure, &failure_)) {}
+
+  ~ScopedSetsockoptFailure() { setsockopt_failure = previous_; }
+
+  ScopedSetsockoptFailure(const ScopedSetsockoptFailure &) = delete;
+  ScopedSetsockoptFailure &operator=(const ScopedSetsockoptFailure &) = delete;
+
+ private:
+  const std::function<bool(int, int, int)> failure_;
+  const std::function<bool(int, int, int)> *previous_;
+};
+
+}  // namespace
+
+extern "C" int __real_setsockopt(
+    int fd, int level, int option, const void *value, socklen_t length);
+
+extern "C" int __wrap_setsockopt(
+    int fd, int level, int option, const void *value, socklen_t length) {
+  if (setsockopt_failure != nullptr && (*setsockopt_failure)(fd, level, option)) {
+    errno = EPERM;
+    return -1;
+  }
+  return __real_setsockopt(fd, level, option, value, length);
+}
+#endif
 
 namespace ray {
 namespace gcs {
@@ -323,6 +364,118 @@ TEST_F(RedisContextKeepaliveTest, EnableFailureStopsBeforeTuning) {
     EXPECT_EQ(raw->err, 0);
   }
 }
+
+#if defined(__linux__) && defined(TCP_KEEPIDLE) && defined(TCP_KEEPINTVL) && \
+    defined(TCP_KEEPCNT)
+class RedisContextKeepaliveConnectFailureTest
+    : public RedisContextKeepaliveTest,
+      public ::testing::WithParamInterface<int> {};
+
+TEST_P(RedisContextKeepaliveConnectFailureTest, TuningFailureAllowsConnectAndCommands) {
+  RayConfig::instance().redis_tcp_keepalive_interval_seconds() = 7;
+  RayConfig::instance().redis_tcp_keepalive_probes() = 4;
+  RayConfig::instance().redis_db_connect_retries() = 3;
+  RayConfig::instance().redis_db_connect_wait_milliseconds() = 0;
+  instrumented_io_context io_service{/*enable_lag_probe=*/false,
+                                     /*running_on_single_thread=*/true};
+  Clock clock;
+  RedisContext context(io_service, clock);
+
+  const std::map<int, int> timing_options = {
+      {TCP_KEEPIDLE, 7}, {TCP_KEEPINTVL, 7}, {TCP_KEEPCNT, 4}};
+  std::map<std::pair<int, int>, int> rejected_values;
+  std::vector<int> configured_fds;
+  size_t timing_calls = 0;
+  Status status;
+  {
+    ScopedSetsockoptFailure failure([&](int fd, int level, int option) {
+      if (level == SOL_SOCKET && option == SO_KEEPALIVE) {
+        configured_fds.push_back(fd);
+      }
+      if (level == IPPROTO_TCP && timing_options.count(option) != 0) {
+        ++timing_calls;
+        if (GetParam() == -1 || option == GetParam()) {
+          rejected_values[{fd, option}] = GetIntSockOpt(fd, level, option);
+          return true;
+        }
+      }
+      return false;
+    });
+    status = ConnectToLocalRedis(context);
+  }
+  ASSERT_TRUE(status.ok()) << status.ToString();
+
+  const std::vector<int> fds = {context.sync_context()->fd,
+                                context.async_context().GetRawRedisAsyncContext()->c.fd};
+  EXPECT_EQ(configured_fds, fds);
+  EXPECT_EQ(timing_calls, fds.size() * timing_options.size());
+  ASSERT_EQ(rejected_values.size(),
+            fds.size() * (GetParam() == -1 ? timing_options.size() : 1));
+  for (const int fd : fds) {
+    EXPECT_EQ(GetIntSockOpt(fd, SOL_SOCKET, SO_KEEPALIVE), 1);
+    for (const auto &[option, requested] : timing_options) {
+      const auto rejected = rejected_values.find({fd, option});
+      const int expected =
+          rejected == rejected_values.end() ? requested : rejected->second;
+      EXPECT_EQ(GetIntSockOpt(fd, IPPROTO_TCP, option), expected);
+    }
+  }
+  EXPECT_EQ(context.sync_context()->err, 0);
+  EXPECT_EQ(context.async_context().GetRawRedisAsyncContext()->c.err, 0);
+  CheckCommands(context);
+}
+
+INSTANTIATE_TEST_SUITE_P(RejectedOptions,
+                         RedisContextKeepaliveConnectFailureTest,
+                         ::testing::Values(TCP_KEEPIDLE, TCP_KEEPINTVL, TCP_KEEPCNT, -1));
+
+class RedisContextKeepaliveEnableFailureTest
+    : public RedisContextKeepaliveTest,
+      public ::testing::WithParamInterface<bool> {};
+
+TEST_P(RedisContextKeepaliveEnableFailureTest, EnableFailureDoesNotRetryAndCleansUp) {
+  const bool fail_async = GetParam();
+  RayConfig::instance().redis_tcp_keepalive_interval_seconds() = 7;
+  RayConfig::instance().redis_tcp_keepalive_probes() = 4;
+  RayConfig::instance().redis_db_connect_retries() = 3;
+  RayConfig::instance().redis_db_connect_wait_milliseconds() = 0;
+  instrumented_io_context io_service{/*enable_lag_probe=*/false,
+                                     /*running_on_single_thread=*/true};
+  Clock clock;
+  RedisContext context(io_service, clock);
+
+  int enable_calls = 0;
+  int timing_calls = 0;
+  Status status;
+  {
+    ScopedSetsockoptFailure failure([&](int, int level, int option) {
+      if (level == SOL_SOCKET && option == SO_KEEPALIVE) {
+        ++enable_calls;
+        // Let the sync context connect when exercising async setup failure.
+        return !fail_async || enable_calls > 1;
+      }
+      if (level == IPPROTO_TCP &&
+          (option == TCP_KEEPIDLE || option == TCP_KEEPINTVL || option == TCP_KEEPCNT)) {
+        ++timing_calls;
+      }
+      return false;
+    });
+    status = ConnectToLocalRedis(context);
+  }
+  EXPECT_TRUE(status.IsIOError()) << status.ToString();
+  // Count calls with a nonzero retry budget instead of relying on elapsed time.
+  EXPECT_EQ(enable_calls, fail_async ? 2 : 1);
+  EXPECT_EQ(timing_calls, fail_async ? 3 : 0);
+
+  // The same object must be reusable after either partial setup failure.
+  ASSERT_TRUE(ConnectToLocalRedis(context).ok());
+  CheckCommands(context);
+}
+
+INSTANTIATE_TEST_SUITE_P(SyncAndAsync,
+                         RedisContextKeepaliveEnableFailureTest,
+                         ::testing::Bool());
+#endif
 
 // Regression guard for the escape hatch: interval 0 must leave the sockets
 // exactly as they were before this feature existed.

--- a/src/ray/gcs/store_client/tests/redis_context_test.cc
+++ b/src/ray/gcs/store_client/tests/redis_context_test.cc
@@ -18,6 +18,10 @@
 #include <netinet/in.h>
 #include <netinet/tcp.h>
 #include <sys/socket.h>
+#ifdef __linux__
+#include <sys/syscall.h>
+#include <unistd.h>
+#endif
 #endif
 
 #include <cerrno>
@@ -62,17 +66,23 @@ class ScopedSetsockoptFailure {
 
 }  // namespace
 
-extern "C" int __real_setsockopt(
-    int fd, int level, int option, const void *value, socklen_t length);
-
-extern "C" int __wrap_setsockopt(
-    int fd, int level, int option, const void *value, socklen_t length) {
+#if defined(__GLIBC__)
+#define RAY_TEST_SOCKET_NOEXCEPT noexcept
+#else
+#define RAY_TEST_SOCKET_NOEXCEPT
+#endif
+extern "C" int setsockopt(int fd,
+                          int level,
+                          int option,
+                          const void *value,
+                          socklen_t length) RAY_TEST_SOCKET_NOEXCEPT {
   if (setsockopt_failure != nullptr && (*setsockopt_failure)(fd, level, option)) {
     errno = EPERM;
     return -1;
   }
-  return __real_setsockopt(fd, level, option, value, length);
+  return static_cast<int>(::syscall(SYS_setsockopt, fd, level, option, value, length));
 }
+#undef RAY_TEST_SOCKET_NOEXCEPT
 #endif
 
 namespace ray {
@@ -227,12 +237,14 @@ class RedisContextKeepaliveTest : public RedisContextConfigTest {
     freeReplyObject(reply);
 
     auto completed = std::make_shared<bool>(false);
-    context.RunArgvAsync({"ECHO", "keepalive"},
-                         [&, completed](std::shared_ptr<CallbackReply> response) {
-                           *completed = true;
-                           EXPECT_EQ(response->ReadAsString(), "keepalive");
-                           context.io_service().stop();
-                         });
+    context.RunArgvAsync(
+        {"ECHO", "keepalive"},
+        [&, completed](std::shared_ptr<CallbackReply> response) {
+          *completed = true;
+          EXPECT_EQ(response->ReadAsString(), "keepalive");
+          context.io_service().stop();
+        },
+        kNoTable);
     context.io_service().restart();
     context.io_service().run_for(std::chrono::seconds(5));
     EXPECT_TRUE(*completed);

--- a/src/ray/gcs/store_client/tests/redis_context_test.cc
+++ b/src/ray/gcs/store_client/tests/redis_context_test.cc
@@ -21,6 +21,7 @@
 #endif
 
 #include <cerrno>
+#include <chrono>
 #include <cstring>
 #include <string>
 #include <vector>
@@ -30,6 +31,7 @@
 #include "ray/common/ray_config.h"
 #include "ray/common/status.h"
 #include "ray/common/test_utils.h"
+#include "ray/gcs/store_client/redis_tcp_keepalive.h"
 #include "ray/util/clock.h"
 
 namespace ray {
@@ -175,13 +177,36 @@ class RedisContextKeepaliveTest : public RedisContextConfigTest {
                            /*password=*/"",
                            /*enable_ssl=*/false);
   }
+
+  void CheckCommands(RedisContext &context) {
+    auto *reply = static_cast<redisReply *>(redisCommand(context.sync_context(), "PING"));
+    ASSERT_NE(reply, nullptr);
+    EXPECT_EQ(reply->type, REDIS_REPLY_STATUS);
+    EXPECT_STREQ(reply->str, "PONG");
+    freeReplyObject(reply);
+
+    auto completed = std::make_shared<bool>(false);
+    context.RunArgvAsync({"ECHO", "keepalive"},
+                         [&, completed](std::shared_ptr<CallbackReply> response) {
+                           *completed = true;
+                           EXPECT_EQ(response->ReadAsString(), "keepalive");
+                           context.io_service().stop();
+                         });
+    context.io_service().restart();
+    context.io_service().run_for(std::chrono::seconds(5));
+    EXPECT_TRUE(*completed);
+  }
 };
 
-// Both the sync and the async hiredis sockets must carry the configured
-// policy at the largest values accepted by Linux.
-TEST_F(RedisContextKeepaliveTest, AppliesMaximumPolicyToSyncAndAsyncSockets) {
-  RayConfig::instance().redis_tcp_keepalive_interval_seconds() = 32767;
-  RayConfig::instance().redis_tcp_keepalive_probes() = 127;
+class RedisContextKeepalivePolicyTest
+    : public RedisContextKeepaliveTest,
+      public ::testing::WithParamInterface<std::pair<int, int>> {};
+
+// Cover the defaults, a custom policy, and Linux's accepted maximum values.
+TEST_P(RedisContextKeepalivePolicyTest, AppliesPolicyToSyncAndAsyncSockets) {
+  const auto [interval, probes] = GetParam();
+  RayConfig::instance().redis_tcp_keepalive_interval_seconds() = interval;
+  RayConfig::instance().redis_tcp_keepalive_probes() = probes;
 
   instrumented_io_context io_service{/*enable_lag_probe=*/false,
                                      /*running_on_single_thread=*/true};
@@ -194,15 +219,108 @@ TEST_F(RedisContextKeepaliveTest, AppliesMaximumPolicyToSyncAndAsyncSockets) {
   const int async_fd = context.async_context().GetRawRedisAsyncContext()->c.fd;
   for (const int fd : {sync_fd, async_fd}) {
     EXPECT_EQ(GetIntSockOpt(fd, SOL_SOCKET, SO_KEEPALIVE), 1) << "fd: " << fd;
-#if defined(__linux__) && defined(__GLIBC__)
-    EXPECT_EQ(GetIntSockOpt(fd, IPPROTO_TCP, TCP_KEEPIDLE), 32767) << "fd: " << fd;
-    // Ray overrides hiredis' derived values (interval/3, 3 probes) so that
-    // probe cadence and time-to-declare-dead can be tuned independently.
-    EXPECT_EQ(GetIntSockOpt(fd, IPPROTO_TCP, TCP_KEEPINTVL), 32767) << "fd: " << fd;
-    EXPECT_EQ(GetIntSockOpt(fd, IPPROTO_TCP, TCP_KEEPCNT), 127) << "fd: " << fd;
+#if defined(__linux__) && defined(TCP_KEEPIDLE) && defined(TCP_KEEPINTVL) && \
+    defined(TCP_KEEPCNT)
+    EXPECT_EQ(GetIntSockOpt(fd, IPPROTO_TCP, TCP_KEEPIDLE), interval) << "fd: " << fd;
+    EXPECT_EQ(GetIntSockOpt(fd, IPPROTO_TCP, TCP_KEEPINTVL), interval) << "fd: " << fd;
+    EXPECT_EQ(GetIntSockOpt(fd, IPPROTO_TCP, TCP_KEEPCNT), probes) << "fd: " << fd;
 #elif defined(__APPLE__) && defined(__MACH__)
-    EXPECT_EQ(GetIntSockOpt(fd, IPPROTO_TCP, TCP_KEEPALIVE), 32767) << "fd: " << fd;
+    EXPECT_EQ(GetIntSockOpt(fd, IPPROTO_TCP, TCP_KEEPALIVE), interval) << "fd: " << fd;
 #endif
+  }
+  CheckCommands(context);
+}
+
+INSTANTIATE_TEST_SUITE_P(Policies,
+                         RedisContextKeepalivePolicyTest,
+                         ::testing::Values(std::make_pair(30, 3),
+                                           std::make_pair(7, 4),
+                                           std::make_pair(32767, 127)));
+
+#if (defined(__linux__) && defined(TCP_KEEPIDLE) && defined(TCP_KEEPINTVL) && \
+     defined(TCP_KEEPCNT)) ||                                                 \
+    (defined(__APPLE__) && defined(__MACH__))
+class RedisContextKeepaliveFailureTest : public RedisContextKeepaliveTest,
+                                         public ::testing::WithParamInterface<int> {};
+
+TEST_P(RedisContextKeepaliveFailureTest, TuningFailurePreservesUsableConnections) {
+  // Establish fresh sockets with OS defaults, then inject failures only at the
+  // keepalive helper's syscall boundary. Both hiredis contexts must remain usable.
+  RayConfig::instance().redis_tcp_keepalive_interval_seconds() = 0;
+  instrumented_io_context io_service{/*enable_lag_probe=*/false,
+                                     /*running_on_single_thread=*/true};
+  Clock clock;
+  RedisContext context(io_service, clock);
+  ASSERT_TRUE(ConnectToLocalRedis(context).ok());
+
+  const std::vector<std::pair<int, int>> timing_options = {
+#if defined(__linux__)
+    {TCP_KEEPIDLE, 7},
+    {TCP_KEEPINTVL, 7},
+    {TCP_KEEPCNT, 4},
+#else
+    {TCP_KEEPALIVE, 7},
+#endif
+  };
+  for (auto *raw :
+       {context.sync_context(), &context.async_context().GetRawRedisAsyncContext()->c}) {
+    std::vector<int> previous_values;
+    for (const auto &[option, value] : timing_options) {
+      previous_values.push_back(GetIntSockOpt(raw->fd, IPPROTO_TCP, option));
+    }
+    const auto result = internal::SetRedisTcpKeepalive(
+        7, 4, [&](int level, int option, const char *, int value) {
+          if (level == IPPROTO_TCP && (GetParam() == -1 || option == GetParam())) {
+            errno = EPERM;
+            return false;
+          }
+          return setsockopt(raw->fd, level, option, &value, sizeof(value)) == 0;
+        });
+    EXPECT_EQ(result, internal::RedisTcpKeepaliveResult::kDegraded);
+    EXPECT_EQ(raw->err, 0);
+    EXPECT_EQ(GetIntSockOpt(raw->fd, SOL_SOCKET, SO_KEEPALIVE), 1);
+    for (size_t i = 0; i < timing_options.size(); ++i) {
+      const auto [option, value] = timing_options[i];
+      const int expected =
+          GetParam() == -1 || option == GetParam() ? previous_values[i] : value;
+      EXPECT_EQ(GetIntSockOpt(raw->fd, IPPROTO_TCP, option), expected);
+    }
+  }
+  CheckCommands(context);
+}
+
+INSTANTIATE_TEST_SUITE_P(RejectedOptions,
+                         RedisContextKeepaliveFailureTest,
+#if defined(__linux__)
+                         ::testing::Values(TCP_KEEPIDLE, TCP_KEEPINTVL, TCP_KEEPCNT, -1)
+#else
+                         ::testing::Values(TCP_KEEPALIVE, -1)
+#endif
+);
+#endif
+
+TEST_F(RedisContextKeepaliveTest, EnableFailureStopsBeforeTuning) {
+  RayConfig::instance().redis_tcp_keepalive_interval_seconds() = 0;
+  instrumented_io_context io_service{/*enable_lag_probe=*/false,
+                                     /*running_on_single_thread=*/true};
+  Clock clock;
+  RedisContext context(io_service, clock);
+  ASSERT_TRUE(ConnectToLocalRedis(context).ok());
+  for (auto *raw :
+       {context.sync_context(), &context.async_context().GetRawRedisAsyncContext()->c}) {
+    int calls = 0;
+    const auto result = internal::SetRedisTcpKeepalive(
+        7, 4, [&](int level, int option, const char *, int) {
+          ++calls;
+          EXPECT_EQ(level, SOL_SOCKET);
+          EXPECT_EQ(option, SO_KEEPALIVE);
+          errno = EPERM;
+          return false;
+        });
+    EXPECT_EQ(result, internal::RedisTcpKeepaliveResult::kFailed);
+    EXPECT_EQ(calls, 1);
+    EXPECT_EQ(GetIntSockOpt(raw->fd, SOL_SOCKET, SO_KEEPALIVE), 0);
+    EXPECT_EQ(raw->err, 0);
   }
 }
 


### PR DESCRIPTION
## Description

Idle GCS-to-external-Redis connections can become unreachable without a FIN or
RST. This PR enables TCP keepalive centrally in `ConnectWithoutRetries` before
TLS, AUTH, or commands, covering sync, async, Sentinel, cluster redirects, and
cleanup connections. Probes can also preserve flows through network devices
that count TCP keepalive as activity.

| Config | Default | Valid values |
| --- | ---: | --- |
| `redis_tcp_keepalive_interval_seconds` | `30` | `0..32767`; `0` disables keepalive |
| `redis_tcp_keepalive_probes` | `3` | `1..127` when enabled |

Linux with the relevant TCP options, including musl, applies idle time, probe
interval, and count explicitly. With all settings applied, an idle blackholed
connection is detected after approximately interval * (1 + probes), or 120
seconds by default. This is not a command timeout or a complete recovery bound.
macOS applies idle time only. Windows applies idle and probe intervals with an
OS-controlled probe count. Other POSIX platforms retain OS timing defaults.

Invalid configuration fails before DNS. On POSIX, failure to enable
`SO_KEEPALIVE` fails the connection immediately; rejected timing options warn
and leave the connection usable. Successful options remain applied and failed
options retain their previous values, so degraded connections do not promise
the requested detection window. Windows retains hiredis' combined enable/tune
operation and failure behavior.

Unexpected async disconnects log hiredis `err`/`errstr` and label `RayConfig`
values as current configuration, not the failed socket's actual policy or proof
of the cause of failure. The guide documents tuning, platform differences,
degradation, and the crash risk in versions without in-place Redis reconnect.

### Context leak fix

The PR also fixes an existing leak in `ConnectWithoutRetries`: hiredis can return
an allocated context with `err` set on connection failure. Acquiring `unique_ptr`
ownership immediately releases that context on every early return, including
both connection errors and keepalive enable failures.

## Related work and duplicate check

The open-PR search for redis keepalive on 2026-09-11 returned this PR, #65298
(in-place Redis reconnect), and #65840 (a Redis TLS documentation example).
The reconnect change complements detection and prevention; it does not add
keepalive socket policy. No competing PR is being opened. Documentation uses
conditional language so it does not become incorrect when reconnect lands.
Issue #66074 tracks coordinated keepalive, request, and reconnect defaults.

## Testing

- `bazel test //src/ray/gcs/store_client/tests:redis_context_test
  --test_output=errors --jobs=1 --nocache_test_results`: passed after rebasing,
  18 cases, including six production-connection-path failure scenarios.
- `bazel test //src/ray/gcs/store_client/tests:all --test_output=errors
  --jobs=1`: passed after rebasing, 11/11 tests (9 executed, 2 cached).
- Pre-commit passed after rebasing on all seven changed files:

  ```sh
  pre-commit run --files \
    doc/source/cluster/kubernetes/user-guides/kuberay-gcs-ft.md \
    src/ray/common/ray_config_def.h \
    src/ray/gcs/store_client/BUILD.bazel \
    src/ray/gcs/store_client/redis_context.cc \
    src/ray/gcs/store_client/redis_tcp_keepalive.h \
    src/ray/gcs/store_client/tests/BUILD.bazel \
    src/ray/gcs/store_client/tests/redis_context_test.cc
  ```

