### PR TITLE
[doc] Pin the RocksDB GCS example to the release that introduced it

### DIFF
--- a/doc/source/cluster/kubernetes/user-guides/kuberay-gcs-rocksdb-ft.md
+++ b/doc/source/cluster/kubernetes/user-guides/kuberay-gcs-rocksdb-ft.md
@@ -36,8 +36,7 @@ For the officially supported, Redis-backed setup, see
 
 ## Prerequisites
 
-* A KubeRay version with embedded RocksDB support. KubeRay v1.6.2 and earlier don't have it,
-  so you need a build from KubeRay master until a release ships it.
+* KubeRay v1.7 or later, which is the first release that supports the embedded RocksDB backend.
 * Ray 2.57.0 or later, which is the first release that contains the embedded RocksDB backend.
 * Linux worker nodes (the RocksDB backend is Linux only).
 * A `StorageClass` that provisions a durable volume which can reattach to the node that runs

--- a/doc/source/cluster/kubernetes/user-guides/kuberay-gcs-rocksdb-ft.md
+++ b/doc/source/cluster/kubernetes/user-guides/kuberay-gcs-rocksdb-ft.md
@@ -36,11 +36,9 @@ For the officially supported, Redis-backed setup, see
 
 ## Prerequisites
 
-* A KubeRay version with embedded RocksDB support. This backend is only on KubeRay master
-  (nightly) at the time of writing; it isn't in a stable KubeRay release yet. Once a release
-  ships with it, use that version.
-* A Ray image that contains the embedded RocksDB backend. It isn't in a stable Ray release
-  yet, so the manifest below uses `rayproject/ray:nightly`.
+* A KubeRay version with embedded RocksDB support. KubeRay v1.6.2 and earlier don't have it,
+  so you need a build from KubeRay master until a release ships it.
+* Ray 2.57.0 or later, which is the first release that contains the embedded RocksDB backend.
 * Linux worker nodes (the RocksDB backend is Linux only).
 * A `StorageClass` that provisions a durable volume which can reattach to the node that runs
   the recovered head Pod.
@@ -120,7 +118,7 @@ spec:
       spec:
         containers:
         - name: ray-head
-          image: rayproject/ray:nightly
+          image: rayproject/ray:2.57.0
   workerGroupSpecs:
   - groupName: small-group
     replicas: 1
@@ -131,7 +129,7 @@ spec:
       spec:
         containers:
         - name: ray-worker
-          image: rayproject/ray:nightly
+          image: rayproject/ray:2.57.0
 ```
 
 ```{admonition} Storage options


### PR DESCRIPTION
## Why

The embedded RocksDB GCS backend page told readers the feature wasn't in a Ray release yet and pointed its manifest at `rayproject/ray:nightly`. The Ray half of that is no longer true: the backend shipped in **2.57.0** (`_is_rocksdb_gcs` is present in `ray-2.57.0`, absent in `ray-2.56.1`), and `rayproject/ray:2.57.0` resolves on Docker Hub.

Beyond the expired claim, a floating tag isn't the right way to flag a preview feature. Docs land on `master` immediately but aren't published until they ship to `latest`, which tracks a Ray release, so by the time a reader sees this page the feature is in a release by construction. Naming the release that introduced it is both accurate and more useful than a nightly build.

## What changed

- Pin both container images to `rayproject/ray:2.57.0` instead of `nightly`.
- Replace the "isn't in a stable Ray release yet" prerequisite with the concrete floor: Ray 2.57.0 or later.
- State the KubeRay prerequisite as KubeRay v1.7 or later, per @andrewsykim's review. `GCSFaultToleranceEmbeddedStorage` is on KubeRay master and absent from `v1.6.2`, the current release, so v1.7 is the release that ships the gate.

The alpha admonition stays. The feature is alpha and gated off by default, which is independent of which release contains it.

## Verification

- `_is_rocksdb_gcs` present in `git show ray-2.57.0:python/ray/_private/node.py`, absent in `ray-2.56.1`.
- `rayproject/ray:2.57.0` returns 200 from the Docker Hub tag API.
- `GCSFaultToleranceEmbeddedStorage` present in `ray-operator/pkg/features/features.go` on kuberay master, absent at tag `v1.6.2`.

