### PR TITLE
[doc] Correct the fake multi-node docker image guidance

### DIFF
--- a/doc/source/ray-contribute/fake-autoscaler.md
+++ b/doc/source/ray-contribute/fake-autoscaler.md
@@ -184,15 +184,15 @@ For the Ray OSS Buildkite environment, we set the following environment variable
 
 * `RAY_TESTHOST="dind-daemon"`. Because the host daemon starts the containers, we can't connect to `localhost`. The ports aren't exposed to the outer container. Thus, we can set the Ray host with this environment variable.
 
-Lastly, Docker Compose requires a Docker image. The default Docker image is `rayproject/ray:nightly`. The Docker image requires `openssh-server` to be installed and enabled. In Buildkite, we build a new image from `rayproject/ray:nightly-py38-cpu` to avoid installing this on the fly for every node, which is the default. This base image is built in one of the previous build steps.
+Lastly, Docker Compose requires a Docker image. The default is `rayproject/ray:nightly-py<major><minor>-cpu`, resolved against the Python version you run the tests with. Nightly is deliberate here: the fake multi-node provider tests the autoscaler on the current master branch, not on a release.
 
-Thus, we set
+The image also needs `openssh-server` installed and enabled. Without it, every node installs the package on startup, which is slow. Build an image that already has it, then set
 
-* `RAY_DOCKER_IMAGE="rayproject/ray:multinode-py38"`
+* `RAY_DOCKER_IMAGE="<your-image>"`
 
 * `RAY_HAS_SSH=1`
 
-to use this Docker image and inform our multinode infrastructure that SSH is already installed.
+to use that image and inform the multinode infrastructure that SSH is already installed.
 
 ## Local development
 

--- a/doc/source/ray-contribute/fake-autoscaler.md
+++ b/doc/source/ray-contribute/fake-autoscaler.md
@@ -186,13 +186,11 @@ For the Ray OSS Buildkite environment, we set the following environment variable
 
 Lastly, Docker Compose requires a Docker image. The default is `rayproject/ray:nightly-py<major><minor>-cpu`, resolved against the Python version you run the tests with. Nightly is deliberate here: the fake multi-node provider tests the autoscaler on the current master branch, not on a release.
 
-The image also needs `openssh-server` installed and enabled. Without it, every node installs the package on startup, which is slow. Build an image that already has it, then set
+The image also needs `openssh-server` installed and enabled. Without it, every node installs the package on startup, which is slow. Build an image that already has it, then set the following to use that image and inform the multinode infrastructure that SSH is already installed:
 
 * `RAY_DOCKER_IMAGE="<your-image>"`
 
 * `RAY_HAS_SSH=1`
-
-to use that image and inform the multinode infrastructure that SSH is already installed.
 
 ## Local development
 


### PR DESCRIPTION
## Why

Three claims in this paragraph are stale or wrong:

1. **The default image is misstated.** The doc says `rayproject/ray:nightly`. The code says `DEFAULT_DOCKER_IMAGE = "rayproject/ray:nightly-py{major}{minor}-cpu"` (`python/ray/autoscaler/_private/fake_multi_node/test_utils.py:26`), formatted with the interpreter's own version at `test_utils.py:195`.
2. **`rayproject/ray:nightly-py38-cpu` is frozen.** Docker Hub last pushed it on 2024-03-13, when py38 support was dropped. It still returns 200, so a contributor who copies it gets a two-year-old image with no error.
3. **The Buildkite image it points at doesn't exist.** `rayproject/ray:multinode-py38` 404s on Docker Hub, and no step in `.buildkite/`, `ci/`, or `docker/` builds it. The paragraph tells contributors to set `RAY_DOCKER_IMAGE` to an image nothing produces.

## What changed

- State the actual default, `rayproject/ray:nightly-py<major><minor>-cpu`, and why nightly is the right default here: this provider tests the autoscaler on master, not on a release.
- Drop the dead Buildkite/`multinode-py38` instructions and keep the reusable advice they were wrapping: bring an image with `openssh-server` already installed and set `RAY_HAS_SSH=1`, otherwise every node installs the package on startup (`node_provider.py:148-155`).

`RAY_DOCKER_IMAGE`, `RAY_HAS_SSH`, `RAY_TEMPDIR`, and `RAY_TESTHOST` are all still read by the provider, so the surrounding guidance stands as written.
