### PR TITLE
[ci] Scope the doc_readme lint check to the files it actually checks

### DIFF
--- a/.buildkite/always.rules.test.txt
+++ b/.buildkite/always.rules.test.txt
@@ -33,5 +33,14 @@ doc/source/data/examples.yml: always lint
 doc/BUILD.bazel: always lint
 
 # Prose outside doc/ is not exempt; the exemption is scoped to doc/.
-README.rst: always lint
 python/ray/data/README.md: always lint
+
+# The two inputs to `lint: doc_readme` add pypi_readme, which is the step's
+# only trigger. README.rst also shows that prose outside doc/ is not exempt
+# from the code-oriented lint matrix.
+README.rst: always lint pypi_readme
+python/setup.py: always lint pypi_readme
+
+# No other path emits pypi_readme, including neighbors of the two inputs.
+python/ray/setup-dev.py: always lint
+python/requirements.txt: always lint

--- a/.buildkite/always.rules.txt
+++ b/.buildkite/always.rules.txt
@@ -19,7 +19,7 @@
 # an edit as a repo-wide change rather than a local one. See the scope notes at
 # the top of test.rules.txt, which apply here too.
 
-! always lint
+! always lint pypi_readme
 
 # Documentation prose (.md and .rst) and static image assets do not need the
 # code-oriented lint checks. A Markdown-only pull request cannot produce a
@@ -63,6 +63,23 @@ doc/*.jpeg
 doc/*.gif
 doc/*.webp
 @ always
+;
+
+# Inputs to `lint: doc_readme`, which runs `setup.py check --restructuredtext
+# --strict --metadata` and so guards how Ray's PyPI long description renders.
+# `--restructuredtext` validates `long_description`, which python/setup.py
+# reads from the repo-root README.rst, and `--metadata` validates setup.py's
+# own fields. Those two files are the whole input set; nothing under doc/
+# feeds the check.
+#
+# The step carries `pypi_readme` alone in lint.rayci.yml, so this rule is its
+# only trigger: no other rule emits the tag, and the catch-all below does not.
+# Both files keep `always lint` as well, since the catch-all would otherwise
+# have given them those tags and dropping them here would silently narrow
+# every other step.
+README.rst
+python/setup.py
+@ always lint pypi_readme
 ;
 
 *

--- a/.buildkite/lint.rayci.yml
+++ b/.buildkite/lint.rayci.yml
@@ -1,11 +1,13 @@
 group: lint
-# The lint matrix is split in two by tag so a documentation-prose pull request
-# skips the checks that cannot apply to it. See the prose rule in
-# always.rules.txt for the mechanism: `always` is emitted for every changed
-# file, `lint` only for files that are not prose.
+# The lint matrix is split by tag so a pull request only runs the checks that
+# can apply to it. See the prose rule in always.rules.txt for the mechanism:
+# `always` is emitted for every changed file, `lint` only for files that are
+# not prose, and narrower tags only for the paths that feed one specific check.
 steps:
   # Lint checks a Markdown or reStructuredText change can actually fail. These
-  # keep `always`, so they run on every pull request.
+  # keep `always`, so they run on every pull request. Adding a step here
+  # asserts that a prose-only diff can fail it; if it can't, give the step a
+  # tag matching its real inputs instead, as `doc_readme` does below.
   #
   # The pre-commit whitespace and end-of-file hooks are deliberately not here.
   # `.pre-commit-config.yaml` excludes `doc/source/` globally, so those hooks
@@ -22,9 +24,30 @@ steps:
     commands:
       - ./ci/lint/lint.sh {{matrix}}
     matrix:
-      - doc_readme
       - documentation_style
       - doc_no_new_rst
+
+  # `doc_readme` runs `setup.py check --restructuredtext --strict --metadata`,
+  # which guards how Ray's PyPI long description renders. Its inputs are the
+  # repo-root README.rst and python/setup.py; nothing under doc/ feeds it, so a
+  # prose change cannot change its result. The name reads like documentation,
+  # which is how it ended up in the prose matrix above, but it belongs to
+  # packaging.
+  #
+  # It carries `pypi_readme` alone so the rule in always.rules.txt naming those
+  # two files is its only trigger. Prose pull requests and code pull requests
+  # that leave both files alone both stop selecting it. One consequence of
+  # dropping `lint`: the microcheck pipeline's hardcoded `tag:lint` selector no
+  # longer makes the step eligible there, so it runs on premerge only.
+  # Microcheck is non-blocking, and premerge is the gate this check has to hold.
+  - label: ":lint-roller: lint: doc_readme"
+    key: lint-pypi-readme
+    tags:
+      - pypi_readme
+    depends_on:
+      - forge
+    commands:
+      - ./ci/lint/lint.sh doc_readme
 
   # Code-oriented lint checks. These carry `lint` without `always`, so they are
   # filtered out when every changed file is documentation prose. Selects and


### PR DESCRIPTION
## Why this change is needed

`lint: doc_readme` carries the `always` tag, so it runs on every pull request, including documentation-prose-only ones. Its inputs are the repo-root `README.rst` and `python/setup.py`. Nothing under `doc/` feeds it, so a prose change cannot change its result.

What it actually checks, from `ci/lint/lint.sh`:

```bash
doc_readme() {
  /usr/bin/python -m pip install -c python/requirements_compiled.txt docutils
  cd python && /usr/bin/python setup.py check --restructuredtext --strict --metadata
}
```

`--restructuredtext` validates `long_description`, which `python/setup.py` reads from the repo-root `README.rst`. `--metadata` validates `setup.py`'s own metadata fields. So the check guards how Ray's PyPI long description renders. It's a useful gate and this PR doesn't touch what it does; it's pointed at the wrong trigger.

It ended up in the `lint-small-prose` matrix, which exists for the opposite reason: that matrix holds the checks a Markdown or reStructuredText change *can* fail, so they survive the prose filter that strips the code-oriented `lint-small` matrix. The name `doc_readme` reads like documentation. The other three steps in that matrix belong there; this one is packaging.

## What this PR does

1. Moves `doc_readme` into its own step tagged `pypi_readme` alone, with no `lint` and no `always`.
2. Adds a rule in `.buildkite/always.rules.txt` emitting `pypi_readme` for `README.rst` and `python/setup.py`. Both files keep `always lint`, which the catch-all would otherwise have given them, so no other step's trigger narrows.
3. Adds test cases to `.buildkite/always.rules.test.txt` for both inputs and for neighbors that must not emit the tag.
4. Rewrites the matrix comment to state the rule rather than imply it: adding a step to the prose matrix asserts a prose-only diff can fail it.

Prose pull requests and code pull requests that leave both files alone both stop selecting the step. The second half of that is broader than strictly necessary to fix the prose case, and it's the point: a check that cannot fail from your change shouldn't be in your PR's status list.

## Two consequences worth flagging

**Microcheck eligibility.** Dropping `lint` from the step means the microcheck pipeline's hardcoded `tag:lint` selector no longer makes it eligible there, so it runs on premerge only. Selects and rule-emitted tags are ANDed in rayci's step filter, so this is the expected outcome rather than a surprise. Microcheck is non-blocking; premerge is the gate this check has to hold. Noted in the step comment.

**Step IDs shift within the lint group.** Step IDs are positional (`fmt.Sprintf("g%d_s%d", i, j)`), so inserting a step moves `api-param-coverage` from `g11_s3` to `g11_s4` and `docs-go-scope` from `g11_s4` to `g11_s5`. `Test.gen_microcheck_step_ids` derives step IDs from recent Bazel test results, and group `g11` contains no Bazel test steps, so nothing keyed on step ID is affected.

## Not a duplicate

No open PR touches `doc_readme` (`gh pr list --repo ray-project/ray --state open --search doc_readme` returns nothing).

#65368 edits the same matrix to remove `banned_words`, so these two will conflict textually. They're independent changes and either merge order works; whichever lands second needs a trivial rebase.

## Testing

Rules layer, from the branch:

```
$ rayci test-rules
$ echo $?
0
```

125 cases pass. Negative control: reverting the `README.rst` expectation to `always lint` fails with `+pypi_readme (unexpected)`, confirming the test is reading the new rule rather than passing vacuously.

Step selection, generating the pipeline that the pinned rayci binary (v0.46.0, from `.rayciversion`) actually emits for a probe diff, rather than reasoning about tags:

| Probe diff | Selected tags | `lint: doc_readme` |
| --- | --- | --- |
| `doc/source/index.rst`, at `master` | `always` | runs, inside the `g11_s0` matrix |
| `doc/source/index.rst`, on this branch | `always` | not emitted |
| `python/ray/actor.py`, on this branch | `always lint …` | not emitted |
| `README.rst`, on this branch | `always lint pypi_readme` | emitted, `g11_s1` |
| `python/setup.py`, on this branch | `… pypi_readme …` | emitted, `g11_s1` |

The `master` row is the before state: on a prose-only diff the emitted prose matrix contains `banned_words`, `doc_readme`, `documentation_style`, `doc_no_new_rst`. On this branch that matrix has three entries and no separate `doc_readme` step appears.

Not verifiable outside Buildkite: `if:` expression evaluation, which this PR doesn't touch.

## AI assistance

AI assistance was used for this change. Every changed line was reviewed by a human before this PR was opened, and the commands above were run locally.
