### PR TITLE
[data] Cap task pool resource demand by runnable inputs

### DIFF
--- a/python/ray/data/_internal/execution/interfaces/physical_operator.py
+++ b/python/ray/data/_internal/execution/interfaces/physical_operator.py
@@ -1086,13 +1086,17 @@ class PhysicalOperator(Operator):
 
     def min_max_resource_requirements(
         self,
+        num_pending_input_bundles: Optional[int] = None,
     ) -> Tuple[ExecutionResources, ExecutionResources]:
         """Returns lower/upper boundary of resource requirements for this operator:
 
         - Minimal: lower bound (min) of resources required to start this operator
-        (for most operators this is 0, except the ones that utilize actors)
+          (for most operators this is 0, except the ones that utilize actors)
         - Maximum: upper bound (max) of how many resources this operator could
-        utilize.
+          utilize.
+
+        If ``num_pending_input_bundles`` is provided, operators may tighten the maximum
+        based on the work currently available to them.
         """
         return ExecutionResources.zero(), ExecutionResources.inf()
 

--- a/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
+++ b/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
@@ -559,6 +559,7 @@ class ActorPoolMapOperator(MapOperator):
 
     def min_max_resource_requirements(
         self,
+        num_pending_input_bundles: Optional[int] = None,
     ) -> Tuple[ExecutionResources, ExecutionResources]:
         min_actors = self._actor_pool.min_size()
         max_actors = self._actor_pool.max_size()

--- a/python/ray/data/_internal/execution/operators/task_pool_map_operator.py
+++ b/python/ray/data/_internal/execution/operators/task_pool_map_operator.py
@@ -234,6 +234,7 @@ class TaskPoolMapOperator(MapOperator):
 
     def min_max_resource_requirements(
         self,
+        num_pending_input_bundles: Optional[int] = None,
     ) -> Tuple[ExecutionResources, ExecutionResources]:
         """Returns min/max resource requirements for this operator.
 
@@ -252,6 +253,11 @@ class TaskPoolMapOperator(MapOperator):
         max_concurrency = (
             self._max_concurrency if self._max_concurrency is not None else float("inf")
         )
+        if num_pending_input_bundles is not None:
+            max_concurrency = min(
+                max_concurrency,
+                self.num_active_tasks() + num_pending_input_bundles,
+            )
         max_resource_usage = ExecutionResources(
             cpu=0 if per_task.cpu == 0 else per_task.cpu * max_concurrency,
             gpu=0 if per_task.gpu == 0 else per_task.gpu * max_concurrency,

--- a/python/ray/data/_internal/execution/resource_manager.py
+++ b/python/ray/data/_internal/execution/resource_manager.py
@@ -3,7 +3,7 @@ import math
 import time
 from abc import ABC, abstractmethod
 from collections import defaultdict
-from typing import TYPE_CHECKING, Callable, Dict, Iterable, List, Optional
+from typing import TYPE_CHECKING, Callable, Dict, Iterable, List, Optional, Tuple
 
 from ray._common.utils import env_bool, env_float
 from ray.data._internal.execution import create_resource_allocator
@@ -680,6 +680,14 @@ class ReservationOpResourceAllocator(OpResourceAllocator):
         # starved of its minimum resources, or None if it currently has them.
         self._op_starved_since: Dict[PhysicalOperator, Optional[float]] = {}
 
+    def _get_min_max_resource_requirements(
+        self, op: PhysicalOperator
+    ) -> Tuple[ExecutionResources, ExecutionResources]:
+        num_pending_input_bundles = sum(
+            len(queue) for queue in self._topology[op].input_queues
+        )
+        return op.min_max_resource_requirements(num_pending_input_bundles)
+
     def _update_reservation(self, limits: ExecutionResources):
         eligible_ops = self._get_eligible_ops()
 
@@ -705,7 +713,10 @@ class ReservationOpResourceAllocator(OpResourceAllocator):
 
             reserved_for_tasks = default_reserved.subtract(reserved_for_outputs)
 
-            min_resource_usage, max_resource_usage = op.min_max_resource_requirements()
+            (
+                min_resource_usage,
+                max_resource_usage,
+            ) = self._get_min_max_resource_requirements(op)
 
             if min_resource_usage is not None:
                 reserved_for_tasks = reserved_for_tasks.max(min_resource_usage)
@@ -893,7 +904,7 @@ class ReservationOpResourceAllocator(OpResourceAllocator):
             # Cap op_shared so that total allocation doesn't exceed max_resource_usage.
             # Total allocation = max(total_reserved, op_usage) + op_shared
             # This ensures excess resources stay in remaining_shared for other operators.
-            _, max_resource_usage = op.min_max_resource_requirements()
+            _, max_resource_usage = self._get_min_max_resource_requirements(op)
             if max_resource_usage != ExecutionResources.inf():
                 total_reserved = self._get_total_reserved(op)
                 op_usage = self._resource_manager.get_op_usage(op)
@@ -913,13 +924,22 @@ class ReservationOpResourceAllocator(OpResourceAllocator):
 
             self._op_budgets[op] = self._op_budgets[op].add(op_shared)
 
-        # Give any remaining shared resources to the most downstream uncapped op.
+        # Give any remaining shared resources to downstream operators with capacity.
         # This can happen when some ops have their shared allocation capped.
         if eligible_ops and not remaining_shared.is_zero():
             for op in reversed(eligible_ops):
-                _, max_resource_usage = op.min_max_resource_requirements()
-                if max_resource_usage == ExecutionResources.inf():
-                    self._op_budgets[op] = self._op_budgets[op].add(remaining_shared)
+                _, max_resource_usage = self._get_min_max_resource_requirements(op)
+                additional = remaining_shared
+                if max_resource_usage != ExecutionResources.inf():
+                    allocation = self.get_allocation(op)
+                    additional = additional.min(
+                        max_resource_usage.subtract(allocation).max(
+                            ExecutionResources.zero()
+                        )
+                    )
+                self._op_budgets[op] = self._op_budgets[op].add(additional)
+                remaining_shared = remaining_shared.subtract(additional)
+                if remaining_shared.is_zero():
                     break
 
         # A materializing operator like `AllToAllOperator` waits for all its input

--- a/python/ray/data/tests/test_actor_pool_map_operator.py
+++ b/python/ray/data/tests/test_actor_pool_map_operator.py
@@ -1165,7 +1165,7 @@ def test_min_max_resource_requirements(restore_data_context):
     (
         min_resource_usage_bound,
         max_resource_usage_bound,
-    ) = op.min_max_resource_requirements()
+    ) = op.min_max_resource_requirements(num_pending_input_bundles=0)
 
     # min_resource_usage: 1 actor * (1 gpu, 3 obj_store_mem)
     # max_resource_usage: 2 actors * (1 gpu)

--- a/python/ray/data/tests/test_reservation_based_resource_allocator.py
+++ b/python/ray/data/tests/test_reservation_based_resource_allocator.py
@@ -360,6 +360,58 @@ class TestReservationOpResourceAllocator:
             cpu=1, object_store_memory=1
         )
 
+    def test_task_pool_allocation_capped_by_runnable_inputs(self, restore_data_context):
+        DataContext.get_current().op_resource_reservation_enabled = True
+        DataContext.get_current().op_resource_reservation_ratio = 0.5
+
+        input_op = InputDataBuffer(DataContext.get_current(), [])
+        task_op = mock_map_op(input_op, ray_remote_args={"num_cpus": 1})
+        downstream_op = mock_map_op(task_op, ray_remote_args={"num_cpus": 1})
+
+        topo = build_streaming_topology(
+            downstream_op, ExecutionOptions(), noop_counter()
+        )
+        task_op_input_queue = MagicMock()
+        task_op_input_queue.__len__.return_value = 1
+        topo[task_op].input_queues = [task_op_input_queue]
+        downstream_input_queue = MagicMock()
+        downstream_input_queue.__len__.return_value = 8
+        topo[downstream_op].input_queues = [downstream_input_queue]
+
+        resource_manager = ResourceManager(
+            topo,
+            ExecutionOptions(),
+            MagicMock(),
+            DataContext.get_current(),
+            BlockRefCounter(add_object_out_of_scope_callback=lambda *_: True),
+        )
+        resource_manager.get_op_usage = MagicMock(
+            return_value=ExecutionResources.zero()
+        )
+        resource_manager.get_global_limits = MagicMock(
+            return_value=ExecutionResources(cpu=8)
+        )
+
+        allocator = resource_manager._op_resource_allocator
+        allocator.update_budgets(limits=resource_manager.get_global_limits())
+
+        assert allocator.get_allocation(task_op).cpu == 1
+        assert allocator.get_allocation(downstream_op).cpu == 7
+
+        task_op_input_queue.__len__.return_value = 0
+        task_op.num_active_tasks = MagicMock(return_value=1)
+        allocator.update_budgets(limits=resource_manager.get_global_limits())
+
+        assert allocator.get_allocation(task_op).cpu == 1
+        assert allocator.get_allocation(downstream_op).cpu == 7
+
+        task_op.num_active_tasks = MagicMock(return_value=0)
+        task_op_input_queue.__len__.return_value = 4
+        allocator.update_budgets(limits=resource_manager.get_global_limits())
+
+        assert allocator.get_allocation(task_op).cpu == 4
+        assert allocator.get_allocation(downstream_op).cpu == 4
+
     def test_budget_capped_by_max_resource_usage(self, restore_data_context):
         """Test that the total allocation is capped by max_resource_usage.
 

--- a/python/ray/data/tests/test_task_pool_map_operator.py
+++ b/python/ray/data/tests/test_task_pool_map_operator.py
@@ -33,6 +33,13 @@ def test_min_max_resource_requirements(ray_start_regular_shared, restore_data_co
     # For CPU-only operators, max GPU/memory is 0 (not inf) to prevent hoarding.
     assert max_resource_usage_bound == ExecutionResources.for_limits(gpu=0, memory=0)
 
+    _, max_resource_usage_bound = op.min_max_resource_requirements(
+        num_pending_input_bundles=2
+    )
+    assert max_resource_usage_bound == ExecutionResources(
+        cpu=2, object_store_memory=float("inf")
+    )
+
 
 def test_dynamic_remote_args_inject_context_label_selector(
     ray_start_regular_shared, restore_data_context


### PR DESCRIPTION
## Description

`TaskPoolMapOperator.min_max_resource_requirements()` reports infinite maximum demand when `max_concurrency` is unset. That is a useful capacity bound, but it is not always a useful fair-share bound: an operator with one active or queued input can run at most one task.

This matters for pipelines where one task fans out into many rows. The following is a complete Ray Data example matching that shape:

```python
from dataclasses import dataclass

import ray


@dataclass
class FilePartitioningTask:
    files: list[str]


def partition_files(_):
    return {
        "item": [
            FilePartitioningTask(files=[f"file-{i}.jsonl"])
            for i in range(20)
        ]
    }


class ProcessFile:
    def __call__(self, batch):
        return batch


ray.init(num_cpus=8)

ds = (
    ray.data.from_items([None])
    .map_batches(
        partition_files,
        batch_size=1,
        compute=ray.data.TaskPoolStrategy(size=1),
        num_cpus=1,
    )
    .repartition(target_num_rows_per_block=1)
    .map_batches(
        ProcessFile,
        batch_size=1,
        compute=ray.data.ActorPoolStrategy(size=7),
        num_cpus=1,
    )
)

assert ds.materialize().count() == 20
```

The first map runs once and returns 20 dataclass rows in one block. `StreamingRepartition` receives one input block, so it can launch one task, then emits 20 one-row blocks for the actor pool. On an 8-CPU local cluster, master allocated as many as 4 CPUs to that single runnable repartition task while the downstream actor pool received 6. With this change, repartition stayed at 1 CPU and the downstream pool received 7 once it had queued work.

This PR caps a task-pool operator's current maximum demand at its active tasks plus queued input bundles. The configured `max_concurrency` remains the upper bound. Resource budgets are recomputed as inputs arrive, so the cap grows with runnable work.

Actor pools continue to report their configured pool bounds. Their actors may need to be created before input arrives, and applying the same input-based cap would change `min_size` and `initial_size` prewarming behavior.

The change applies to task-pool operators generally; it does not inspect operator names or special-case `StreamingRepartition`. Capacity left by an operator's current-demand cap is offered to downstream operators that can use it.

## Trade-offs

Benefits:

- Fair-share allocation reflects work the task pool can run now.
- Otherwise-unused CPU or GPU capacity can serve runnable downstream work.
- Allocation expands on later scheduler updates when more input becomes available.
- Actor-pool startup and autoscaling behavior is unchanged.

Costs:

- Ray tasks are not preemptive. If downstream borrows the capacity and more upstream input later arrives, the allocator stops admitting additional downstream work, but already-running downstream tasks keep their resources until they finish.
- The allocator does not reserve speculative headroom for inputs that an upstream operator has not produced yet.
- This changes fair-share accounting for every task-pool map operator, not only streaming repartition.

The first two costs are the work-conserving trade-off: idle capacity is used now in exchange for reacquisition waiting on already-running work if demand returns.

I searched open issues and PRs for the same change. #62232 is related to StreamingRepartition concurrency, but it enforces an explicit user-configured ceiling. This PR instead changes fair-share accounting for currently runnable work.

Short local wall-clock results varied with actor startup and autoscaling, so the local validation above is evidence for the allocation change, not a throughput claim.

AI assistance was used to help investigate, implement, and test this change.

## Related issues

Fixes #65433

## Tests

- `.venv/bin/python -m pytest -q python/ray/data/tests/test_reservation_based_resource_allocator.py` — 18 passed
- `.venv/bin/python -m pytest -q python/ray/data/tests/test_task_pool_map_operator.py::test_min_max_resource_requirements` — 1 passed
- `.venv/bin/python -m pytest -q python/ray/data/tests/test_actor_pool_map_operator.py -k 'test_min_max_resource_requirements or test_min_max_resource_requirements_unbounded'` — 2 passed
- Standalone example above — passed with 20 output rows
- Ray pre-commit hooks on all changed files — passed
