### PR TITLE
[Serve][2/2] Propagate TracingConfig to proxies via long poll

### DIFF
--- a/python/ray/serve/_private/controller.py
+++ b/python/ray/serve/_private/controller.py
@@ -131,6 +131,27 @@ TRACING_CONFIG_CHECKPOINT_KEY = "serve-tracing-config-checkpoint"
 SHUTDOWN_IN_PROGRESS_KEY = "serve-shutdown-in-progress"
 
 
+def _coerce_tracing_config(
+    tracing_config: Union[None, Dict, TracingConfig],
+) -> TracingConfig:
+    """Normalize an optional dict / model into a validated TracingConfig.
+
+    Defaults to an env-var-sourced ``TracingConfig`` so the global tracing
+    config is never None, and validates eagerly because the config is
+    broadcast to every proxy.
+    """
+    if tracing_config is None:
+        return TracingConfig()
+    if isinstance(tracing_config, TracingConfig):
+        return tracing_config
+    if isinstance(tracing_config, dict):
+        return TracingConfig(**tracing_config)
+    raise TypeError(
+        "tracing_config must be a dict, TracingConfig, or None; got "
+        f"{type(tracing_config).__name__}."
+    )
+
+
 class ServeController:
     """Responsible for managing the state of the serving system.
 
@@ -197,8 +218,8 @@ class ServeController:
         tracing_config_checkpoint = self.kv_store.get(TRACING_CONFIG_CHECKPOINT_KEY)
         if tracing_config_checkpoint is not None:
             global_tracing_config = pickle.loads(tracing_config_checkpoint)
-        self.global_tracing_config: TracingConfig = (
-            global_tracing_config or TracingConfig()
+        self.global_tracing_config: TracingConfig = _coerce_tracing_config(
+            global_tracing_config
         )
         if tracing_config_checkpoint is None:
             self.kv_store.put(
@@ -375,13 +396,7 @@ class ServeController:
         The config is validated/coerced here because it is broadcast to every
         proxy, which would otherwise fail on a malformed payload.
         """
-        if isinstance(global_tracing_config, dict):
-            global_tracing_config = TracingConfig(**global_tracing_config)
-        elif not isinstance(global_tracing_config, TracingConfig):
-            raise TypeError(
-                "global_tracing_config must be a dict or TracingConfig; got "
-                f"{type(global_tracing_config).__name__}."
-            )
+        global_tracing_config = _coerce_tracing_config(global_tracing_config)
 
         if self.global_tracing_config == global_tracing_config:
             return

--- a/python/ray/serve/_private/controller.py
+++ b/python/ray/serve/_private/controller.py
@@ -127,6 +127,7 @@ _CRASH_AFTER_CHECKPOINT_PROBABILITY = 0
 
 CONFIG_CHECKPOINT_KEY = "serve-app-config-checkpoint"
 LOGGING_CONFIG_CHECKPOINT_KEY = "serve-logging-config-checkpoint"
+TRACING_CONFIG_CHECKPOINT_KEY = "serve-tracing-config-checkpoint"
 SHUTDOWN_IN_PROGRESS_KEY = "serve-shutdown-in-progress"
 
 
@@ -167,8 +168,6 @@ class ServeController:
         if RAY_SERVE_THROUGHPUT_OPTIMIZED:
             self._log_throughput_opt_message()
 
-        self.global_tracing_config = global_tracing_config
-
         self._controller_node_id = ray.get_runtime_context().get_node_id()
         assert (
             self._controller_node_id == get_head_node_id()
@@ -190,6 +189,25 @@ class ServeController:
         if log_config_checkpoint is not None:
             global_logging_config = pickle.loads(log_config_checkpoint)
         self.reconfigure_global_logging_config(global_logging_config)
+
+        # Tracing config: a checkpointed config takes precedence over the one
+        # passed in the constructor. Defaults to an env-var-sourced
+        # TracingConfig so it is never None (single source of truth for
+        # setup_tracing).
+        tracing_config_checkpoint = self.kv_store.get(TRACING_CONFIG_CHECKPOINT_KEY)
+        if tracing_config_checkpoint is not None:
+            global_tracing_config = pickle.loads(tracing_config_checkpoint)
+        self.global_tracing_config: TracingConfig = (
+            global_tracing_config or TracingConfig()
+        )
+        if tracing_config_checkpoint is None:
+            self.kv_store.put(
+                TRACING_CONFIG_CHECKPOINT_KEY, pickle.dumps(self.global_tracing_config)
+            )
+        # Publish the initial snapshot so proxies receive it on their first poll.
+        self.long_poll_host.notify_changed(
+            {LongPollNamespace.GLOBAL_TRACING_CONFIG: self.global_tracing_config}
+        )
 
         configure_component_memory_profiler(
             component_name="controller", component_id=str(os.getpid())
@@ -345,9 +363,37 @@ class ServeController:
         msg += f"  • Request path log buffer size: {RAY_SERVE_REQUEST_PATH_LOG_BUFFER_SIZE}\n"
         logger.info(msg)
 
-    def get_tracing_config(self) -> Optional[TracingConfig]:
+    def get_tracing_config(self) -> "TracingConfig":
         """Return the global tracing config."""
         return self.global_tracing_config
+
+    def reconfigure_global_tracing_config(
+        self, global_tracing_config: Union[Dict, TracingConfig]
+    ):
+        """Apply a new global tracing config: checkpoint it and broadcast it.
+
+        The config is validated/coerced here because it is broadcast to every
+        proxy, which would otherwise fail on a malformed payload.
+        """
+        if isinstance(global_tracing_config, dict):
+            global_tracing_config = TracingConfig(**global_tracing_config)
+        elif not isinstance(global_tracing_config, TracingConfig):
+            raise TypeError(
+                "global_tracing_config must be a dict or TracingConfig; got "
+                f"{type(global_tracing_config).__name__}."
+            )
+
+        if self.global_tracing_config == global_tracing_config:
+            return
+
+        self.kv_store.put(
+            TRACING_CONFIG_CHECKPOINT_KEY, pickle.dumps(global_tracing_config)
+        )
+        self.global_tracing_config = global_tracing_config
+
+        self.long_poll_host.notify_changed(
+            {LongPollNamespace.GLOBAL_TRACING_CONFIG: global_tracing_config}
+        )
 
     def reconfigure_global_logging_config(self, global_logging_config: LoggingConfig):
         if (
@@ -1068,6 +1114,7 @@ class ServeController:
             self._shutdown_flag_persisted = True
         self.kv_store.delete(CONFIG_CHECKPOINT_KEY)
         self.kv_store.delete(LOGGING_CONFIG_CHECKPOINT_KEY)
+        self.kv_store.delete(TRACING_CONFIG_CHECKPOINT_KEY)
         self.application_state_manager.shutdown()
         self.deployment_state_manager.shutdown()
         self.endpoint_state.shutdown()
@@ -1243,10 +1290,11 @@ class ServeController:
         self._target_capacity = config.target_capacity
 
         # If a global tracing config is provided in the declarative config,
-        # store it so replicas and proxies started for this config pick it up
-        # when they fetch the tracing config from the controller.
+        # apply it: this checkpoints it and broadcasts it via long poll so
+        # already-running proxies pick up the change at runtime. Replicas read
+        # the config when they start, so they pick it up on their next start.
         if config.tracing_config is not None:
-            self.global_tracing_config = config.tracing_config
+            self.reconfigure_global_tracing_config(config.tracing_config)
 
         for app_config in config.applications:
             # If the application logging config is not set, use the global logging

--- a/python/ray/serve/_private/controller.py
+++ b/python/ray/serve/_private/controller.py
@@ -230,6 +230,10 @@ class ServeController:
         self.long_poll_host.notify_changed(
             {LongPollNamespace.GLOBAL_TRACING_CONFIG: self.global_tracing_config}
         )
+        # The tracing config's fields are resolved here (from the checkpoint or
+        # the RAY_SERVE_TRACING_* env vars read controller-side), so log it:
+        # this is the only place the effective, cluster-wide config is visible.
+        logger.info(f"Global tracing config: {self.global_tracing_config}.")
 
         configure_component_memory_profiler(
             component_name="controller", component_id=str(os.getpid())
@@ -416,6 +420,7 @@ class ServeController:
         self.long_poll_host.notify_changed(
             {LongPollNamespace.GLOBAL_TRACING_CONFIG: global_tracing_config}
         )
+        logger.info(f"Updated global tracing config to: {global_tracing_config}.")
 
     def reconfigure_global_logging_config(self, global_logging_config: LoggingConfig):
         if (

--- a/python/ray/serve/_private/controller.py
+++ b/python/ray/serve/_private/controller.py
@@ -81,6 +81,7 @@ from ray.serve._private.node_port_manager import NodePortManager
 from ray.serve._private.proxy import ProxyActor
 from ray.serve._private.proxy_state import ProxyStateManager
 from ray.serve._private.storage.kv_store import RayInternalKVStore
+from ray.serve._private.tracing_utils import validate_tracing_exporter_import_path
 from ray.serve._private.usage import ServeUsageTag
 from ray.serve._private.utils import (
     call_function_from_import_path,
@@ -397,6 +398,12 @@ class ServeController:
         proxy, which would otherwise fail on a malformed payload.
         """
         global_tracing_config = _coerce_tracing_config(global_tracing_config)
+
+        # Resolve the exporter import path now so an invalid path fails this
+        # `serve deploy` / `apply_config` request fast, instead of being
+        # checkpointed below and only surfacing later at each proxy/replica's
+        # `setup_tracing` (and reloading on controller recovery).
+        validate_tracing_exporter_import_path(global_tracing_config)
 
         if self.global_tracing_config == global_tracing_config:
             return

--- a/python/ray/serve/_private/controller.py
+++ b/python/ray/serve/_private/controller.py
@@ -1317,9 +1317,11 @@ class ServeController:
         self._target_capacity = config.target_capacity
 
         # If a global tracing config is provided in the declarative config,
-        # apply it: this checkpoints it and broadcasts it via long poll so
-        # already-running proxies pick up the change at runtime. Replicas read
-        # the config when they start, so they pick it up on their next start.
+        # apply it: this checkpoints it and broadcasts it via long poll.
+        # Proxies that have not yet set up tracing (started before it was
+        # enabled, or created afterward) pick it up; a proxy already tracing
+        # keeps its config for the life of its process (OpenTelemetry sets the
+        # tracer provider once). Replicas read the config when they start.
         if config.tracing_config is not None:
             self.reconfigure_global_tracing_config(config.tracing_config)
 

--- a/python/ray/serve/_private/long_poll.py
+++ b/python/ray/serve/_private/long_poll.py
@@ -61,6 +61,7 @@ class LongPollNamespace(Enum):
     DEPLOYMENT_TARGETS = auto()
     ROUTE_TABLE = auto()
     GLOBAL_LOGGING_CONFIG = auto()
+    GLOBAL_TRACING_CONFIG = auto()
     DEPLOYMENT_CONFIG = auto()
     TARGET_GROUPS = auto()
     FALLBACK_TARGETS = auto()

--- a/python/ray/serve/_private/proxy.py
+++ b/python/ray/serve/_private/proxy.py
@@ -1495,6 +1495,10 @@ class ProxyActorInterface(ABC):
         self._node_ip_address = node_ip_address
         self._logging_config = logging_config
         self._tracing_config = tracing_config
+        # Whether setup_tracing has already succeeded in this process. Tracing is
+        # set up at most once: OpenTelemetry only honors the first
+        # set_tracer_provider call per process.
+        self._tracing_setup_succeeded = False
         self._log_buffer_size = log_buffer_size
 
         self._update_logging_config(logging_config)
@@ -1623,22 +1627,31 @@ class ProxyActorInterface(ABC):
         Called with the initial long-poll snapshot and again whenever the global
         tracing config changes at runtime.
         """
-        if tracing_config == self._tracing_config:
-            # Already set up with this config. Re-running setup_tracing would
-            # not take effect anyway: OpenTelemetry only honors the first
-            # set_tracer_provider call in a process.
+        if self._tracing_setup_succeeded:
+            # OpenTelemetry only honors the first set_tracer_provider call in a
+            # process, so re-running setup here would keep the old sampler and
+            # attach duplicate span processors. Surface the ignored change
+            # instead of silently misapplying it.
+            if tracing_config != self._tracing_config:
+                logger.warning(
+                    "Tracing is already set up in this proxy, so the updated "
+                    "tracing config will only take effect once it restarts."
+                )
             return
+
         self._tracing_config = tracing_config
 
         # Never let this raise: it runs as a long poll callback, and an
         # exception would stop the proxy's long poll client from being
-        # rescheduled, freezing route table updates.
+        # rescheduled, freezing route table updates. Leave
+        # _tracing_setup_succeeded unset so a later update can retry.
         try:
             if setup_tracing(
                 component_name="proxy",
                 component_id=self._node_ip_address,
                 tracing_config=tracing_config,
             ):
+                self._tracing_setup_succeeded = True
                 logger.info("Successfully set up tracing for proxy")
         except Exception:
             logger.exception("Failed to set up tracing for proxy.")

--- a/python/ray/serve/_private/proxy.py
+++ b/python/ray/serve/_private/proxy.py
@@ -1617,6 +1617,32 @@ class ProxyActorInterface(ABC):
             buffer_size=self._log_buffer_size,
         )
 
+    def _update_tracing_config(self, tracing_config: TracingConfig):
+        """Set up tracing from a TracingConfig broadcast by the controller.
+
+        Called with the initial long-poll snapshot and again whenever the global
+        tracing config changes at runtime.
+        """
+        if tracing_config == self._tracing_config:
+            # Already set up with this config. Re-running setup_tracing would
+            # not take effect anyway: OpenTelemetry only honors the first
+            # set_tracer_provider call in a process.
+            return
+        self._tracing_config = tracing_config
+
+        # Never let this raise: it runs as a long poll callback, and an
+        # exception would stop the proxy's long poll client from being
+        # rescheduled, freezing route table updates.
+        try:
+            if setup_tracing(
+                component_name="proxy",
+                component_id=self._node_ip_address,
+                tracing_config=tracing_config,
+            ):
+                logger.info("Successfully set up tracing for proxy")
+        except Exception:
+            logger.exception("Failed to set up tracing for proxy.")
+
 
 @ray.remote(num_cpus=0)
 class ProxyActor(ProxyActorInterface):
@@ -1647,19 +1673,12 @@ class ProxyActor(ProxyActorInterface):
             ray.get_actor(SERVE_CONTROLLER_NAME, namespace=SERVE_NAMESPACE),
             {
                 LongPollNamespace.GLOBAL_LOGGING_CONFIG: self._update_logging_config,
+                LongPollNamespace.GLOBAL_TRACING_CONFIG: self._update_tracing_config,
                 LongPollNamespace.ROUTE_TABLE: self._update_routes_in_proxies,
             },
             call_in_event_loop=event_loop,
             client_id=f"{type(self).__name__}:{ray.get_runtime_context().get_actor_id()}",
         )
-
-        is_tracing_setup_successful = setup_tracing(
-            component_name="proxy",
-            component_id=node_ip_address,
-            tracing_config=self._tracing_config,
-        )
-        if is_tracing_setup_successful:
-            logger.info("Successfully set up tracing for proxy")
 
         startup_msg = f"Proxy starting on node {self._node_id} (HTTP port: {self._http_options.port}"
         if grpc_enabled:

--- a/python/ray/serve/_private/proxy.py
+++ b/python/ray/serve/_private/proxy.py
@@ -1624,18 +1624,26 @@ class ProxyActorInterface(ABC):
     def _update_tracing_config(self, tracing_config: TracingConfig):
         """Set up tracing from a TracingConfig broadcast by the controller.
 
-        Called with the initial long-poll snapshot and again whenever the global
-        tracing config changes at runtime.
+        Tracing can only be *set up* once per proxy process: OpenTelemetry
+        honors just the first ``set_tracer_provider`` call. So this enables
+        tracing on a proxy that started before tracing was configured, but once
+        a proxy is tracing, later config changes (sampling ratio, disabling, or
+        the exporter) do not take effect in that process -- they only apply to
+        proxies started afterward.
         """
         if self._tracing_setup_succeeded:
             # OpenTelemetry only honors the first set_tracer_provider call in a
-            # process, so re-running setup here would keep the old sampler and
-            # attach duplicate span processors. Surface the ignored change
-            # instead of silently misapplying it.
+            # process, so a changed config cannot be applied here: re-running
+            # setup would keep the original sampler and duplicate span
+            # processors. Store the new config first so this warns only once
+            # (not on every controller-recovery re-broadcast), then surface
+            # that the change is not applied rather than silently dropping it.
             if tracing_config != self._tracing_config:
+                self._tracing_config = tracing_config
                 logger.warning(
-                    "Tracing is already set up in this proxy, so the updated "
-                    "tracing config will only take effect once it restarts."
+                    "Tracing is already set up in this proxy; the updated "
+                    "tracing config does not take effect in this process. It "
+                    "applies only to proxies started afterward."
                 )
             return
 

--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -1197,7 +1197,7 @@ class Replica:
             component_name=self._component_name,
             component_id=self._component_id,
             # ray.get of the ActorHandle result is mistyped as list; it is a
-            # TracingConfig | None at runtime.
+            # TracingConfig at runtime (the controller never returns None).
             tracing_config=tracing_config,  # type: ignore[arg-type]
         )
         if is_tracing_setup_successful:

--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -1192,16 +1192,25 @@ class Replica:
         tracing_config = ray.get(
             self._controller_handle.get_tracing_config.remote()  # type: ignore[attr-defined]
         )
-        is_tracing_setup_successful = setup_tracing(
-            component_type=ServeComponentType.REPLICA,
-            component_name=self._component_name,
-            component_id=self._component_id,
-            # ray.get of the ActorHandle result is mistyped as list; it is a
-            # TracingConfig at runtime (the controller never returns None).
-            tracing_config=tracing_config,  # type: ignore[arg-type]
-        )
-        if is_tracing_setup_successful:
-            logger.info("Successfully set up tracing for replica")
+        # Never let a bad tracing config crash replica startup: mirror the
+        # proxy's long-poll handler, which logs and continues. A bad
+        # `exporter_import_path` raises out of `import_attr` inside
+        # `setup_tracing`; the controller validates the path at deploy time,
+        # but that check runs against the head node, so a path importable
+        # there may still fail to import on this worker node.
+        try:
+            is_tracing_setup_successful = setup_tracing(
+                component_type=ServeComponentType.REPLICA,
+                component_name=self._component_name,
+                component_id=self._component_id,
+                # ray.get of the ActorHandle result is mistyped as list; it is a
+                # TracingConfig at runtime (the controller never returns None).
+                tracing_config=tracing_config,  # type: ignore[arg-type]
+            )
+            if is_tracing_setup_successful:
+                logger.info("Successfully set up tracing for replica")
+        except Exception:
+            logger.exception("Failed to set up tracing for replica.")
 
         # get node ID
         self._node_id = ray.get_runtime_context().get_node_id()

--- a/python/ray/serve/_private/tracing_utils.py
+++ b/python/ray/serve/_private/tracing_utils.py
@@ -8,8 +8,6 @@ from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, cast
 from ray._common.utils import import_attr
 from ray.serve._private.constants import (
     DEFAULT_TRACING_EXPORTER_IMPORT_PATH,
-    RAY_SERVE_TRACING_EXPORTER_IMPORT_PATH,
-    RAY_SERVE_TRACING_SAMPLING_RATIO,
 )
 
 if TYPE_CHECKING:
@@ -241,7 +239,8 @@ def setup_tracing(
     component_name: str,
     component_id: str,
     component_type: Optional["ServeComponentType"] = None,  # noqa: F821
-    tracing_config: Optional["TracingConfig"] = None,  # noqa: F821
+    *,
+    tracing_config: "TracingConfig",  # noqa: F821
 ) -> bool:
     """
     Set up tracing for a specific Serve component.
@@ -250,33 +249,24 @@ def setup_tracing(
         component_name: The name of the component.
         component_id: The unique identifier of the component.
         component_type: The type of the component.
-        tracing_config: Optional TracingConfig instance. When provided, the
-            exporter and sampling ratio are read from it. When None, tracing
-            falls back to the RAY_SERVE_TRACING_* environment variables.
+        tracing_config: The TracingConfig to set up tracing with. This is the
+            single source of truth; its fields default from the
+            RAY_SERVE_TRACING_* environment variables (see TracingConfig).
 
     Returns:
         bool: True if tracing setup is successful, False otherwise.
     """
     global _tracing_enabled
 
-    if tracing_config is not None:
-        # Use TracingConfig-based configuration
-        if not tracing_config.enabled:
-            _tracing_enabled = False
-            return False
-        tracing_exporter_import_path = tracing_config.exporter_import_path
-        # Fill default exporter if enabled but path is empty
-        if not tracing_exporter_import_path:
-            tracing_exporter_import_path = DEFAULT_TRACING_EXPORTER_IMPORT_PATH
-        tracing_sampling_ratio = tracing_config.sampling_ratio
-    else:
-        # No TracingConfig provided: fall back to env-var configuration.
-        tracing_exporter_import_path = RAY_SERVE_TRACING_EXPORTER_IMPORT_PATH
-        tracing_sampling_ratio = RAY_SERVE_TRACING_SAMPLING_RATIO
-
-    if tracing_exporter_import_path == "":
+    if not tracing_config.enabled:
         _tracing_enabled = False
         return False
+
+    tracing_exporter_import_path = tracing_config.exporter_import_path
+    # Fill default exporter if enabled but path is empty
+    if not tracing_exporter_import_path:
+        tracing_exporter_import_path = DEFAULT_TRACING_EXPORTER_IMPORT_PATH
+    tracing_sampling_ratio = tracing_config.sampling_ratio
 
     # Check dependencies
     if not trace:

--- a/python/ray/serve/_private/tracing_utils.py
+++ b/python/ray/serve/_private/tracing_utils.py
@@ -235,6 +235,32 @@ def tracing_decorator_factory(
     return tracing_decorator
 
 
+def validate_tracing_exporter_import_path(
+    tracing_config: "TracingConfig",  # noqa: F821
+) -> None:
+    """Eagerly resolve the exporter import path so a bad one fails fast.
+
+    Mirrors the path resolution in ``setup_tracing``: when tracing is enabled,
+    the effective exporter import path (the user-provided path, or the default
+    when empty) must be importable. Propagates whatever ``import_attr`` raises
+    (e.g. ``ModuleNotFoundError`` / ``AttributeError``).
+
+    The controller calls this before checkpointing/broadcasting a config so an
+    invalid path fails the ``serve deploy`` / ``apply_config`` request instead
+    of being persisted and only surfacing later at each proxy/replica. Note
+    this validates against the *caller's* environment, so proxies and replicas
+    still guard their own ``setup_tracing`` calls (a path importable on the
+    head node may not be importable on a worker node).
+    """
+    if not tracing_config.enabled:
+        return
+    exporter_import_path = (
+        tracing_config.exporter_import_path or DEFAULT_TRACING_EXPORTER_IMPORT_PATH
+    )
+    # We only need to confirm the path resolves; discard the result.
+    import_attr(exporter_import_path)
+
+
 def setup_tracing(
     component_name: str,
     component_id: str,

--- a/python/ray/serve/tests/test_standalone.py
+++ b/python/ray/serve/tests/test_standalone.py
@@ -709,14 +709,11 @@ def test_serve_start_proxy_location(ray_shutdown, options):
 
 def test_serve_start_tracing_config_imperative_flow(ray_shutdown):
     """Tracing config passed to ``serve.start()`` reaches the controller and is
-    applied to replicas (the imperative flow).
+    applied to both replicas and proxies (the imperative flow).
 
-    Verifies that the controller stores the config and that, after a request,
-    a tracing span file is produced for the replica -- proving the config
-    propagated from serve.start() through the controller to the replica.
-
-    Note: proxy tracing is not wired via this path (proxies start before the
-    controller is queryable); that is handled separately via long poll.
+    Verifies the controller stores the config and that, after a request, tracing
+    span files are produced for the replica (which pulls the config at init) and
+    the proxy (which receives it via the GLOBAL_TRACING_CONFIG long poll).
     """
     tracing_config = TracingConfig(enabled=True, sampling_ratio=1.0)
     serve.start(
@@ -742,15 +739,43 @@ def test_serve_start_tracing_config_imperative_flow(ray_shutdown):
     url = get_application_url("HTTP")
     assert httpx.post(f"{url}/").text == "hello"
 
-    serve.shutdown()
-
-    # Tracing was set up on the replica, so a replica span file exists.
+    # Tracing was set up on the replica and (via long poll) the proxy, so span
+    # files are produced for both.
     spans_dir = os.path.join(get_serve_logs_dir(), "spans")
-    span_files = os.listdir(spans_dir)
+
+    def replica_and_proxy_traces_created() -> bool:
+        if not os.path.isdir(spans_dir):
+            return False
+        files = os.listdir(spans_dir)
+        return any("replica" in f for f in files) and any("proxy" in f for f in files)
+
     try:
-        assert any("replica" in f for f in span_files), span_files
+        wait_for_condition(replica_and_proxy_traces_created, timeout=20)
     finally:
+        serve.shutdown()
         shutil.rmtree(spans_dir, ignore_errors=True)
+
+
+def test_serve_tracing_config_survives_controller_recovery(ray_shutdown):
+    """A tracing config is checkpointed and restored after controller recovery."""
+    serve.start(tracing_config=TracingConfig(enabled=True, sampling_ratio=0.5))
+    client = _get_global_client()
+
+    # Change the config after startup so the checkpoint is the only place the
+    # new value exists: Ray replays the controller's constructor args on
+    # restart, so a config passed to serve.start() would be restored even
+    # without a checkpoint.
+    updated_config = TracingConfig(enabled=True, sampling_ratio=1.0)
+    ray.get(client._controller.reconfigure_global_tracing_config.remote(updated_config))
+    assert ray.get(client._controller.get_tracing_config.remote()) == updated_config
+
+    # Kill the controller; on recovery it should restore the updated config from
+    # its checkpoint rather than the (stale) constructor argument.
+    pid = ray.get(client._controller.get_pid.remote())
+    ray.kill(client._controller, no_restart=False)
+    wait_for_condition(lambda: ray.get(client._controller.get_pid.remote()) != pid)
+
+    assert ray.get(client._controller.get_tracing_config.remote()) == updated_config
 
 
 @pytest.mark.parametrize(

--- a/python/ray/serve/tests/test_standalone.py
+++ b/python/ray/serve/tests/test_standalone.py
@@ -22,6 +22,7 @@ from ray import serve
 from ray._common.test_utils import run_string_as_driver, wait_for_condition
 from ray._raylet import GcsClient
 from ray.cluster_utils import Cluster, cluster_not_supported
+from ray.exceptions import RayTaskError
 from ray.serve._private.api import serve_start_async
 from ray.serve._private.constants import (
     RAY_SERVE_ENABLE_HA_PROXY,
@@ -707,6 +708,27 @@ def test_serve_start_proxy_location(ray_shutdown, options):
     assert client.get_serve_details()["proxy_location"] == expected
 
 
+def _span_file_contains(spans_dir: str, component: str, span_name: str) -> bool:
+    """Whether a span file for ``component`` records a span named ``span_name``.
+
+    The default file exporter opens the span file at setup time, so a file
+    merely existing does not prove a span was emitted; the exported span JSON
+    embeds its name, so assert on file contents instead.
+    """
+    if not os.path.isdir(spans_dir):
+        return False
+    for fname in os.listdir(spans_dir):
+        if component not in fname:
+            continue
+        try:
+            with open(os.path.join(spans_dir, fname)) as f:
+                if span_name in f.read():
+                    return True
+        except OSError:
+            continue
+    return False
+
+
 def test_serve_start_tracing_config_imperative_flow(ray_shutdown):
     """Tracing config passed to ``serve.start()`` reaches the controller and is
     applied to both replicas and proxies (the imperative flow).
@@ -739,15 +761,18 @@ def test_serve_start_tracing_config_imperative_flow(ray_shutdown):
     url = get_application_url("HTTP")
     assert httpx.post(f"{url}/").text == "hello"
 
-    # Tracing was set up on the replica and (via long poll) the proxy, so span
-    # files are produced for both.
+    # Tracing was set up on the replica and (via long poll) the proxy, so each
+    # emits a span. Assert on span *contents*, not just file existence: the file
+    # exporter creates the file at setup time, so an empty file would pass an
+    # existence-only check even if no span was ever emitted.
     spans_dir = os.path.join(get_serve_logs_dir(), "spans")
 
     def replica_and_proxy_traces_created() -> bool:
-        if not os.path.isdir(spans_dir):
-            return False
-        files = os.listdir(spans_dir)
-        return any("replica" in f for f in files) and any("proxy" in f for f in files)
+        # The replica runs the user code that emits ``application_span``; the
+        # proxy emits ``proxy_http_request`` for the HTTP request it forwards.
+        return _span_file_contains(
+            spans_dir, "replica", "application_span"
+        ) and _span_file_contains(spans_dir, "proxy", "proxy_http_request")
 
     try:
         wait_for_condition(replica_and_proxy_traces_created, timeout=20)
@@ -776,6 +801,77 @@ def test_serve_tracing_config_survives_controller_recovery(ray_shutdown):
     wait_for_condition(lambda: ray.get(client._controller.get_pid.remote()) != pid)
 
     assert ray.get(client._controller.get_tracing_config.remote()) == updated_config
+
+
+def test_serve_tracing_config_enabled_at_runtime_reaches_proxy(ray_shutdown):
+    """Enabling tracing at runtime propagates to an already-running proxy.
+
+    The proxy subscribes to the GLOBAL_TRACING_CONFIG long poll, so a config
+    change made after the proxy started still reaches it and it begins emitting
+    spans. This is the runtime-reconfiguration path this PR adds.
+    """
+    # Start with tracing disabled so the proxy has not set tracing up yet:
+    # OpenTelemetry only honors the first set_tracer_provider per process, so a
+    # proxy that started enabled could not adopt a later change.
+    serve.start(
+        http_options=HTTPOptions(host="0.0.0.0"),
+        tracing_config=TracingConfig(enabled=False),
+    )
+    client = _get_global_client()
+
+    @serve.deployment
+    class Model:
+        def __call__(self, request):
+            return "hello"
+
+    serve.run(Model.bind())
+
+    url = get_application_url("HTTP")
+    assert httpx.post(f"{url}/").text == "hello"
+
+    spans_dir = os.path.join(get_serve_logs_dir(), "spans")
+    # Drop any files from the disabled phase so we only observe post-enable spans.
+    shutil.rmtree(spans_dir, ignore_errors=True)
+
+    # Enable tracing at runtime; the controller broadcasts it over long poll.
+    ray.get(
+        client._controller.reconfigure_global_tracing_config.remote(
+            TracingConfig(enabled=True, sampling_ratio=1.0)
+        )
+    )
+
+    def proxy_emits_span() -> bool:
+        # Drive traffic each poll so the proxy has a request to trace once its
+        # long-poll callback has set tracing up.
+        httpx.post(f"{url}/")
+        return _span_file_contains(spans_dir, "proxy", "proxy_http_request")
+
+    try:
+        wait_for_condition(proxy_emits_span, timeout=30)
+    finally:
+        serve.shutdown()
+        shutil.rmtree(spans_dir, ignore_errors=True)
+
+
+def test_reconfigure_rejects_bad_exporter_import_path(ray_shutdown):
+    """A bad exporter_import_path is rejected before it is checkpointed/broadcast.
+
+    The controller resolves the path eagerly, so `serve deploy` / `apply_config`
+    fails fast and the previously-applied config is left untouched (rather than
+    persisting a value that would only break later at each proxy/replica).
+    """
+    good_config = TracingConfig(enabled=True, sampling_ratio=1.0)
+    serve.start(tracing_config=good_config)
+    client = _get_global_client()
+    assert ray.get(client._controller.get_tracing_config.remote()) == good_config
+
+    bad_config = TracingConfig(enabled=True, exporter_import_path="no.such.module:nope")
+    with pytest.raises(RayTaskError):
+        ray.get(client._controller.reconfigure_global_tracing_config.remote(bad_config))
+
+    # The rejected config was not applied; the previous one is still in effect.
+    assert ray.get(client._controller.get_tracing_config.remote()) == good_config
+    serve.shutdown()
 
 
 @pytest.mark.parametrize(

--- a/python/ray/serve/tests/test_standalone.py
+++ b/python/ray/serve/tests/test_standalone.py
@@ -25,6 +25,7 @@ from ray.cluster_utils import Cluster, cluster_not_supported
 from ray.exceptions import RayTaskError
 from ray.serve._private.api import serve_start_async
 from ray.serve._private.constants import (
+    RAY_SERVE_ENABLE_DIRECT_INGRESS,
     RAY_SERVE_ENABLE_HA_PROXY,
     SERVE_DEFAULT_APP_NAME,
     SERVE_NAMESPACE,
@@ -708,6 +709,13 @@ def test_serve_start_proxy_location(ray_shutdown, options):
     assert client.get_serve_details()["proxy_location"] == expected
 
 
+# The Python proxy only sits in the HTTP request path (and emits
+# ``proxy_http_request`` spans) in the default ingress mode. Under HAProxy or
+# direct ingress the data plane bypasses it, so proxy-span assertions do not
+# apply; skip proxy-focused tracing tests in those modes.
+_ALT_INGRESS_ENABLED = RAY_SERVE_ENABLE_HA_PROXY or RAY_SERVE_ENABLE_DIRECT_INGRESS
+
+
 def _span_file_contains(spans_dir: str, component: str, span_name: str) -> bool:
     """Whether a span file for ``component`` records a span named ``span_name``.
 
@@ -729,6 +737,10 @@ def _span_file_contains(spans_dir: str, component: str, span_name: str) -> bool:
     return False
 
 
+@pytest.mark.skipif(
+    _ALT_INGRESS_ENABLED,
+    reason="Proxy does not emit request spans under HAProxy/direct ingress.",
+)
 def test_serve_start_tracing_config_imperative_flow(ray_shutdown):
     """Tracing config passed to ``serve.start()`` reaches the controller and is
     applied to both replicas and proxies (the imperative flow).
@@ -803,6 +815,10 @@ def test_serve_tracing_config_survives_controller_recovery(ray_shutdown):
     assert ray.get(client._controller.get_tracing_config.remote()) == updated_config
 
 
+@pytest.mark.skipif(
+    _ALT_INGRESS_ENABLED,
+    reason="Proxy does not emit request spans under HAProxy/direct ingress.",
+)
 def test_serve_tracing_config_enabled_at_runtime_reaches_proxy(ray_shutdown):
     """Enabling tracing at runtime propagates to an already-running proxy.
 

--- a/python/ray/serve/tests/test_tracing_utils.py
+++ b/python/ray/serve/tests/test_tracing_utils.py
@@ -38,6 +38,7 @@ from ray.serve._private.tracing_utils import (
     _validate_tracing_exporter_processors,
     set_trace_status,
     setup_tracing,
+    validate_tracing_exporter_import_path,
 )
 from ray.serve.config import HTTPOptions, gRPCOptions
 from ray.serve.generated import serve_pb2, serve_pb2_grpc
@@ -110,6 +111,41 @@ def test_validate_tracing_exporter_with_string():
     for invalid_exporter in invalid_exporters:
         with pytest.raises(TypeError, match=expected_exception):
             _validate_tracing_exporter(invalid_exporter)
+
+
+def test_validate_tracing_exporter_import_path():
+    """The controller-side fail-fast validator resolves the exporter path.
+
+    Regression coverage for #65437 review: a bad `exporter_import_path` must
+    fail the deploy request rather than being checkpointed/broadcast.
+    """
+    # Disabled tracing never resolves the path, even a bogus one.
+    validate_tracing_exporter_import_path(
+        TracingConfig(enabled=False, exporter_import_path="no.such.module:nope")
+    )
+
+    # Enabled with an empty path falls back to the (importable) default.
+    validate_tracing_exporter_import_path(TracingConfig(enabled=True))
+    validate_tracing_exporter_import_path(
+        TracingConfig(
+            enabled=True, exporter_import_path=DEFAULT_TRACING_EXPORTER_IMPORT_PATH
+        )
+    )
+
+    # Enabled with a bogus path fails fast.
+    with pytest.raises((ImportError, AttributeError)):
+        validate_tracing_exporter_import_path(
+            TracingConfig(enabled=True, exporter_import_path="no.such.module:nope")
+        )
+    with pytest.raises((ImportError, AttributeError)):
+        validate_tracing_exporter_import_path(
+            TracingConfig(
+                enabled=True,
+                exporter_import_path=(
+                    "ray.serve._private.tracing_utils:does_not_exist"
+                ),
+            )
+        )
 
 
 def test_validate_tracing_exporter_with_args():

--- a/python/ray/serve/tests/unit/test_proxy.py
+++ b/python/ray/serve/tests/unit/test_proxy.py
@@ -1,6 +1,7 @@
 import asyncio
 import pickle
 import sys
+from types import SimpleNamespace
 from typing import Dict, List, Tuple
 from unittest.mock import AsyncMock
 
@@ -13,6 +14,7 @@ from ray.serve._private.constants import HEALTHY_MESSAGE
 from ray.serve._private.proxy import (
     DRAINING_MESSAGE,
     HTTPProxy,
+    ProxyActorInterface,
     ResponseGenerator,
     ResponseStatus,
     gRPCProxy,
@@ -488,6 +490,35 @@ class TestgRPCProxy:
         assert context.details() == ""
 
 
+def test_update_tracing_config_swallows_setup_failure():
+    """A bad tracing config must not crash the proxy's long-poll handler.
+
+    Regression coverage for #65437 review: `_update_tracing_config` runs as a
+    long-poll callback, so a raising `setup_tracing` (e.g. a bad
+    `exporter_import_path`) must be swallowed. Setup is left marked
+    unsucceeded so a later (valid) delivery can retry.
+
+    `_update_tracing_config` only reads/writes `_tracing_setup_succeeded`,
+    `_tracing_config`, and `_node_ip_address`, so exercise it against a
+    lightweight stand-in rather than constructing a full proxy actor.
+    """
+    proxy = SimpleNamespace(
+        _tracing_setup_succeeded=False,
+        _tracing_config=None,
+        _node_ip_address="fake-node-ip",
+    )
+
+    # A bogus exporter path raises inside setup_tracing; the callback must not
+    # propagate it (which would wedge the proxy's long poll client).
+    ProxyActorInterface._update_tracing_config(
+        proxy,
+        TracingConfig(enabled=True, exporter_import_path="no.such.module:nope"),
+    )
+
+    # Setup did not succeed, so a later valid update can still retry.
+    assert proxy._tracing_setup_succeeded is False
+
+
 class TestHTTPProxy:
     """Test methods implemented on HTTPProxy"""
 
@@ -508,26 +539,6 @@ class TestHTTPProxy:
             proxy_router=FakeProxyRouter(),
             self_actor_name="fake-proxy-name",
         )
-
-    def test_update_tracing_config_swallows_setup_failure(self):
-        """A bad tracing config must not crash the proxy's long-poll handler.
-
-        Regression coverage for #65437 review: `_update_tracing_config` runs as
-        a long-poll callback, so a raising `setup_tracing` (e.g. a bad
-        `exporter_import_path`) must be swallowed. Setup is left marked
-        unsucceeded so a later (valid) delivery can retry.
-        """
-        http_proxy = self.create_http_proxy()
-        assert http_proxy._tracing_setup_succeeded is False
-
-        # A bogus exporter path raises inside setup_tracing; the callback must
-        # not propagate it (which would wedge the proxy's long poll client).
-        http_proxy._update_tracing_config(
-            TracingConfig(enabled=True, exporter_import_path="no.such.module:nope")
-        )
-
-        # Setup did not succeed, so a later valid update can still retry.
-        assert http_proxy._tracing_setup_succeeded is False
 
     @pytest.mark.asyncio
     async def test_not_found_response(self):

--- a/python/ray/serve/tests/unit/test_proxy.py
+++ b/python/ray/serve/tests/unit/test_proxy.py
@@ -31,6 +31,7 @@ from ray.serve._private.test_utils import FakeGrpcContext, MockDeploymentHandle
 from ray.serve._private.thirdparty.get_asgi_route_name import RoutePattern
 from ray.serve.generated import serve_pb2
 from ray.serve.grpc_util import RayServegRPCContext
+from ray.serve.schema import TracingConfig
 
 ROUTER_NOT_READY_FOR_TRAFFIC_MESSAGE = "Router is not ready for traffic"
 
@@ -507,6 +508,26 @@ class TestHTTPProxy:
             proxy_router=FakeProxyRouter(),
             self_actor_name="fake-proxy-name",
         )
+
+    def test_update_tracing_config_swallows_setup_failure(self):
+        """A bad tracing config must not crash the proxy's long-poll handler.
+
+        Regression coverage for #65437 review: `_update_tracing_config` runs as
+        a long-poll callback, so a raising `setup_tracing` (e.g. a bad
+        `exporter_import_path`) must be swallowed. Setup is left marked
+        unsucceeded so a later (valid) delivery can retry.
+        """
+        http_proxy = self.create_http_proxy()
+        assert http_proxy._tracing_setup_succeeded is False
+
+        # A bogus exporter path raises inside setup_tracing; the callback must
+        # not propagate it (which would wedge the proxy's long poll client).
+        http_proxy._update_tracing_config(
+            TracingConfig(enabled=True, exporter_import_path="no.such.module:nope")
+        )
+
+        # Setup did not succeed, so a later valid update can still retry.
+        assert http_proxy._tracing_setup_succeeded is False
 
     @pytest.mark.asyncio
     async def test_not_found_response(self):


### PR DESCRIPTION
Follow-up to #63273 ([1/2]) completing the TracingConfig feature.

- Added a `GLOBAL_TRACING_CONFIG` long-poll namespace. The controller broadcasts the global tracing config which is subscribed by the proxies, which runs `setup_tracing` on delivery. This wires proxy tracing without the init-time controller callback that cannot work (proxies can start before the controller). This broadcast mechanism also lets users change the tracing config at runtime through the existing serve-config API.

- Controller: 
  - checkpoint-ing the tracing config (So that it can be restored during the recovery).  
  - Default it to an env-var-sourced TracingConfig() so it is never `None`, else it will cause attribute error.
  - Publishing the initial snapshot, and broadcasting changes from apply_config. get_tracing_config().
  - reconfigure validates its input since the value is broadcasted cluster-wide.

- `tracing_utils.setup_tracing`: 
  - dropped the env-var fallback and the empty-path check,
  - `tracing_config` is now required (single source of truth). Its fields already default from the RAY_SERVE_TRACING_* env vars.

- Proxy sets tracing up only from the long-poll callback, so `set_tracer_provider` is called once per process.

- Replicas continue to read the config when they start.

- Tests: assert proxy traces are produced via the imperative flow, and that a tracing config changed after startup survives controller recovery (so the checkpoint, not the constructor arg, is exercised).


This PR used Claude Code Assistant for writing code. 
