### PR TITLE
[serve][llm] Surface engine errors on the direct-streaming ASGI app

### DIFF
--- a/python/ray/llm/_internal/serve/engines/vllm/vllm_engine.py
+++ b/python/ray/llm/_internal/serve/engines/vllm/vllm_engine.py
@@ -357,6 +357,13 @@ class VLLMEngine(LLMEngine):
             self._vllm_args,
             supported_tasks=supported_tasks,
         )
+        # On an engine error, vLLM's handler reads state.server -- the uvicorn.Server
+        # its own launcher sets -- and flips should_exit on it, which is what makes
+        # uvicorn stop serving and the process exit. Ray runs no uvicorn loop to
+        # observe that flag (Serve restarts the replica via check_health), but the
+        # read must still succeed: otherwise it raises AttributeError, and that
+        # replaces the engine error in the response.
+        app.state.server = types.SimpleNamespace()
         if self._token_receiver is not None:
             install_prompt_token_forwarding(
                 app.state,

--- a/python/ray/llm/tests/serve/cpu/deployments/llm/test_llm_server.py
+++ b/python/ray/llm/tests/serve/cpu/deployments/llm/test_llm_server.py
@@ -3,10 +3,14 @@ import sys
 import time
 from types import SimpleNamespace
 from typing import AsyncGenerator, Optional
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import numpy as np
 import pytest
+from fastapi.testclient import TestClient
+from vllm.entrypoints.openai.cli_args import make_arg_parser
+from vllm.utils.argparse_utils import FlexibleArgumentParser
+from vllm.v1.engine.exceptions import EngineDeadError
 
 from ray import serve
 from ray.llm._internal.serve.core.configs.llm_config import (
@@ -18,6 +22,7 @@ from ray.llm._internal.serve.core.configs.openai_api_models import CompletionReq
 from ray.llm._internal.serve.core.protocol import RawRequestInfo
 from ray.llm._internal.serve.core.server.llm_server import LLMServer
 from ray.llm._internal.serve.engines.vllm.vllm_engine import (
+    VLLMEngine,
     _canonicalize_request_id_header,
 )
 from ray.llm.tests.serve.mocks.mock_vllm_engine import (
@@ -783,6 +788,41 @@ class TestMaybeAddRequestId:
         finally:
             serve.context._serve_request_context.set(serve.context._RequestContext())
         assert not hasattr(req, "request_id")
+
+
+class TestBuildAsgiApp:
+    """``VLLMEngine.build_asgi_app`` must produce an app vLLM's error handlers work on."""
+
+    @pytest.mark.asyncio
+    async def test_engine_error_reaches_the_client(self):
+        """A dead engine reports vLLM's error, not the handler's own AttributeError.
+
+        vLLM's engine error handler reads ``app.state.server``, which neither
+        ``build_app`` nor ``init_app_state`` sets.
+        """
+        vllm_args = make_arg_parser(FlexibleArgumentParser()).parse_args([])
+        engine = VLLMEngine.__new__(VLLMEngine)
+        engine._vllm_args = vllm_args
+        engine._engine_client = SimpleNamespace(model_config=None)
+        engine._token_receiver = None
+
+        # init_app_state needs a live engine; supply only what the handler reads.
+        with patch(
+            "vllm.entrypoints.openai.api_server.init_app_state",
+            new_callable=AsyncMock,
+        ):
+            app = await engine.build_asgi_app()
+        app.state.args = vllm_args
+        app.state.engine_client = SimpleNamespace(errored=True, is_running=False)
+
+        @app.get("/engine_dead")
+        async def engine_dead():
+            raise EngineDeadError()
+
+        response = TestClient(app, raise_server_exceptions=False).get("/engine_dead")
+
+        assert response.status_code == 500
+        assert "EngineCore encountered an issue" in response.json()["error"]["message"]
 
 
 if __name__ == "__main__":

--- a/python/ray/llm/tests/serve/cpu/deployments/llm/test_llm_server.py
+++ b/python/ray/llm/tests/serve/cpu/deployments/llm/test_llm_server.py
@@ -800,6 +800,14 @@ class TestBuildAsgiApp:
         vLLM's engine error handler reads ``app.state.server``, which neither
         ``build_app`` nor ``init_app_state`` sets.
         """
+        # Building the parser resolves VllmConfig's defaults, which infer the device
+        # type. A GPU-less CI node has no vLLM platform, so pin one; this app is never
+        # served and no engine is started.
+        from vllm.platforms import current_platform
+
+        if not current_platform.device_type:
+            current_platform.device_type = "cpu"
+
         vllm_args = make_arg_parser(FlexibleArgumentParser()).parse_args([])
         engine = VLLMEngine.__new__(VLLMEngine)
         engine._vllm_args = vllm_args


### PR DESCRIPTION
## Description
vLLM's **engine error handler** reads `app.state.server` to flip `should_exit` and stop the uvicorn server its launcher created. `VLLMEngine.build_asgi_app` calls only `build_app` and `init_app_state`, neither of which sets it. So on the direct-streaming path, every `EngineGenerateError` / `EngineDeadError` raises `AttributeError` inside the handler, and that replaces the engine error, and therefore clients get 'State' object has no attribute 'server' instead of the real failure.

## Solution
Supply a dummy object that just tolerates an attribute write `types.SimpleNamespace()`. Nothing reads `should_exit`; `terminate_if_errored` only assigns it. With the read satisfied, the handler runs on to `create_error_response(exc)` and returns vLLM's real error. Discarding the write is safe: `should_exit` only stops vLLM's uvicorn loop, which Ray never runs — Serve restarts replicas via `LLMServer.check_health`.

## Reproduction
Stand up a server with the following script and environment variables `RAY_SERVE_LLM_ENABLE_DIRECT_STREAMING=1` and `RAY_SERVE_ENABLE_HA_PROXY=1`.
```
# serve_app.py
from ray import serve
from ray.serve.llm import LLMConfig, LLMServingArgs, build_openai_app

llm_config = LLMConfig(
    model_loading_config=dict(
        model_id="qwen",
        model_source="Qwen/Qwen3-0.6B",
    ),
    deployment_config=dict(
        autoscaling_config=dict(min_replicas=1, max_replicas=1),
    ),
)

serve.run(build_openai_app(LLMServingArgs(llm_configs=[llm_config])), blocking=True)

```

- Before
```
{
  "error": {
    "message": "'State' object has no attribute 'server'",
    "type": "InternalServerError",
    "param": null,
    "code": 500
  }
}
```

- After
```
{
  "error": {
    "message": "EngineCore encountered an issue. See stack trace (above) for the root cause.",
    "type": "InternalServerError",
    "param": null,
    "code": 500
  }
}
```

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
### Why is this bug only discovered when we upgrade to vLLM 0.27.0?
`app.state.server` was always missing in Ray: only vLLM's launcher sets it, and Ray runs no uvicorn loop. In 0.26, handlers were registered per exception type: a bad request stayed a `ValueError` and matched a handler that never reads `state.server`. Only a genuine engine death reached the one that does, which release tests never provoked. In 0.27, `generate()` wraps bad requests as `EngineGenerateError`, routing routine 4xx traffic through that handler and exposing the `AttributeError`.
