### PR TITLE
[Data] Cluster autoscaler requests a bundle larger than the node it was copied from, because node memory is rounded up

### DIFF
--- a/python/ray/data/_internal/cluster_autoscaler/default_cluster_autoscaler_v2.py
+++ b/python/ray/data/_internal/cluster_autoscaler/default_cluster_autoscaler_v2.py
@@ -33,6 +33,12 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+# Granularity that node memory is quantized to when building a node resource
+# spec. Nodes of the same type can report slightly different physical memory
+# (e.g. 14.87 GiB vs 14.93 GiB) because of non-deterministic memory
+# availability at Ray init time.
+_MEMORY_QUANTIZATION_BYTES = GiB
+
 
 @dataclass(frozen=True)
 class _NodeResourceSpec:
@@ -59,9 +65,13 @@ class _NodeResourceSpec:
     def of(cls, *, cpu=0, gpu=0, mem=0):
         cpu = math.floor(cpu)
         gpu = math.floor(gpu)
-        # Round memory to the nearest 0.1 GiB so that nodes of the same type
-        # with slightly different reported physical memory are grouped together.
-        mem = int(round(mem / GiB, 1) * GiB) if mem > 0 else 0
+        # Quantize memory *down* so that nodes of the same type with slightly
+        # different reported physical memory are grouped together. Rounding down
+        # (instead of to the nearest multiple) keeps the spec from ever claiming
+        # more memory than the node it was derived from: a bundle bigger than
+        # its source node doesn't fit on that node type, so the autoscaler would
+        # treat the request as infeasible instead of scaling up.
+        mem = math.floor(mem / _MEMORY_QUANTIZATION_BYTES) * _MEMORY_QUANTIZATION_BYTES
         return cls(cpu=cpu, gpu=gpu, mem=mem)
 
     @classmethod

--- a/python/ray/data/tests/test_default_cluster_autoscaler_v2.py
+++ b/python/ray/data/tests/test_default_cluster_autoscaler_v2.py
@@ -881,6 +881,40 @@ class TestClusterAutoscaling:
         spec_b = _NodeResourceSpec.of(cpu=8, gpu=0, mem=int(14.93 * GiB))
         assert spec_a == spec_b
 
+    @pytest.mark.parametrize(
+        "mem",
+        [0, 1000, int(0.5 * GiB), int(14.87 * GiB), int(14.93 * GiB), 32 * GiB],
+    )
+    def test_spec_never_exceeds_node_memory(self, mem):
+        """A spec must never claim more memory than the node it came from.
+
+        The bundles built from a spec are requested from the autoscaler as-is.
+        A bundle larger than its source node doesn't fit on that node type, so
+        the autoscaler can never satisfy it.
+        """
+        spec = _NodeResourceSpec.of(cpu=8, gpu=0, mem=mem)
+        assert spec.mem <= mem
+        assert spec.to_bundle()["memory"] <= mem
+
+    def test_bundles_fit_on_the_nodes_they_were_derived_from(self):
+        """Bundles derived from live nodes are schedulable on those nodes."""
+        node_resources = {"CPU": 8, "memory": int(14.93 * GiB)}
+        node_table = [{"Resources": node_resources, "Alive": True}]
+
+        with (
+            patch("ray.nodes", return_value=node_table),
+            patch(
+                "ray._private.state.state.get_cluster_config",
+                return_value=None,
+            ),
+        ):
+            specs = _get_node_resource_spec_and_count()
+
+        assert len(specs) == 1
+        bundle = next(iter(specs)).to_bundle()
+        for resource, amount in bundle.items():
+            assert amount <= node_resources.get(resource, 0), (bundle, node_resources)
+
     def test_debug_log_when_autoscaling_disabled(self, propagate_logs, caplog):
         """Test that autoscaling log is at DEBUG level when autoscaling is disabled."""
         fake_coordinator = FakeAutoscalingCoordinator()


### PR DESCRIPTION
# Issue #65237 — autoscaler requests a bundle larger than the node it was copied from

## 1. Root cause

`DefaultClusterAutoscalerV2` builds its autoscaler request out of node *shapes*:
`_get_node_resource_spec_and_count()` turns every live worker node's resource dict into a
`_NodeResourceSpec`, and `try_trigger_scaling()` sends `spec.to_bundle()` back to the
autoscaler as active bundles (one per existing node) and pending bundles (the scale-up
delta).

`_NodeResourceSpec.of()` quantized memory with a *nearest*-multiple rounding
(`python/ray/data/_internal/cluster_autoscaler/default_cluster_autoscaler_v2.py:64`
before the fix):

```python
mem = int(round(mem / GiB, 1) * GiB) if mem > 0 else 0
```

The quantization exists so that two nodes of the same instance type that report slightly
different physical memory (Ray derives the `memory` resource from memory available at
init time, so it jitters) collapse into one shape instead of two.

Rounding to the *nearest* 0.1 GiB rounds **up** for anything in the upper half of a
bucket. A node reporting 14.87 GiB becomes a 14.9 GiB bundle: strictly larger than the
node it was copied from. That bundle does not fit on any node of that type, so the
autoscaler treats the demand as infeasible rather than launching the node, and the
cluster never scales up (CPU and GPU were already floored, so memory was the only
resource with this defect).

## 2. The fix and why

Quantize memory **down** instead of to the nearest multiple:

```python
mem = math.floor(mem / _MEMORY_QUANTIZATION_BYTES) * _MEMORY_QUANTIZATION_BYTES
```

Rounding down makes `spec.mem <= node_memory` an invariant, which is the property the
request actually needs: a bundle must be schedulable on the node shape it describes.
The error is now asymmetric in the safe direction — under-requesting memory still lands
on a node of that type, over-requesting can never be satisfied.

The granularity is a named constant `_MEMORY_QUANTIZATION_BYTES = GiB`. It was widened
from 0.1 GiB to 1 GiB because flooring at 0.1 GiB would have *lost* the grouping
property the quantization was added for: 14.87 GiB and 14.93 GiB floor to 14.8 and
14.9, i.e. two shapes for one instance type (this is exactly what
`test_nodes_with_similar_memory_grouped` covers). A 1 GiB bucket keeps both nodes on the
same shape and gives 10x more slack against reported-memory jitter than the original
rounding did, while never exceeding the source node.

Matching CPU/GPU are still exact, so the coarser memory bucket does not realistically
make the request match a different (smaller) instance type.

## 3. Files changed

- `python/ray/data/_internal/cluster_autoscaler/default_cluster_autoscaler_v2.py`
  — added `_MEMORY_QUANTIZATION_BYTES`; `_NodeResourceSpec.of()` now floors memory to it.
- `python/ray/data/tests/test_default_cluster_autoscaler_v2.py`
  — added `test_spec_never_exceeds_node_memory` (parametrized invariant check) and
  `test_bundles_fit_on_the_nodes_they_were_derived_from` (end-to-end through
  `_get_node_resource_spec_and_count`, asserting every resource in the emitted bundle
  fits the source node).

## 4. Risk / uncertainty

- Memory demand per node is now under-reported by up to 1 GiB (previously by up to
  0.05 GiB, or over-reported by up to 0.05 GiB). Under-reporting is safe for
  feasibility. It does slightly loosen `cap_resource_request_to_limits`: with a
  user-configured `resource_limits.memory`, pending bundles are measured with the
  floored value, so a scale-up can overshoot the configured memory limit by up to 1 GiB
  per pending bundle (bounded by `cluster_scaling_up_delta`, default 1, times the number
  of node shapes). The old 0.1 GiB rounding had the same failure mode, an order of
  magnitude smaller.
- Nodes with less than 1 GiB of Ray `memory` now produce `memory: 0` bundles (the old
  code did this below 0.05 GiB). Such worker nodes are not realistic in an autoscaling
  Ray Data cluster, and CPU/GPU still carry the demand.
- The choice of 1 GiB is a judgement call: it is the smallest round bucket that keeps
  the existing same-node-type grouping test passing under flooring. A maintainer may
  prefer a different constant; it is isolated in one named variable.
- Head-node-group detection (`node_group_config` shape vs. the running head node's
  shape) also compares quantized specs. Coarser buckets make that comparison neither
  better nor worse in a way I could establish, since a configured shape and the reported
  shape can straddle a bucket boundary at any granularity.

## 5. How I verified it

Ray is not installed in this environment (`import ray` fails), so the test suite could
not be executed here. Verification done:

- Extracted the real `_NodeResourceSpec` class from the patched source with `ast` and
  exec'd it against stubs, then checked, for `mem` in
  `{0, 1000 B, 0.5, 14.87, 14.93, 32, 8, 1.999, 2 GiB}`: the quantized value is always
  `<= mem`, is an `int` (the frozen dataclass asserts this in `__post_init__`), and
  `of(mem=14.87 GiB) == of(mem=14.93 GiB)` still holds. All passed; the pre-fix code
  returns 14.9 GiB for a 14.87 GiB node, reproducing the issue.
- Hand-checked every existing memory value in
  `test_default_cluster_autoscaler_v2.py` against the new quantization: the small
  byte-valued fixtures (1000/2000/3000) already quantized to 0 under the old rounding
  and still do; the GiB-valued fixtures (2, 4, 8, 32 GiB) are exact multiples and are
  unchanged, including the `memory: 8.0GiB` log-message assertion.
- `grep` confirmed `_NodeResourceSpec` / `_get_node_resource_spec_and_count` have no
  consumers outside this module and its test file.
- `python -m py_compile` on both changed files; no line exceeds the configured ruff
  `line-length = 88`.

Suggested command for a human to run before submitting:

```bash
pytest -q python/ray/data/tests/test_default_cluster_autoscaler_v2.py
```
