### PR TITLE
[doc] Pin the ReDoc bundle to v2.5.3 instead of tracking the CDN latest tag

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -783,7 +783,15 @@ redoc = [
     },
 ]
 
-redoc_uri = "https://cdn.redoc.ly/redoc/latest/bundles/redoc.standalone.js"
+# Pin the ReDoc bundle version rather than tracking the CDN's `latest` tag.
+# sphinxcontrib-redoc injects this script instead of bundling a renderer, so the
+# Jobs API page is rendered client-side at page-view time by whatever this URL
+# serves. On `latest`, a breaking change in the bundle degrades the published page
+# with no build-time signal, because the Sphinx build never executes it.
+# When bumping this, load the api.html page in the Read the Docs PR preview and
+# confirm the three-panel layout and the endpoint list still render. A green
+# Sphinx build proves nothing about this page.
+redoc_uri = "https://cdn.redoc.ly/redoc/v2.5.3/bundles/redoc.standalone.js"
 
 autosummary_filename_map = AUTOSUMMARY_FILENAME_MAP
 


### PR DESCRIPTION
## Why this change is needed

`doc/source/conf.py` points `redoc_uri` at the ReDoc CDN's unpinned `latest` tag:

```python
redoc_uri = "https://cdn.redoc.ly/redoc/latest/bundles/redoc.standalone.js"
```

`sphinxcontrib-redoc` injects that script tag alongside the spec; it doesn't bundle a renderer. So the published Jobs API page at `cluster/running-applications/job-submission/api.html` is rendered client-side, at page-view time, by whatever Redocly currently serves at `latest`. If a breaking change lands in that bundle, the live page degrades with no build-time signal at all, because the Sphinx build never executes the script. The build stays green while the page is broken.

This pins the version so the renderer stops moving underneath the docs unobserved.

## Related changes

None. This is deliberately scoped to the one line plus a comment.

## What changes

- Pin `redoc_uri` to `v2.5.3`.
- Add a comment recording why it's pinned and that bumping it requires a visual check on the Read the Docs preview, so a future dependency sweep doesn't helpfully restore `latest`.

## Why v2.5.3, and why this is a no-op today

`v2.5.3` is what `latest` currently resolves to, so the pin doesn't silently downgrade the rendering. The two bundles are byte-identical, verified 2026-08-13:

| URL | HTTP | Bytes | sha256 |
| --- | --- | --- | --- |
| `.../redoc/latest/bundles/redoc.standalone.js` | 200 | 1,097,271 | `1320f442151c57c447d3b70c7ffc6c4f86d08464020fe34c8cc5d3164e9944f0` |
| `.../redoc/v2.5.3/bundles/redoc.standalone.js` | 200 | 1,097,271 | `1320f442151c57c447d3b70c7ffc6c4f86d08464020fe34c8cc5d3164e9944f0` |

`2.5.3` is also the current `latest` dist-tag on npm. The next release line is `3.0.0-rc.0`, which is exactly the kind of bundle that would arrive through this URL unannounced and unverified today.

For context on why the unpinned tag isn't hypothetical, `latest` has already moved well away from older 2.x builds: `v2.5.0` is 910,994 bytes against the current 1,097,271.

## Checks

- [x] `doc/source/conf.py` parses; `pre-commit run` clean on the staged change.
- [ ] Loaded `api.html` in the Read the Docs preview for this PR and confirmed the three-panel layout and the endpoint list render. Will confirm here once the preview build finishes — a green Sphinx build proves nothing for a client-rendered page.

## Out of scope

Replacing the unmaintained `sphinxcontrib-redoc` extension, and the separate question of the spec's declared OpenAPI version. Both are tracked separately and neither blocks this pin, which is worth having regardless of how they land.
