### PR TITLE
[doc] Remove invalid summary keys from Jobs API spec Response Objects

### DIFF
--- a/doc/source/cluster/running-applications/job-submission/openapi.yml
+++ b/doc/source/cluster/running-applications/job-submission/openapi.yml
@@ -16,7 +16,6 @@ paths:
         Get the Ray Jobs API version and the Ray version running on the cluster.
       responses:
         200:
-          summary: Version
           description: |
             The Ray Jobs API version and the Ray version running on the cluster.
           content:
@@ -49,7 +48,6 @@ paths:
               $ref: '#/components/schemas/JobSubmitRequest'
       responses:
         200:
-          summary: Job Submit Response
           description: |
             The ID of the submitted job.
           content:
@@ -57,7 +55,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/JobSubmitResponse'
         400:
-          summary: Job Submit Validation Error
           description: |
             A TypeError or ValueError was raised when submitting the job.
           content:
@@ -66,7 +63,6 @@ paths:
                 description: The error message.
                 type: string
         500:
-          summary: Job Submit Internal Error
           description: |
             An internal error occurred when submitting the job.
           content:
@@ -80,7 +76,6 @@ paths:
         List all submitted jobs in the cluster and their details.
       responses:
         200:
-          summary: List of Job Details
           description: |
             The details of the jobs.
           content:
@@ -104,7 +99,6 @@ paths:
             type: string
       responses:
         200:
-          summary: Job Details
           description: |
             The details of the job.
           content:
@@ -112,7 +106,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/JobDetails'
         404:
-          summary: Job Not Found
           description: |
             The job does not exist.
           content:
@@ -134,7 +127,6 @@ paths:
             type: string
       responses:
         200:
-          summary: Job Status
           description: |
             The status of the job.
           content:
@@ -143,7 +135,6 @@ paths:
                 description: Whether the job was successfully deleted.
                 type: boolean
         500:
-          summary: Internal Error
           description: |
             An internal error occurred when deleting the job, or the job was not in a terminal state.
           content:
@@ -152,7 +143,6 @@ paths:
                 description: The error message.
                 type: string
         404:
-          summary: Job Not Found
           description: |
             The job does not exist.
           content:
@@ -161,7 +151,6 @@ paths:
                 description: The error message.
                 type: string
         400:
-          summary: Wrong Job Type
           description: |
             The job was not submitted via the Ray Jobs API, so it cannot be deleted.
           content:
@@ -184,7 +173,6 @@ paths:
             type: string
       responses:
         200:
-          summary: Job Status
           description: |
             The status of the job.
           content:
@@ -192,7 +180,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/JobStatus'
         500:
-          summary: Internal Error
           description: |
             An internal error occurred when stopping the job.
           content:
@@ -201,7 +188,6 @@ paths:
                 description: The error message.
                 type: string
         404:
-          summary: Job Not Found
           description: |
             The job does not exist.
           content:
@@ -210,7 +196,6 @@ paths:
                 description: The error message.
                 type: string
         400:
-          summary: Wrong Job Type
           description: |
             The job was not submitted via the Ray Jobs API, so it cannot be stopped.
           content:
@@ -233,7 +218,6 @@ paths:
             type: string
       responses:
         200:
-          summary: Job Logs
           description: |
             The logs of the job.
           content:
@@ -245,7 +229,6 @@ paths:
                     type: string
                     description: The logs of the job.
         500:
-          summary: Job Logs Internal Error
           description: |
             An internal error occurred when getting the logs of the job.
           content:
@@ -254,7 +237,6 @@ paths:
                 description: The error message.
                 type: string
         404:
-          summary: Job Not Found
           description: |
             The job does not exist.
           content:
@@ -263,7 +245,6 @@ paths:
                 description: The error message.
                 type: string
         400:
-          summary: Wrong Job Type
           description: |
             The job was not submitted via the Ray Jobs API, so its logs cannot be retrieved.
           content:
@@ -289,7 +270,6 @@ paths:
             type: string
       responses:
         404:
-          summary: Job Not Found
           description: |
             The job does not exist.
           content:
@@ -298,7 +278,6 @@ paths:
                 description: The error message.
                 type: string
         400:
-          summary: Wrong Job Type
           description: |
             The job was not submitted via the Ray Jobs API, so its logs cannot be retrieved.
           content:


### PR DESCRIPTION
## Why this change is needed

`summary` isn't a valid field on an OpenAPI Response Object, in either 3.0.x or 3.1. The valid fields are `description`, `headers`, `content`, and `links`. `doc/source/cluster/running-applications/job-submission/openapi.yml` carries 21 of them, and they make the document fail validation against the `3.1.0` version it declares:

```
$ openapi-spec-validator openapi.yml
openapi.yml: Validation Error: Unevaluated properties are not allowed ('summary' was unexpected)

Failed validating 'unevaluatedProperties' in
  schema['properties']['paths'][...]['responses'][...]
  $comment: https://spec.openapis.org/oas/v3.1.0#response-object
On instance['paths']['/api/version']['get']['responses']['200']
```

So the spec is invalid against its own declared version today. That matters because `rest.rst` explicitly invites readers to generate client libraries from this spec, and it blocks wiring a validation check into CI, since a validator that has to be run with known-failing output is one nobody will adopt.

## Related changes

None. This is scoped to removing the invalid keys.

## What changes

Removes the 21 `summary` keys from Response Objects. Nothing else — the diff is 21 deletions and zero insertions.

The 8 operation-level `summary` fields are untouched. Those are valid on an Operation Object and they do render, as the endpoint titles in the sidebar and section headings. Only the response-level ones go.

## This does not change the published page

ReDoc ignores unknown keys, so the rendered output is unaffected. Rather than assert that, I verified it against the live page by probing the rendered DOM after the ReDoc bundle ran:

- All 21 summary values are **absent** from the rendered body text. The six that are unique to a response `summary` and appear nowhere else in the spec — `Job Submit Response`, `Job Submit Validation Error`, `Job Submit Internal Error`, `List of Job Details`, `Job Logs Internal Error`, `Wrong Job Type` — return no match.
- They **are** present in the raw page HTML, because the spec is embedded in the page as JSON. The data reaches the browser; ReDoc simply doesn't render it.
- The sibling `description` of those same Response Objects **does** render, which rules out the alternative explanation that those responses were never reached or stayed collapsed.

For example, the rendered Responses block for `POST /api/jobs` reads:

```
Responses
200   The ID of the submitted job.
400   A TypeError or ValueError was raised when submitting the job.
500   An internal error occurred when submitting the job.
```

Status code and `description`, with the three `summary` values for those exact responses nowhere in the output.

## No documented content is lost

Every one of the 21 affected responses already has a `description` that states the same thing in prose, and `description` is the required field on a Response Object. A few examples:

| Path | Removed `summary` | Retained `description` |
| --- | --- | --- |
| `GET /api/version` 200 | `Version` | The Ray Jobs API version and the Ray version running on the cluster. |
| `POST /api/jobs` 400 | `Job Submit Validation Error` | A TypeError or ValueError was raised when submitting the job. |
| `DELETE /api/jobs/{submission_id}` 400 | `Wrong Job Type` | The job was not submitted via the Ray Jobs API, so it cannot be deleted. |

Verified programmatically that all 21 responses retain a `description` after the edit, so none becomes invalid for the opposite reason.

## Checks

- [x] Spec parses; the parsed document is identical to the previous one with exactly those 21 keys removed and no other difference.
- [x] `openapi-spec-validator` now reports `OK` against the declared 3.1.0. It failed before this change.
- [x] Rendered-DOM probe of the live page, described above.
- [x] `pre-commit run` clean on the staged change.
- [ ] Confirm `api.html` is unchanged in the Read the Docs preview for this PR. Will confirm here once the preview build finishes — this is a client-rendered page, so a green Sphinx build proves nothing about it.

## Note for reviewers

The invalidity is pre-existing and isn't caused by any version change. It fails under 3.0.x too, so this cleanup is worth having independently of the separate open question about which OpenAPI version this document should declare. After this change the spec validates against both 3.1.0 and 3.0.3, which leaves that question free to be decided on its own merits.
