### PR TITLE
[doc] Record what blocks lifting the setuptools ceiling and replacing sphinxcontrib-redoc

### DIFF
--- a/doc/requirements-doc.txt
+++ b/doc/requirements-doc.txt
@@ -16,21 +16,29 @@
 # dropping that one extension is sufficient to lift this ceiling.
 #
 # sphinxcontrib-openapi 0.9.0 was evaluated as the maintained replacement and
-# is not usable yet. It needs no setuptools and builds this repo's spec with
-# zero warnings, but only in its default configuration, which renders no
-# request or response schemas at all -- paths, parameters, and status codes
-# only, where ReDoc renders the full schemas. Every configuration that restores
-# the schema content emits Sphinx warnings, and .readthedocs.yaml sets
-# fail_on_warning: true:
-#   - old renderer with :request: emits a sourcecode directive with no trailing
-#     blank line ("Explicit markup ends without a blank line").
-#   - old renderer with :examples: generates an example the Pygments http lexer
-#     rejects.
-#   - the httpdomain renderer leaks literal ** into the output and warns
-#     "Inline strong start-string without end-string".
-# Suppressing those would trade one workaround for another, so this stays on
-# pinned ReDoc until they're fixed upstream. Re-evaluate on a release that
-# fixes them rather than re-deriving the above.
+# is technically viable. It needs no setuptools, and it renders this repo's spec
+# with full request and response schemas and zero warnings under
+# fail_on_warning, but only in one specific configuration:
+#   - openapi_default_renderer = "httpdomain" in conf.py, then a plain
+#     `.. openapi::` directive. The default renderer (httpdomain:old) renders no
+#     request or response schemas at all, just paths, parameters, and status
+#     codes. Invoking the new one as `.. openapi:httpdomain::` instead of via
+#     the config value adds an "unknown directive name" warning.
+#   - operation `summary` fields must be plain scalars, not YAML block scalars.
+#     A block scalar leaves a trailing newline in the value, which the renderer
+#     interpolates into `**...**` and breaks, emitting literal asterisks onto
+#     the page (sphinx-contrib/openapi#173).
+# Configurations that don't work, all filed upstream: the old renderer with
+# :request: emits a sourcecode directive with no trailing blank line
+# (sphinx-contrib/openapi#171), and with :examples: it emits a schema-derived
+# string example unencoded as an application/json body, which the Pygments http
+# lexer rejects (sphinx-contrib/openapi#172).
+#
+# What migrating is still gated on is not technical: it replaces ReDoc's
+# standalone three-panel page with output rendered inline in the site theme.
+# That's a visible change to a published reference page and needs maintainer
+# sign-off, so it isn't a dependency-hygiene decision. Until that call is made,
+# this stays on pinned ReDoc.
 setuptools==80.9.0
 
 # Syntax highlighting

--- a/doc/requirements-doc.txt
+++ b/doc/requirements-doc.txt
@@ -8,6 +8,29 @@
 # No released sphinxcontrib-redoc fixes this. 1.6.0 is the latest release and
 # dates from 2020; the 2.0.0a1 alpha still imports pkg_resources. Lifting this
 # ceiling means replacing or vendoring that extension.
+#
+# sphinxcontrib-redoc is the only blocker. Verified by installing every
+# extension conf.py loads into an environment with no setuptools and no
+# importable pkg_resources: all of them import cleanly except
+# sphinxcontrib.redoc, which raises "No module named 'pkg_resources'". So
+# dropping that one extension is sufficient to lift this ceiling.
+#
+# sphinxcontrib-openapi 0.9.0 was evaluated as the maintained replacement and
+# is not usable yet. It needs no setuptools and builds this repo's spec with
+# zero warnings, but only in its default configuration, which renders no
+# request or response schemas at all -- paths, parameters, and status codes
+# only, where ReDoc renders the full schemas. Every configuration that restores
+# the schema content emits Sphinx warnings, and .readthedocs.yaml sets
+# fail_on_warning: true:
+#   - old renderer with :request: emits a sourcecode directive with no trailing
+#     blank line ("Explicit markup ends without a blank line").
+#   - old renderer with :examples: generates an example the Pygments http lexer
+#     rejects.
+#   - the httpdomain renderer leaks literal ** into the output and warns
+#     "Inline strong start-string without end-string".
+# Suppressing those would trade one workaround for another, so this stays on
+# pinned ReDoc until they're fixed upstream. Re-evaluate on a release that
+# fixes them rather than re-deriving the above.
 setuptools==80.9.0
 
 # Syntax highlighting


### PR DESCRIPTION
> **Stacked PR.** Fourth in a chain: #65456 (pin ReDoc) → #65457 (spec validity) → #65458 (declare 3.0.3) → this. It's independent in substance and touches only `doc/requirements-doc.txt`, so it can be retargeted to `master` if you'd rather take it on its own.

## Why this change is needed

The `setuptools==80.9.0` pin in `doc/requirements-doc.txt` exists because `sphinxcontrib-redoc` imports `pkg_resources` at module load, and setuptools 82 removed it. The comment ends with "Lifting this ceiling means replacing or vendoring that extension," which leaves two questions open:

1. Is `sphinxcontrib-redoc` actually the *only* thing in the doc environment that needs `pkg_resources`? If not, removing it wouldn't lift the ceiling anyway.
2. Is there a usable replacement?

I evaluated both. This records the answers so the next person hitting this pin doesn't re-derive them.

## Related changes

Fourth in the chain above. No functional dependency on the three below it.

## What changes

A comment in `doc/requirements-doc.txt`. No behavior change, no dependency change, no build change.

## Finding 1: `sphinxcontrib-redoc` is the sole blocker

Installed every extension `conf.py` loads into an environment with no setuptools and no importable `pkg_resources`, then imported each one:

| Result | Extensions |
| --- | --- |
| Import cleanly | `sphinx.ext.autodoc`, `viewcode`, `napoleon`, `doctest`, `coverage`, `autosummary`, `intersphinx`, `sphinx_click.ext`, `sphinxemoji`, `sphinx_copybutton`, `sphinx_sitemap`, `myst_nb`, `sphinxcontrib.autodoc_pydantic`, `sphinx_remove_toctrees`, `sphinx_design`, `sphinx_docsearch`, `sphinx_collections`, `sphinxext.opengraph` |
| **Fails** | `sphinxcontrib.redoc` — `ModuleNotFoundError: No module named 'pkg_resources'` |

That failure is the control: it reproduces the exact documented breakage, which confirms the test has power rather than passing vacuously. So dropping that one extension is sufficient to lift the ceiling.

## Finding 2: the maintained replacement works, in exactly one configuration

`sphinxcontrib-openapi` 0.9.0 (released 2026-02-10, `requires_python >=3.10`) is the actively maintained alternative from the same `sphinx-contrib` org. It needs no setuptools, and it **does** render this spec with full request and response schemas and **zero warnings under `-W`** — but only with both of these:

- `openapi_default_renderer = "httpdomain"` in `conf.py`, then a plain `.. openapi::` directive.
- Operation `summary` fields as plain scalars rather than YAML block scalars.

Neither is obvious, and each failure mode is silent or fatal rather than self-explaining:

| Configuration | Schema content | Warnings under `-W` |
| --- | --- | --- |
| default renderer (`httpdomain:old`) | **none** — paths, parameters, status codes only | 0 |
| `httpdomain:old` + `:request:` | request bodies only, as a raw JSON blob | 1 — [#171](https://github.com/sphinx-contrib/openapi/issues/171) |
| `httpdomain:old` + `:examples:` | full | 1 — [#172](https://github.com/sphinx-contrib/openapi/issues/172) |
| `httpdomain`, block-scalar summaries | full | 2 — [#173](https://github.com/sphinx-contrib/openapi/issues/173), plus literal `**` on the page |
| **`httpdomain`, plain-scalar summaries** | **full** | **0** |

The literal-asterisk defect is worth calling out because it's triggered by this repo's own spec: two operations use `summary: |`, which leaves a trailing newline in the value that the renderer interpolates straight into `**...**`. Changing those two lines to plain scalars is sufficient. The three configurations that genuinely don't work are filed upstream with minimal reproducers.

## So what actually gates migrating

Not dependency hygiene, and not warnings. It's that ReDoc's standalone three-panel page would be replaced by output rendered inline in the site theme. That's a visible change to a published reference page, so it's a maintainer call rather than a docs-tooling cleanup, and this PR doesn't make it.

Two things worth weighing whenever that call happens.

In favor: the current page is a client-rendered JavaScript island. It's in no toctree, it's reachable only through a hardcoded `<api.html>` link at `rest.rst:94`, and its endpoint content isn't in the built HTML, so it doesn't participate in Sphinx search or cross-referencing. The trial build produced real Sphinx nodes and an `http-routingtable` index. Migrating would also let the `setuptools` ceiling lift, per finding 1.

Against: it's a published reference page that readers may have bookmarked in its current form, and the inline rendering is a different reading experience rather than a strictly better one. My trial builds used the `basic` theme, so I can't show what it looks like under this site's actual theme without a full doc build.

## Checks

- [x] Comment-only change; `pre-commit run` clean.
- [x] Every claim in the comment verified by the trial builds described above.
