### PR TITLE
[doc] llms.txt: tell agents the page links also serve Markdown

### DIFF
--- a/doc/source/_ext/llms_txt.py
+++ b/doc/source/_ext/llms_txt.py
@@ -63,6 +63,11 @@ Config values (set generic defaults here; Ray specifics live in ``conf.py``):
     Absolute base URL for generated links. Defaults to ``html_baseurl``; set it
     to the current build's canonical URL (e.g. ``READTHEDOCS_CANONICAL_URL``) so
     links track the version being built rather than a pinned SEO canonical.
+``llms_txt_markdown_hint``
+    Whether to tell agents that the page URLs also serve Markdown under an
+    ``Accept: text/markdown`` request (default ``False``). Only enable it where
+    the host actually negotiates that type — otherwise the index advertises a
+    representation that doesn't exist.
 
 All work happens in ``build-finished`` so it is parallel-safe, and the module
 sticks to APIs that survive the Sphinx 8 -> 9 jump (``findall`` not
@@ -365,6 +370,7 @@ def _render_index(
     meta_types,
     cache,
     full_enabled,
+    markdown_hint=False,
 ):
     """Render the root ``llms.txt`` index as a string.
 
@@ -380,6 +386,13 @@ def _render_index(
         lines += [
             "Full page text, grouped by section, is in "
             f"[llms-full.txt]({_asset_url(app, 'llms-full.txt')}).",
+            "",
+        ]
+    if markdown_hint:
+        lines += [
+            "Request the links that follow with the HTTP header "
+            "`Accept: text/markdown` to retrieve a Markdown rendering of the "
+            "page.",
             "",
         ]
 
@@ -712,6 +725,7 @@ def on_build_finished(app, exception):
         meta_types,
         cache,
         full_enabled,
+        getattr(config, "llms_txt_markdown_hint", False),
     )
     (Path(app.outdir) / "llms.txt").write_text(index, encoding="utf-8")
     logger.info("[llms_txt] wrote llms.txt (%d sections)", len(sections))
@@ -732,6 +746,7 @@ def setup(app):
     app.add_config_value("llms_txt_full_max_shard_tokens", 200000, "html")
     app.add_config_value("llms_txt_build", True, "html")
     app.add_config_value("llms_txt_base_url", None, "html")
+    app.add_config_value("llms_txt_markdown_hint", False, "html")
 
     app.connect("build-finished", on_build_finished)
 

--- a/doc/source/_ext/test_llms_txt.py
+++ b/doc/source/_ext/test_llms_txt.py
@@ -447,14 +447,40 @@ def test_base_url_override():
     return True
 
 
+def test_markdown_hint():
+    """llms_txt_markdown_hint adds the Accept: text/markdown pointer, and is off
+    by default so a host that doesn't negotiate Markdown never advertises it."""
+    with tempfile.TemporaryDirectory() as tmp:
+        out = _build(Path(tmp), extra_conf="\nllms_txt_markdown_hint = True\n")
+        index = (out / "llms.txt").read_text(encoding="utf-8")
+        _check(
+            "Accept: text/markdown" in index,
+            "markdown hint missing when llms_txt_markdown_hint is True",
+        )
+        # The pointer belongs in the header, before the first section.
+        _check(
+            index.index("Accept: text/markdown") < index.index("## "),
+            "markdown hint rendered after the first section heading",
+        )
+    with tempfile.TemporaryDirectory() as tmp:
+        out = _build(Path(tmp))
+        index = (out / "llms.txt").read_text(encoding="utf-8")
+        _check(
+            "Accept: text/markdown" not in index,
+            "markdown hint present without llms_txt_markdown_hint",
+        )
+    return True
+
+
 if __name__ == "__main__":
     test_llms_txt()
     test_notebook_exclusion()
     test_build_gate()
     test_clean_coercion()
+    test_markdown_hint()
     test_base_url_override()
     print(
         "PASS: llms_txt extension produced a correct index, Optional section, "
-        "llms-full shards, excludes notebooks by source type, and honors the "
-        "llms_txt_build gate."
+        "llms-full shards, excludes notebooks by source type, gates the "
+        "Markdown pointer, and honors the llms_txt_build gate."
     )

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -338,6 +338,15 @@ html_baseurl = "https://docs.ray.io/en/latest/"
 # fall back to html_baseurl for local builds. (DOC-1130)
 llms_txt_base_url = os.getenv("READTHEDOCS_CANONICAL_URL") or html_baseurl
 
+# Read the Docs serves a Markdown rendering of any page from that page's own
+# `.html` URL, under an `Accept: text/markdown` request — there is no separate
+# `.md` file to link to (`page.md`, `page.html.md`, and `?format=md` all 404).
+# So the `.html` links in llms.txt are already the Markdown links; nothing in
+# the file tells an agent that, hence this pointer. Content negotiation happens
+# on the rendered HTML, so it works the same whether a page's source is .rst or
+# .md, and it stays correct as pages migrate between the two.
+llms_txt_markdown_hint = True
+
 # `html_baseurl` already encodes `/en/latest/`, so override sphinx-sitemap's
 # default `{lang}{version}{link}` scheme to just `{link}`. Otherwise the
 # extension prepends `en/` again, producing URLs like `en/latesten/<page>`.


### PR DESCRIPTION
## Summary

Follow-up to #64458. Adds one line to `llms.txt` telling agents that the page links also serve Markdown.

Read the Docs serves a Markdown rendering of any page **from that page's own `.html` URL**, under an `Accept: text/markdown` request. There is no separate `.md` file to link to — `page.md`, `page.html.md`, `/md/<page>.md`, and `?format=md` all 404, and no `Link: rel=alternate` header advertises one.

So the `.html` links `llms.txt` already emits *are* the Markdown links. Nothing in the file says so, and an agent has no way to discover it.

```
# Ray

> Ray is an open-source unified compute framework for scaling AI and Python workloads…

Full page text, grouped by section, is in [llms-full.txt](https://docs.ray.io/en/master/llms-full.txt).

Request the links that follow with the HTTP header `Accept: text/markdown` to retrieve a Markdown rendering of the page.

## Overview
…
```

## The header has to be explicit

Measured against `docs.ray.io/en/master/data/data.html`:

| `Accept:` sent | returns |
|---|---|
| `*/*` — the default for curl, `requests`, `httpx` | `text/html` |
| `text/html,application/xhtml+xml,*/*;q=0.8` — browser default | `text/html` |
| `text/plain` | `text/html` |
| `text/markdown` | **`text/markdown`** |
| `text/markdown, */*` | **`text/markdown`** |
| `text/markdown;q=1.0, text/html;q=0.9` | **`text/markdown`** |

A wildcard isn't enough; the type has to be named. A client gets Markdown only by asking deliberately, so the pointer has a real audience.

## Config-gated

New `llms_txt_markdown_hint`, **default `False`**. Content negotiation is a property of the host, not of the generator — a build served from somewhere that doesn't negotiate Markdown would otherwise advertise a representation that doesn't exist. `conf.py` sets it `True` for Ray.

## Wording note

It says "a Markdown rendering of **the page**", deliberately not "the source". What comes back is the built page converted to Markdown — front matter, then site chrome (`Skip to main content`, theme switcher, version picker), then the content. That is not what `_sources/<page>.<ext>.txt` returns, and `_sources` genuinely exists, so calling it "the source" would point agents at the wrong artifact.

## Why not link `_sources/<page>.<ext>.txt` instead

Considered and rejected:

- **It leaks the source format to the consumer.** master is **363 `.rst` to 232 `.md`**, so most pages would hand back reStructuredText, not Markdown — noisier for an agent than the HTML→Markdown conversion.
- **The URL isn't derivable from the page URL** — it depends on each page's source suffix (`index.md.txt` vs `installation.rst.txt`).
- **It isn't human-clickable.**
- **It would churn.** As pages migrate to MyST, each link would change from `.rst.txt` to `.md.txt`. Negotiation happens on the rendered HTML, so it's identical for both source formats and survives the migration.
- **It's redundant** — the verbatim source is already in the `llms-full.txt` shards.

## Testing

```
$ python doc/source/_ext/test_llms_txt.py
PASS: llms_txt extension produced a correct index, Optional section, llms-full shards,
excludes notebooks by source type, gates the Markdown pointer, and honors the llms_txt_build gate.

$ ruff check doc/source/_ext/llms_txt.py doc/source/_ext/test_llms_txt.py
All checks passed!
```

New `test_markdown_hint` covers both directions: the pointer appears in the header (asserted to sit before the first `##` section) when the config is on, and is absent when it's off. The header table above was produced by probing the live `docs.ray.io`.

All three changed files route to `@ doc doc_api` under the current `.buildkite/test.rules.txt`, so `doc: test llms.txt extension` runs on this PR.

Not a duplicate: `gh pr list --state open` finds no other open PR touching `llms.txt` or Markdown content negotiation.

## AI assistance

Drafted with Claude Code. The behavioural claims here (which `Accept` values return what, which `.md` URL forms 404, the negotiated output including page chrome) were each verified against the live site rather than assumed.
