### PR TITLE
core: release runtime env per-job loggers

### DIFF
--- a/python/ray/_private/runtime_env/agent/runtime_env_agent.py
+++ b/python/ray/_private/runtime_env/agent/runtime_env_agent.py
@@ -207,6 +207,7 @@ class RuntimeEnvAgent:
 
         self._runtime_env_dir = runtime_env_dir
         self._per_job_logger_cache = dict()
+        self._per_job_logger_ref_counts: Dict[str, int] = defaultdict(int)
         # Cache the results of creating envs to avoid repeatedly calling into
         # conda and other slow calls.
         self._env_cache: Dict[str, CreatedEnvResult] = dict()
@@ -301,7 +302,7 @@ class RuntimeEnvAgent:
             else:
                 delete_runtime_env()
 
-    def get_or_create_logger(self, job_id: bytes, log_files: List[str]):
+    def _acquire_per_job_logger(self, job_id: bytes, log_files: List[str]):
         job_id = job_id.decode()
         if job_id not in self._per_job_logger_cache:
             params = self._logging_params.copy()
@@ -310,7 +311,26 @@ class RuntimeEnvAgent:
             params["propagate"] = False
             per_job_logger = setup_component_logger(**params)
             self._per_job_logger_cache[job_id] = per_job_logger
+        self._per_job_logger_ref_counts[job_id] += 1
         return self._per_job_logger_cache[job_id]
+
+    def _release_per_job_logger(self, job_id: bytes):
+        job_id = job_id.decode()
+        ref_count = self._per_job_logger_ref_counts[job_id]
+        if ref_count > 1:
+            self._per_job_logger_ref_counts[job_id] = ref_count - 1
+            return
+
+        del self._per_job_logger_ref_counts[job_id]
+        per_job_logger = self._per_job_logger_cache.pop(job_id)
+        for handler in per_job_logger.handlers[:]:
+            per_job_logger.removeHandler(handler)
+            handler.close()
+
+        # logging keeps loggers alive in a process-wide registry. Remove this
+        # instance so completed jobs do not accumulate there either.
+        if logging.Logger.manager.loggerDict.get(per_job_logger.name) is per_job_logger:
+            del logging.Logger.manager.loggerDict[per_job_logger.name]
 
     async def GetOrCreateRuntimeEnv(self, request):
         self._logger.debug(
@@ -325,48 +345,58 @@ class RuntimeEnvAgent:
         ):
             log_files = runtime_env_config.get("log_files", [])
             # Use a separate logger for each job.
-            per_job_logger = self.get_or_create_logger(request.job_id, log_files)
-            context = RuntimeEnvContext(env_vars=runtime_env.env_vars())
+            per_job_logger = self._acquire_per_job_logger(request.job_id, log_files)
+            try:
+                context = RuntimeEnvContext(env_vars=runtime_env.env_vars())
 
-            # Warn about unrecognized fields in the runtime env.
-            for name, _ in runtime_env.plugins():
-                if name not in self._plugin_manager.plugins:
-                    per_job_logger.warning(
-                        f"runtime_env field {name} is not recognized by "
-                        "Ray and will be ignored.  In the future, unrecognized "
-                        "fields in the runtime_env will raise an exception."
-                    )
-
-            # Creates each runtime env URI by their priority. `working_dir` is special
-            # because it needs to be created before other plugins. All other plugins are
-            # created in the priority order (smaller priority value -> earlier to
-            # create), with a special environment variable being set to the working dir.
-            # ${RAY_RUNTIME_ENV_CREATE_WORKING_DIR}
-
-            # First create working dir...
-            working_dir_ctx = self._plugin_manager.plugins[WorkingDirPlugin.name]
-            await create_for_plugin_if_needed(
-                runtime_env,
-                working_dir_ctx.class_instance,
-                working_dir_ctx.uri_cache,
-                context,
-                per_job_logger,
-            )
-
-            # Then within the working dir, create the other plugins.
-            working_dir_uri_or_none = runtime_env.working_dir_uri()
-            with self._working_dir_plugin.with_working_dir_env(working_dir_uri_or_none):
-                """Run setup for each plugin unless it has already been cached."""
-                for (
-                    plugin_setup_context
-                ) in self._plugin_manager.sorted_plugin_setup_contexts():
-                    plugin = plugin_setup_context.class_instance
-                    if plugin.name != WorkingDirPlugin.name:
-                        uri_cache = plugin_setup_context.uri_cache
-                        await create_for_plugin_if_needed(
-                            runtime_env, plugin, uri_cache, context, per_job_logger
+                # Warn about unrecognized fields in the runtime env.
+                for name, _ in runtime_env.plugins():
+                    if name not in self._plugin_manager.plugins:
+                        per_job_logger.warning(
+                            f"runtime_env field {name} is not recognized by "
+                            "Ray and will be ignored.  In the future, unrecognized "
+                            "fields in the runtime_env will raise an exception."
                         )
-            return context
+
+                # Creates each runtime env URI by their priority. `working_dir` is
+                # special because it needs to be created before other plugins. All
+                # other plugins are created in the priority order (smaller priority
+                # value -> earlier to create), with a special environment variable
+                # being set to the working dir.
+                # ${RAY_RUNTIME_ENV_CREATE_WORKING_DIR}
+
+                # First create working dir...
+                working_dir_ctx = self._plugin_manager.plugins[WorkingDirPlugin.name]
+                await create_for_plugin_if_needed(
+                    runtime_env,
+                    working_dir_ctx.class_instance,
+                    working_dir_ctx.uri_cache,
+                    context,
+                    per_job_logger,
+                )
+
+                # Then within the working dir, create the other plugins.
+                working_dir_uri_or_none = runtime_env.working_dir_uri()
+                with self._working_dir_plugin.with_working_dir_env(
+                    working_dir_uri_or_none
+                ):
+                    """Run setup for each plugin unless it has already been cached."""
+                    for (
+                        plugin_setup_context
+                    ) in self._plugin_manager.sorted_plugin_setup_contexts():
+                        plugin = plugin_setup_context.class_instance
+                        if plugin.name != WorkingDirPlugin.name:
+                            uri_cache = plugin_setup_context.uri_cache
+                            await create_for_plugin_if_needed(
+                                runtime_env,
+                                plugin,
+                                uri_cache,
+                                context,
+                                per_job_logger,
+                            )
+                return context
+            finally:
+                self._release_per_job_logger(request.job_id)
 
         async def _create_runtime_env_with_retry(
             runtime_env: RuntimeEnv,

--- a/python/ray/_private/runtime_env/agent/runtime_env_agent.py
+++ b/python/ray/_private/runtime_env/agent/runtime_env_agent.py
@@ -316,21 +316,30 @@ class RuntimeEnvAgent:
 
     def _release_per_job_logger(self, job_id: bytes):
         job_id = job_id.decode()
-        ref_count = self._per_job_logger_ref_counts[job_id]
+        ref_count = self._per_job_logger_ref_counts.get(job_id, 0)
+        if ref_count == 0:
+            return
         if ref_count > 1:
             self._per_job_logger_ref_counts[job_id] = ref_count - 1
             return
 
-        del self._per_job_logger_ref_counts[job_id]
-        per_job_logger = self._per_job_logger_cache.pop(job_id)
+        self._per_job_logger_ref_counts.pop(job_id, None)
+        per_job_logger = self._per_job_logger_cache.pop(job_id, None)
+        if per_job_logger is None:
+            return
+
         for handler in per_job_logger.handlers[:]:
             per_job_logger.removeHandler(handler)
             handler.close()
 
         # logging keeps loggers alive in a process-wide registry. Remove this
         # instance so completed jobs do not accumulate there either.
-        if logging.Logger.manager.loggerDict.get(per_job_logger.name) is per_job_logger:
-            del logging.Logger.manager.loggerDict[per_job_logger.name]
+        with logging._lock:
+            if (
+                logging.Logger.manager.loggerDict.get(per_job_logger.name)
+                is per_job_logger
+            ):
+                del logging.Logger.manager.loggerDict[per_job_logger.name]
 
     async def GetOrCreateRuntimeEnv(self, request):
         self._logger.debug(

--- a/python/ray/tests/test_runtime_env_agent.py
+++ b/python/ray/tests/test_runtime_env_agent.py
@@ -2,6 +2,7 @@ import logging
 import os
 import sys
 import time
+from collections import defaultdict
 from typing import List, Tuple
 
 import pytest
@@ -9,7 +10,11 @@ import pytest
 import ray
 from ray._common.test_utils import wait_for_condition
 from ray._private import ray_constants
-from ray._private.runtime_env.agent.runtime_env_agent import ReferenceTable, UriType
+from ray._private.runtime_env.agent.runtime_env_agent import (
+    ReferenceTable,
+    RuntimeEnvAgent,
+    UriType,
+)
 from ray._private.test_utils import (
     get_error_message,
     init_error_pubsub,
@@ -20,6 +25,40 @@ from ray.runtime_env import RuntimeEnv
 import psutil
 
 logger = logging.getLogger(__name__)
+
+
+def test_per_job_logger_released_after_last_setup(tmp_path):
+    agent = RuntimeEnvAgent.__new__(RuntimeEnvAgent)
+    agent._logging_params = {
+        "logging_level": logging.INFO,
+        "logging_format": "%(message)s",
+        "log_dir": str(tmp_path),
+        "max_bytes": 0,
+        "backup_count": 0,
+    }
+    agent._per_job_logger_cache = {}
+    agent._per_job_logger_ref_counts = defaultdict(int)
+
+    job_id = b"01000000"
+    logger_name = f"runtime_env_{job_id.decode()}"
+    first_logger = agent._acquire_per_job_logger(job_id, ["custom.log"])
+    second_logger = agent._acquire_per_job_logger(job_id, ["custom.log"])
+    handlers = first_logger.handlers[:]
+
+    assert second_logger is first_logger
+    assert len(handlers) == 2
+    assert agent._per_job_logger_ref_counts[job_id.decode()] == 2
+
+    agent._release_per_job_logger(job_id)
+    assert agent._per_job_logger_cache[job_id.decode()] is first_logger
+    assert all(handler.stream is not None for handler in handlers)
+
+    agent._release_per_job_logger(job_id)
+    assert job_id.decode() not in agent._per_job_logger_cache
+    assert job_id.decode() not in agent._per_job_logger_ref_counts
+    assert logger_name not in logging.Logger.manager.loggerDict
+    assert first_logger.handlers == []
+    assert all(handler.stream is None for handler in handlers)
 
 
 def test_reference_table():

--- a/python/ray/tests/test_runtime_env_agent.py
+++ b/python/ray/tests/test_runtime_env_agent.py
@@ -60,6 +60,17 @@ def test_per_job_logger_released_after_last_setup(tmp_path):
     assert first_logger.handlers == []
     assert all(handler.stream is None for handler in handlers)
 
+    # Cleanup runs in a finally block and must not mask the setup exception.
+    with pytest.raises(RuntimeError, match="setup failed"):
+        try:
+            raise RuntimeError("setup failed")
+        finally:
+            agent._release_per_job_logger(job_id)
+
+    agent._per_job_logger_ref_counts[job_id.decode()] = 1
+    agent._release_per_job_logger(job_id)
+    assert job_id.decode() not in agent._per_job_logger_ref_counts
+
 
 def test_reference_table():
     expected_unused_uris = []


### PR DESCRIPTION
> **Superseded by #65452.** That PR merged on August 29 and closed #65451 with a more comprehensive setup-scoped logger implementation, including pooled handlers and late-write protections. This draft is retained only as historical context and should not be merged.

## Description

Release per-job runtime environment loggers after their last active setup user
finishes. The runtime env agent previously cached each job logger forever, while
its rotating file handlers and Python's global logging registry kept the logger
and its file descriptors alive for the lifetime of the agent.

The cache now tracks active setup users with reference counts. Final release
closes and removes all handlers, evicts both agent-side entries, and removes the
same logger instance from the global registry under the logging lock. Cleanup
runs from `finally` and is defensive so it cannot mask the original setup
exception. Concurrent setup calls for one job continue sharing a live logger.

## Related issues

Fixes #65451.

## Duplicate check

Before implementation and again before publication, I searched open Ray PRs by
issue number, `per-job logger`, `runtime env logger`, and `runtime_env_setup`.
No competing implementation was open at those checkpoints.

## Tests

- Focused source-module pytest harness for
  `test_per_job_logger_released_after_last_setup`: `1 passed in 0.07s`.
  The source module was loaded against an installed Ray binary because this
  checkout does not contain the compiled `_raylet` extension.
- `.venv/bin/pre-commit run --files python/ray/_private/runtime_env/agent/runtime_env_agent.py python/ray/tests/test_runtime_env_agent.py`: all applicable hooks passed, including Ruff, Black, pydoclint, import-order checks, Semgrep, and Ray-specific checks.
- `git diff --check`: passed.
