### PR TITLE
[cherry-pick][2.58.0][serve][test] Wait for controller after chat-template test (#65380)

### DIFF
--- a/release/llm_tests/serve/test_llm_serve_integration.py
+++ b/release/llm_tests/serve/test_llm_serve_integration.py
@@ -477,7 +477,7 @@ def test_chat_completion_with_default_chat_template_kwargs():
     assert response.status_code == 200, response.text
     assert response.json()["choices"][0]["message"]["content"]
 
-    serve.shutdown()
+    shutdown_serve_and_wait_for_controller()
     time.sleep(1)
 
 


### PR DESCRIPTION
Cherry-pick of #65380 (merge commit `85cd8fd301a9aa108cfb29e3613bd4e645c2b798`, authored by @eicherseiji) onto `releases/2.58.0`. Clean pick, no conflicts — test-only change (`release/llm_tests/serve/test_llm_serve_integration.py`, +1/-1).

## Description

The direct-streaming LLM serve suite runs `test_chat_completion_with_default_chat_template_kwargs` immediately before the fault-tolerance test. Its plain `serve.shutdown()` can return before the controller exits, so the next test reconnects during shutdown and fails. This switches that call to the controller-waiting shutdown helper (`shutdown_serve_and_wait_for_controller`, added in #65116), which every other test in the file already uses.

`shutdown_serve_and_wait_for_controller` is already present on `releases/2.58.0` (imported at line 18 and used by the other 7 tests), so the pick applies with no additional dependency.

Not a duplicate: no existing cherry-pick PR for #65380 targets this branch.

## Related issues

Related to #65380

## Additional information

Checks run:

- `git cherry-pick -x -s` applied cleanly; the resulting diff is byte-identical to the master change.
- `pre-commit run --files release/llm_tests/serve/test_llm_serve_integration.py` — passed (same check the original PR ran).
- AI assistance (Claude Code) was used to prepare this cherry-pick; reviewed by the submitter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)