### PR TITLE
[Data] Increase `test_tensor` timeout classification to Medium

### DIFF
--- a/python/ray/data/BUILD.bazel
+++ b/python/ray/data/BUILD.bazel
@@ -1128,7 +1128,7 @@ py_test(
 
 py_test(
     name = "test_tensor",
-    size = "small",
+    size = "medium",
     srcs = ["tests/test_tensor.py"],
     tags = [
         "exclusive",


### PR DESCRIPTION
## Description
Change `//python/ray/data:test_tensor` from Bazel size `small` to `medium`.

## Related issues
closes #65481.

## Additional information