### PR TITLE
[doc][KubeRay] document ingressOptions for the built-in Ingress

### DIFF
--- a/doc/source/cluster/kubernetes/k8s-ecosystem/ingress.md
+++ b/doc/source/cluster/kubernetes/k8s-ecosystem/ingress.md
@@ -26,17 +26,17 @@ The following examples show how to use Ingress or Gateway to access your Ray clu
 (kuberay-builtin-ingress)=
 ## KubeRay built-in Ingress
 
-Instead of writing an Ingress manifest yourself, you can let KubeRay create and manage the Ingress for the Ray head service. Set `enableIngress` to `true` in `headGroupSpec`, and customize the generated Ingress with `ingressOptions`. KubeRay 1.7.0 and later support `ingressOptions`.
+KubeRay 1.7.0 adds `ingressOptions`, which lets the operator generate and manage an Ingress for the Ray head service. You can configure the Ingress directly in the RayCluster using `ingressOptions`. The operator creates the corresponding Ingress, updates it when the configuration changes, and deletes it when the RayCluster is deleted.
 
 ### Prerequisites
 
-* An Ingress controller running in your cluster, for example the [NGINX Ingress Controller](https://kubernetes.github.io/ingress-nginx/). See [Manually setting up NGINX Ingress on Kind](kuberay-nginx) for a Kind-based setup.
+- KubeRay operator v1.7 or later installed.
 
-* KubeRay 1.7 or later.
+- An Ingress controller running in your cluster. See the [Kubernetes Ingress Controllers documentation](https://kubernetes.io/docs/concepts/services-networking/ingress-controllers/) for more information.
 
-### Instructions
+### Configure `ingressOptions`
 
-Save the following file as `ray-cluster-builtin-ingress.yaml`:
+Set `enableIngress` to `true` and add `ingressOptions` to `headGroupSpec`:
 
 ```yaml
 apiVersion: ray.io/v1
@@ -44,11 +44,8 @@ kind: RayCluster
 metadata:
   name: raycluster-ingress
   annotations:
-    # KubeRay sets `spec.ingressClassName` on the generated Ingress from this annotation, and
-    # copies every other RayCluster annotation to the Ingress unchanged.
     kubernetes.io/ingress.class: nginx
 spec:
-  rayVersion: "2.52.0" # should match the Ray version in the image of the containers
   headGroupSpec:
     enableIngress: true
     ingressOptions:
@@ -59,50 +56,9 @@ spec:
         - hosts:
             - ray-dashboard.example.com
           secretName: ray-dashboard-tls
-    rayStartParams: {}
-    template:
-      spec:
-        containers:
-          - name: ray-head
-            image: rayproject/ray:2.52.0
-            ports:
-              - containerPort: 6379
-                name: gcs-server
-              - containerPort: 8265 # Ray dashboard
-                name: dashboard
-              - containerPort: 10001
-                name: client
-  workerGroupSpecs:
-    - groupName: small-group
-      replicas: 1
-      rayStartParams: {}
-      template:
-        spec:
-          containers:
-            - name: ray-worker
-              image: rayproject/ray:2.52.0
 ```
-Now run the following commands:
 
-```bash
-# Step 1: Install KubeRay operator and CRD
-helm repo add kuberay https://ray-project.github.io/kuberay-helm/
-helm repo update
-helm install kuberay-operator kuberay/kuberay-operator --version 1.7.0
-
-# Step 2: Create the RayCluster. KubeRay creates an Ingress named
-#         `<raycluster-name>-head-ingress` that points at the dashboard port of the head
-#         service, which is 8265 by default.
-kubectl apply -f ray-cluster-builtin-ingress.yaml
-
-# Step 3: Check the ingress created in Step 2.
-kubectl describe ingress raycluster-ingress-head-ingress
-
-# Step 4: Check the Ray Dashboard at the host you configured in `ingressOptions.host`.
-
-# Step 5: Delete the RayCluster. KubeRay deletes the generated Ingress along with it.
-kubectl delete -f ray-cluster-builtin-ingress.yaml
-```
+The operator generates an Ingress named `<raycluster-name>-head-ingress` that routes to the head service on the dashboard port.
 
 Every field under `ingressOptions` is optional:
 
@@ -114,12 +70,6 @@ Every field under `ingressOptions` is optional:
 | `tls`      | TLS termination for the generated Ingress, using the Kubernetes [IngressTLS](https://kubernetes.io/docs/reference/kubernetes-api/service-resources/ingress-v1/#IngressSpec) schema. | Unset, which serves plain HTTP. |
 
 If you set only `enableIngress: true`, KubeRay generates an Ingress that matches any host and routes `/` to the dashboard. If you update `ingressOptions` on an existing RayCluster, KubeRay updates the generated Ingress to match.
-
-```{note}
-KubeRay only manages the Ingress it creates. It doesn't modify an Ingress that it doesn't own, even if the name matches. On OpenShift, KubeRay creates a Route instead of an Ingress, and `ingressOptions` doesn't apply.
-```
-
-
 
 (kuberay-aws-alb)=
 ## AWS Application Load Balancer (ALB) Ingress support on AWS EKS

--- a/doc/source/cluster/kubernetes/k8s-ecosystem/ingress.md
+++ b/doc/source/cluster/kubernetes/k8s-ecosystem/ingress.md
@@ -9,6 +9,7 @@ myst:
 # Ingress
 
 The following examples show how to use Ingress or Gateway to access your Ray clusters:
+
   * [KubeRay built-in Ingress](kuberay-builtin-ingress)
   * [AWS Application Load Balancer (ALB) Ingress support on AWS EKS](kuberay-aws-alb)
   * [GKE Ingress support](kuberay-gke-ingress)

--- a/doc/source/cluster/kubernetes/k8s-ecosystem/ingress.md
+++ b/doc/source/cluster/kubernetes/k8s-ecosystem/ingress.md
@@ -1,7 +1,7 @@
 ---
 myst:
   html_meta:
-    description: "Expose Ray clusters on Kubernetes through AWS ALB ingress on EKS, GKE Ingress, or the GKE Gateway API."
+    description: "Expose Ray clusters on Kubernetes through the KubeRay built-in Ingress, AWS ALB ingress on EKS, GKE Ingress, or the GKE Gateway API."
 ---
 
 (kuberay-ingress)=
@@ -9,7 +9,7 @@ myst:
 # Ingress
 
 The following examples show how to use Ingress or Gateway to access your Ray clusters:
-
+  * [KubeRay built-in Ingress](kuberay-builtin-ingress)
   * [AWS Application Load Balancer (ALB) Ingress support on AWS EKS](kuberay-aws-alb)
   * [GKE Ingress support](kuberay-gke-ingress)
   * [GKE Gateway API support](kuberay-gke-gateway)
@@ -21,6 +21,103 @@ The following examples show how to use Ingress or Gateway to access your Ray clu
 :class: warning
 **Only expose Ingresses or Gateways to authorized users.** The Ray Dashboard provides read and write access to the Ray Cluster. Anyone with access to this Ingress or Gateway can execute arbitrary code on the Ray Cluster.
 ```
+
+(kuberay-builtin-ingress)=
+## KubeRay built-in Ingress
+
+Instead of writing an Ingress manifest yourself, you can let KubeRay create and manage the Ingress for the Ray head service. Set `enableIngress` to `true` in `headGroupSpec`, and customize the generated Ingress with `ingressOptions`. KubeRay 1.7.0 and later support `ingressOptions`.
+
+### Prerequisites
+
+* An Ingress controller running in your cluster, for example the [NGINX Ingress Controller](https://kubernetes.github.io/ingress-nginx/). See [Manually setting up NGINX Ingress on Kind](kuberay-nginx) for a Kind-based setup.
+
+* KubeRay 1.7 or later.
+
+### Instructions
+
+Save the following file as `ray-cluster-builtin-ingress.yaml`:
+
+```yaml
+apiVersion: ray.io/v1
+kind: RayCluster
+metadata:
+  name: raycluster-ingress
+  annotations:
+    # KubeRay sets `spec.ingressClassName` on the generated Ingress from this annotation, and
+    # copies every other RayCluster annotation to the Ingress unchanged.
+    kubernetes.io/ingress.class: nginx
+spec:
+  rayVersion: "2.52.0" # should match the Ray version in the image of the containers
+  headGroupSpec:
+    enableIngress: true
+    ingressOptions:
+      host: ray-dashboard.example.com
+      path: /
+      pathType: Prefix
+      tls:
+        - hosts:
+            - ray-dashboard.example.com
+          secretName: ray-dashboard-tls
+    rayStartParams: {}
+    template:
+      spec:
+        containers:
+          - name: ray-head
+            image: rayproject/ray:2.52.0
+            ports:
+              - containerPort: 6379
+                name: gcs-server
+              - containerPort: 8265 # Ray dashboard
+                name: dashboard
+              - containerPort: 10001
+                name: client
+  workerGroupSpecs:
+    - groupName: small-group
+      replicas: 1
+      rayStartParams: {}
+      template:
+        spec:
+          containers:
+            - name: ray-worker
+              image: rayproject/ray:2.52.0
+```
+Now run the following commands:
+
+```bash
+# Step 1: Install KubeRay operator and CRD
+helm repo add kuberay https://ray-project.github.io/kuberay-helm/
+helm repo update
+helm install kuberay-operator kuberay/kuberay-operator --version 1.7.0
+
+# Step 2: Create the RayCluster. KubeRay creates an Ingress named
+#         `<raycluster-name>-head-ingress` that points at the dashboard port of the head
+#         service, which is 8265 by default.
+kubectl apply -f ray-cluster-builtin-ingress.yaml
+
+# Step 3: Check the ingress created in Step 2.
+kubectl describe ingress raycluster-ingress-head-ingress
+
+# Step 4: Check the Ray Dashboard at the host you configured in `ingressOptions.host`.
+
+# Step 5: Delete the RayCluster. KubeRay deletes the generated Ingress along with it.
+kubectl delete -f ray-cluster-builtin-ingress.yaml
+```
+
+Every field under `ingressOptions` is optional:
+
+| Field      | Description                                                                                                                                                                         | Default                         |
+| ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------- |
+| `host`     | Fully qualified domain name that routes external traffic to the Ray head dashboard.                                                                                                 | Unset, which matches any host.  |
+| `path`     | HTTP path that routes to the dashboard.                                                                                                                                             | `/`                             |
+| `pathType` | Path matching mode for `path`. One of `Exact`, `Prefix`, or `ImplementationSpecific`.                                                                                               | `Prefix`                        |
+| `tls`      | TLS termination for the generated Ingress, using the Kubernetes [IngressTLS](https://kubernetes.io/docs/reference/kubernetes-api/service-resources/ingress-v1/#IngressSpec) schema. | Unset, which serves plain HTTP. |
+
+If you set only `enableIngress: true`, KubeRay generates an Ingress that matches any host and routes `/` to the dashboard. If you update `ingressOptions` on an existing RayCluster, KubeRay updates the generated Ingress to match.
+
+```{note}
+KubeRay only manages the Ingress it creates. It doesn't modify an Ingress that it doesn't own, even if the name matches. On OpenShift, KubeRay creates a Route instead of an Ingress, and `ingressOptions` doesn't apply.
+```
+
 
 
 (kuberay-aws-alb)=


### PR DESCRIPTION
## Description

KubeRay 1.7 added `ingressOptions` on `headGroupSpec` (ray-project/kuberay#4901), which lets the
operator generate the head-service Ingress with a custom host, path, path type, and TLS
configuration. The feature landed without documentation, and this page currently only covers
writing Ingress and Gateway manifests by hand.

This adds a "KubeRay built-in Ingress" section covering `enableIngress`, the `ingressOptions`
fields and their defaults, and the fact that the ingress class comes from the
`kubernetes.io/ingress.class` annotation on the RayCluster rather than from `ingressOptions`.

## Related issues

Closes ray-project/kuberay#5127

## Additional information

`ingressOptions` isn't in KubeRay v1.6.0, and v1.7.0 isn't tagged yet (latest release is
v1.6.2), so the helm command pins `1.7.0` on the assumption this doc lands with the 1.7.0
release. Happy to change the pin if you'd prefer otherwise.
