### PR TITLE
[serve] Declare __all__ in ray.serve.request_router

### DIFF
--- a/python/ray/serve/request_router.py
+++ b/python/ray/serve/request_router.py
@@ -1,14 +1,32 @@
-from ray.serve._private.common import ReplicaID  # noqa: F401
+from ray.serve._private.common import ReplicaID
 from ray.serve._private.replica_result import ReplicaResult  # noqa: F401
-from ray.serve._private.request_router.common import (  # noqa: F401
+from ray.serve._private.request_router.common import (
     PendingRequest,
 )
-from ray.serve._private.request_router.replica_wrapper import (  # noqa: F401
+from ray.serve._private.request_router.replica_wrapper import (
     RunningReplica,
 )
-from ray.serve._private.request_router.request_router import (  # noqa: F401
+from ray.serve._private.request_router.request_router import (
     FIFOMixin,
     LocalityMixin,
     MultiplexMixin,
     RequestRouter,
 )
+
+# The public request-router extension surface. Every name here is decorated
+# `@PublicAPI` at its definition site and documented in the Serve API reference
+# under its `serve.request_router.*` path, so declaring them explicitly records
+# an existing contract rather than creating a new one.
+#
+# `ReplicaResult` is deliberately absent: it carries no API annotation and has no
+# reference-page entry, so it isn't part of this public surface. It keeps an
+# explicit F401 suppression because the re-export itself is still in use.
+__all__ = [
+    "FIFOMixin",
+    "LocalityMixin",
+    "MultiplexMixin",
+    "PendingRequest",
+    "ReplicaID",
+    "RequestRouter",
+    "RunningReplica",
+]


### PR DESCRIPTION
## Why

`python/ray/serve/request_router.py` re-exports the public request-router extension surface, but declares it implicitly through `# noqa: F401` imports rather than explicitly through `__all__`. This declares it.

The seven names are each decorated `@PublicAPI(stability="alpha")` at their definition site and documented in the Serve API reference at `doc/source/serve/api/index.md` under their `serve.request_router.*` path. `doc/source/serve/advanced-guides/custom-request-router.md` and its `doc_code/custom_request_router.py` teach users to import from this module. So the change records an existing contract rather than creating a new one.

It also makes the surface visible to the API-doc consistency check. `API._is_public_reexport()`, added in #65340, treats a name in a public module's `__all__` as public regardless of where its implementation lives, but it requires an *explicit* `__all__` entry, which this module didn't have.

## Coordination

This is a small mechanical change, so per `AGENTS.md` it's worth saying it was coordinated rather than volunteered. It follows from a ruling Richard Liaw gave on Ray's API location policy: a private definition re-exported through a public module's `__all__` is compliant, and the test that matters is whether users have to import a private package. Declaring the surface here is the fix that ruling implies. Happy to close this if the Serve team would rather handle the module differently.

## `ReplicaResult` is deliberately excluded

It's the one name in the file left out of `__all__`, because unlike the other seven it carries no API annotation (`class ReplicaResult(ABC)`, no decorator) and has no reference-page entry. Including it would newly assert a public contract instead of recording one. Its import keeps an F401 suppression since the re-export is still in use.

**This is the one judgment call in the PR and it's yours to make.** If Serve considers `ReplicaResult` part of the public extension surface, say so and I'll add it.

`PowerOfTwoChoicesRequestRouter` is out of scope: it's absent from both this module's re-exports and the autosummary, so it needs a separate decision.

## Removing the per-import suppressions

The seven declared names lose their `# noqa: F401` comments. A name listed in `__all__` counts as used, so pyflakes and ruff no longer flag it. `ReplicaResult` keeps its suppression.

## Testing

Verified statically:

- `ruff check python/ray/serve/request_router.py` — passes.
- `black --check` and `ruff format --check` — already formatted.
- Full `pre-commit run` on the changed file — all applicable hooks pass (ruff, black, pydoclint, docstyle, import order, semgrep).
- Confirmed the declared `__all__` is exactly the set of seven names in the `serve.request_router.*` autosummary block, with no extras and nothing missing.

**Not verified locally: `api_policy_check`.** It needs a Ray build, and master's Python source doesn't import against a released binary, so I'm relying on CI for that check rather than claiming a local run. The expected effect is on the resolve check only. I'm specifically *not* claiming this clears the `tracked_doc_debt` entries for these symbols: those fail the must-be-documented check, which #65340 explicitly left untouched. If CI shows any of them can drop, I'll follow up separately rather than bundling it here.

## Duplicate check

No open PR touches `python/ray/serve/request_router.py`. #65410 (`[serve] Enforce type checking on the scheduling/routing modules`) touches `_private/request_router/request_router.py` but not this module, so no conflict.

## AI assistance

AI-assisted, per `AGENTS.md`: the analysis and the patch were drafted with Claude Code, and I reviewed every changed line.
