### PR TITLE
[serve][llm] Add Native Anthropic Messages API (/v1/messages) Support

### DIFF
--- a/python/ray/llm/_internal/serve/core/configs/anthropic_api_models.py
+++ b/python/ray/llm/_internal/serve/core/configs/anthropic_api_models.py
@@ -1,0 +1,61 @@
+"""This module contains wrapper classes for Anthropic-compatible protocol models.
+
+Supports vLLM as the underlying engine. If vLLM is not installed or fails to
+import, an ImportError is raised at import time.
+"""
+
+from pydantic import ConfigDict
+
+try:
+    from vllm.entrypoints.anthropic.protocol import (
+        AnthropicCountTokensRequest as _AnthropicCountTokensRequest,
+        AnthropicCountTokensResponse as _AnthropicCountTokensResponse,
+        AnthropicError as _AnthropicError,
+        AnthropicErrorResponse as _AnthropicErrorResponse,
+        AnthropicMessagesRequest as _AnthropicMessagesRequest,
+        AnthropicMessagesResponse as _AnthropicMessagesResponse,
+    )
+    from vllm.entrypoints.anthropic.serving import (
+        AnthropicServingMessages as _AnthropicServingMessages,
+    )
+except ImportError as _vllm_import_error:
+    if isinstance(_vllm_import_error, ModuleNotFoundError) and (
+        _vllm_import_error.name == "vllm"
+        or (_vllm_import_error.name or "").startswith("vllm.")
+    ):
+        raise ImportError(
+            "vLLM is not installed. Anthropic Messages API models require vLLM. "
+            "Install with: `pip install ray[llm]`"
+        ) from _vllm_import_error
+    raise ImportError(
+        "vLLM is installed but failed to import. Anthropic Messages API models "
+        "require a working vLLM installation. "
+        f"Original error: {_vllm_import_error}"
+    ) from _vllm_import_error
+
+
+class AnthropicCountTokensRequest(_AnthropicCountTokensRequest):
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+
+class AnthropicCountTokensResponse(_AnthropicCountTokensResponse):
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+
+class AnthropicError(_AnthropicError):
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+
+class AnthropicErrorResponse(_AnthropicErrorResponse):
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+
+class AnthropicMessagesRequest(_AnthropicMessagesRequest):
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+
+class AnthropicMessagesResponse(_AnthropicMessagesResponse):
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+
+AnthropicServingMessages = _AnthropicServingMessages

--- a/python/ray/llm/_internal/serve/core/engine/protocol.py
+++ b/python/ray/llm/_internal/serve/core/engine/protocol.py
@@ -8,6 +8,12 @@ from ray.llm._internal.serve.core.configs.llm_config import (
 from ray.llm._internal.serve.core.protocol import RawRequestInfo
 
 if TYPE_CHECKING:
+    from ray.llm._internal.serve.core.configs.anthropic_api_models import (
+        AnthropicCountTokensRequest,
+        AnthropicCountTokensResponse,
+        AnthropicMessagesRequest,
+        AnthropicMessagesResponse,
+    )
     from ray.llm._internal.serve.core.configs.openai_api_models import (
         ChatCompletionRequest,
         ChatCompletionResponse,
@@ -172,6 +178,64 @@ class LLMEngine(abc.ABC):
             None when the generator is done.
         """
         pass
+
+    async def messages(
+        self,
+        request: "AnthropicMessagesRequest",
+        raw_request_info: Optional[RawRequestInfo] = None,
+    ) -> AsyncGenerator[Union[str, "AnthropicMessagesResponse", "ErrorResponse"], None]:
+        """Run an Anthropic Messages request with the engine.
+
+        Optional. Engines that do not support the Anthropic Messages API can
+        leave the default implementation.
+
+        This method is an async generator. We have the following convention:
+
+        * In case of streaming, yield a string representing an SSE event for
+          each chunk. This should already be Anthropic compatible, so the
+          higher level can yield it directly to the client.
+        * In case of non-streaming, yield a single object of type
+          AnthropicMessagesResponse.
+        * In case of error, yield a single object of type ErrorResponse.
+
+        Args:
+            request: The Anthropic Messages request.
+            raw_request_info: Optional RawRequestInfo containing data from the
+                original HTTP request.
+
+        Yields:
+            Union[str, AnthropicMessagesResponse, ErrorResponse]: A string
+            representing a chunk of the response, an AnthropicMessagesResponse
+            object, or an ErrorResponse object.
+        """
+        raise NotImplementedError(
+            f"{type(self).__name__} does not support the Anthropic Messages API."
+        )
+        yield  # Make this an async generator.
+
+    async def count_tokens(
+        self,
+        request: "AnthropicCountTokensRequest",
+        raw_request_info: Optional[RawRequestInfo] = None,
+    ) -> AsyncGenerator[Union["AnthropicCountTokensResponse", "ErrorResponse"], None]:
+        """Count tokens for an Anthropic Messages request.
+
+        Optional. Engines that do not support Anthropic token counting can
+        leave the default implementation.
+
+        Args:
+            request: The Anthropic count_tokens request.
+            raw_request_info: Optional RawRequestInfo containing data from the
+                original HTTP request.
+
+        Yields:
+            Union[AnthropicCountTokensResponse, ErrorResponse]: An
+            AnthropicCountTokensResponse object, or an ErrorResponse object.
+        """
+        raise NotImplementedError(
+            f"{type(self).__name__} does not support Anthropic token counting."
+        )
+        yield  # Make this an async generator.
 
     async def tokenize(
         self,

--- a/python/ray/llm/_internal/serve/core/ingress/anthropic_utils.py
+++ b/python/ray/llm/_internal/serve/core/ingress/anthropic_utils.py
@@ -1,0 +1,41 @@
+"""Helpers for Anthropic ingress, mirroring vLLM's anthropic api_router."""
+
+from typing import AsyncGenerator, Union
+
+from starlette.responses import JSONResponse, Response, StreamingResponse
+
+from ray.llm._internal.serve.core.configs.anthropic_api_models import (
+    AnthropicError,
+    AnthropicErrorResponse,
+    AnthropicMessagesResponse,
+)
+from ray.llm._internal.serve.core.configs.openai_api_models import ErrorResponse
+
+
+def translate_error_response(response: ErrorResponse) -> JSONResponse:
+    anthropic_error = AnthropicErrorResponse(
+        error=AnthropicError(
+            type=response.error.type,
+            message=response.error.message,
+        )
+    )
+    return JSONResponse(
+        status_code=response.error.code,
+        content=anthropic_error.model_dump(exclude_none=True),
+    )
+
+
+def anthropic_messages_http_response(
+    result: Union[
+        ErrorResponse,
+        AnthropicMessagesResponse,
+        AsyncGenerator[str, None],
+    ],
+) -> Response:
+    if isinstance(result, ErrorResponse):
+        return translate_error_response(result)
+
+    if isinstance(result, AnthropicMessagesResponse):
+        return JSONResponse(content=result.model_dump(exclude_none=True))
+
+    return StreamingResponse(content=result, media_type="text/event-stream")

--- a/python/ray/llm/_internal/serve/core/ingress/anthropic_utils.py
+++ b/python/ray/llm/_internal/serve/core/ingress/anthropic_utils.py
@@ -2,6 +2,9 @@
 
 from typing import AsyncGenerator, Union
 
+from fastapi import FastAPI, Request, status
+from fastapi.exceptions import RequestValidationError
+from starlette.exceptions import HTTPException
 from starlette.responses import JSONResponse, Response, StreamingResponse
 
 from ray.llm._internal.serve.core.configs.anthropic_api_models import (
@@ -12,17 +15,71 @@ from ray.llm._internal.serve.core.configs.anthropic_api_models import (
 from ray.llm._internal.serve.core.configs.openai_api_models import ErrorResponse
 
 
-def translate_error_response(response: ErrorResponse) -> JSONResponse:
-    anthropic_error = AnthropicErrorResponse(
-        error=AnthropicError(
-            type=response.error.type,
-            message=response.error.message,
-        )
+def _anthropic_error_response(
+    *, status_code: int, error_type: str, message: str
+) -> JSONResponse:
+    error_response = AnthropicErrorResponse(
+        error=AnthropicError(type=error_type, message=message)
     )
     return JSONResponse(
-        status_code=response.error.code,
-        content=anthropic_error.model_dump(exclude_none=True),
+        status_code=status_code,
+        content=error_response.model_dump(exclude_none=True),
     )
+
+
+def translate_error_response(response: ErrorResponse) -> JSONResponse:
+    return _anthropic_error_response(
+        status_code=response.error.code,
+        error_type=response.error.type,
+        message=response.error.message,
+    )
+
+
+async def _handle_anthropic_validation_error(
+    request: Request, exc: RequestValidationError
+) -> JSONResponse:
+    error_details = exc.errors()[0] if exc.errors() else {"msg": "Invalid request"}
+    message = error_details.get("msg", "Unknown validation error")
+    location = error_details.get("loc")
+    if location:
+        message = f"{message} at {location}"
+
+    return _anthropic_error_response(
+        status_code=status.HTTP_400_BAD_REQUEST,
+        error_type="invalid_request_error",
+        message=message,
+    )
+
+
+async def _handle_anthropic_http_error(
+    request: Request, exc: HTTPException
+) -> JSONResponse:
+    # Anthropic error types:
+    # https://platform.claude.com/docs/en/api/errors
+    if exc.status_code == status.HTTP_404_NOT_FOUND:
+        error_type = "not_found_error"
+    elif (
+        status.HTTP_400_BAD_REQUEST
+        <= exc.status_code
+        < status.HTTP_500_INTERNAL_SERVER_ERROR
+    ):
+        error_type = "invalid_request_error"
+    else:
+        error_type = "api_error"
+
+    return _anthropic_error_response(
+        status_code=exc.status_code,
+        error_type=error_type,
+        message=str(exc.detail),
+    )
+
+
+def add_anthropic_exception_handlers(app: FastAPI) -> None:
+    """Install Anthropic-compatible handlers for client-facing errors."""
+    app.add_exception_handler(
+        RequestValidationError, _handle_anthropic_validation_error
+    )
+    app.add_exception_handler(HTTPException, _handle_anthropic_http_error)
 
 
 def anthropic_messages_http_response(

--- a/python/ray/llm/_internal/serve/core/ingress/builder.py
+++ b/python/ray/llm/_internal/serve/core/ingress/builder.py
@@ -345,7 +345,10 @@ def build_anthropic_app(builder_config: dict) -> Application:
             )
         ingress_cls_config = builder_config.ingress_cls_config
         if ingress_cls_config.ingress_cls == OpenAiIngress:
-            ingress_cls_config = IngressClsConfig(ingress_cls=AnthropicIngress)
+            ingress_cls_config = IngressClsConfig(
+                ingress_cls=AnthropicIngress,
+                ingress_extra_kwargs=ingress_cls_config.ingress_extra_kwargs,
+            )
         _validate_direct_streaming_ingress_config(
             builder_config.ingress_deployment_config,
             ingress_cls_config,

--- a/python/ray/llm/_internal/serve/core/ingress/builder.py
+++ b/python/ray/llm/_internal/serve/core/ingress/builder.py
@@ -17,6 +17,7 @@ from ray.llm._internal.serve.core.ingress.ingress import (
     DEFAULT_ANTHROPIC_ENDPOINTS,
     AnthropicIngress,
     OpenAiIngress,
+    init_anthropic,
     make_fastapi_ingress,
 )
 from ray.llm._internal.serve.core.server.builder import (
@@ -391,6 +392,7 @@ def build_anthropic_app(builder_config: dict) -> Application:
     ingress_cls = make_fastapi_ingress(
         ingress_cls_config.ingress_cls,
         endpoint_map=DEFAULT_ANTHROPIC_ENDPOINTS,
+        app=init_anthropic(),
     )
 
     logger.info("============== Ingress Options ==============")

--- a/python/ray/llm/_internal/serve/core/ingress/builder.py
+++ b/python/ray/llm/_internal/serve/core/ingress/builder.py
@@ -14,6 +14,8 @@ from ray.llm._internal.serve.constants import RAY_SERVE_LLM_ENABLE_DIRECT_STREAM
 from ray.llm._internal.serve.core.configs.llm_config import LLMConfig
 from ray.llm._internal.serve.core.configs.openai_api_models import to_model_metadata
 from ray.llm._internal.serve.core.ingress.ingress import (
+    DEFAULT_ANTHROPIC_ENDPOINTS,
+    AnthropicIngress,
     OpenAiIngress,
     make_fastapi_ingress,
 )
@@ -122,6 +124,28 @@ def _build_openai_ingress_request_router(
     )
 
 
+def _build_anthropic_ingress_request_router(
+    *, server: Application, llm_config: LLMConfig
+) -> Application:
+    """Build the ingress request router peer for Anthropic compatible LLM apps."""
+    from ray.llm._internal.serve.core.ingress.router import LLMRouter
+
+    ray_actor_options: Dict[str, Any] = {"num_cpus": 0}
+    if is_kv_aware(llm_config):
+        runtime_env = _get_tokenizing_router_runtime_env(llm_config)
+        if runtime_env is not None:
+            ray_actor_options["runtime_env"] = runtime_env
+    deployment = serve.deployment(
+        LLMRouter,
+        max_ongoing_requests=1000,
+        ray_actor_options=ray_actor_options,
+    )
+    return deployment.bind(
+        server=server,
+        llm_config=llm_config if is_kv_aware(llm_config) else None,
+    )
+
+
 class IngressClsConfig(BaseModelExtended):
     ingress_cls: Union[str, Type[OpenAiIngress]] = Field(
         default=OpenAiIngress,
@@ -204,6 +228,8 @@ class LLMServingArgs(BaseModelExtended):
 def _validate_direct_streaming_ingress_config(
     ingress_deployment_config: Optional[dict],
     ingress_cls_config: IngressClsConfig,
+    *,
+    default_ingress_cls: Type[OpenAiIngress] = OpenAiIngress,
 ) -> None:
     if ingress_deployment_config:
         raise ValueError(
@@ -214,7 +240,7 @@ def _validate_direct_streaming_ingress_config(
         )
 
     if (
-        ingress_cls_config.ingress_cls != OpenAiIngress
+        ingress_cls_config.ingress_cls != default_ingress_cls
         or ingress_cls_config.ingress_extra_kwargs
     ):
         raise ValueError(
@@ -283,6 +309,86 @@ def build_openai_app(builder_config: dict) -> Application:
     )
 
     ingress_cls = make_fastapi_ingress(ingress_cls_config.ingress_cls)
+
+    logger.info("============== Ingress Options ==============")
+    logger.info(pprint.pformat(ingress_options))
+
+    return serve.deployment(ingress_cls, **ingress_options).bind(
+        llm_deployments=llm_deployments,
+        model_cards=model_cards,
+        lora_paths=lora_paths,
+        **ingress_cls_config.ingress_extra_kwargs,
+    )
+
+
+def build_anthropic_app(builder_config: dict) -> Application:
+    """Build an Anthropic Messages API compatible app with the llm deployment
+    setup from the given builder configuration.
+
+    Args:
+        builder_config: The configuration for the builder. It has to conform
+            to the LLMServingArgs pydantic model.
+
+    Returns:
+        The configured Ray Serve Application router.
+    """
+    builder_config = LLMServingArgs.model_validate(builder_config)
+    llm_configs = builder_config.llm_configs
+
+    if RAY_SERVE_LLM_ENABLE_DIRECT_STREAMING:
+        if len(llm_configs) > 1:
+            raise ValueError(
+                "RAY_SERVE_LLM_ENABLE_DIRECT_STREAMING currently supports exactly "
+                "one LLM config. Multi-model direct streaming requires composing "
+                "multiple LLMServer deployments into the main application graph, "
+                "which is not supported yet."
+            )
+        ingress_cls_config = builder_config.ingress_cls_config
+        if ingress_cls_config.ingress_cls == OpenAiIngress:
+            ingress_cls_config = IngressClsConfig(ingress_cls=AnthropicIngress)
+        _validate_direct_streaming_ingress_config(
+            builder_config.ingress_deployment_config,
+            ingress_cls_config,
+            default_ingress_cls=AnthropicIngress,
+        )
+        direct_deployment = _build_direct_streaming_llm_deployment(llm_configs[0])
+        logger.info(
+            "Direct streaming enabled: "
+            "LLMServer=ingress, LLMRouter=ingress_request_router"
+        )
+        return direct_deployment._with_ingress_request_router(
+            _build_anthropic_ingress_request_router(
+                server=direct_deployment, llm_config=llm_configs[0]
+            )
+        )
+
+    llm_deployments = {c.model_id: build_llm_deployment(c) for c in llm_configs}
+    model_cards = {c.model_id: to_model_metadata(c.model_id, c) for c in llm_configs}
+    lora_paths = {
+        c.model_id: c.lora_config.dynamic_lora_loading_path
+        for c in llm_configs
+        if c.lora_config is not None
+    }
+
+    ingress_cls_config = builder_config.ingress_cls_config
+    if ingress_cls_config.ingress_cls == OpenAiIngress:
+        ingress_cls_config = IngressClsConfig(
+            ingress_cls=AnthropicIngress,
+            ingress_extra_kwargs=ingress_cls_config.ingress_extra_kwargs,
+        )
+
+    default_ingress_options = ingress_cls_config.ingress_cls.get_deployment_options(
+        llm_configs
+    )
+
+    ingress_options = maybe_apply_llm_deployment_config_defaults(
+        default_ingress_options, builder_config.ingress_deployment_config
+    )
+
+    ingress_cls = make_fastapi_ingress(
+        ingress_cls_config.ingress_cls,
+        endpoint_map=DEFAULT_ANTHROPIC_ENDPOINTS,
+    )
 
     logger.info("============== Ingress Options ==============")
     logger.info(pprint.pformat(ingress_options))

--- a/python/ray/llm/_internal/serve/core/ingress/ingress.py
+++ b/python/ray/llm/_internal/serve/core/ingress/ingress.py
@@ -30,6 +30,11 @@ from ray.llm._internal.serve.constants import (
     DEFAULT_MAX_ONGOING_REQUESTS,
     DEFAULT_MAX_TARGET_ONGOING_REQUESTS,
 )
+from ray.llm._internal.serve.core.configs.anthropic_api_models import (
+    AnthropicCountTokensRequest,
+    AnthropicCountTokensResponse,
+    AnthropicMessagesRequest,
+)
 from ray.llm._internal.serve.core.configs.llm_config import LLMConfig
 from ray.llm._internal.serve.core.configs.openai_api_models import (
     ChatCompletionRequest,
@@ -52,6 +57,10 @@ from ray.llm._internal.serve.core.configs.openai_api_models import (
     TokenizeCompletionRequest,
     TokenizeResponse,
     TranscriptionRequest,
+)
+from ray.llm._internal.serve.core.ingress.anthropic_utils import (
+    anthropic_messages_http_response,
+    translate_error_response,
 )
 from ray.llm._internal.serve.core.ingress.middleware import (
     SetRequestIdMiddleware,
@@ -130,6 +139,11 @@ DEFAULT_ENDPOINTS = {
     "score": lambda app: app.post("/v1/score"),
     "tokenize": lambda app: app.post("/tokenize"),
     "detokenize": lambda app: app.post("/detokenize"),
+}
+
+DEFAULT_ANTHROPIC_ENDPOINTS = {
+    "messages": lambda app: app.post("/v1/messages"),
+    "count_tokens": lambda app: app.post("/v1/messages/count_tokens"),
 }
 
 
@@ -692,3 +706,81 @@ class OpenAiIngress(DeploymentProtocol):
         if _all_models_scale_to_zero(llm_configs):
             options.setdefault("autoscaling_config", {})["min_replicas"] = 0
         return options
+
+
+class AnthropicIngress(OpenAiIngress):
+    """Anthropic Messages API compatible model router."""
+
+    async def _stream_anthropic_response(
+        self,
+        *,
+        body: AnthropicMessagesRequest,
+        call_method: str,
+        raw_request: Optional[Request] = None,
+    ):
+        model_id = await self._get_model_id(body.model)
+        model_handle = self._get_configured_serve_handle(model_id)
+
+        if raw_request is not None:
+            session_id = session_id_from_headers(raw_request.headers)
+            if session_id:
+                model_handle = model_handle.options(session_id=session_id)
+
+        raw_request_info: Optional[RawRequestInfo] = None
+        if raw_request is not None:
+            raw_request_info = RawRequestInfo.from_starlette_request(raw_request)
+
+        async for response in getattr(model_handle, call_method).remote(
+            body, raw_request_info
+        ):
+            yield response
+
+    async def messages(
+        self, body: AnthropicMessagesRequest, request: Request
+    ) -> Response:
+        async with router_request_timeout(DEFAULT_LLM_ROUTER_HTTP_TIMEOUT):
+            gen = self._stream_anthropic_response(
+                body=body, call_method="messages", raw_request=request
+            )
+
+            initial_response, gen = await _peek_at_generator(gen)
+
+            if isinstance(initial_response, ErrorResponse):
+                return translate_error_response(initial_response)
+
+            if isinstance(initial_response, str):
+
+                async def stream():
+                    yield initial_response
+                    async for item in gen:
+                        yield item
+
+                return anthropic_messages_http_response(stream())
+
+            return anthropic_messages_http_response(initial_response)
+
+    async def count_tokens(
+        self, body: AnthropicCountTokensRequest, request: Request
+    ) -> Response:
+        async with router_request_timeout(DEFAULT_LLM_ROUTER_HTTP_TIMEOUT):
+            model_id = await self._get_model_id(body.model)
+            model_handle = self._get_configured_serve_handle(model_id)
+
+            session_id = session_id_from_headers(request.headers)
+            if session_id:
+                model_handle = model_handle.options(session_id=session_id)
+
+            raw_request_info = RawRequestInfo.from_starlette_request(request)
+            results = model_handle.count_tokens.remote(body, raw_request_info)
+            result = await results.__anext__()
+
+            if isinstance(result, ErrorResponse):
+                return translate_error_response(result)
+
+            if isinstance(result, AnthropicCountTokensResponse):
+                return JSONResponse(content=result.model_dump(exclude_none=True))
+
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="Unexpected response type from count_tokens",
+            )

--- a/python/ray/llm/_internal/serve/core/ingress/ingress.py
+++ b/python/ray/llm/_internal/serve/core/ingress/ingress.py
@@ -59,6 +59,7 @@ from ray.llm._internal.serve.core.configs.openai_api_models import (
     TranscriptionRequest,
 )
 from ray.llm._internal.serve.core.ingress.anthropic_utils import (
+    add_anthropic_exception_handlers,
     anthropic_messages_http_response,
     translate_error_response,
 )
@@ -180,6 +181,13 @@ def init() -> FastAPI:
     _fastapi_router_app.add_middleware(SetRequestIdMiddleware)
 
     return _fastapi_router_app
+
+
+def init_anthropic() -> FastAPI:
+    """Create a FastAPI app with Anthropic-compatible error responses."""
+    app = init()
+    add_anthropic_exception_handlers(app)
+    return app
 
 
 def make_fastapi_ingress(
@@ -749,13 +757,7 @@ class AnthropicIngress(OpenAiIngress):
                 return translate_error_response(initial_response)
 
             if isinstance(initial_response, str):
-
-                async def stream():
-                    yield initial_response
-                    async for item in gen:
-                        yield item
-
-                return anthropic_messages_http_response(stream())
+                return anthropic_messages_http_response(gen)
 
             return anthropic_messages_http_response(initial_response)
 

--- a/python/ray/llm/_internal/serve/core/protocol.py
+++ b/python/ray/llm/_internal/serve/core/protocol.py
@@ -13,6 +13,12 @@ from typing import (
 from starlette.requests import Request
 
 if TYPE_CHECKING:
+    from ray.llm._internal.serve.core.configs.anthropic_api_models import (
+        AnthropicCountTokensRequest,
+        AnthropicCountTokensResponse,
+        AnthropicMessagesRequest,
+        AnthropicMessagesResponse,
+    )
     from ray.llm._internal.serve.core.configs.llm_config import LLMConfig
     from ray.llm._internal.serve.core.configs.openai_api_models import (
         ChatCompletionRequest,
@@ -113,6 +119,20 @@ class LLMServerProtocol(DeploymentProtocol):
         """
         Inferencing to the engine for completion api, and return the response.
         """
+
+    async def messages(
+        self,
+        request: "AnthropicMessagesRequest",
+        raw_request_info: Optional[RawRequestInfo] = None,
+    ) -> AsyncGenerator[Union[str, "AnthropicMessagesResponse", "ErrorResponse"], None]:
+        """Inferencing to the engine for Anthropic Messages API."""
+
+    async def count_tokens(
+        self,
+        request: "AnthropicCountTokensRequest",
+        raw_request_info: Optional[RawRequestInfo] = None,
+    ) -> AsyncGenerator[Union["AnthropicCountTokensResponse", "ErrorResponse"], None]:
+        """Count tokens for an Anthropic Messages request."""
 
     async def check_health(self) -> None:
         """

--- a/python/ray/llm/_internal/serve/core/server/llm_server.py
+++ b/python/ray/llm/_internal/serve/core/server/llm_server.py
@@ -49,6 +49,12 @@ from ray.llm._internal.serve.utils.server_utils import (
 )
 
 if TYPE_CHECKING:
+    from ray.llm._internal.serve.core.configs.anthropic_api_models import (
+        AnthropicCountTokensRequest,
+        AnthropicCountTokensResponse,
+        AnthropicMessagesRequest,
+        AnthropicMessagesResponse,
+    )
     from ray.llm._internal.serve.core.configs.openai_api_models import (
         ChatCompletionRequest,
         ChatCompletionResponse,
@@ -426,6 +432,29 @@ class LLMServer(LLMServerProtocol):
             batch_output_stream=True,
             raw_request_info=raw_request_info,
         )
+
+    async def messages(
+        self,
+        request: "AnthropicMessagesRequest",
+        raw_request_info: Optional[RawRequestInfo] = None,
+    ) -> AsyncGenerator[
+        Union[str, "AnthropicMessagesResponse", "ErrorResponse"],
+        None,
+    ]:
+        """Runs an Anthropic Messages request to the LLM engine."""
+        await self._maybe_resolve_lora_from_multiplex()
+        async for response in self.engine.messages(request, raw_request_info):
+            yield response
+
+    async def count_tokens(
+        self,
+        request: "AnthropicCountTokensRequest",
+        raw_request_info: Optional[RawRequestInfo] = None,
+    ) -> AsyncGenerator[Union["AnthropicCountTokensResponse", "ErrorResponse"], None]:
+        """Runs an Anthropic count_tokens request to the LLM engine."""
+        await self._maybe_resolve_lora_from_multiplex()
+        async for response in self.engine.count_tokens(request, raw_request_info):
+            yield response
 
     async def embeddings(
         self,

--- a/python/ray/llm/_internal/serve/engines/vllm/vllm_engine.py
+++ b/python/ray/llm/_internal/serve/engines/vllm/vllm_engine.py
@@ -29,6 +29,12 @@ from ray.llm._internal.common.utils.import_utils import try_import
 from ray.llm._internal.serve.constants import (
     RAY_SERVE_LLM_ENABLE_DECODE_BLOCK_PROGRESS,
 )
+from ray.llm._internal.serve.core.configs.anthropic_api_models import (
+    AnthropicCountTokensRequest,
+    AnthropicCountTokensResponse,
+    AnthropicMessagesRequest,
+    AnthropicMessagesResponse,
+)
 from ray.llm._internal.serve.core.configs.llm_config import (
     DiskMultiplexConfig,
     LLMConfig,
@@ -445,6 +451,9 @@ class VLLMEngine(LLMEngine):
         self._oai_serving_tokenization = getattr(
             state, "openai_serving_tokenization", None
         )
+        self._anthropic_serving_messages = getattr(
+            state, "anthropic_serving_messages", None
+        )
 
         self._validate_openai_serving_models()
         self._validate_engine_client()
@@ -532,6 +541,10 @@ class VLLMEngine(LLMEngine):
                 "This model does not support the 'tokenization' task. "
                 "The tokenization endpoint is not available for this model."
             )
+
+    def _validate_anthropic_serving_messages(self) -> Optional[ErrorResponse]:
+        if self._anthropic_serving_messages is None:
+            return self._make_error("The model does not support Messages API")
 
     def _validate_engine_client(self):
         assert hasattr(
@@ -699,6 +712,77 @@ class VLLMEngine(LLMEngine):
                 yield ErrorResponse(error=ErrorInfo(**chat_response.error.model_dump()))
             else:
                 yield ChatCompletionResponse(**chat_response.model_dump())
+
+    async def messages(
+        self,
+        request: AnthropicMessagesRequest,
+        raw_request_info: Optional[RawRequestInfo] = None,
+    ) -> AsyncGenerator[Union[str, AnthropicMessagesResponse, ErrorResponse], None]:
+        if error := self._validate_anthropic_serving_messages():
+            yield error
+            return
+
+        raw_request: Optional[Request] = RawRequestInfo.to_starlette_request_optional(
+            raw_request_info
+        )
+        try:
+            messages_response = await self._anthropic_serving_messages.create_messages(  # type: ignore[attr-defined]
+                request,
+                raw_request=raw_request,
+            )
+        except ValueError as e:
+            yield self._make_error_response(self._anthropic_serving_messages, e)
+            return
+        except Exception as e:
+            yield self._make_error_response(self._anthropic_serving_messages, e)
+            return
+
+        if isinstance(messages_response, AsyncGenerator):
+            async for response in messages_response:
+                if not isinstance(response, str):
+                    raise ValueError(
+                        "Expected create_messages to return a stream of strings, "
+                        f"got an item with type {type(response)}"
+                    )
+                yield response
+        else:
+            if isinstance(messages_response, VLLMErrorResponse):
+                yield ErrorResponse(
+                    error=ErrorInfo(**messages_response.error.model_dump())
+                )
+            else:
+                yield AnthropicMessagesResponse(**messages_response.model_dump())
+
+    async def count_tokens(
+        self,
+        request: AnthropicCountTokensRequest,
+        raw_request_info: Optional[RawRequestInfo] = None,
+    ) -> AsyncGenerator[Union[AnthropicCountTokensResponse, ErrorResponse], None]:
+        if error := self._validate_anthropic_serving_messages():
+            yield error
+            return
+
+        raw_request: Optional[Request] = RawRequestInfo.to_starlette_request_optional(
+            raw_request_info
+        )
+        try:
+            count_tokens_response = await self._anthropic_serving_messages.count_tokens(  # type: ignore[attr-defined]
+                request,
+                raw_request=raw_request,
+            )
+        except ValueError as e:
+            yield self._make_error_response(self._anthropic_serving_messages, e)
+            return
+        except Exception as e:
+            yield self._make_error_response(self._anthropic_serving_messages, e)
+            return
+
+        if isinstance(count_tokens_response, VLLMErrorResponse):
+            yield ErrorResponse(
+                error=ErrorInfo(**count_tokens_response.error.model_dump())
+            )
+        else:
+            yield AnthropicCountTokensResponse(**count_tokens_response.model_dump())
 
     async def completions(
         self,

--- a/python/ray/llm/tests/serve/cpu/configs/test_anthropic_api_models_backends.py
+++ b/python/ray/llm/tests/serve/cpu/configs/test_anthropic_api_models_backends.py
@@ -1,0 +1,97 @@
+"""Tests for anthropic_api_models.py vLLM import behaviour."""
+
+import importlib
+import sys
+
+import pytest
+
+_ANTHROPIC_MODELS_MOD = "ray.llm._internal.serve.core.configs.anthropic_api_models"
+
+
+class _VLLMImportBlocker:
+    def find_spec(self, fullname, path=None, target=None):
+        if fullname == "vllm" or fullname.startswith("vllm."):
+            err = ModuleNotFoundError(f"Mocked: {fullname} is not installed")
+            err.name = fullname
+            raise err
+        return None
+
+
+class _VLLMBrokenInstallBlocker:
+    def __init__(self, error: ImportError):
+        self._error = error
+
+    def find_spec(self, fullname, path=None, target=None):
+        if fullname == "vllm" or fullname.startswith("vllm."):
+            raise self._error
+        return None
+
+
+class TestVLLMBackend:
+    def test_wrapper_classes_inherit_from_vllm(self):
+        from ray.llm._internal.serve.core.configs.anthropic_api_models import (
+            AnthropicCountTokensRequest,
+            AnthropicMessagesRequest,
+            AnthropicMessagesResponse,
+        )
+
+        assert "vllm" in AnthropicMessagesRequest.__mro__[1].__module__
+        assert "vllm" in AnthropicMessagesResponse.__mro__[1].__module__
+        assert "vllm" in AnthropicCountTokensRequest.__mro__[1].__module__
+
+    def test_messages_request_round_trip(self):
+        from ray.llm._internal.serve.core.configs.anthropic_api_models import (
+            AnthropicMessagesRequest,
+        )
+
+        request = AnthropicMessagesRequest(
+            model="test-model",
+            max_tokens=16,
+            messages=[{"role": "user", "content": "hello"}],
+        )
+        dumped = request.model_dump()
+        assert dumped["model"] == "test-model"
+        assert dumped["messages"][0]["content"] == "hello"
+
+    def _reload_anthropic_models_with_blocker(self, blocker):
+        saved = {
+            k: sys.modules.pop(k)
+            for k in list(sys.modules)
+            if k == "vllm" or k.startswith("vllm.")
+        }
+        sys.modules.pop(_ANTHROPIC_MODELS_MOD, None)
+        sys.meta_path.insert(0, blocker)
+        try:
+            importlib.import_module(_ANTHROPIC_MODELS_MOD)
+        finally:
+            sys.meta_path.remove(blocker)
+            sys.modules.pop(_ANTHROPIC_MODELS_MOD, None)
+            sys.modules.update(saved)
+
+    def test_import_error_when_vllm_blocked(self):
+        with pytest.raises(ImportError, match="vLLM is not installed"):
+            self._reload_anthropic_models_with_blocker(_VLLMImportBlocker())
+
+    def test_vllm_installed_but_broken_cuda(self):
+        cuda_err = ImportError(
+            "libcudart.so.12: cannot open shared object file: No such file or directory"
+        )
+        blocker = _VLLMBrokenInstallBlocker(cuda_err)
+        with pytest.raises(ImportError, match="vLLM is installed but failed to import"):
+            self._reload_anthropic_models_with_blocker(blocker)
+
+    def test_public_reexports_stable(self):
+        from ray.serve.llm.anthropic_api_models import AnthropicMessagesRequest
+
+        assert any(
+            "vllm" in cls.__module__ for cls in AnthropicMessagesRequest.__mro__[1:]
+        )
+
+    def test_build_anthropic_app_in_all(self):
+        from ray.serve import llm
+
+        assert "build_anthropic_app" in llm.__all__
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-v", __file__]))

--- a/python/ray/llm/tests/serve/cpu/deployments/routers/test_anthropic_http.py
+++ b/python/ray/llm/tests/serve/cpu/deployments/routers/test_anthropic_http.py
@@ -56,11 +56,17 @@ def ray_instance():
 
 
 @pytest.fixture
-def anthropic_app(ray_instance, llm_config_with_mock_engine, disable_placement_bundles):
-    app = build_anthropic_app(LLMServingArgs(llm_configs=[llm_config_with_mock_engine]))
-    serve.run(app, name="anthropic-app")
-    yield llm_config_with_mock_engine.model_id
-    serve.delete("anthropic-app", _blocking=True)
+def anthropic_app(ray_instance):
+    llm_config = _mock_llm_config()
+    with patch.object(
+        VLLMEngineConfig,
+        "placement_bundles",
+        new_callable=lambda: property(lambda self: []),
+    ):
+        app = build_anthropic_app(LLMServingArgs(llm_configs=[llm_config]))
+        serve.run(app, name="anthropic-app")
+        yield llm_config.model_id
+        serve.delete("anthropic-app", _blocking=True)
 
 
 class TestAnthropicHttp:
@@ -104,14 +110,8 @@ class TestAnthropicHttp:
         assert response.status_code == 404
 
     @pytest.mark.asyncio
-    async def test_direct_streaming_messages(self, monkeypatch):
+    async def test_direct_streaming_messages(self):
         from fastapi.testclient import TestClient
-
-        monkeypatch.setattr(
-            "ray.llm._internal.serve.core.ingress.builder."
-            "RAY_SERVE_LLM_ENABLE_DIRECT_STREAMING",
-            True,
-        )
 
         llm_config = _mock_llm_config()
         with patch.object(
@@ -133,14 +133,8 @@ class TestAnthropicHttp:
         assert response.json()["type"] == "message"
 
     @pytest.mark.asyncio
-    async def test_direct_streaming_count_tokens(self, monkeypatch):
+    async def test_direct_streaming_count_tokens(self):
         from fastapi.testclient import TestClient
-
-        monkeypatch.setattr(
-            "ray.llm._internal.serve.core.ingress.builder."
-            "RAY_SERVE_LLM_ENABLE_DIRECT_STREAMING",
-            True,
-        )
 
         llm_config = _mock_llm_config()
         with patch.object(

--- a/python/ray/llm/tests/serve/cpu/deployments/routers/test_anthropic_http.py
+++ b/python/ray/llm/tests/serve/cpu/deployments/routers/test_anthropic_http.py
@@ -1,6 +1,7 @@
 """HTTP tests for Anthropic Messages API ingress."""
 
 import sys
+from typing import List
 from unittest.mock import patch
 
 import httpx
@@ -26,10 +27,19 @@ MESSAGES_BODY = {
     "messages": [{"role": "user", "content": "hi"}],
 }
 
+STREAMING_MESSAGES_BODY = {**MESSAGES_BODY, "stream": True}
+
 COUNT_TOKENS_BODY = {
     "model": "test-model",
     "messages": [{"role": "user", "content": "hi there"}],
 }
+
+
+def _sse_event_names(body: str) -> List[str]:
+    prefix = "event: "
+    return [
+        line[len(prefix) :] for line in body.splitlines() if line.startswith(prefix)
+    ]
 
 
 def _mock_llm_config() -> LLMConfig:
@@ -84,6 +94,24 @@ class TestAnthropicHttp:
         assert payload["role"] == "assistant"
 
     @pytest.mark.asyncio
+    async def test_messages_stream(self, anthropic_app):
+        async with httpx.AsyncClient(timeout=60.0) as client:
+            response = await client.post(
+                "http://localhost:8000/v1/messages",
+                json=STREAMING_MESSAGES_BODY,
+            )
+
+        assert response.status_code == 200, response.text
+        assert response.headers["content-type"].startswith("text/event-stream")
+        # The ingress peeks at the first chunk to detect errors, so every event
+        # must reach the client exactly once and in the order the engine emitted.
+        assert _sse_event_names(response.text) == [
+            "message_start",
+            "content_block_delta",
+            "message_stop",
+        ]
+
+    @pytest.mark.asyncio
     async def test_count_tokens(self, anthropic_app):
         async with httpx.AsyncClient(timeout=60.0) as client:
             response = await client.post(
@@ -97,17 +125,46 @@ class TestAnthropicHttp:
         assert payload["input_tokens"] > 0
 
     @pytest.mark.asyncio
-    async def test_messages_missing_model(self, anthropic_app):
+    @pytest.mark.parametrize(
+        ("endpoint", "body"),
+        [
+            ("/v1/messages", MESSAGES_BODY),
+            ("/v1/messages/count_tokens", COUNT_TOKENS_BODY),
+        ],
+    )
+    async def test_missing_model_error_envelope(self, anthropic_app, endpoint, body):
         async with httpx.AsyncClient(timeout=60.0) as client:
             response = await client.post(
-                "http://localhost:8000/v1/messages",
+                f"http://localhost:8000{endpoint}",
                 json={
-                    **MESSAGES_BODY,
+                    **body,
                     "model": "missing-model",
                 },
             )
 
         assert response.status_code == 404
+        payload = response.json()
+        assert payload["type"] == "error"
+        assert payload["error"]["type"] == "not_found_error"
+        assert "missing-model" in payload["error"]["message"]
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "endpoint",
+        ["/v1/messages", "/v1/messages/count_tokens"],
+    )
+    async def test_validation_error_envelope(self, anthropic_app, endpoint):
+        async with httpx.AsyncClient(timeout=60.0) as client:
+            response = await client.post(
+                f"http://localhost:8000{endpoint}",
+                json={},
+            )
+
+        assert response.status_code == 400
+        payload = response.json()
+        assert payload["type"] == "error"
+        assert payload["error"]["type"] == "invalid_request_error"
+        assert payload["error"]["message"]
 
     @pytest.mark.asyncio
     async def test_direct_streaming_messages(self):

--- a/python/ray/llm/tests/serve/cpu/deployments/routers/test_anthropic_http.py
+++ b/python/ray/llm/tests/serve/cpu/deployments/routers/test_anthropic_http.py
@@ -1,0 +1,168 @@
+"""HTTP tests for Anthropic Messages API ingress."""
+
+import sys
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+import ray
+from ray import serve
+from ray.llm._internal.serve.core.configs.llm_config import (
+    LLMConfig,
+    ModelLoadingConfig,
+)
+from ray.llm._internal.serve.core.ingress.builder import (
+    LLMServingArgs,
+    build_anthropic_app,
+)
+from ray.llm._internal.serve.core.server.llm_server import LLMServer
+from ray.llm._internal.serve.engines.vllm.vllm_models import VLLMEngineConfig
+from ray.llm.tests.serve.mocks.mock_vllm_engine import MockVLLMEngine
+
+MESSAGES_BODY = {
+    "model": "test-model",
+    "max_tokens": 4,
+    "messages": [{"role": "user", "content": "hi"}],
+}
+
+COUNT_TOKENS_BODY = {
+    "model": "test-model",
+    "messages": [{"role": "user", "content": "hi there"}],
+}
+
+
+def _mock_llm_config() -> LLMConfig:
+    return LLMConfig(
+        model_loading_config=ModelLoadingConfig(model_id="test-model"),
+        runtime_env={
+            "env_vars": {
+                "RAYLLM_VLLM_ENGINE_CLS": (
+                    "ray.llm.tests.serve.mocks.mock_vllm_engine.MockVLLMEngine"
+                )
+            }
+        },
+        log_engine_metrics=False,
+    )
+
+
+@pytest.fixture(scope="module")
+def ray_instance():
+    if not ray.is_initialized():
+        ray.init()
+    yield
+    serve.shutdown()
+    ray.shutdown()
+
+
+@pytest.fixture
+def anthropic_app(ray_instance, llm_config_with_mock_engine, disable_placement_bundles):
+    app = build_anthropic_app(LLMServingArgs(llm_configs=[llm_config_with_mock_engine]))
+    serve.run(app, name="anthropic-app")
+    yield llm_config_with_mock_engine.model_id
+    serve.delete("anthropic-app", _blocking=True)
+
+
+class TestAnthropicHttp:
+    @pytest.mark.asyncio
+    async def test_messages_non_stream(self, anthropic_app):
+        async with httpx.AsyncClient(timeout=60.0) as client:
+            response = await client.post(
+                "http://localhost:8000/v1/messages",
+                json=MESSAGES_BODY,
+            )
+
+        assert response.status_code == 200, response.text
+        payload = response.json()
+        assert payload["type"] == "message"
+        assert payload["role"] == "assistant"
+
+    @pytest.mark.asyncio
+    async def test_count_tokens(self, anthropic_app):
+        async with httpx.AsyncClient(timeout=60.0) as client:
+            response = await client.post(
+                "http://localhost:8000/v1/messages/count_tokens",
+                json=COUNT_TOKENS_BODY,
+            )
+
+        assert response.status_code == 200, response.text
+        payload = response.json()
+        assert "input_tokens" in payload
+        assert payload["input_tokens"] > 0
+
+    @pytest.mark.asyncio
+    async def test_messages_missing_model(self, anthropic_app):
+        async with httpx.AsyncClient(timeout=60.0) as client:
+            response = await client.post(
+                "http://localhost:8000/v1/messages",
+                json={
+                    **MESSAGES_BODY,
+                    "model": "missing-model",
+                },
+            )
+
+        assert response.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_direct_streaming_messages(self, monkeypatch):
+        from fastapi.testclient import TestClient
+
+        monkeypatch.setattr(
+            "ray.llm._internal.serve.core.ingress.builder."
+            "RAY_SERVE_LLM_ENABLE_DIRECT_STREAMING",
+            True,
+        )
+
+        llm_config = _mock_llm_config()
+        with patch.object(
+            VLLMEngineConfig,
+            "placement_bundles",
+            new_callable=lambda: property(lambda self: []),
+        ), patch(
+            "ray.llm._internal.serve.core.server.llm_server."
+            "push_telemetry_report_for_all_models"
+        ):
+            server = LLMServer.sync_init(llm_config, engine_cls=MockVLLMEngine)
+            await server.start()
+            app = await server.__serve_build_asgi_app__()
+
+            with TestClient(app) as client:
+                response = client.post("/v1/messages", json=MESSAGES_BODY)
+
+        assert response.status_code == 200, response.text
+        assert response.json()["type"] == "message"
+
+    @pytest.mark.asyncio
+    async def test_direct_streaming_count_tokens(self, monkeypatch):
+        from fastapi.testclient import TestClient
+
+        monkeypatch.setattr(
+            "ray.llm._internal.serve.core.ingress.builder."
+            "RAY_SERVE_LLM_ENABLE_DIRECT_STREAMING",
+            True,
+        )
+
+        llm_config = _mock_llm_config()
+        with patch.object(
+            VLLMEngineConfig,
+            "placement_bundles",
+            new_callable=lambda: property(lambda self: []),
+        ), patch(
+            "ray.llm._internal.serve.core.server.llm_server."
+            "push_telemetry_report_for_all_models"
+        ):
+            server = LLMServer.sync_init(llm_config, engine_cls=MockVLLMEngine)
+            await server.start()
+            app = await server.__serve_build_asgi_app__()
+
+            with TestClient(app) as client:
+                response = client.post(
+                    "/v1/messages/count_tokens", json=COUNT_TOKENS_BODY
+                )
+
+        assert response.status_code == 200, response.text
+        assert response.json()["input_tokens"] > 0
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-v", __file__]))

--- a/python/ray/llm/tests/serve/cpu/deployments/routers/test_anthropic_ingress.py
+++ b/python/ray/llm/tests/serve/cpu/deployments/routers/test_anthropic_ingress.py
@@ -1,0 +1,39 @@
+"""Tests for Anthropic ingress route registration."""
+
+import sys
+
+import pytest
+from fastapi import FastAPI
+from fastapi.routing import APIRoute
+
+from ray.llm._internal.serve.core.ingress.ingress import (
+    DEFAULT_ANTHROPIC_ENDPOINTS,
+    AnthropicIngress,
+    make_fastapi_ingress,
+)
+
+
+class TestAnthropicIngressRoutes:
+    def test_anthropic_ingress_registers_messages_route(self):
+        app = FastAPI()
+        make_fastapi_ingress(
+            AnthropicIngress, endpoint_map=DEFAULT_ANTHROPIC_ENDPOINTS, app=app
+        )
+        route_paths = [
+            route.path for route in app.routes if isinstance(route, APIRoute)
+        ]
+        assert "/v1/messages" in route_paths
+
+    def test_anthropic_ingress_registers_count_tokens_route(self):
+        app = FastAPI()
+        make_fastapi_ingress(
+            AnthropicIngress, endpoint_map=DEFAULT_ANTHROPIC_ENDPOINTS, app=app
+        )
+        route_paths = [
+            route.path for route in app.routes if isinstance(route, APIRoute)
+        ]
+        assert "/v1/messages/count_tokens" in route_paths
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-v", __file__]))

--- a/python/ray/llm/tests/serve/cpu/deployments/routers/test_builder_ingress.py
+++ b/python/ray/llm/tests/serve/cpu/deployments/routers/test_builder_ingress.py
@@ -18,9 +18,13 @@ from ray.llm._internal.serve.core.configs.llm_config import (
 from ray.llm._internal.serve.core.ingress.builder import (
     IngressClsConfig,
     LLMServingArgs,
+    build_anthropic_app,
     build_openai_app,
 )
-from ray.llm._internal.serve.core.ingress.ingress import OpenAiIngress
+from ray.llm._internal.serve.core.ingress.ingress import (
+    AnthropicIngress,
+    OpenAiIngress,
+)
 from ray.llm._internal.serve.serving_patterns.data_parallel.builder import (
     build_dp_openai_app,
 )
@@ -487,6 +491,96 @@ class TestBuildOpenaiApp:
 
         with pytest.raises(ValueError, match=match):
             build_openai_app(LLMServingArgs(llm_configs=[llm_config], **builder_kwargs))
+
+
+class TestBuildAnthropicApp:
+    def test_build_anthropic_app(
+        self, get_llm_serve_args, shutdown_ray_and_serve, disable_placement_bundles
+    ):
+        app = build_anthropic_app(get_llm_serve_args)
+        assert app is not None
+        serve.run(app)
+
+    def test_direct_streaming_builds_ingress_with_router_attached(
+        self, llm_config, disable_placement_bundles, monkeypatch
+    ):
+        monkeypatch.setattr(
+            "ray.llm._internal.serve.core.ingress.builder."
+            "RAY_SERVE_LLM_ENABLE_DIRECT_STREAMING",
+            True,
+        )
+
+        app = build_anthropic_app(LLMServingArgs(llm_configs=[llm_config]))
+        ingress_request_router = app._ingress_request_router
+
+        assert app._bound_deployment.name == "LLMServer:test-model"
+        assert issubclass(app._bound_deployment.func_or_class, ASGIAppReplicaWrapper)
+        assert ingress_request_router is not None
+        assert ingress_request_router._bound_deployment.name == "LLMRouter"
+        assert ingress_request_router._bound_deployment.init_kwargs["server"] is app
+
+    def test_direct_streaming_rejects_multiple_llm_configs(
+        self, llm_config, disable_placement_bundles, monkeypatch
+    ):
+        monkeypatch.setattr(
+            "ray.llm._internal.serve.core.ingress.builder."
+            "RAY_SERVE_LLM_ENABLE_DIRECT_STREAMING",
+            True,
+        )
+        other_llm_config = LLMConfig(
+            model_loading_config=ModelLoadingConfig(model_id="other-model")
+        )
+
+        with pytest.raises(
+            ValueError,
+            match="currently supports exactly one LLM config",
+        ):
+            build_anthropic_app(
+                LLMServingArgs(llm_configs=[llm_config, other_llm_config])
+            )
+
+    @pytest.mark.parametrize(
+        ("builder_kwargs", "match"),
+        [
+            (
+                {"ingress_deployment_config": {"num_replicas": 2}},
+                "does not support ingress_deployment_config",
+            ),
+            (
+                {"ingress_cls_config": {"ingress_extra_kwargs": {"key": "value"}}},
+                "does not support ingress_cls_config",
+            ),
+        ],
+    )
+    def test_direct_streaming_rejects_ingress_config(
+        self,
+        llm_config,
+        disable_placement_bundles,
+        monkeypatch,
+        builder_kwargs,
+        match,
+    ):
+        monkeypatch.setattr(
+            "ray.llm._internal.serve.core.ingress.builder."
+            "RAY_SERVE_LLM_ENABLE_DIRECT_STREAMING",
+            True,
+        )
+
+        with pytest.raises(ValueError, match=match):
+            build_anthropic_app(
+                LLMServingArgs(llm_configs=[llm_config], **builder_kwargs)
+            )
+
+    def test_standard_path_uses_anthropic_ingress(
+        self, llm_config, disable_placement_bundles, monkeypatch
+    ):
+        monkeypatch.setattr(
+            "ray.llm._internal.serve.core.ingress.builder."
+            "RAY_SERVE_LLM_ENABLE_DIRECT_STREAMING",
+            False,
+        )
+        app = build_anthropic_app(LLMServingArgs(llm_configs=[llm_config]))
+        assert issubclass(app._bound_deployment.func_or_class, AnthropicIngress)
 
 
 class TestDirectStreamingDP:

--- a/python/ray/llm/tests/serve/cpu/deployments/routers/test_builder_ingress.py
+++ b/python/ray/llm/tests/serve/cpu/deployments/routers/test_builder_ingress.py
@@ -494,6 +494,15 @@ class TestBuildOpenaiApp:
 
 
 class TestBuildAnthropicApp:
+    @pytest.fixture
+    def llm_config(self):
+        """Basic LLMConfig for testing."""
+        return LLMConfig(
+            model_loading_config=ModelLoadingConfig(
+                model_id="test-model", model_source="test-source"
+            )
+        )
+
     def test_build_anthropic_app(
         self, get_llm_serve_args, shutdown_ray_and_serve, disable_placement_bundles
     ):
@@ -518,6 +527,33 @@ class TestBuildAnthropicApp:
         assert ingress_request_router is not None
         assert ingress_request_router._bound_deployment.name == "LLMRouter"
         assert ingress_request_router._bound_deployment.init_kwargs["server"] is app
+
+        request_router_config = (
+            app._bound_deployment._deployment_config.request_router_config
+        )
+        assert request_router_config.request_router_class == (
+            f"{RoundRobinRouter.__module__}.{RoundRobinRouter.__name__}"
+        )
+
+    def test_direct_streaming_user_request_router_config_wins(
+        self, llm_config, disable_placement_bundles, monkeypatch
+    ):
+        monkeypatch.setattr(
+            "ray.llm._internal.serve.core.ingress.builder."
+            "RAY_SERVE_LLM_ENABLE_DIRECT_STREAMING",
+            True,
+        )
+        llm_config.deployment_config["request_router_config"] = RequestRouterConfig(
+            request_router_class=ConsistentHashRouter,
+        )
+
+        app = build_anthropic_app(LLMServingArgs(llm_configs=[llm_config]))
+        request_router_config = (
+            app._bound_deployment._deployment_config.request_router_config
+        )
+        assert request_router_config.request_router_class == (
+            f"{ConsistentHashRouter.__module__}.{ConsistentHashRouter.__name__}"
+        )
 
     def test_direct_streaming_rejects_multiple_llm_configs(
         self, llm_config, disable_placement_bundles, monkeypatch

--- a/python/ray/llm/tests/serve/mocks/mock_vllm_engine.py
+++ b/python/ray/llm/tests/serve/mocks/mock_vllm_engine.py
@@ -8,6 +8,12 @@ from fastapi import FastAPI, HTTPException, Request
 from starlette.responses import JSONResponse, StreamingResponse
 
 from ray.llm._internal.common.utils.cloud_utils import LoraMirrorConfig
+from ray.llm._internal.serve.core.configs.anthropic_api_models import (
+    AnthropicCountTokensRequest,
+    AnthropicCountTokensResponse,
+    AnthropicMessagesRequest,
+    AnthropicMessagesResponse,
+)
 from ray.llm._internal.serve.core.configs.llm_config import (
     DiskMultiplexConfig,
     LLMConfig,
@@ -236,6 +242,24 @@ class MockVLLMEngine(LLMEngine):
             check_model(body.model)
             return await to_response(self.completions(body))
 
+        @app.post("/v1/messages")
+        async def messages(request: Request):
+            body = AnthropicMessagesRequest.model_validate(await request.json())
+            check_model(body.model)
+            return await to_response(self.messages(body))
+
+        @app.post("/v1/messages/count_tokens")
+        async def count_tokens(request: Request):
+            body = AnthropicCountTokensRequest.model_validate(await request.json())
+            check_model(body.model)
+            result = await self.count_tokens(body).__anext__()
+            if isinstance(result, ErrorResponse):
+                raise HTTPException(
+                    status_code=result.error.code,
+                    detail=result.error.message,
+                )
+            return JSONResponse(content=result.model_dump(exclude_none=True))
+
         return app
 
     async def chat(
@@ -279,6 +303,88 @@ class MockVLLMEngine(LLMEngine):
             request=request, prompt_text=prompt_text, max_tokens=max_tokens
         ):
             yield response
+
+    async def messages(
+        self,
+        request: AnthropicMessagesRequest,
+        raw_request_info: Optional[RawRequestInfo] = None,
+    ) -> AsyncGenerator[Union[str, AnthropicMessagesResponse, ErrorResponse], None]:
+        """Mock Anthropic Messages API."""
+        if not self.started:
+            raise RuntimeError("Engine not started")
+
+        prompt_text = ""
+        for message in request.messages:
+            content = message.content
+            if isinstance(content, str):
+                prompt_text += content + " "
+            elif content is not None:
+                for block in content:
+                    if getattr(block, "text", None):
+                        prompt_text += block.text + " "
+
+        max_tokens = request.max_tokens
+        model_name = request.model or self.llm_config.model_id
+
+        if request.stream:
+            message_id = f"msg_{random.randint(1000, 9999)}"
+            start_event = {
+                "type": "message_start",
+                "message": {
+                    "id": message_id,
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [],
+                    "model": model_name,
+                    "usage": {"input_tokens": 1, "output_tokens": 0},
+                },
+            }
+            yield f"event: message_start\ndata: {json.dumps(start_event)}\n\n"
+
+            text = " ".join(f"test_{i}" for i in range(max_tokens))
+            delta_event = {
+                "type": "content_block_delta",
+                "index": 0,
+                "delta": {"type": "text_delta", "text": text},
+            }
+            yield f"event: content_block_delta\ndata: {json.dumps(delta_event)}\n\n"
+            yield "event: message_stop\ndata: {}\n\n"
+            return
+
+        response = AnthropicMessagesResponse(
+            id=f"msg_{random.randint(1000, 9999)}",
+            type="message",
+            role="assistant",
+            content=[{"type": "text", "text": "mock anthropic response"}],
+            model=model_name,
+            stop_reason="end_turn",
+            usage={
+                "input_tokens": len(prompt_text.split()),
+                "output_tokens": max_tokens,
+            },
+        )
+        yield response
+
+    async def count_tokens(
+        self,
+        request: AnthropicCountTokensRequest,
+        raw_request_info: Optional[RawRequestInfo] = None,
+    ) -> AsyncGenerator[Union[AnthropicCountTokensResponse, ErrorResponse], None]:
+        """Mock Anthropic count_tokens."""
+        if not self.started:
+            raise RuntimeError("Engine not started")
+
+        token_count = 0
+        for message in request.messages:
+            content = message.content
+            if isinstance(content, str):
+                token_count += len(content.split())
+            elif content is not None:
+                for block in content:
+                    if getattr(block, "text", None):
+                        token_count += len(block.text.split())
+
+        yield AnthropicCountTokensResponse(input_tokens=max(token_count, 1))
 
     async def embeddings(
         self,

--- a/python/ray/serve/llm/__init__.py
+++ b/python/ray/serve/llm/__init__.py
@@ -250,6 +250,111 @@ def build_openai_app(llm_serving_args: dict) -> "Application":
     return build_openai_app(builder_config=llm_serving_args)
 
 
+@PublicAPI(stability="alpha")
+def build_anthropic_app(llm_serving_args: dict) -> "Application":
+    """Helper to build an Anthropic compatible app with the llm deployment setup from
+    the given llm serving args. This is the main entry point for users to create a
+    Serve application serving LLMs.
+
+
+    Examples:
+        .. code-block:: python
+            :caption: Example usage in code.
+
+            from ray import serve
+            from ray.serve.llm import LLMConfig, LLMServingArgs, build_anthropic_app
+
+            llm_config1 = LLMConfig(
+                model_loading_config=dict(
+                    model_id="qwen-0.5b",
+                    model_source="Qwen/Qwen2.5-0.5B-Instruct",
+                ),
+                deployment_config=dict(
+                    autoscaling_config=dict(
+                        min_replicas=1, max_replicas=2,
+                    )
+                ),
+                accelerator_type="A10G",
+            )
+
+            llm_config2 = LLMConfig(
+                model_loading_config=dict(
+                    model_id="qwen-1.5b",
+                    model_source="Qwen/Qwen2.5-1.5B-Instruct",
+                ),
+                deployment_config=dict(
+                    autoscaling_config=dict(
+                        min_replicas=1, max_replicas=2,
+                    )
+                ),
+                accelerator_type="A10G",
+            )
+
+            # Deploy the application
+            llm_app = build_anthropic_app(
+                LLMServingArgs(
+                    llm_configs=[
+                        llm_config1,
+                        llm_config2,
+                    ]
+                )
+            )
+            serve.run(llm_app)
+
+
+            # Querying the model via anthropic client
+            from anthropic import Anthropic
+
+            # Initialize client
+            client = Anthropic(base_url="http://localhost:8000/v1", api_key="fake-key")
+
+            # Basic messages
+            response = client.messages.create(
+                model="qwen-0.5b",
+                messages=[{"role": "user", "content": "Hello!"}]
+            )
+
+        .. code-block:: yaml
+            :caption: Example usage in YAML.
+
+            # config.yaml
+            applications:
+            - args:
+                llm_configs:
+                    - model_loading_config:
+                        model_id: qwen-0.5b
+                        model_source: Qwen/Qwen2.5-0.5B-Instruct
+                      accelerator_type: A10G
+                      deployment_config:
+                        autoscaling_config:
+                            min_replicas: 1
+                            max_replicas: 2
+                    - model_loading_config:
+                        model_id: qwen-1.5b
+                        model_source: Qwen/Qwen2.5-1.5B-Instruct
+                      accelerator_type: A10G
+                      deployment_config:
+                        autoscaling_config:
+                            min_replicas: 1
+                            max_replicas: 2
+              import_path: ray.serve.llm:build_anthropic_app
+              name: llm_app
+              route_prefix: "/"
+
+
+    Args:
+        llm_serving_args: A dict that conforms to the LLMServingArgs pydantic model.
+
+    Returns:
+        The configured Ray Serve Application router.
+    """
+    from ray.llm._internal.serve.core.ingress.builder import (
+        build_anthropic_app,
+    )
+
+    return build_anthropic_app(builder_config=llm_serving_args)
+
+
 @PublicAPI(stability="stable")
 def build_pd_openai_app(pd_serving_args: dict) -> "Application":
     """Build a deployable application utilizing P/D disaggregation.
@@ -402,6 +507,7 @@ __all__ = [
     "LoraConfig",
     "build_llm_deployment",
     "build_openai_app",
+    "build_anthropic_app",
     "build_pd_openai_app",
     "build_dp_deployment",
     "build_dp_openai_app",

--- a/python/ray/serve/llm/anthropic_api_models.py
+++ b/python/ray/serve/llm/anthropic_api_models.py
@@ -1,0 +1,63 @@
+from ray.llm._internal.serve.core.configs.anthropic_api_models import (
+    AnthropicCountTokensRequest as _AnthropicCountTokensRequest,
+    AnthropicCountTokensResponse as _AnthropicCountTokensResponse,
+    AnthropicError as _AnthropicError,
+    AnthropicErrorResponse as _AnthropicErrorResponse,
+    AnthropicMessagesRequest as _AnthropicMessagesRequest,
+    AnthropicMessagesResponse as _AnthropicMessagesResponse,
+)
+from ray.util.annotations import PublicAPI
+
+
+@PublicAPI(stability="stable")
+class AnthropicMessagesRequest(_AnthropicMessagesRequest):
+    """AnthropicMessagesRequest is the request body for the Messages API.
+
+    This model is compatible with vLLM's Anthropic API models.
+    """
+
+    pass
+
+
+@PublicAPI(stability="stable")
+class AnthropicMessagesResponse(_AnthropicMessagesResponse):
+    """AnthropicMessagesResponse is the response body for the Messages API.
+
+    This model is compatible with vLLM's Anthropic API models.
+    """
+
+    pass
+
+
+@PublicAPI(stability="stable")
+class AnthropicCountTokensRequest(_AnthropicCountTokensRequest):
+    """AnthropicCountTokensRequest is the request body for count_tokens.
+
+    This model is compatible with vLLM's Anthropic API models.
+    """
+
+    pass
+
+
+@PublicAPI(stability="stable")
+class AnthropicCountTokensResponse(_AnthropicCountTokensResponse):
+    """AnthropicCountTokensResponse is the response body for count_tokens.
+
+    This model is compatible with vLLM's Anthropic API models.
+    """
+
+    pass
+
+
+@PublicAPI(stability="stable")
+class AnthropicError(_AnthropicError):
+    """Anthropic error payload."""
+
+    pass
+
+
+@PublicAPI(stability="stable")
+class AnthropicErrorResponse(_AnthropicErrorResponse):
+    """The returned response in case of an Anthropic API error."""
+
+    pass

--- a/python/ray/serve/llm/anthropic_api_models.py
+++ b/python/ray/serve/llm/anthropic_api_models.py
@@ -9,7 +9,7 @@ from ray.llm._internal.serve.core.configs.anthropic_api_models import (
 from ray.util.annotations import PublicAPI
 
 
-@PublicAPI(stability="stable")
+@PublicAPI(stability="alpha")
 class AnthropicMessagesRequest(_AnthropicMessagesRequest):
     """AnthropicMessagesRequest is the request body for the Messages API.
 
@@ -19,7 +19,7 @@ class AnthropicMessagesRequest(_AnthropicMessagesRequest):
     pass
 
 
-@PublicAPI(stability="stable")
+@PublicAPI(stability="alpha")
 class AnthropicMessagesResponse(_AnthropicMessagesResponse):
     """AnthropicMessagesResponse is the response body for the Messages API.
 
@@ -29,7 +29,7 @@ class AnthropicMessagesResponse(_AnthropicMessagesResponse):
     pass
 
 
-@PublicAPI(stability="stable")
+@PublicAPI(stability="alpha")
 class AnthropicCountTokensRequest(_AnthropicCountTokensRequest):
     """AnthropicCountTokensRequest is the request body for count_tokens.
 
@@ -39,7 +39,7 @@ class AnthropicCountTokensRequest(_AnthropicCountTokensRequest):
     pass
 
 
-@PublicAPI(stability="stable")
+@PublicAPI(stability="alpha")
 class AnthropicCountTokensResponse(_AnthropicCountTokensResponse):
     """AnthropicCountTokensResponse is the response body for count_tokens.
 
@@ -49,14 +49,14 @@ class AnthropicCountTokensResponse(_AnthropicCountTokensResponse):
     pass
 
 
-@PublicAPI(stability="stable")
+@PublicAPI(stability="alpha")
 class AnthropicError(_AnthropicError):
     """Anthropic error payload."""
 
     pass
 
 
-@PublicAPI(stability="stable")
+@PublicAPI(stability="alpha")
 class AnthropicErrorResponse(_AnthropicErrorResponse):
     """The returned response in case of an Anthropic API error."""
 

--- a/python/ray/serve/llm/ingress.py
+++ b/python/ray/serve/llm/ingress.py
@@ -1,8 +1,22 @@
 from ray.llm._internal.serve.core.ingress.ingress import (
+    DEFAULT_ANTHROPIC_ENDPOINTS,
+    AnthropicIngress as _AnthropicIngress,
     OpenAiIngress as _OpenAiIngress,
     make_fastapi_ingress,
 )
 from ray.util.annotations import PublicAPI
+
+
+@PublicAPI(stability="alpha")
+class AnthropicIngress(_AnthropicIngress):
+    """The implementation of the Anthropic Messages API compatible model router.
+
+    This deployment creates the following endpoints:
+      - /v1/messages: Anthropic Messages API
+      - /v1/messages/count_tokens: Anthropic token counting API
+    """
+
+    pass
 
 
 @PublicAPI(stability="stable")
@@ -99,4 +113,9 @@ class OpenAiIngress(_OpenAiIngress):
     pass
 
 
-__all__ = ["OpenAiIngress", "make_fastapi_ingress"]
+__all__ = [
+    "AnthropicIngress",
+    "DEFAULT_ANTHROPIC_ENDPOINTS",
+    "OpenAiIngress",
+    "make_fastapi_ingress",
+]

--- a/python/ray/serve/tests/unit/test_llm_imports.py
+++ b/python/ray/serve/tests/unit/test_llm_imports.py
@@ -28,6 +28,7 @@ def test_serve_llm_import_does_not_error():
         )
     with pytest.raises(ImportError):
         from ray.serve.llm import (
+            build_anthropic_app,  # noqa: F401
             build_llm_deployment,  # noqa: F401
             build_openai_app,  # noqa: F401
         )


### PR DESCRIPTION
## Description

Adds first-class Anthropic Messages API support to Ray Serve LLM for vLLM-based deployments. This allows Anthropic-compatible clients, including Claude Code, to communicate directly with Ray Serve LLM without an additional translation proxy such as LiteLLM or Claude Code Router. The initial implementation supports:
- `POST /v1/messages`
- `POST /v1/messages/count_tokens`
- Streaming and non-streaming message responses.
- Standard ingress and direct-streaming deployments.
- **Vanilla vLLM deployments.** SGlang fallbacks on import failure, P/D disaggregation and data parallel deployments are outside this PR's scope.

## Related issues
- Closes #64965

## Implementation

- Added Ray wrappers and alpha public APIs for vLLM's Anthropic request, response, token-counting, and error models.
- Extended `LLMEngine`, `LLMServerProtocol`, and `LLMServer` with `messages` and `count_tokens` operations.
- Initialized and delegated requests to vLLM's `AnthropicServingMessages`.
- Added `AnthropicIngress` (which inherits from `OpenaiIngress`), reusing the existing ingress model resolution, LoRA routing, handle caching, session affinity, and deployment configuration.
- Translateed internal vLLM errors into Anthropic-compatible error payloads at the HTTP boundary.
- Preserved vLLM-generated Anthropic SSE events for streaming responses.
- Added `build_anthropic_app` with support for both standard ingress and direct streaming.
- Extended the mock vLLM engine with Anthropic routes and responses.
- Added tests covering model imports, route registration, builder behavior, error responses, token counting, and streaming/non-streaming requests.

## Testing

### pytest

```
PYTHONPATH=python python -m pytest -v \
  python/ray/llm/tests/serve/cpu/configs/test_anthropic_api_models_backends.py \
  python/ray/llm/tests/serve/cpu/deployments/routers/test_anthropic_ingress.py \
  python/ray/llm/tests/serve/cpu/deployments/routers/test_anthropic_http.py \
  python/ray/llm/tests/serve/cpu/deployments/routers/test_builder_ingress.py -k Anthropic
```

### API

I tested this using the `anthropic==0.106.0` & `vllm==0.26.0` python library, and **have not used Claude Code (yet).** Testing infra had the following specs:

- GPU: NVIDIA GeForce RTX 4090 (24 GB VRAM)
- Driver Version: 580.126.20
- CUDA Version: 13.0

<details>
<summary>Ray LLMServer Setup Script</summary>

```python
from ray import serve
from ray.serve.llm import LLMConfig, build_anthropic_app

llm_config = LLMConfig(
    model_loading_config={
        "model_id": "qwen-0.5b",
        "model_source": "Qwen/Qwen2.5-0.5B-Instruct",
    },
    deployment_config={
        "autoscaling_config": {
            "min_replicas": 1,
            "max_replicas": 2,
        }
    },
    # Pass the desired accelerator type (e.g. A10G, L4, etc.)
    # accelerator_type="A10G",
    # You can customize the engine arguments (e.g. vLLM engine kwargs)
    engine_kwargs={
        "tensor_parallel_size": 1,
    },
)

app = build_anthropic_app({"llm_configs": [llm_config]})
serve.run(app, blocking=True)
```

</details>

<details>
<summary>Ray LLMServer Setup Logs</summary>

```python
(.venv) root@e698b1650b1b:/workspace# bash setup_ray_anthropic_api_pr.sh 
>>> Checking out Ray branch: ray-serve-llm/anthropic-messages-api
branch 'ray-serve-llm/anthropic-messages-api' set up to track 'origin/ray-serve-llm/anthropic-messages-api'.
Switched to a new branch 'ray-serve-llm/anthropic-messages-api'
>>> Starting the Anthropic-compatible Ray Serve API...
>>> Run scripts/test_ray_anthropic_api.sh from another terminal to test it.
/workspace/ray/.venv/lib/python3.12/site-packages/torch/cuda/__init__.py:61: FutureWarning: The pynvml package is deprecated. Please install nvidia-ml-py instead. If you did not install pynvml directly, please report this to the maintainers of the package that installed pynvml for you.
  import pynvml  # type: ignore[import]
Usage stats collection is enabled by default for nightly wheels. To disable this, run the following command: `ray disable-usage-stats` before starting Ray. See https://docs.ray.io/en/master/cluster/usage-stats.html for more details.
2026-08-14 11:53:47,802 ERROR services.py:1431 -- Failed to start the dashboard 
2026-08-14 11:53:47,802 ERROR services.py:1456 -- Error should be written to 'dashboard.log' or 'dashboard.err'. We are printing the last 20 lines for you. See 'https://docs.ray.io/en/master/ray-observability/user-guides/configure-logging.html#logging-directory-structure' to find where the log file is.
2026-08-14 11:53:47,802 ERROR services.py:1500 -- 
The last 20 lines of /tmp/ray/session_2026-08-14_11-52-47_396084_60616/logs/dashboard.log (it contains the error message from the dashboard): 
    loop.run_until_complete(dashboard.run())
  File "/usr/lib/python3.12/asyncio/base_events.py", line 687, in run_until_complete
    return future.result()
           ^^^^^^^^^^^^^^^
  File "/workspace/ray/.venv/lib/python3.12/site-packages/ray/dashboard/dashboard.py", line 107, in run
    await self.dashboard_head.run()
  File "/workspace/ray/.venv/lib/python3.12/site-packages/ray/dashboard/head.py", line 513, in run
    await self._configure_http_server(
  File "/workspace/ray/.venv/lib/python3.12/site-packages/ray/dashboard/head.py", line 153, in _configure_http_server
    self.http_server = HttpServerDashboardHead(
                       ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspace/ray/.venv/lib/python3.12/site-packages/ray/dashboard/http_server_head.py", line 122, in __init__
    raise ex
  File "/workspace/ray/.venv/lib/python3.12/site-packages/ray/dashboard/http_server_head.py", line 113, in __init__
    build_dir = setup_static_dir()
                ^^^^^^^^^^^^^^^^^^
  File "/workspace/ray/.venv/lib/python3.12/site-packages/ray/dashboard/http_server_head.py", line 71, in setup_static_dir
    raise dashboard_utils.FrontendNotFoundError(
ray.dashboard.utils.FrontendNotFoundError: [Errno 2] Dashboard build directory not found. If installing from source, please follow the additional steps required to build the dashboard(cd python/ray/dashboard/client && npm ci && npm run build): '/workspace/ray/.venv/lib/python3.12/site-packages/ray/dashboard/client/build'
2026-08-14 11:53:47,803 WARNING utils.py:473 -- Detecting docker specified CPUs. In previous versions of Ray, CPU detection in containers was incorrect. Please ensure that Ray has enough CPUs allocated. As a temporary workaround to revert to the prior behavior, set `RAY_USE_MULTIPROCESSING_CPU_COUNT=1` as an env var before starting Ray. Set the env var: `RAY_DISABLE_DOCKER_CPU_WARNING=1` to mute this warning.
2026-08-14 11:53:47,803 WARNING utils.py:485 -- Ray currently does not support initializing Ray with fractional cpus. Your num_cpus will be truncated from 10.2 to 10.
2026-08-14 11:53:53,032 INFO worker.py:2024 -- Started a local Ray instance.
INFO 2026-08-14 11:53:57,015 serve 60616 -- ============== Deployment Options ==============
INFO 2026-08-14 11:53:57,015 serve 60616 -- {'autoscaling_config': {'max_replicas': 2,
                        'min_replicas': 1,
                        'target_ongoing_requests': 1000000000},
 'health_check_period_s': 10,
 'health_check_timeout_s': 10,
 'max_ongoing_requests': 1000000000,
 'name': 'LLMServer:qwen-0_5b',
 'placement_group_bundles': [{'CPU': 1, 'GPU': 1}],
 'placement_group_strategy': 'PACK',
 'ray_actor_options': {'runtime_env': {'worker_process_setup_hook': 'ray.llm._internal.serve._worker_process_setup_hook'}}}
INFO 2026-08-14 11:53:57,141 serve 60616 -- ============== Ingress Options ==============
INFO 2026-08-14 11:53:57,141 serve 60616 -- {'autoscaling_config': {'target_ongoing_requests': 1000000000},
 'max_ongoing_requests': 1000000000}
(ProxyActor pid=61920) INFO 2026-08-14 11:54:03,929 proxy 172.20.0.2 -- Proxy starting on node 378dbf39e6a51915676f01de61f3bcca7b66933744f44a833683bca7 (HTTP port: 8000).
INFO 2026-08-14 11:54:04,135 serve 60616 -- Started Serve in namespace "serve".
(ProxyActor pid=61920) INFO 2026-08-14 11:54:04,131 proxy 172.20.0.2 -- Got updated endpoints: {}.
(ServeController pid=61919) INFO 2026-08-14 11:54:04,222 controller 61919 -- Registering autoscaling state for deployment Deployment(name='LLMServer:qwen-0_5b', app='default')
(ServeController pid=61919) INFO 2026-08-14 11:54:04,223 controller 61919 -- Deploying new version of Deployment(name='LLMServer:qwen-0_5b', app='default') (initial target replicas: 1).
(ServeController pid=61919) INFO 2026-08-14 11:54:04,224 controller 61919 -- Registering autoscaling state for deployment Deployment(name='AnthropicIngress', app='default')
(ServeController pid=61919) INFO 2026-08-14 11:54:04,225 controller 61919 -- Deploying new version of Deployment(name='AnthropicIngress', app='default') (initial target replicas: 1).
(ProxyActor pid=61920) INFO 2026-08-14 11:54:04,231 proxy 172.20.0.2 -- Got updated endpoints: {Deployment(name='AnthropicIngress', app='default'): EndpointInfo(route='/', app_is_cross_language=False, route_patterns=None)}.
(ProxyActor pid=61920) INFO 2026-08-14 11:54:04,239 proxy 172.20.0.2 -- Started <ray.serve._private.router.SharedRouterLongPollClient object at 0x76763de9e720>.
(ServeController pid=61919) INFO 2026-08-14 11:54:04,332 controller 61919 -- Adding 1 replica to Deployment(name='LLMServer:qwen-0_5b', app='default').
(ServeController pid=61919) INFO 2026-08-14 11:54:04,335 controller 61919 -- Adding 1 replica to Deployment(name='AnthropicIngress', app='default').
(ServeReplica:default:AnthropicIngress pid=61926) /workspace/ray/.venv/lib/python3.12/site-packages/torch/cuda/__init__.py:61: FutureWarning: The pynvml package is deprecated. Please install nvidia-ml-py instead. If you did not install pynvml directly, please report this to the maintainers of the package that installed pynvml for you.
(ServeReplica:default:AnthropicIngress pid=61926)   import pynvml  # type: ignore[import]
(ServeController pid=61919) WARNING 2026-08-14 11:54:34,365 controller 61919 -- Deployment 'LLMServer:qwen-0_5b' in application 'default' has 1 replicas that have taken more than 30s to be scheduled. This may be due to waiting for the cluster to auto-scale or for a runtime environment to be installed. Resources required for each replica: [{"GPU": 1.0, "CPU": 1.0}], total resources available: {}. Use `ray status` for more details.
(ServeController pid=61919) WARNING 2026-08-14 11:54:34,366 controller 61919 -- Deployment 'AnthropicIngress' in application 'default' has 1 replicas that have taken more than 30s to be scheduled. This may be due to waiting for the cluster to auto-scale or for a runtime environment to be installed. Resources required for each replica: {"CPU": 1}, total resources available: {"CPU": 8.0}. Use `ray status` for more details.
(ServeReplica:default:LLMServer:qwen-0_5b pid=62683) /workspace/ray/.venv/lib/python3.12/site-packages/torch/cuda/__init__.py:61: FutureWarning: The pynvml package is deprecated. Please install nvidia-ml-py instead. If you did not install pynvml directly, please report this to the maintainers of the package that installed pynvml for you.
(ServeReplica:default:LLMServer:qwen-0_5b pid=62683)   import pynvml  # type: ignore[import]
(ProxyActor pid=61920) INFO 2026-08-14 11:54:48,194 proxy 172.20.0.2 -- Got updated endpoints: {Deployment(name='AnthropicIngress', app='default'): EndpointInfo(route='/', app_is_cross_language=False, route_patterns=[RoutePattern(methods=['GET', 'HEAD'], path='/docs'), RoutePattern(methods=['GET', 'HEAD'], path='/docs/oauth2-redirect'), RoutePattern(methods=['GET', 'HEAD'], path='/openapi.json'), RoutePattern(methods=['GET', 'HEAD'], path='/redoc'), RoutePattern(methods=['POST'], path='/v1/messages'), RoutePattern(methods=['POST'], path='/v1/messages/count_tokens')])}.
(ServeReplica:default:LLMServer:qwen-0_5b pid=62683) INFO 2026-08-14 11:54:53,441 default_LLMServer:qwen-0_5b kqnimn62 -- Running tasks to download model files on worker nodes
(pid=63324) /workspace/ray/.venv/lib/python3.12/site-packages/torch/cuda/__init__.py:61: FutureWarning: The pynvml package is deprecated. Please install nvidia-ml-py instead. If you did not install pynvml directly, please report this to the maintainers of the package that installed pynvml for you.
(pid=63324)   import pynvml  # type: ignore[import]
(ServeController pid=61919) WARNING 2026-08-14 11:55:04,382 controller 61919 -- Deployment 'LLMServer:qwen-0_5b' in application 'default' has 1 replicas that have taken more than 30s to initialize.
(ServeController pid=61919) This may be caused by a slow __init__ or reconfigure method.
(initialize_remote_node pid=63324) No cloud storage mirror configured
(_get_vllm_engine_config pid=63324) Warning: You are sending unauthenticated requests to the HF Hub. Please set a HF_TOKEN to enable higher rate limits and faster downloads.
(_get_vllm_engine_config pid=63324) {"asctime": "2026-08-14 11:55:32,220", "levelname": "WARNING", "message": "Warning: You are sending unauthenticated requests to the HF Hub. Please set a HF_TOKEN to enable higher rate limits and faster downloads.", "filename": "_http.py", "lineno": 904, "process": 63324, "job_id": "01000000", "worker_id": "4695f65c75a37c9cac9b14261922d4d488aba1b0eb9b71dc216a6ee3", "node_id": "378dbf39e6a51915676f01de61f3bcca7b66933744f44a833683bca7", "task_id": "aaf9253a9eca5fc2ffffffffffffffffffffffff01000000", "task_name": "_get_vllm_engine_config", "task_func_name": "ray.llm._internal.serve.engines.vllm.vllm_engine._get_vllm_engine_config", "timestamp_ns": 1786708532220740688}
(ServeController pid=61919) WARNING 2026-08-14 11:55:34,433 controller 61919 -- Deployment 'LLMServer:qwen-0_5b' in application 'default' has 1 replicas that have taken more than 30s to initialize.
(ServeController pid=61919) This may be caused by a slow __init__ or reconfigure method.
(ServeController pid=61919) WARNING 2026-08-14 11:56:04,447 controller 61919 -- Deployment 'LLMServer:qwen-0_5b' in application 'default' has 1 replicas that have taken more than 30s to initialize.
(ServeController pid=61919) This may be caused by a slow __init__ or reconfigure method.
(_get_vllm_engine_config pid=63324) INFO 08-14 11:56:25 [model.py:623] Resolved architecture: Qwen2ForCausalLM
(_get_vllm_engine_config pid=63324) INFO 08-14 11:56:25 [model.py:1788] Using max model len 32768
(_get_vllm_engine_config pid=63324) INFO 08-14 11:56:25 [arg_utils.py:1951] Using ray runtime env (env vars redacted): {'worker_process_setup_hook': 'ray.llm._internal.serve._worker_process_setup_hook'}
(_get_vllm_engine_config pid=63324) INFO 08-14 11:56:25 [scheduler.py:252] Chunked prefill is enabled with max_num_batched_tokens=2048.
(_get_vllm_engine_config pid=63324) INFO 08-14 11:56:25 [vllm.py:1109] Asynchronous scheduling is enabled.
(_get_vllm_engine_config pid=63324) INFO 08-14 11:56:25 [kernel.py:295] Final IR op priority after setting platform defaults: IrOpPriorityConfig(rms_norm=['native'], fused_add_rms_norm=['native'])
(ServeReplica:default:LLMServer:qwen-0_5b pid=62683) INFO 2026-08-14 11:56:26,134 default_LLMServer:qwen-0_5b kqnimn62 -- Clearing the current platform cache ...
(ServeReplica:default:LLMServer:qwen-0_5b pid=62683) INFO 2026-08-14 11:56:26,159 default_LLMServer:qwen-0_5b kqnimn62 -- Using executor class: <class 'vllm.v1.executor.ray_executor_v2.RayExecutorV2'>
(ServeReplica:default:LLMServer:qwen-0_5b pid=62683) Warning: You are sending unauthenticated requests to the HF Hub. Please set a HF_TOKEN to enable higher rate limits and faster downloads.
(ServeReplica:default:LLMServer:qwen-0_5b pid=62683) WARNING 08-14 11:56:31 [system_utils.py:157] We must use the `spawn` multiprocessing start method. Overriding VLLM_WORKER_MULTIPROC_METHOD to 'spawn'. See https://docs.vllm.ai/en/latest/usage/troubleshooting.html#python-multiprocessing for more information. Reasons: In a Ray actor and can only be spawned
(ServeReplica:default:LLMServer:qwen-0_5b pid=62683) /workspace/ray/.venv/lib/python3.12/site-packages/torch/cuda/__init__.py:61: FutureWarning: The pynvml package is deprecated. Please install nvidia-ml-py instead. If you did not install pynvml directly, please report this to the maintainers of the package that installed pynvml for you.
(ServeReplica:default:LLMServer:qwen-0_5b pid=62683)   import pynvml  # type: ignore[import]
(ServeController pid=61919) WARNING 2026-08-14 11:56:34,478 controller 61919 -- Deployment 'LLMServer:qwen-0_5b' in application 'default' has 1 replicas that have taken more than 30s to initialize.
(ServeController pid=61919) This may be caused by a slow __init__ or reconfigure method.
(ServeController pid=61919) WARNING 2026-08-14 11:57:04,556 controller 61919 -- Deployment 'LLMServer:qwen-0_5b' in application 'default' has 1 replicas that have taken more than 30s to initialize.
(ServeController pid=61919) This may be caused by a slow __init__ or reconfigure method.
(ServeReplica:default:LLMServer:qwen-0_5b pid=62683) (EngineCore pid=64296) INFO 08-14 11:57:16 [core.py:116] Initializing a V1 LLM engine (v0.26.0) with config: model='Qwen/Qwen2.5-0.5B-Instruct', speculative_config=None, tokenizer='Qwen/Qwen2.5-0.5B-Instruct', skip_tokenizer_init=False, tokenizer_mode=auto, revision=None, tokenizer_revision=None, trust_remote_code=False, dtype=torch.bfloat16, max_seq_len=32768, download_dir=None, load_format=auto, tensor_parallel_size=1, pipeline_parallel_size=1, data_parallel_size=1, decode_context_parallel_size=1, dcp_comm_backend=ag_rs, disable_custom_all_reduce=False, quantization=None, quantization_config=None, enforce_eager=False, enable_return_routed_experts=False, kv_cache_dtype=auto, device_config=cuda, structured_outputs_config=StructuredOutputsConfig(backend='auto', disable_any_whitespace=False, disable_additional_properties=False, reasoning_parser='', reasoning_parser_plugin='', enable_in_reasoning=False), observability_config=ObservabilityConfig(show_hidden_metrics_for_version=None, otlp_traces_endpoint=None, collect_detailed_traces=None, kv_cache_metrics=False, kv_cache_metrics_sample=0.01, cudagraph_metrics=False, enable_layerwise_nvtx_tracing=False, enable_mfu_metrics=False, enable_mm_processor_stats=False, enable_logging_iteration_details=False, jit_monitor_mode='warn', jit_monitor_verbose=False), seed=0, served_model_name=qwen-0.5b, enable_prefix_caching=True, enable_chunked_prefill=True, pooler_config=None, compilation_config={'mode': <CompilationMode.VLLM_COMPILE: 3>, 'debug_dump_path': None, 'cache_dir': '', 'compile_cache_save_format': 'binary', 'backend': 'inductor', 'custom_ops': ['none'], 'ir_enable_torch_wrap': True, 'splitting_ops': ['vllm::unified_attention_with_output', 'vllm::unified_mla_attention_with_output', 'vllm::mamba_mixer2', 'vllm::mamba_mixer', 'vllm::short_conv', 'vllm::linear_attention', 'vllm::plamo2_mamba_mixer', 'vllm::qwen_gdn_attention_core', 'vllm::gdn_attention_core_xpu', 'vllm::olmo_hybrid_gdn_full_forward', 'vllm::kda_attention', 'vllm::sparse_attn_indexer', 'vllm::rocm_aiter_sparse_attn_indexer', 'vllm::deepseek_v4_attention', 'vllm::hpc_rope_norm_forward', 'vllm::unified_kv_cache_update', 'vllm::unified_mla_kv_cache_update'], 'compile_mm_encoder': False, 'cudagraph_mm_encoder': False, 'encoder_cudagraph_token_budgets': [], 'encoder_cudagraph_max_vision_items_per_batch': 0, 'encoder_cudagraph_max_frames_per_batch': None, 'compile_sizes': [], 'compile_ranges_endpoints': [2048], 'inductor_compile_config': {'enable_auto_functionalized_v2': False, 'size_asserts': False, 'alignment_asserts': False, 'scalar_asserts': False, 'combo_kernels': True, 'benchmark_combo_kernel': True}, 'inductor_passes': {}, 'cudagraph_mode': <CUDAGraphMode.FULL_AND_PIECEWISE: (2, 1)>, 'cudagraph_num_of_warmups': 1, 'cudagraph_capture_sizes': [1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64, 72, 80, 88, 96, 104, 112, 120, 128, 136, 144, 152, 160, 168, 176, 184, 192, 200, 208, 216, 224, 232, 240, 248, 256, 272, 288, 304, 320, 336, 352, 368, 384, 400, 416, 432, 448, 464, 480, 496, 512], 'cudagraph_copy_inputs': False, 'cudagraph_specialize_lora': True, 'use_inductor_graph_partition': False, 'pass_config': {'fuse_norm_quant': False, 'fuse_act_quant': False, 'fuse_attn_quant': False, 'enable_sp': False, 'fuse_gemm_comms': False, 'fuse_allreduce_rms': False, 'enable_qk_norm_rope_fusion': False, 'fuse_rope_kvcache_cat_mla': False, 'fuse_act_padding': False, 'fuse_qk_norm_rope_kvcache': False}, 'max_cudagraph_capture_size': 512, 'dynamic_shapes_config': {'type': <DynamicShapesType.BACKED: 'backed'>, 'evaluate_guards': False, 'assume_32_bit_indexing': False}, 'local_cache_dir': None, 'fast_moe_cold_start': False, 'static_all_moe_layers': []}, kernel_config=KernelConfig(ir_op_priority=IrOpPriorityConfig(rms_norm=['native'], fused_add_rms_norm=['native']), enable_flashinfer_autotune=True, enable_cutedsl_warmup=True, enable_bf16x3_router_gemm=False, moe_backend='auto', linear_backend='auto')
(ServeReplica:default:LLMServer:qwen-0_5b pid=62683) (EngineCore pid=64296) 2026-08-14 11:57:16,125     INFO worker.py:1683 -- Using address 172.20.0.2:44883 set in the environment variable RAY_ADDRESS
(ServeReplica:default:LLMServer:qwen-0_5b pid=62683) (EngineCore pid=64296) INFO 08-14 11:57:16 [ray_utils.py:602] Using the existing placement group
(ServeReplica:default:LLMServer:qwen-0_5b pid=62683) (EngineCore pid=64296) 2026-08-14 11:57:16,138     INFO worker.py:1833 -- Connecting to existing Ray cluster at address: 172.20.0.2:44883...
(ServeReplica:default:LLMServer:qwen-0_5b pid=62683) (EngineCore pid=64296) 2026-08-14 11:57:16,157     INFO worker.py:2024 -- Connected to Ray cluster.
(ServeReplica:default:AnthropicIngress pid=61926) INFO 2026-08-14 11:57:22,980 default_AnthropicIngress i763jp1f 178d4f4d-8ab3-4635-9760-364998a841e3 -- Started <ray.serve._private.router.SharedRouterLongPollClient object at 0x7aa6c8b8cda0>.
(pid=65043) /workspace/ray/.venv/lib/python3.12/site-packages/torch/cuda/__init__.py:61: FutureWarning: The pynvml package is deprecated. Please install nvidia-ml-py instead. If you did not install pynvml directly, please report this to the maintainers of the package that installed pynvml for you.
(pid=65043)   import pynvml  # type: ignore[import]
(ServeReplica:default:LLMServer:qwen-0_5b pid=62683) (EngineCore pid=64296) (pid=65043) /workspace/ray/.venv/lib/python3.12/site-packages/torch/cuda/__init__.py:61: FutureWarning: The pynvml package is deprecated. Please install nvidia-ml-py instead. If you did not install pynvml directly, please report this to the maintainers of the package that installed pynvml for you.
(ServeReplica:default:LLMServer:qwen-0_5b pid=62683) (EngineCore pid=64296) (pid=65043)   import pynvml  # type: ignore[import]
(ServeController pid=61919) WARNING 2026-08-14 11:57:34,580 controller 61919 -- Deployment 'LLMServer:qwen-0_5b' in application 'default' has 1 replicas that have taken more than 30s to initialize.
(ServeController pid=61919) This may be caused by a slow __init__ or reconfigure method.
(RayWorkerProc pid=65043) WARNING 08-14 11:58:02 [worker_base.py:306] Missing `shared_worker_lock` argument from executor. This argument is needed for mm_processor_cache_type='shm'.
(ServeReplica:default:LLMServer:qwen-0_5b pid=62683) (EngineCore pid=64296) (RayWorkerProc pid=65043) WARNING 08-14 11:58:02 [worker_base.py:306] Missing `shared_worker_lock` argument from executor. This argument is needed for mm_processor_cache_type='shm'.
(RayWorkerProc pid=65043) (Worker pid=65043) INFO 08-14 11:58:02 [parallel_state.py:1615] world_size=1 rank=0 local_rank=0 distributed_init_method=tcp://172.20.0.2:100 backend=nccl
(RayWorkerProc pid=65043) (Worker pid=65043) INFO 08-14 11:58:02 [parallel_state.py:1946] rank 0 in world size 1 is assigned as DP rank 0, PP rank 0, PCP rank 0, TP rank 0, EP rank N/A, EPLB rank N/A
(RayWorkerProc pid=65043) (Worker pid=65043) INFO 08-14 11:58:02 [gpu_worker.py:378] Using V2 Model Runner
(ServeReplica:default:LLMServer:qwen-0_5b pid=62683) (EngineCore pid=64296) (RayWorkerProc pid=65043) (Worker pid=65043) INFO 08-14 11:58:02 [parallel_state.py:1615] world_size=1 rank=0 local_rank=0 distributed_init_method=tcp://172.20.0.2:100 backend=nccl
(ServeReplica:default:LLMServer:qwen-0_5b pid=62683) (EngineCore pid=64296) (RayWorkerProc pid=65043) (Worker pid=65043) INFO 08-14 11:58:02 [parallel_state.py:1946] rank 0 in world size 1 is assigned as DP rank 0, PP rank 0, PCP rank 0, TP rank 0, EP rank N/A, EPLB rank N/A
(ServeReplica:default:LLMServer:qwen-0_5b pid=62683) (EngineCore pid=64296) (RayWorkerProc pid=65043) (Worker pid=65043) INFO 08-14 11:58:02 [gpu_worker.py:378] Using V2 Model Runner
(RayWorkerProc pid=65043) (Worker pid=65043) INFO 08-14 11:58:03 [model_runner.py:284] Loading model from scratch...
(ServeReplica:default:LLMServer:qwen-0_5b pid=62683) (EngineCore pid=64296) (RayWorkerProc pid=65043) (Worker pid=65043) INFO 08-14 11:58:03 [model_runner.py:284] Loading model from scratch...
(RayWorkerProc pid=65043) (Worker pid=65043) INFO 08-14 11:58:04 [cuda.py:482] Using FLASH_ATTN attention backend out of potential backends: ['FLASH_ATTN', 'FLASHINFER', 'TRITON_ATTN', 'FLEX_ATTENTION'].
(RayWorkerProc pid=65043) (Worker pid=65043) INFO 08-14 11:58:04 [flash_attn.py:776] Using FlashAttention version 2
(ServeReplica:default:LLMServer:qwen-0_5b pid=62683) (EngineCore pid=64296) (RayWorkerProc pid=65043) (Worker pid=65043) INFO 08-14 11:58:04 [cuda.py:482] Using FLASH_ATTN attention backend out of potential backends: ['FLASH_ATTN', 'FLASHINFER', 'TRITON_ATTN', 'FLEX_ATTENTION'].
(ServeReplica:default:LLMServer:qwen-0_5b pid=62683) (EngineCore pid=64296) (RayWorkerProc pid=65043) (Worker pid=65043) INFO 08-14 11:58:04 [flash_attn.py:776] Using FlashAttention version 2
(ServeController pid=61919) WARNING 2026-08-14 11:58:04,666 controller 61919 -- Deployment 'LLMServer:qwen-0_5b' in application 'default' has 1 replicas that have taken more than 30s to initialize.
(ServeController pid=61919) This may be caused by a slow __init__ or reconfigure method.
(ServeController pid=61919) WARNING 2026-08-14 11:58:34,694 controller 61919 -- Deployment 'LLMServer:qwen-0_5b' in application 'default' has 1 replicas that have taken more than 30s to initialize.
(ServeController pid=61919) This may be caused by a slow __init__ or reconfigure method.
(RayWorkerProc pid=65043) (Worker pid=65043) INFO 08-14 11:58:40 [weight_utils.py:530] Time spent downloading weights for Qwen/Qwen2.5-0.5B-Instruct: 35.615082 seconds
(ServeReplica:default:LLMServer:qwen-0_5b pid=62683) (EngineCore pid=64296) (RayWorkerProc pid=65043) (Worker pid=65043) INFO 08-14 11:58:40 [weight_utils.py:530] Time spent downloading weights for Qwen/Qwen2.5-0.5B-Instruct: 35.615082 seconds
(RayWorkerProc pid=65043) (Worker pid=65043) INFO 08-14 11:58:40 [weight_utils.py:574] No model.safetensors.index.json found in remote.
(RayWorkerProc pid=65043) (Worker pid=65043) INFO 08-14 11:58:40 [weight_utils.py:869] Filesystem type for checkpoints: NFS4. Checkpoint size: 0.92 GiB. Available RAM: 152.67 GiB.
(RayWorkerProc pid=65043) (Worker pid=65043) INFO 08-14 11:58:40 [weight_utils.py:831] Prefetching checkpoint files into page cache started (in background, num_threads=8, block_size=16777216 bytes)
Loading safetensors checkpoint shards:   0% Completed | 0/1 [00:00<?, ?it/s]
(ServeReplica:default:LLMServer:qwen-0_5b pid=62683) (EngineCore pid=64296) (RayWorkerProc pid=65043) (Worker pid=65043) INFO 08-14 11:58:40 [weight_utils.py:574] No model.safetensors.index.json found in remote.
(ServeReplica:default:LLMServer:qwen-0_5b pid=62683) (EngineCore pid=64296) (RayWorkerProc pid=65043) (Worker pid=65043) INFO 08-14 11:58:40 [weight_utils.py:869] Filesystem type for checkpoints: NFS4. Checkpoint size: 0.92 GiB. Available RAM: 152.67 GiB.
(ServeReplica:default:LLMServer:qwen-0_5b pid=62683) (EngineCore pid=64296) (RayWorkerProc pid=65043) (Worker pid=65043) INFO 08-14 11:58:40 [weight_utils.py:831] Prefetching checkpoint files into page cache started (in background, num_threads=8, block_size=16777216 bytes)
Loading safetensors checkpoint shards:   0% Completed | 0/1 [00:00<?, ?it/s](RayWorkerProc pid=65043) (Worker pid=65043) 
(RayWorkerProc pid=65043) (Worker pid=65043) INFO 08-14 11:58:42 [weight_utils.py:803] Prefetching checkpoint files: 10% (1/1)
(RayWorkerProc pid=65043) (Worker pid=65043) INFO 08-14 11:58:42 [weight_utils.py:826] Prefetching checkpoint files into page cache finished in 1.29s
(RayWorkerProc pid=65043) (Worker pid=65043) INFO 08-14 11:58:42 [default_loader.py:430] Loading weights took 1.35 seconds
Loading safetensors checkpoint shards: 100% Completed | 1/1 [00:01<00:00,  1.29s/it]
Loading safetensors checkpoint shards: 100% Completed | 1/1 [00:01<00:00,  1.29s/it]
(RayWorkerProc pid=65043) (Worker pid=65043) 
(ServeReplica:default:LLMServer:qwen-0_5b pid=62683) (EngineCore pid=64296) (RayWorkerProc pid=65043) (Worker pid=65043) INFO 08-14 11:58:42 [weight_utils.py:803] Prefetching checkpoint files: 10% (1/1)
(ServeReplica:default:LLMServer:qwen-0_5b pid=62683) (EngineCore pid=64296) (RayWorkerProc pid=65043) (Worker pid=65043) INFO 08-14 11:58:42 [weight_utils.py:826] Prefetching checkpoint files into page cache finished in 1.29s
(ServeReplica:default:LLMServer:qwen-0_5b pid=62683) (EngineCore pid=64296) (RayWorkerProc pid=65043) (Worker pid=65043) INFO 08-14 11:58:42 [default_loader.py:430] Loading weights took 1.35 seconds
Loading safetensors checkpoint shards: 100% Completed | 1/1 [00:01<00:00,  1.29s/it]erProc pid=65043) (Worker pid=65043) 
Loading safetensors checkpoint shards: 100% Completed | 1/1 [00:01<00:00,  1.29s/it]erProc pid=65043) (Worker pid=65043) 
(ServeReplica:default:LLMServer:qwen-0_5b pid=62683) (EngineCore pid=64296) (RayWorkerProc pid=65043) (Worker pid=65043) 
(RayWorkerProc pid=65043) (Worker pid=65043) INFO 08-14 11:58:42 [model_runner.py:305] Model loading took 0.93 GiB and 39.315232 seconds
(RayWorkerProc pid=65043) (Worker pid=65043) INFO 08-14 11:58:42 [topk_topp_sampler.py:55] Using FlashInfer for top-p & top-k sampling.
(ServeReplica:default:LLMServer:qwen-0_5b pid=62683) (EngineCore pid=64296) (RayWorkerProc pid=65043) (Worker pid=65043) INFO 08-14 11:58:42 [model_runner.py:305] Model loading took 0.93 GiB and 39.315232 seconds
(ServeReplica:default:LLMServer:qwen-0_5b pid=62683) (EngineCore pid=64296) (RayWorkerProc pid=65043) (Worker pid=65043) INFO 08-14 11:58:42 [topk_topp_sampler.py:55] Using FlashInfer for top-p & top-k sampling.
(RayWorkerProc pid=65043) (Worker pid=65043) INFO 08-14 11:58:52 [backends.py:1094] Using cache directory: /root/.cache/vllm/torch_compile_cache/8ffdbad051/rank_0_0/backbone for vLLM's torch.compile
(RayWorkerProc pid=65043) (Worker pid=65043) INFO 08-14 11:58:52 [backends.py:1155] Dynamo bytecode transform time: 9.53 s
(ServeReplica:default:LLMServer:qwen-0_5b pid=62683) (EngineCore pid=64296) (RayWorkerProc pid=65043) (Worker pid=65043) INFO 08-14 11:58:52 [backends.py:1094] Using cache directory: /root/.cache/vllm/torch_compile_cache/8ffdbad051/rank_0_0/backbone for vLLM's torch.compile
(ServeReplica:default:LLMServer:qwen-0_5b pid=62683) (EngineCore pid=64296) (RayWorkerProc pid=65043) (Worker pid=65043) INFO 08-14 11:58:52 [backends.py:1155] Dynamo bytecode transform time: 9.53 s
(RayWorkerProc pid=65043) (Worker pid=65043) INFO 08-14 11:58:56 [backends.py:378] Cache the graph of compile range (1, 2048) for later use
(ServeReplica:default:LLMServer:qwen-0_5b pid=62683) (EngineCore pid=64296) (RayWorkerProc pid=65043) (Worker pid=65043) INFO 08-14 11:58:56 [backends.py:378] Cache the graph of compile range (1, 2048) for later use
(RayWorkerProc pid=65043) (Worker pid=65043) INFO 08-14 11:58:58 [backends.py:393] Compiling a graph for compile range (1, 2048) takes 5.77 s
(ServeReplica:default:LLMServer:qwen-0_5b pid=62683) (EngineCore pid=64296) (RayWorkerProc pid=65043) (Worker pid=65043) INFO 08-14 11:58:58 [backends.py:393] Compiling a graph for compile range (1, 2048) takes 5.77 s
(RayWorkerProc pid=65043) (Worker pid=65043) INFO 08-14 11:59:00 [decorators.py:708] saved AOT compiled function to /root/.cache/vllm/torch_compile_cache/torch_aot_compile/b68dab0d49da0c8f877964e68ddced248a227ec851f8e93b13e0819b0be6c086/rank_0_0/model
(RayWorkerProc pid=65043) (Worker pid=65043) INFO 08-14 11:59:00 [monitor.py:53] torch.compile took 16.88 s in total
(ServeReplica:default:LLMServer:qwen-0_5b pid=62683) (EngineCore pid=64296) (RayWorkerProc pid=65043) (Worker pid=65043) INFO 08-14 11:59:00 [decorators.py:708] saved AOT compiled function to /root/.cache/vllm/torch_compile_cache/torch_aot_compile/b68dab0d49da0c8f877964e68ddced248a227ec851f8e93b13e0819b0be6c086/rank_0_0/model
(ServeReplica:default:LLMServer:qwen-0_5b pid=62683) (EngineCore pid=64296) (RayWorkerProc pid=65043) (Worker pid=65043) INFO 08-14 11:59:00 [monitor.py:53] torch.compile took 16.88 s in total
(RayWorkerProc pid=65043) (Worker pid=65043) INFO 08-14 11:59:00 [monitor.py:81] Initial profiling/warmup run took 0.30 s
(ServeReplica:default:LLMServer:qwen-0_5b pid=62683) (EngineCore pid=64296) (RayWorkerProc pid=65043) (Worker pid=65043) INFO 08-14 11:59:00 [monitor.py:81] Initial profiling/warmup run took 0.30 s
(ServeReplica:default:LLMServer:qwen-0_5b pid=62683) (EngineCore pid=64296) INFO 08-14 11:59:01 [kv_cache_utils.py:2177] GPU KV cache size: 1,778,288 tokens
(ServeReplica:default:LLMServer:qwen-0_5b pid=62683) (EngineCore pid=64296) INFO 08-14 11:59:01 [kv_cache_utils.py:2178] Maximum concurrency for 32,768 tokens per request: 54.27x
(RayWorkerProc pid=65043) (Worker pid=65043) INFO 08-14 11:59:01 [gpu_worker.py:560] Available KV cache memory: 20.35 GiB
(ServeReplica:default:LLMServer:qwen-0_5b pid=62683) (EngineCore pid=64296) (RayWorkerProc pid=65043) (Worker pid=65043) INFO 08-14 11:59:01 [gpu_worker.py:560] Available KV cache memory: 20.35 GiB
(RayWorkerProc pid=65043) (Worker pid=65043) INFO 08-14 11:59:02 [cutedsl_warmup.py:101] Skipping CuTeDSL warmup because no compile units were requested.
(ServeReplica:default:LLMServer:qwen-0_5b pid=62683) (EngineCore pid=64296) (RayWorkerProc pid=65043) (Worker pid=65043) INFO 08-14 11:59:02 [cutedsl_warmup.py:101] Skipping CuTeDSL warmup because no compile units were requested.
Capturing CUDA graphs (PIECEWISE):   0%|          | 0/51 [00:00<?, ?it/s]
Capturing CUDA graphs (PIECEWISE):   0%|          | 0/51 [00:00<?, ?it/s]6) (RayWorkerProc pid=65043) (Worker pid=65043) 
Capturing CUDA graphs (PIECEWISE):  10%|▉         | 5/51 [00:00<00:01, 28.97it/s]
Capturing CUDA graphs (PIECEWISE):  10%|▉         | 5/51 [00:00<00:01, 28.97it/s]orkerProc pid=65043) 
Capturing CUDA graphs (PIECEWISE):  20%|█▉        | 10/51 [00:00<00:01, 37.50it/s]
Capturing CUDA graphs (PIECEWISE):  20%|█▉        | 10/51 [00:00<00:01, 37.50it/s]rkerProc pid=65043) 
Capturing CUDA graphs (PIECEWISE):  33%|███▎      | 17/51 [00:00<00:00, 47.91it/s]
Capturing CUDA graphs (PIECEWISE):  33%|███▎      | 17/51 [00:00<00:00, 47.91it/s]rkerProc pid=65043) 
Capturing CUDA graphs (PIECEWISE):  45%|████▌     | 23/51 [00:00<00:00, 51.07it/s]
Capturing CUDA graphs (PIECEWISE):  45%|████▌     | 23/51 [00:00<00:00, 51.07it/s]rkerProc pid=65043) 
Capturing CUDA graphs (PIECEWISE):  59%|█████▉    | 30/51 [00:00<00:00, 54.98it/s]
Capturing CUDA graphs (PIECEWISE):  59%|█████▉    | 30/51 [00:00<00:00, 54.98it/s]rkerProc pid=65043) 
Capturing CUDA graphs (PIECEWISE):  73%|███████▎  | 37/51 [00:00<00:00, 57.12it/s]
Capturing CUDA graphs (PIECEWISE):  73%|███████▎  | 37/51 [00:00<00:00, 57.12it/s]rkerProc pid=65043) 
Capturing CUDA graphs (PIECEWISE):  86%|████████▋ | 44/51 [00:00<00:00, 58.95it/s]
Capturing CUDA graphs (PIECEWISE):  86%|████████▋ | 44/51 [00:00<00:00, 58.95it/s]rkerProc pid=65043) 
Capturing CUDA graphs (PIECEWISE): 100%|██████████| 51/51 [00:00<00:00, 51.64it/s]
Capturing CUDA graphs (FULL):   0%|          | 0/35 [00:00<?, ?it/s]
Capturing CUDA graphs (PIECEWISE): 100%|██████████| 51/51 [00:00<00:00, 51.64it/s]rkerProc pid=65043) 
Capturing CUDA graphs (FULL):   0%|          | 0/35 [00:00<?, ?it/s]=64296) (RayWorkerProc pid=65043) (Worker pid=65043) 
Capturing CUDA graphs (FULL):   6%|▌         | 2/35 [00:00<00:01, 18.83it/s]
Capturing CUDA graphs (FULL):   6%|▌         | 2/35 [00:00<00:01, 18.83it/s](RayWorkerProc pid=65043) 
Capturing CUDA graphs (FULL):  26%|██▌       | 9/35 [00:00<00:00, 44.40it/s]
Capturing CUDA graphs (FULL):  26%|██▌       | 9/35 [00:00<00:00, 44.40it/s](RayWorkerProc pid=65043) 
Capturing CUDA graphs (FULL):  46%|████▌     | 16/35 [00:00<00:00, 52.91it/s]
Capturing CUDA graphs (FULL):  46%|████▌     | 16/35 [00:00<00:00, 52.91it/s]RayWorkerProc pid=65043) 
Capturing CUDA graphs (FULL):  63%|██████▎   | 22/35 [00:00<00:00, 44.01it/s]
Capturing CUDA graphs (FULL):  63%|██████▎   | 22/35 [00:00<00:00, 44.01it/s]RayWorkerProc pid=65043) 
Capturing CUDA graphs (FULL):  83%|████████▎ | 29/35 [00:00<00:00, 50.64it/s]
Capturing CUDA graphs (FULL):  83%|████████▎ | 29/35 [00:00<00:00, 50.64it/s]RayWorkerProc pid=65043) 
(RayWorkerProc pid=65043) (Worker pid=65043) INFO 08-14 11:59:04 [model_runner.py:747] Graph capturing finished in 2 secs, took 0.41 GiB
(RayWorkerProc pid=65043) (Worker pid=65043) INFO 08-14 11:59:04 [gpu_worker.py:857] Free memory on device (23.13/23.52 GiB) on startup. Desired GPU memory utilization is (0.92, 21.64 GiB). Actual usage is 0.93 GiB for weight, 0.26 GiB for peak activation, 0.1 GiB for non-torch memory, and 0.41 GiB for CUDAGraph memory. Replace gpu_memory_utilization config with `--kv-cache-memory=21249853666` (19.79 GiB) to fit into requested memory, or `--kv-cache-memory=22856568320` (21.29 GiB) to fully utilize gpu memory. Current kv cache memory in use is 20.35 GiB.
Capturing CUDA graphs (FULL): 100%|██████████| 35/35 [00:00<00:00, 49.24it/s]
(ServeReplica:default:LLMServer:qwen-0_5b pid=62683) (EngineCore pid=64296) (RayWorkerProc pid=65043) (Worker pid=65043) INFO 08-14 11:59:04 [model_runner.py:747] Graph capturing finished in 2 secs, took 0.41 GiB
(ServeReplica:default:LLMServer:qwen-0_5b pid=62683) (EngineCore pid=64296) (RayWorkerProc pid=65043) (Worker pid=65043) INFO 08-14 11:59:04 [gpu_worker.py:857] Free memory on device (23.13/23.52 GiB) on startup. Desired GPU memory utilization is (0.92, 21.64 GiB). Actual usage is 0.93 GiB for weight, 0.26 GiB for peak activation, 0.1 GiB for non-torch memory, and 0.41 GiB for CUDAGraph memory. Replace gpu_memory_utilization config with `--kv-cache-memory=21249853666` (19.79 GiB) to fit into requested memory, or `--kv-cache-memory=22856568320` (21.29 GiB) to fully utilize gpu memory. Current kv cache memory in use is 20.35 GiB.
Capturing CUDA graphs (FULL): 100%|██████████| 35/35 [00:00<00:00, 49.24it/s]RayWorkerProc pid=65043) 
(ServeController pid=61919) WARNING 2026-08-14 11:59:04,783 controller 61919 -- Deployment 'LLMServer:qwen-0_5b' in application 'default' has 1 replicas that have taken more than 30s to initialize.
(ServeController pid=61919) This may be caused by a slow __init__ or reconfigure method.
(RayWorkerProc pid=65043) (Worker pid=65043) INFO 08-14 11:59:11 [jit_monitor.py:79] Kernel JIT monitor activated; monitored JIT compilations during inference will use mode=warn.
(ServeReplica:default:LLMServer:qwen-0_5b pid=62683) (EngineCore pid=64296) (RayWorkerProc pid=65043) (Worker pid=65043) INFO 08-14 11:59:11 [jit_monitor.py:79] Kernel JIT monitor activated; monitored JIT compilations during inference will use mode=warn.
(ServeReplica:default:LLMServer:qwen-0_5b pid=62683) (EngineCore pid=64296) INFO 08-14 11:59:11 [core.py:340] init engine (profile, create kv cache, warmup model) took 28.77 s (compilation: 16.88 s)
(ServeReplica:default:LLMServer:qwen-0_5b pid=62683) (EngineCore pid=64296) Warning: You are sending unauthenticated requests to the HF Hub. Please set a HF_TOKEN to enable higher rate limits and faster downloads.
(ServeReplica:default:LLMServer:qwen-0_5b pid=62683) (EngineCore pid=64296) INFO 08-14 11:59:20 [vllm.py:1109] Asynchronous scheduling is enabled.
(ServeReplica:default:LLMServer:qwen-0_5b pid=62683) (EngineCore pid=64296) INFO 08-14 11:59:20 [kernel.py:295] Final IR op priority after setting platform defaults: IrOpPriorityConfig(rms_norm=['native'], fused_add_rms_norm=['native'])
(ServeReplica:default:LLMServer:qwen-0_5b pid=62683) WARNING 08-14 11:59:20 [model.py:1546] Default vLLM sampling parameters have been overridden by the model's `generation_config.json`: `{'repetition_penalty': 1.1, 'temperature': 0.7, 'top_k': 20, 'top_p': 0.8}`. If this is not intended, please relaunch vLLM instance with `--generation-config vllm`.
(ServeReplica:default:LLMServer:qwen-0_5b pid=62683) INFO 08-14 11:59:22 [hf.py:540] Detected the chat template content format to be 'string'. You can set `--chat-template-content-format` to override this.
(ServeReplica:default:LLMServer:qwen-0_5b pid=62683) INFO 2026-08-14 11:59:22,925 default_LLMServer:qwen-0_5b kqnimn62 -- Started vLLM engine.
(pid=67341) /workspace/ray/.venv/lib/python3.12/site-packages/torch/cuda/__init__.py:61: FutureWarning: The pynvml package is deprecated. Please install nvidia-ml-py instead. If you did not install pynvml directly, please report this to the maintainers of the package that installed pynvml for you.
(pid=67341)   import pynvml  # type: ignore[import]
(ServeReplica:default:AnthropicIngress pid=61926) INFO 2026-08-14 11:59:32,848 default_AnthropicIngress i763jp1f 178d4f4d-8ab3-4635-9760-364998a841e3 -- POST /v1/messages 200 129876.8ms
(ServeReplica:default:LLMServer:qwen-0_5b pid=62683) INFO 2026-08-14 11:59:32,846 default_LLMServer:qwen-0_5b kqnimn62 178d4f4d-8ab3-4635-9760-364998a841e3 -- CALL messages OK 242.2ms
INFO 2026-08-14 11:59:33,048 serve 60616 -- Application 'default' is ready at http://127.0.0.1:8000/.
(ServeReplica:default:AnthropicIngress pid=61926) INFO 2026-08-14 12:00:28,505 default_AnthropicIngress i763jp1f f9e40442-a2d8-460e-b9a5-7957b9625fc5 -- GET / 404 2.2ms
(ServeReplica:default:LLMServer:qwen-0_5b pid=62683) INFO 2026-08-14 12:00:28,684 default_LLMServer:qwen-0_5b kqnimn62 9a041229-1885-40aa-b6cc-62c7919c18ad -- CALL messages OK 90.6ms
(ServeReplica:default:AnthropicIngress pid=61926) INFO 2026-08-14 12:00:28,687 default_AnthropicIngress i763jp1f 9a041229-1885-40aa-b6cc-62c7919c18ad -- POST /v1/messages 200 101.5ms
(ServeReplica:default:AnthropicIngress pid=61926) INFO 2026-08-14 12:00:28,738 default_AnthropicIngress i763jp1f eabae3ac-dd5c-4ae1-99e8-c39cb41ff53f -- GET / 404 1.8ms
(ServeReplica:default:AnthropicIngress pid=61926) INFO 2026-08-14 12:01:46,286 default_AnthropicIngress i763jp1f 4c4f943d-3dea-4d47-9262-cf1279ca224e -- POST /v1/messages 200 283.0ms
(ServeReplica:default:LLMServer:qwen-0_5b pid=62683) INFO 2026-08-14 12:01:46,284 default_LLMServer:qwen-0_5b kqnimn62 4c4f943d-3dea-4d47-9262-cf1279ca224e -- CALL messages OK 273.6ms
```

</details>

This sets up the `ANTHROPIC_BASE_URL` at: http://localhost:8000/v1/messages.

<details>
<summary>Anthropic API Tests Script</summary>

```python
import os

from anthropic import Anthropic

client = Anthropic(
    api_key=os.environ["ANTHROPIC_API_KEY"],
    base_url=os.environ["ANTHROPIC_BASE_URL"],
)

prompts = [
    "Who is Anwar Ibrahim? Answer in one sentence.",
    "What is Ray Serve? Answer in one sentence.",
    "What is Ray Serve? Answer in one sentence.",
]

for prompt in prompts:
    print(f"\nPrompt: {prompt}")
    response = client.messages.create(
        model=os.environ["MODEL_ID"],
        max_tokens=128,
        messages=[{"role": "user", "content": prompt}],
    )

    for block in response.content:
        if block.type == "text":
            print(f"Response: {block.text}")
```

</details>

<details>
<summary>Anthropic API Tests Logs</summary>

```python
root@e698b1650b1b:/# bash test_ray_anthropic_api.sh 
>>> Installing the Anthropic Python SDK...
Requirement already satisfied: anthropic in ./ray/.venv/lib/python3.12/site-packages (0.122.0)
Requirement already satisfied: anyio<5,>=3.5.0 in ./ray/.venv/lib/python3.12/site-packages (from anthropic) (4.14.2)
Requirement already satisfied: distro<2,>=1.7.0 in ./ray/.venv/lib/python3.12/site-packages (from anthropic) (1.9.0)
Requirement already satisfied: docstring-parser<1,>=0.15 in ./ray/.venv/lib/python3.12/site-packages (from anthropic) (0.18.0)
Requirement already satisfied: httpx<1,>=0.25.0 in ./ray/.venv/lib/python3.12/site-packages (from anthropic) (0.28.1)
Requirement already satisfied: jiter<1,>=0.4.0 in ./ray/.venv/lib/python3.12/site-packages (from anthropic) (0.16.0)
Requirement already satisfied: pydantic<3,>=1.9.0 in ./ray/.venv/lib/python3.12/site-packages (from anthropic) (2.13.4)
Requirement already satisfied: sniffio<2,>=1 in ./ray/.venv/lib/python3.12/site-packages (from anthropic) (1.3.1)
Requirement already satisfied: typing-extensions<5,>=4.14 in ./ray/.venv/lib/python3.12/site-packages (from anthropic) (4.16.0)
Requirement already satisfied: idna>=2.8 in ./ray/.venv/lib/python3.12/site-packages (from anyio<5,>=3.5.0->anthropic) (3.18)
Requirement already satisfied: certifi in ./ray/.venv/lib/python3.12/site-packages (from httpx<1,>=0.25.0->anthropic) (2026.7.22)
Requirement already satisfied: httpcore==1.* in ./ray/.venv/lib/python3.12/site-packages (from httpx<1,>=0.25.0->anthropic) (1.0.9)
Requirement already satisfied: h11>=0.16 in ./ray/.venv/lib/python3.12/site-packages (from httpcore==1.*->httpx<1,>=0.25.0->anthropic) (0.16.0)
Requirement already satisfied: annotated-types>=0.6.0 in ./ray/.venv/lib/python3.12/site-packages (from pydantic<3,>=1.9.0->anthropic) (0.8.0)
Requirement already satisfied: pydantic-core==2.46.4 in ./ray/.venv/lib/python3.12/site-packages (from pydantic<3,>=1.9.0->anthropic) (2.46.4)
Requirement already satisfied: typing-inspection>=0.4.2 in ./ray/.venv/lib/python3.12/site-packages (from pydantic<3,>=1.9.0->anthropic) (0.4.4)
>>> Querying http://127.0.0.1:8000/v1/messages with model qwen-0.5b...

Prompt: Who is Anwar Ibrahim? Answer in one sentence.
Response: Anwar Ibrahim is a prominent Malaysian politician and businessman who has served as the Prime Minister of Malaysiasince 2018. He was previously the Deputy Prime Minister from 2013 to 2018 and also holds other positions such as Minister for Finance and Minister for Health. Ibrahim is known for his economic reforms, including his efforts to liberalize the economyand increase investment in infrastructure and education.

Prompt: What is Ray Serve? Answer in one sentence.
Response: Ray Serve is an open-source framework designed to simplify the deployment and management of machine learning models using Ray's GPU-based parallel computing capabilities. It provides tools for deploying models across multiple nodes on GPUs, enabling efficient training and inference processes.

Prompt: What is Ray Serve? Answer in one sentence.
Response: Ray Serve is a distributed computing framework designed to efficiently process and deploy machine learning models across multiple servers or instances, enabling rapid experimentation with new algorithms and data sets while maintaining highperformance for real-time applications.
```

</details>

## AI assistance

AI assistance was used during implementation. I reviewed the changed code and am responsible for understanding, testing, and maintaining it. Used Cursor: GPT-5.6 Sol, Cursor Grok 4.6