### PR TITLE
[serve] Deflake test_handle_deleted_on_crashed_replica

### DIFF
--- a/python/ray/serve/tests/test_autoscaling_policy.py
+++ b/python/ray/serve/tests/test_autoscaling_policy.py
@@ -298,7 +298,13 @@ class TestAutoscalingMetrics:
                 await signal.wait.remote()
                 return "sup"
 
-        @serve.deployment(graceful_shutdown_timeout_s=1, max_ongoing_requests=50)
+        # Health check often so the controller notices the killed replica (and drops
+        # its handle metrics) in ~1s; the default 10s period is what made this flaky.
+        @serve.deployment(
+            graceful_shutdown_timeout_s=1,
+            max_ongoing_requests=50,
+            health_check_period_s=1,
+        )
         class Router:
             def __init__(self, handle: DeploymentHandle):
                 if use_get_handle_api:
@@ -329,8 +335,10 @@ class TestAutoscalingMetrics:
         print(f"Killing Router ({router_info['actor_id']}) at", time.time())
         ray.kill(router)
 
-        wait_for_condition(check_num_replicas_eq, name="A", target=0)
-        wait_for_condition(check_num_requests_eq, client=client, id=dep_id, expected=0)
+        wait_for_condition(check_num_replicas_eq, name="A", target=0, timeout=20)
+        wait_for_condition(
+            check_num_requests_eq, client=client, id=dep_id, expected=0, timeout=20
+        )
 
         # Wait for new Router replica to start, so we avoid potential
         # race conditions during test shutdown.
@@ -338,7 +346,7 @@ class TestAutoscalingMetrics:
         # initializes the test shutdown procedure deletes the Router
         # deployment, replica initializes and tries to get deployment
         # handle to `A` and fails.)
-        wait_for_condition(check_num_replicas_eq, name="Router", target=1)
+        wait_for_condition(check_num_replicas_eq, name="Router", target=1, timeout=20)
 
     @skip_if_haproxy(
         "direct ingress makes the ingress replicas self-report a source-agnostic "


### PR DESCRIPTION
After the Router is killed (ray.kill), the deployment can only scale to 0 once the Controller notices that the Router replica has died and drops the handle metrics it owns.  The Router did not have health_check_period_s set, so detection took up to the 10s default,  the same size as the bare 10s wait_for_condition the test gave the entire drain.  In a reproduced failure the crash was detected 9s after the kill and the downscale decision came soon after 10s, but the test had already given up after 10s.

The fix is to health check the Router every 1s, as another deployment in this test already does, and give the three post-kill waits the 20s that sibling test test_handle_deleted_on_non_serve_actor already uses for the same drain.
