### PR TITLE
[serve][doc] Document the '#' constraint on deployment names

### DIFF
--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -570,7 +570,9 @@ def deployment(
     Args:
         _func_or_class: The class or function to be decorated.
         name: Name uniquely identifying this deployment within the application.
-            If not provided, the name of the class or function is used.
+            If not provided, the name of the class or function is used. The name
+            must not contain the `#` character, which Serve reserves as the
+            replica ID delimiter; passing one raises a ValueError.
         version: Removed. Specifying this argument raises a ValueError.
         num_replicas: Number of replicas to run that handle requests to
             this deployment. Defaults to 1.


### PR DESCRIPTION
## Why this change

#65215 ("[serve] remove deprecated Serve APIs") turned a deployment name containing `#` from a `FutureWarning` into a hard `ValueError`:

```python
# python/ray/serve/deployment.py
# '#' is the replica ID delimiter, so it cannot appear in a name.
if "#" in name:
    raise ValueError(...)
```

The constraint isn't documented anywhere. The `@serve.deployment` docstring says only that `name` uniquely identifies the deployment within the application, and no page under `doc/source/serve/` mentions a character restriction. So a reader who picks a name containing `#` now gets a runtime error with nothing to point them at.

This adds the restriction and the reason to the `name` argument. `Deployment.options()` tells readers to "refer to the `@serve.deployment` decorator docs for available arguments," so the single edit covers both public surfaces.

The reason given is accurate: `ReplicaID.to_full_id_str()` joins app name, deployment name, and unique ID with `#`, and `ReplicaID.from_full_id_str()` splits on it, so a `#` in a deployment name would corrupt round-tripping.

## Not a duplicate

- `gh pr list --state open --search "deployment name validate"` and `"serve deployment name docstring"` return nothing covering this.
- #65215, which introduced the hard error, is merged and did not document it.

## Testing

Docstring only; no runtime code path is touched, so there's no behavior to test. The documented behavior is already asserted by the `pytest.raises(ValueError)` cases in `python/ray/serve/tests/unit/test_build_app.py` that #65215 added.

`pre-commit run --files python/ray/serve/api.py` passes, including `pydoclint` and the Ray docstyle check.

## AI assistance

AI assistance was used to find the undocumented constraint and draft the wording. I reviewed every changed line and verified the delimiter claim against `python/ray/serve/_private/common.py` before submitting.
