### PR TITLE
[cherry-pick][2.58.0][Data] Check object store utilization instead of any spilling in release tests (#65222)

### DIFF
--- a/release/ray_release/command_runner/_anyscale_job_wrapper.py
+++ b/release/ray_release/command_runner/_anyscale_job_wrapper.py
@@ -9,13 +9,14 @@ have access to the ray_release package.
 import argparse
 import json
 import logging
+import math
 import multiprocessing
 import os
 import subprocess
 import sys
 import time
 from pathlib import Path
-from typing import List, Optional, Tuple
+from typing import List, Optional, Tuple, TypedDict
 from urllib.parse import urlparse
 
 AZURE_STORAGE_ACCOUNT = "rayreleasetests"
@@ -35,6 +36,20 @@ formatter = logging.Formatter(
 )
 handler.setFormatter(formatter)
 logger.addHandler(handler)
+
+
+class PrometheusSeries(TypedDict):
+    """A single time series from a Prometheus query result.
+
+    Attributes:
+        metric: The series' label set, e.g. ``{"Type": ..., "Name": ...}``. Empty
+            when the query aggregated the labels away.
+        values: ``[timestamp, value]`` samples over the queried range. Prometheus
+            renders the values as strings.
+    """
+
+    metric: dict[str, str]
+    values: list[list]
 
 
 def exponential_backoff_retry(
@@ -366,6 +381,68 @@ def run_spilling_check():
     return return_code
 
 
+def run_obj_store_util_check(max_percent: str):
+    """Fail if peak object store utilization exceeded ``max_percent`` percent."""
+    check_name = "Object store utilization check"
+    env_var = "RAYTEST_MAX_OBJ_STORE_UTIL_PERCENT"
+
+    try:
+        threshold = float(max_percent)
+    except ValueError:
+        logger.error(f"{check_name}: {env_var!r} isn't a number: {max_percent!r}.")
+        return 1
+
+    if threshold < 0:
+        logger.info(f"{check_name} skipped: {env_var} is {max_percent}.")
+        return 0
+
+    metrics = _load_metrics_for_check(check_name, env_var)
+    if metrics is None:
+        return 1
+    if _metric_unavailable(check_name, metrics, "object_store_util_percent"):
+        return 1
+
+    peak_percent = _peak_metric_value(metrics["object_store_util_percent"])
+    if peak_percent is None:
+        logger.error(
+            f"{check_name}: 'object_store_util_percent' contains no samples, likely "
+            "a collection issue."
+        )
+        return 0
+
+    if peak_percent > threshold:
+        logger.error(
+            f"Test failed: peak object store utilization {peak_percent:.1f}% exceeded "
+            f"the {threshold:.1f}% limit set by {env_var}."
+        )
+        return 1
+
+    logger.info(
+        f"{check_name} passed: peak object store utilization {peak_percent:.1f}% "
+        f"is within the {threshold:.1f}% limit."
+    )
+    return 0
+
+
+def _peak_metric_value(series: list[PrometheusSeries]) -> float | None:
+    """Return the largest sample across a Prometheus query result.
+
+    Args:
+        series: One entry per label set the query returned, each holding that
+            series' samples over the queried range.
+
+    Returns:
+        The largest value, or ``None`` if there aren't any valid values.
+    """
+    values = [
+        float(value)
+        for entry in series
+        for _, value in entry.get("values", [])
+        if not math.isnan(float(value))
+    ]
+    return max(values) if values else None
+
+
 def run_dead_node_check():
     # Connect to the cluster and check for dead nodes
     import ray
@@ -491,6 +568,14 @@ def main(
         # Fail if any object-store spilling occurred
         if return_code == 0 and test_fail_on_spilling:
             return_code = run_spilling_check()
+
+        max_obj_store_util_percent = os.environ.get(
+            "RAYTEST_MAX_OBJ_STORE_UTIL_PERCENT"
+        )
+
+        # Fail if the object store filled up beyond the configured limit.
+        if return_code == 0 and max_obj_store_util_percent:
+            return_code = run_obj_store_util_check(max_obj_store_util_percent)
 
         uploaded_artifact = run_storage_cp(
             artifact_path,

--- a/release/ray_release/command_runner/_prometheus_metrics.py
+++ b/release/ray_release/command_runner/_prometheus_metrics.py
@@ -97,6 +97,11 @@ async def _get_prometheus_metrics(
         if session_name
         else '{State="Spilled"}'
     )
+    sf_obj_store_capacity = (
+        f'{{Name="object_store_memory",SessionName="{session_name}"}}'
+        if session_name
+        else '{Name="object_store_memory"}'
+    )
     metrics = {
         "cpu_utilization": client.query_prometheus(
             query=f"ray_node_cpu_utilization{sf} * ray_node_cpu_count{sf} / 100",
@@ -173,6 +178,14 @@ async def _get_prometheus_metrics(
         # are point-in-time / transient); `> 0` drops always-emitted 0 points.
         "spilled_bytes": client.query_prometheus(
             query=f"sum(ray_spill_manager_objects_bytes{sf_spilled}) > 0",
+            **kwargs,
+        ),
+        # Cluster-wide object store utilization, as a percentage of total capacity.
+        "object_store_util_percent": client.query_prometheus(
+            query=(
+                f"sum(ray_object_store_memory{sf}) / on() "
+                f"sum(ray_resources{sf_obj_store_capacity}) * 100"
+            ),
             **kwargs,
         ),
     }

--- a/release/ray_release/tests/test_anyscale_job_wrapper.py
+++ b/release/ray_release/tests/test_anyscale_job_wrapper.py
@@ -10,6 +10,7 @@ from ray_release.command_runner._anyscale_job_wrapper import (
     TIMEOUT_RETURN_CODE,
     main,
     run_bash_command,
+    run_obj_store_util_check,
     run_spilling_check,
 )
 
@@ -234,6 +235,71 @@ def test_run_spilling_check_non_dict_json(tmpdir, payload):
         json.dump(payload, f)
     with patch.dict(os.environ, {"METRICS_OUTPUT_JSON": metrics_path}):
         assert run_spilling_check() == 1
+
+
+class TestRunObjStoreUtilCheck:
+    def test_peak_below_limit_passes(self, tmp_path, monkeypatch):
+        metrics_path = tmp_path / "metrics.json"
+        metrics_path.write_text(
+            json.dumps({"object_store_util_percent": [{"values": [[0, "79"]]}]})
+        )
+        monkeypatch.setenv("METRICS_OUTPUT_JSON", str(metrics_path))
+
+        assert run_obj_store_util_check("80") == 0
+
+    def test_peak_at_limit_passes(self, tmp_path, monkeypatch):
+        metrics_path = tmp_path / "metrics.json"
+        metrics_path.write_text(
+            json.dumps({"object_store_util_percent": [{"values": [[0, "80"]]}]})
+        )
+        monkeypatch.setenv("METRICS_OUTPUT_JSON", str(metrics_path))
+
+        assert run_obj_store_util_check("80") == 0
+
+    def test_peak_above_limit_fails(self, tmp_path, monkeypatch):
+        metrics_path = tmp_path / "metrics.json"
+        metrics_path.write_text(
+            json.dumps({"object_store_util_percent": [{"values": [[0, "81"]]}]})
+        )
+        monkeypatch.setenv("METRICS_OUTPUT_JSON", str(metrics_path))
+
+        assert run_obj_store_util_check("80") == 1
+
+    def test_earlier_sample_above_limit_fails(self, tmp_path, monkeypatch):
+        metrics_path = tmp_path / "metrics.json"
+        metrics_path.write_text(
+            json.dumps(
+                {"object_store_util_percent": [{"values": [[0, "81"], [1, "0"]]}]}
+            )
+        )
+        monkeypatch.setenv("METRICS_OUTPUT_JSON", str(metrics_path))
+
+        assert run_obj_store_util_check("80") == 1
+
+    def test_no_samples_passes(self, tmp_path, monkeypatch):
+        metrics_path = tmp_path / "metrics.json"
+        metrics_path.write_text(json.dumps({"object_store_util_percent": []}))
+        monkeypatch.setenv("METRICS_OUTPUT_JSON", str(metrics_path))
+
+        assert run_obj_store_util_check("80") == 0
+
+    def test_only_nan_samples_passes(self, tmp_path, monkeypatch):
+        metrics_path = tmp_path / "metrics.json"
+        metrics_path.write_text(
+            json.dumps({"object_store_util_percent": [{"values": [[0, "NaN"]]}]})
+        )
+        monkeypatch.setenv("METRICS_OUTPUT_JSON", str(metrics_path))
+
+        assert run_obj_store_util_check("80") == 0
+
+    def test_negative_limit_skips_check(self, tmp_path, monkeypatch):
+        metrics_path = tmp_path / "metrics.json"
+        metrics_path.write_text(
+            json.dumps({"object_store_util_percent": [{"values": [[0, "500"]]}]})
+        )
+        monkeypatch.setenv("METRICS_OUTPUT_JSON", str(metrics_path))
+
+        assert run_obj_store_util_check("-1") == 0
 
 
 if __name__ == "__main__":

--- a/release/release_data_tests.yaml
+++ b/release/release_data_tests.yaml
@@ -14,8 +14,12 @@
         - RAYTEST_FAIL_ON_WORKER_OOM=1
         # Fail the test if a node dies
         - RAYTEST_FAIL_ON_DEAD_NODES=1
-        # Fail the test if a worker spills
-        - RAYTEST_FAIL_ON_SPILLING=1
+        # Ray Data attempts to limit cluster-wide object store usage of primary copies
+        # to 50% with its `ResourceBudget` backpressure policy. Since Ray Data doesn't
+        # keep track of secondary copies, the worst case utilization is 50% * 2 copies
+        # = 100%. If we exceed this amount on a linear pipeline, it means backpressure
+        # is very broken.
+        - RAYTEST_MAX_OBJ_STORE_UTIL_PERCENT=100
 
       # 'type: gpu' means: use the 'ray-ml' image.
       type: gpu
@@ -251,7 +255,6 @@
         - RAY_DATA_DEBUG_RESOURCE_MANAGER=1
         - RAYTEST_FAIL_ON_WORKER_OOM=1
         - RAYTEST_FAIL_ON_DEAD_NODES=1
-        - RAYTEST_FAIL_ON_SPILLING=0
     cluster_compute: "{{scaling}}_all_to_all_compute.yaml"
 
   run:
@@ -278,7 +281,6 @@
         - RAY_DATA_DEBUG_RESOURCE_MANAGER=1
         - RAYTEST_FAIL_ON_WORKER_OOM=1
         - RAYTEST_FAIL_ON_DEAD_NODES=1
-        - RAYTEST_FAIL_ON_SPILLING=0
     cluster_compute: "{{scaling}}_all_to_all_compute.yaml"
 
   run:
@@ -319,7 +321,6 @@
         - RAY_DATA_DEBUG_RESOURCE_MANAGER=1
         - RAYTEST_FAIL_ON_WORKER_OOM=1
         - RAYTEST_FAIL_ON_DEAD_NODES=1
-        - RAYTEST_FAIL_ON_SPILLING=0
     cluster_compute: fixed_size_all_to_all_compute.yaml
 
   matrix:
@@ -352,7 +353,7 @@
         - RAY_DATA_DEBUG_RESOURCE_MANAGER=1
         - RAYTEST_FAIL_ON_WORKER_OOM=1
         - RAYTEST_FAIL_ON_DEAD_NODES=1
-        - RAYTEST_FAIL_ON_SPILLING=1
+        - RAYTEST_MAX_OBJ_STORE_UTIL_PERCENT=100
         # S3 tensor data was written by Ray 2.49-2.54 using cloudpickle.
         - RAY_DATA_AUTOLOAD_CLOUDPICKLE_TENSOR_METADATA=1
     cluster_compute: fixed_size_cpu_compute.yaml
@@ -468,7 +469,6 @@
             - RAY_DATA_DEBUG_RESOURCE_MANAGER=1
             - RAYTEST_FAIL_ON_WORKER_OOM=1
             - RAYTEST_FAIL_ON_DEAD_NODES=0
-            - RAYTEST_FAIL_ON_SPILLING=1
       run:
         prepare: >
           python setup_chaos.py --kill-interval 200 --max-to-kill 1 --task-names
@@ -556,7 +556,7 @@
         - RAY_DATA_DEBUG_RESOURCE_MANAGER=1
         - RAYTEST_FAIL_ON_WORKER_OOM=1
         - RAYTEST_FAIL_ON_DEAD_NODES=1
-        - RAYTEST_FAIL_ON_SPILLING=1
+        - RAYTEST_MAX_OBJ_STORE_UTIL_PERCENT=100
     cluster_compute: training_ingest_regression_test/compute.yaml
 
   variations:
@@ -792,7 +792,6 @@
         - RAY_DATA_DEBUG_RESOURCE_MANAGER=1
         - RAYTEST_FAIL_ON_WORKER_OOM=1
         - RAYTEST_FAIL_ON_DEAD_NODES=1
-        - RAYTEST_FAIL_ON_SPILLING=0
     cluster_compute: "{{scaling}}_all_to_all_compute.yaml"
 
   run:
@@ -812,7 +811,6 @@
         - RAY_DATA_DEBUG_RESOURCE_MANAGER=1
         - RAYTEST_FAIL_ON_WORKER_OOM=1
         - RAYTEST_FAIL_ON_DEAD_NODES=0
-        - RAYTEST_FAIL_ON_SPILLING=0
     cluster_compute: dataset/autoscaling_all_to_all_compute.yaml
 
   run:
@@ -840,7 +838,6 @@
         - RAY_DATA_DEBUG_RESOURCE_MANAGER=1
         - RAYTEST_FAIL_ON_WORKER_OOM=1
         - RAYTEST_FAIL_ON_DEAD_NODES=1
-        - RAYTEST_FAIL_ON_SPILLING=0
     cluster_compute: "{{scaling}}_all_to_all_compute.yaml"
 
   run:
@@ -862,7 +859,6 @@
         - RAY_DATA_DEBUG_RESOURCE_MANAGER=1
         - RAYTEST_FAIL_ON_WORKER_OOM=1
         - RAYTEST_FAIL_ON_DEAD_NODES=0
-        - RAYTEST_FAIL_ON_SPILLING=0
     cluster_compute: dataset/autoscaling_all_to_all_compute.yaml
 
   run:
@@ -893,7 +889,7 @@
         - RAY_DATA_DEBUG_RESOURCE_MANAGER=1
         - RAYTEST_FAIL_ON_WORKER_OOM=1
         - RAYTEST_FAIL_ON_DEAD_NODES=1
-        - RAYTEST_FAIL_ON_SPILLING=0
+        - RAYTEST_MAX_OBJ_STORE_UTIL_PERCENT=100
     cluster_compute: heterogeneous_memory_compute.yaml
 
   run:
@@ -918,6 +914,7 @@
         - RAY_DATA_DEBUG_RESOURCE_MANAGER=1
         - RAYTEST_FAIL_ON_WORKER_OOM=0
         - RAYTEST_FAIL_ON_DEAD_NODES=0
+        - RAYTEST_MAX_OBJ_STORE_UTIL_PERCENT=100
         - RAY_MAX_LIMIT_FROM_API_SERVER=20000
         - RAY_MAX_LIMIT_FROM_DATA_SOURCE=20000
     cluster_compute: heterogeneous_memory_compute_multitenancy.yaml
@@ -965,7 +962,6 @@
         - RAY_DATA_DEBUG_RESOURCE_MANAGER=1
         - RAYTEST_FAIL_ON_WORKER_OOM=1
         - RAYTEST_FAIL_ON_DEAD_NODES=0
-        - RAYTEST_FAIL_ON_SPILLING=0
       # NOTE: Image classification have to pin Pyarrow to 19.0 due to dataset using
       #       previous tensor extension type inheriting from ``pyarrow.PyExtensionType``
       #       that is removed in Pyarrow 21.0
@@ -1018,32 +1014,27 @@
       cluster_type: []
       args: []
       fail_on_dead_nodes: []
-      fail_on_spilling: []
+      max_obj_store_util_percent: []
     adjustments:
       - with:
           case: fixed_size
           cluster_type: fixed_size
           args: --inference-concurrency 100 100
           fail_on_dead_nodes: 1
-          # In general, Ray Data shouldn't spill on stable fixed-size clusters, but
-          # we've observed occasional and negligible O(~10 GiB) spills in weekly runs.
-          # The spilling is likely due to unbalanced object distribution.
-          #
-          # To avoid creating low-signal failures, we've disabled the spill check on
-          # this test.
-          fail_on_spilling: 0
+          max_obj_store_util_percent: 100
       - with:
           case: autoscaling
           cluster_type: autoscaling
           args: --inference-concurrency 1 100
           fail_on_dead_nodes: 1
-          fail_on_spilling: 0  # We expect bounded spills with autoscaling.
+          max_obj_store_util_percent: 100
       - with:
           case: fixed_size_chaos
           cluster_type: fixed_size
           args: --inference-concurrency 100 100 --chaos
           fail_on_dead_nodes: 0
-          fail_on_spilling: 0  # We expected bounded spills with chaos.
+          # A negative limit disables the check. We expect bounded spills with chaos.
+          max_obj_store_util_percent: -1
 
   cluster:
     anyscale_sdk_2026: true
@@ -1053,7 +1044,7 @@
         - RAY_DATA_DEBUG_RESOURCE_MANAGER=1
         - RAYTEST_FAIL_ON_WORKER_OOM=1
         - RAYTEST_FAIL_ON_DEAD_NODES={{fail_on_dead_nodes}}
-        - RAYTEST_FAIL_ON_SPILLING={{fail_on_spilling}}
+        - RAYTEST_MAX_OBJ_STORE_UTIL_PERCENT={{max_obj_store_util_percent}}
   run:
     timeout: 3600
     script: python image_embedding_from_uris/main.py {{args}}
@@ -1071,7 +1062,7 @@
       args: []
       frequency: []
       fail_on_dead_nodes: []
-      fail_on_spilling: []
+      max_obj_store_util_percent: []
     adjustments:
       - with:
           case: fixed_size
@@ -1079,14 +1070,14 @@
           args: --inference-concurrency 40 40
           frequency: weekly
           fail_on_dead_nodes: 0 # Allow node death during test
-          fail_on_spilling: 1
+          max_obj_store_util_percent: 100
       - with:
           case: autoscaling
           cluster_type: autoscaling
           args: --inference-concurrency 1 40
           frequency: weekly
           fail_on_dead_nodes: 1
-          fail_on_spilling: 0  # We expected bounded spills with autoscaling.
+          max_obj_store_util_percent: 100
       - with:
           case: fixed_size_chaos
           cluster_type: fixed_size
@@ -1095,21 +1086,22 @@
           # fail.
           frequency: manual
           fail_on_dead_nodes: 0
-          fail_on_spilling: 0  # We expected bounded spills with chaos.
+          # A negative limit disables the check. We expect bounded spills with chaos.
+          max_obj_store_util_percent: -1
       - with:
           case: fake_gpu_fixed_size
           cluster_type: fake_gpu_fixed_size
           args: --inference-concurrency 40 40 --fake-gpu
           frequency: weekly
           fail_on_dead_nodes: 0 # Allow node death during test
-          fail_on_spilling: 1
+          max_obj_store_util_percent: 100
       - with:
           case: fake_gpu_autoscaling
           cluster_type: fake_gpu_autoscaling
           args: --inference-concurrency 1 40 --fake-gpu
           frequency: weekly
           fail_on_dead_nodes: 1
-          fail_on_spilling: 0  # We expected bounded spills with autoscaling.
+          max_obj_store_util_percent: 100
       - with:
           case: fake_gpu_fixed_size_chaos
           cluster_type: fake_gpu_fixed_size
@@ -1118,7 +1110,8 @@
           # fail.
           frequency: manual
           fail_on_dead_nodes: 0
-          fail_on_spilling: 0  # We expected bounded spills with chaos.
+          # A negative limit disables the check. We expect bounded spills with chaos.
+          max_obj_store_util_percent: -1
 
   cluster:
     anyscale_sdk_2026: true
@@ -1128,7 +1121,7 @@
         - RAY_DATA_DEBUG_RESOURCE_MANAGER=1
         - RAYTEST_FAIL_ON_WORKER_OOM=1
         - RAYTEST_FAIL_ON_DEAD_NODES={{fail_on_dead_nodes}}
-        - RAYTEST_FAIL_ON_SPILLING={{fail_on_spilling}}
+        - RAYTEST_MAX_OBJ_STORE_UTIL_PERCENT={{max_obj_store_util_percent}}
 
   run:
     timeout: 3600
@@ -1170,7 +1163,7 @@
         - RAY_DATA_DEBUG_RESOURCE_MANAGER=1
         - RAYTEST_FAIL_ON_WORKER_OOM=1
         - RAYTEST_FAIL_ON_DEAD_NODES={{fail_on_dead_nodes}}
-        - RAYTEST_FAIL_ON_SPILLING=1
+        - RAYTEST_MAX_OBJ_STORE_UTIL_PERCENT=100
       type: cu123
       post_build_script: byod_install_text_embedding.sh
 
@@ -1254,7 +1247,6 @@
         - RAY_DATA_DEBUG_RESOURCE_MANAGER=1
         - RAYTEST_FAIL_ON_WORKER_OOM=1
         - RAYTEST_FAIL_ON_DEAD_NODES=1
-        - RAYTEST_FAIL_ON_SPILLING=0
     cluster_compute: "{{scaling}}_all_to_all_compute.yaml"
 
   run:
@@ -1358,7 +1350,6 @@
         - RAY_DATA_DEBUG_RESOURCE_MANAGER=1
         - RAYTEST_FAIL_ON_WORKER_OOM=1
         - RAYTEST_FAIL_ON_DEAD_NODES=1
-        - RAYTEST_FAIL_ON_SPILLING=0
     cluster_compute: "{{scaling}}_all_to_all_compute.yaml"
 
   run:
@@ -1380,7 +1371,6 @@
         - RAY_DATA_DEBUG_RESOURCE_MANAGER=1
         - RAYTEST_FAIL_ON_WORKER_OOM=1
         - RAYTEST_FAIL_ON_DEAD_NODES=1
-        - RAYTEST_FAIL_ON_SPILLING=0
     cluster_compute: "{{scaling}}_all_to_all_compute.yaml"
 
   run:
@@ -1692,7 +1682,7 @@
         - RAY_health_check_timeout_ms=100000
         - RAY_health_check_failure_threshold=10
         - RAY_gcs_rpc_server_connect_timeout_s=60
-        - RAYTEST_FAIL_ON_SPILLING=1
+        - RAYTEST_MAX_OBJ_STORE_UTIL_PERCENT=100
     cluster_compute: dataset/cross_az_250_350_compute_gce.yaml
 
   run:

--- a/release/release_multimodal_inference_benchmarks_tests.yaml
+++ b/release/release_multimodal_inference_benchmarks_tests.yaml
@@ -13,8 +13,12 @@
         - RAYTEST_FAIL_ON_WORKER_OOM=1
         # Fail the test if a node dies
         - RAYTEST_FAIL_ON_DEAD_NODES=1
-        # Fail on spilling
-        - RAYTEST_FAIL_ON_SPILLING=1
+        # Ray Data attempts to limit cluster-wide object store usage of primary copies
+        # to 50% with its `ResourceBudget` backpressure policy. Since Ray Data doesn't
+        # keep track of secondary copies, the worst case utilization is 50% * 2 copies
+        # = 100%. If we exceed this amount on a linear pipeline, it means backpressure
+        # is very broken.
+        - RAYTEST_MAX_OBJ_STORE_UTIL_PERCENT=100
 
 - name: image_classification
 
@@ -114,18 +118,6 @@
     byod:
       post_build_script: byod_install_multimodal_inference_benchmarks_transcription.sh
       python_depset: video_object_detection_py3.10.lock
-      runtime_env:
-        # Fail the test if a worker OOMs
-        - RAYTEST_FAIL_ON_WORKER_OOM=1
-        # Fail the test if a node dies
-        - RAYTEST_FAIL_ON_DEAD_NODES=1
-          # In general, Ray Data shouldn't spill on stable fixed-size clusters, but
-          # we've observed occasional and negligible O(~10 GiB) spills in weekly runs.
-          # The spilling is likely due to unbalanced object distribution.
-          #
-          # To avoid creating low-signal failures, we've disabled the spill check on
-          # this test.
-        - RAYTEST_FAIL_ON_SPILLING=0
   run:
     timeout: 3600
 


### PR DESCRIPTION
Cherry-pick of #65222 (merge commit `68bbf43df11d8df2cb4a5ddfbebd4c2831a1d228`, authored by @bveeramani) onto `releases/2.58.0`. Clean pick, no conflicts — release-test tooling and config only (`release/ray_release/command_runner/_anyscale_job_wrapper.py`, `release/ray_release/command_runner/_prometheus_metrics.py`, `release/ray_release/tests/test_anyscale_job_wrapper.py`, `release/release_data_tests.yaml`, `release/release_multimodal_inference_benchmarks_tests.yaml`; +199/-53). No Ray runtime code is touched.

## Description

Ray Data release tests currently fail if there is *any* object spilling. The backpressure policy only kicks in on cluster-wide object store utilization rather than per-node, so uneven object distribution produces tiny spills (e.g. ~6 GiB over a whole job) that fail otherwise-healthy tests — the autoscaling map-batches test has been flaky for this reason.

This replaces the "no spilling at all" check with a check on peak object store utilization, failing only when a job exceeds 100% of object store capacity. Ray Data targets 50% utilization but can exceed it due to secondary copies, so 100% is the guarantee the current policy actually makes and is stable over time. The release test YAMLs are updated to use the new utilization threshold instead of the spilling flag.

Picking this into `releases/2.58.0` so the 2.58.0 release test runs aren't blocked by spurious spill-based failures.

## Related issues

Related to #65222

## Additional information

Not a duplicate: no existing cherry-pick PR for #65222 targets this branch (checked open and closed PRs).

Checks run:

- `git cherry-pick -x -s` applied cleanly; the resulting diff is byte-identical to the master change (verified with `diff` of both `git show` outputs).
- `bazel test //release:test_anyscale_job_wrapper` — PASSED in 38.2s.
- `pre-commit run --files <changed files>` — all applicable hooks passed.
- AI assistance (Claude Code) was used to prepare this cherry-pick; reviewed by the submitter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
