### PR TITLE
[Serve] Add enable_strict_max_ongoing_requests deployment flag

### DIFF
--- a/python/ray/serve/_private/config.py
+++ b/python/ray/serve/_private/config.py
@@ -163,6 +163,16 @@ class DeploymentConfig(BaseModel):
         rolling_update_percentage: The fraction of replicas (of
             ``target_num_replicas``) to update at a time during a rolling
             update. Must be in ``(0.0, 1.0]``. Defaults to 0.2 (20%).
+        enable_strict_max_ongoing_requests: Whether the router enforces strict
+            in-flight rejection of requests that would exceed
+            ``max_ongoing_requests``. Defaults to True. When False, the router
+            skips the accept/reject streaming handshake for unary calls,
+            restoring pre-2.10 ``_to_object_ref()`` behavior (the returned
+            ``ObjectRef`` resolves once the request is scheduled rather than
+            when it completes) at the cost of softer backpressure: the router's
+            queue-length cache becomes the only guard against overshooting
+            ``max_ongoing_requests`` (identical semantics to how Serve already
+            handles Java replicas).
     """
 
     num_replicas: Optional[NonNegativeInt] = Field(
@@ -250,6 +260,11 @@ class DeploymentConfig(BaseModel):
         default=DEFAULT_ROLLING_UPDATE_PERCENTAGE,
         gt=0.0,
         le=1.0,
+        update_type=DeploymentOptionUpdateType.LightWeight,
+    )
+
+    enable_strict_max_ongoing_requests: bool = Field(
+        default=True,
         update_type=DeploymentOptionUpdateType.LightWeight,
     )
 

--- a/python/ray/serve/_private/router.py
+++ b/python/ray/serve/_private/router.py
@@ -648,6 +648,12 @@ class AsyncioRouter:
             request_router_kwargs if request_router_kwargs else {}
         )
         self._enable_strict_max_ongoing_requests = enable_strict_max_ongoing_requests
+        # Per-deployment opt-out of strict in-flight rejection, delivered via
+        # the deployment config long poll. Defaults to True until the first
+        # config arrives so behavior is unchanged during startup. Combined with
+        # the capability gate above to decide whether to use the reject/stream
+        # handshake (see `_send_request`).
+        self._deployment_enable_strict_max_ongoing_requests = True
         self._node_id = node_id
         self._availability_zone = availability_zone
         self._prefer_local_node_routing = prefer_local_node_routing
@@ -832,6 +838,9 @@ class AsyncioRouter:
             self._running_replicas_populated = True
 
     def update_deployment_config(self, deployment_config: DeploymentConfig):
+        self._deployment_enable_strict_max_ongoing_requests = (
+            deployment_config.enable_strict_max_ongoing_requests
+        )
         self._request_router_class = (
             deployment_config.request_router_config.get_request_router_class()
         )
@@ -1040,8 +1049,15 @@ class AsyncioRouter:
                 # If the queue len cache is disabled or we're sending a request to Java,
                 # then directly send the query and hand the response back. The replica will
                 # never reject requests in this code path.
+                #
+                # A deployment can also opt out of strict rejection via
+                # `enable_strict_max_ongoing_requests=False`, which routes unary
+                # calls through the plain (non-streaming) handler so
+                # `_to_object_ref()` resolves at scheduling time rather than
+                # blocking until the request completes. See issue #46893.
                 with_rejection = (
                     self._enable_strict_max_ongoing_requests
+                    and self._deployment_enable_strict_max_ongoing_requests
                     and not replica.is_cross_language
                 )
                 result = replica.try_send_request(pr, with_rejection=with_rejection)

--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -552,6 +552,7 @@ def deployment(
         Optional[List[Union[Dict, DeploymentActorConfig]]]
     ] = DEFAULT.VALUE,
     rolling_update_percentage: Default[float] = DEFAULT.VALUE,
+    enable_strict_max_ongoing_requests: Default[bool] = DEFAULT.VALUE,
 ) -> Callable[[Callable], Deployment]:
     """Decorator that converts a Python class to a `Deployment`.
 
@@ -639,6 +640,14 @@ def deployment(
         rolling_update_percentage: The fraction of replicas to update at a
             time during a rolling update. Must be in ``(0.0, 1.0]``.
             Defaults to ``0.2`` (20%).
+        enable_strict_max_ongoing_requests: Whether the router enforces strict
+            in-flight rejection of requests that would exceed
+            ``max_ongoing_requests``. Defaults to ``True``. Set to ``False`` on
+            a unary deployment to restore pre-2.10 ``_to_object_ref()``
+            behavior (the returned ``ObjectRef`` resolves once the request is
+            scheduled rather than when it completes), at the cost of softer
+            backpressure: the router's queue-length cache becomes the only
+            guard against overshooting ``max_ongoing_requests``.
 
     Returns:
         `Deployment`
@@ -722,6 +731,7 @@ def deployment(
         gang_scheduling_config=gang_scheduling_config,
         deployment_actors=deployment_actors,
         rolling_update_percentage=rolling_update_percentage,
+        enable_strict_max_ongoing_requests=enable_strict_max_ongoing_requests,
     )
     deployment_config.user_configured_option_names = set(user_configured_option_names)
 

--- a/python/ray/serve/deployment.py
+++ b/python/ray/serve/deployment.py
@@ -515,6 +515,9 @@ def deployment_to_schema(d: Deployment) -> DeploymentSchema:
         "gang_scheduling_config": d._deployment_config.gang_scheduling_config,
         "deployment_actors": d._deployment_config.deployment_actors,
         "rolling_update_percentage": d._deployment_config.rolling_update_percentage,
+        "enable_strict_max_ongoing_requests": (
+            d._deployment_config.enable_strict_max_ongoing_requests
+        ),
     }
 
     # Let non-user-configured options be set to defaults. If the schema
@@ -580,6 +583,7 @@ def schema_to_deployment(s: DeploymentSchema) -> Deployment:
         gang_scheduling_config=s.gang_scheduling_config,
         deployment_actors=s.deployment_actors,
         rolling_update_percentage=s.rolling_update_percentage,
+        enable_strict_max_ongoing_requests=s.enable_strict_max_ongoing_requests,
     )
     deployment_config.user_configured_option_names = (
         s._get_user_configured_option_names()

--- a/python/ray/serve/schema.py
+++ b/python/ray/serve/schema.py
@@ -550,6 +550,18 @@ class DeploymentSchema(BaseModel):
         gt=0.0,
         le=1.0,
     )
+    enable_strict_max_ongoing_requests: bool = Field(
+        default=DEFAULT.VALUE,
+        description=(
+            "Whether the router enforces strict in-flight rejection of "
+            "requests that would exceed `max_ongoing_requests`. Defaults to "
+            "True. When False, the router skips the accept/reject handshake "
+            "for unary calls, restoring pre-2.10 `_to_object_ref()` behavior "
+            "(the ObjectRef resolves at scheduling time) at the cost of softer "
+            "backpressure: the queue-length cache becomes the only guard "
+            "against overshooting `max_ongoing_requests`."
+        ),
+    )
 
     @model_validator(mode="before")
     @classmethod
@@ -751,6 +763,9 @@ def _deployment_info_to_schema(name: str, info: DeploymentInfo) -> DeploymentSch
         ray_actor_options=info.replica_config.ray_actor_options,
         request_router_config=info.deployment_config.request_router_config,
         rolling_update_percentage=info.deployment_config.rolling_update_percentage,
+        enable_strict_max_ongoing_requests=(
+            info.deployment_config.enable_strict_max_ongoing_requests
+        ),
     )
 
     if info.deployment_config.autoscaling_config is not None:

--- a/python/ray/serve/tests/test_controller.py
+++ b/python/ray/serve/tests/test_controller.py
@@ -216,6 +216,7 @@ def test_get_serve_instance_details_json_serializable(serve_instance, policy_nam
                                     "max_backoff_s": 0.5,
                                 },
                                 "rolling_update_percentage": 0.2,
+                                "enable_strict_max_ongoing_requests": True,
                             },
                             "target_num_replicas": 1,
                             "required_resources": {"CPU": 1},

--- a/python/ray/serve/tests/test_direct_ingress.py
+++ b/python/ray/serve/tests/test_direct_ingress.py
@@ -2597,6 +2597,7 @@ def test_get_serve_instance_details_json_serializable(
                                     "max_backoff_s": 0.5,
                                 },
                                 "rolling_update_percentage": 0.2,
+                                "enable_strict_max_ongoing_requests": True,
                             },
                             "target_num_replicas": 1,
                             "required_resources": {"CPU": 1},

--- a/python/ray/serve/tests/test_handle.py
+++ b/python/ray/serve/tests/test_handle.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 import re
 
@@ -57,6 +58,40 @@ async def test_by_reference_false_raises_error(serve_instance):
         await response._to_object_ref()
 
     await signal.send.remote()
+
+
+@pytest.mark.asyncio
+@pytest.mark.timeout(60)
+async def test_to_object_ref_resolves_before_completion_when_rejection_disabled(
+    serve_instance,
+):
+    """With `enable_strict_max_ongoing_requests=False`, `_to_object_ref()`
+    resolves once the request is scheduled instead of blocking until the
+    replica finishes computing, restoring the pre-2.10 behavior.
+
+    Regression test for https://github.com/ray-project/ray/issues/46893.
+    """
+    signal = SignalActor.remote()
+
+    @serve.deployment(enable_strict_max_ongoing_requests=False)
+    async def f():
+        # Block so the request is scheduled but not yet complete.
+        await signal.wait.remote()
+        return "hi"
+
+    h = serve.run(f.bind())
+
+    response = h.remote()
+    # The replica is blocked on the signal (the request has NOT completed), but
+    # the object ref must still resolve because the non-rejection path returns
+    # it at scheduling time. Under strict rejection this call would block until
+    # `signal.send` is called and would time out here.
+    obj_ref = await asyncio.wait_for(response._to_object_ref(), timeout=10)
+    assert isinstance(obj_ref, ray.ObjectRef)
+
+    # Let the computation finish and confirm the result still flows through.
+    await signal.send.remote()
+    assert await response == "hi"
 
 
 @pytest.mark.parametrize("inner_by_reference", [True, False])

--- a/python/ray/serve/tests/unit/test_config.py
+++ b/python/ray/serve/tests/unit/test_config.py
@@ -270,6 +270,33 @@ class TestDeploymentConfig:
         assert from_old_proto.backpressure_config.status_code == 503
         assert from_old_proto.backpressure_config.retry_after_s is None
 
+    def test_enable_strict_max_ongoing_requests_proto_round_trip(self):
+        # Defaults to True.
+        assert DeploymentConfig().enable_strict_max_ongoing_requests is True
+
+        # Explicit False survives the proto round trip (must not be swallowed
+        # by proto3's zero-default for bool).
+        config = DeploymentConfig(enable_strict_max_ongoing_requests=False)
+        round_tripped = DeploymentConfig.from_proto_bytes(config.to_proto_bytes())
+        assert round_tripped.enable_strict_max_ongoing_requests is False
+
+        # Explicit True survives the round trip.
+        round_tripped = DeploymentConfig.from_proto_bytes(
+            DeploymentConfig(enable_strict_max_ongoing_requests=True).to_proto_bytes()
+        )
+        assert round_tripped.enable_strict_max_ongoing_requests is True
+
+        # Protos from older versions don't have the field at all (e.g., sent by
+        # an older controller during a rolling upgrade); simulate by clearing
+        # it so it's absent from the wire format. It must fall back to the
+        # default (True), not False.
+        old_proto = DeploymentConfig(
+            enable_strict_max_ongoing_requests=False
+        ).to_proto()
+        old_proto.ClearField("enable_strict_max_ongoing_requests")
+        from_old_proto = DeploymentConfig.from_proto(old_proto)
+        assert from_old_proto.enable_strict_max_ongoing_requests is True
+
     def test_deployment_config_update(self):
         b = DeploymentConfig(num_replicas=1, max_ongoing_requests=1)
 

--- a/python/ray/serve/tests/unit/test_router.py
+++ b/python/ray/serve/tests/unit/test_router.py
@@ -918,6 +918,68 @@ class TestAssignRequest:
 
     @pytest.mark.parametrize(
         "setup_router",
+        [{"enable_strict_max_ongoing_requests": True, "enable_queue_len_cache": True}],
+        indirect=True,
+    )
+    async def test_update_deployment_config_sets_strict_rejection_flag(
+        self,
+        setup_router: Tuple[AsyncioRouter, FakeRequestRouter],
+    ):
+        """The deployment config long poll toggles the per-deployment strict
+        rejection flag. See issue #46893."""
+        router, _ = setup_router
+
+        # Defaults to True before any config arrives.
+        assert router._deployment_enable_strict_max_ongoing_requests is True
+
+        router.update_deployment_config(
+            DeploymentConfig(enable_strict_max_ongoing_requests=False)
+        )
+        assert router._deployment_enable_strict_max_ongoing_requests is False
+
+        router.update_deployment_config(
+            DeploymentConfig(enable_strict_max_ongoing_requests=True)
+        )
+        assert router._deployment_enable_strict_max_ongoing_requests is True
+
+    @pytest.mark.parametrize(
+        "setup_router",
+        [{"enable_strict_max_ongoing_requests": True, "enable_queue_len_cache": True}],
+        indirect=True,
+    )
+    async def test_deployment_opt_out_skips_rejection_for_unary(
+        self,
+        setup_router: Tuple[AsyncioRouter, FakeRequestRouter],
+    ):
+        """When a deployment opts out of strict rejection, unary calls skip the
+        accept/reject streaming handshake and get a plain (non-generator)
+        result, so `_to_object_ref()` resolves at scheduling time rather than
+        blocking until completion. See issue #46893."""
+        router, fake_request_router = setup_router
+
+        # Deployment opts out of strict in-flight rejection.
+        router._deployment_enable_strict_max_ongoing_requests = False
+
+        r1_id = ReplicaID(
+            unique_id="test-replica-1", deployment_id=DeploymentID(name="test")
+        )
+        replica = FakeReplica(
+            r1_id,
+            queue_len_info=ReplicaQueueLengthInfo(
+                accepted=True, num_ongoing_requests=10
+            ),
+        )
+        fake_request_router.set_replica_to_return(replica)
+
+        replica_result = await router.assign_request(
+            dummy_request_metadata(is_streaming=False)
+        )
+        # Non-rejection path: unary result is not a generator.
+        assert not replica_result._is_generator_object
+        assert replica._requests_sent[-1]["with_rejection"] is False
+
+    @pytest.mark.parametrize(
+        "setup_router",
         [
             {
                 "enable_strict_max_ongoing_requests": True,

--- a/src/ray/protobuf/serve.proto
+++ b/src/ray/protobuf/serve.proto
@@ -255,6 +255,16 @@ message DeploymentConfig {
   // older controller during a rolling upgrade) falls back to the Python-side
   // defaults.
   BackpressureConfig backpressure_config = 24;
+
+  // Whether the router enforces strict in-flight rejection of requests that
+  // would exceed `max_ongoing_requests`. Declared `optional` so that unset
+  // (e.g. from an older controller during a rolling upgrade) is
+  // distinguishable from an explicit value; when unset the Python side falls
+  // back to the default (True). When False, the router skips the
+  // accept/reject streaming handshake for unary calls, restoring pre-2.10
+  // `_to_object_ref()` behavior (resolves at scheduling time) at the cost of
+  // softer backpressure (the queue-length cache becomes the only guard).
+  optional bool enable_strict_max_ongoing_requests = 25;
 }
 
 // Configuration of the HTTP response returned when a request is rejected due


### PR DESCRIPTION
Mitigation for #46893: `DeploymentResponse._to_object_ref()` blocks until the replica finishes computing instead of resolving once the request is scheduled (a regression since Ray 2.10, because unary calls are routed through the streaming reject/accept handshake).

Add an opt-in deployment option `enable_strict_max_ongoing_requests` (default True; behavior unchanged for existing deployments). When set to False on a unary deployment, the router computes `with_rejection=False`, so `send_request_python` falls through to the plain `handle_request` branch and `.remote()` returns a regular ObjectRef. `_to_object_ref()` then resolves at scheduling time, restoring the pre-2.10 chaining pattern `await asyncio.wait_for(response._to_object_ref(), timeout=N)`.

Trade-off: in-flight rejection is skipped for that deployment, so the router's queue-length cache becomes the only guard against overshooting `max_ongoing_requests` (identical semantics to how Serve already handles Java replicas). This is a mitigation, not the core fix, and does not close #46893.

- DeploymentConfig: new bool field (default True).
- serve.proto: `optional bool` field so an unset value (older controller during a rolling upgrade) falls back to the Python default (True).
- DeploymentSchema + decorator + schema<->deployment conversions.
- Router: capture the flag from the deployment-config long poll and combine it with the existing capability gate when deciding rejection.
- Tests: proto round-trip (incl. rolling-upgrade fallback), router config wiring, router opt-out routing, and an e2e regression test asserting `_to_object_ref()` resolves before the request completes.