### PR TITLE
[Data] Modify maximum memory to OOM prevention docs

### DIFF
--- a/doc/source/data/how-to-avoid-ooms.md
+++ b/doc/source/data/how-to-avoid-ooms.md
@@ -129,7 +129,7 @@ If your UDF runs on GPU, a good rule of thumb is to use about 1/4 of the GPU mem
 
 If a task or actor uses more than a few GiB of memory, set ``memory``. This tells Ray Data how much memory each task or actor needs so it doesn't launch too many at once.
 
-To pick a value for ``memory``, read the Ray Data log file and look for the `max_uss_bytes` field. Ray typically writes the log file to `/tmp/ray/session-latest/ray-data/ray-data.log`.
+To pick a value for ``memory``, read the Ray Data log file and look for the `max` value in the `max_uss_bytes` field. Set ``memory`` to 1.25 times that value. This keeps the observed maximum worker heap usage at 80% of the requested memory, leaving a 20% buffer. Ray typically writes the log file to `/tmp/ray/session-latest/ray-data/ray-data.log`.
 
 ```
 ReadRange->MapBatches(uses_lots_of_memory): {'average_num_outputs_per_task': 1.0, ..., 'max_uss_bytes': {'num_samples': 20, 'mean': 4393336422.4, 'variance': 26855731156.89417, 'min': 4393119744, 'max': 4393529344, 'p50': 4393418752.0, 'p90': 4393500672.0, 'p95': 4393529344.0, 'p99': 4393529344.0}, ...}
@@ -150,8 +150,6 @@ To change the frequency of this warning, set
 `DataContext.get_current().issue_detectors_config.high_memory_detector_config.detection_time_interval_s`,
 or disable the warning by setting value to -1. (current value: 30)
 ```
-
-Set ``memory`` to 1.25 times the `max` value in `max_uss_bytes`. At the observed maximum, worker heap usage is 80% of the requested memory, leaving a 20% buffer.
 
 ### Enable default map memory
 

--- a/doc/source/data/how-to-avoid-ooms.md
+++ b/doc/source/data/how-to-avoid-ooms.md
@@ -151,6 +151,8 @@ To change the frequency of this warning, set
 or disable the warning by setting value to -1. (current value: 30)
 ```
 
+Set ``memory`` to 1.25 times the maximum `max_uss_bytes` value. At the observed maximum, worker heap usage is 80% of the requested memory, leaving a 20% buffer.
+
 ### Enable default map memory
 
 Unless you specify a value, Ray Data assumes a UDF needs 0 ``memory``. So even if you've set ``memory`` correctly for some APIs, Ray Data can still oversubscribe tasks and actors for the ones you haven't.
@@ -210,11 +212,11 @@ If you do all of the following:
 - Start Ray with resource isolation enabled.
 - Set system memory large enough to cover everything used outside of Ray worker tasks and actors
 - Set logical memory to physical memory minus system memory minus object store memory.
-- Set ``memory`` for each API to at least the heap memory that API needs to run.
+- Set ``memory`` for each API to at least 125% of its maximum observed heap memory.
 
 Then you shouldn't see OOMs or node deaths.
 
-The main limitation of these configurations is performance. When you set ``memory`` based on worst-case heap memory use, the system might launch fewer tasks or actors than it might be able to, and that can decrease throughput.
+The main limitation of these configurations is performance. When you set ``memory`` based on maximum observed heap memory use, the system might launch fewer tasks or actors than it might be able to, and that can decrease throughput.
 
 If you want to experiment with oversubscription at the risk of potential OOMs, decrease `memory`.
 

--- a/doc/source/data/how-to-avoid-ooms.md
+++ b/doc/source/data/how-to-avoid-ooms.md
@@ -151,7 +151,7 @@ To change the frequency of this warning, set
 or disable the warning by setting value to -1. (current value: 30)
 ```
 
-Set ``memory`` to 1.25 times the maximum `max_uss_bytes` value. At the observed maximum, worker heap usage is 80% of the requested memory, leaving a 20% buffer.
+Set ``memory`` to 1.25 times the `max` value in `max_uss_bytes`. At the observed maximum, worker heap usage is 80% of the requested memory, leaving a 20% buffer.
 
 ### Enable default map memory
 


### PR DESCRIPTION
## Description
Update the Ray Data OOM prevention guide to recommend setting ``memory`` to 125% of the maximum observed worker heap memory. This leaves a 20% buffer for variation between jobs and future increases in memory use.

## Related issues
closes #65508.

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
