### PR TITLE
[cherry-pick][2.58.0][doc][History server] Update doc for history server for `RAY_ROOT_DIR` -> `STORAGE_ROOT_DIR` (#65441)

### DIFF
--- a/doc/source/cluster/kubernetes/user-guides/kuberay-history-server.md
+++ b/doc/source/cluster/kubernetes/user-guides/kuberay-history-server.md
@@ -206,10 +206,10 @@ Configure the collector sidecar container with the following environment variabl
   - 
   - No
   - Owner resource name, if applicable.
-* - `RAY_ROOT_DIR`
-  - `--ray-root-dir`
+* - `STORAGE_ROOT_DIR`
+  - `--storage-root-dir`
   - No
-  - Root path prefix for stored Ray logs in object storage (defaults to `"log"`).
+  - Root path prefix inside the object storage bucket (defaults to `""`).
 * - `EVENTS_PORT`
   - `--events-port`
   - No
@@ -241,7 +241,7 @@ kubectl logs -l ray.io/node-type=head -c collector --tail=20
 List the bucket contents to confirm session log uploads:
 
 ```sh
-gcloud storage ls gs://${GCS_BUCKET}/log/
+gcloud storage ls gs://${GCS_BUCKET}/
 ```
 
 ## Terminate the RayCluster
@@ -256,10 +256,10 @@ After the RayCluster terminates, the collector uploads the final events and logs
 
 ### Storage layout
 
-The collector organizes files in object storage according to the following directory structure:
+The collector organizes files in object storage according to the following directory structure (if `STORAGE_ROOT_DIR` is set, paths are prefixed with that directory):
 
 ```text
-gs://${GCS_BUCKET}/${RAY_ROOT_DIR}/
+gs://${GCS_BUCKET}/
 ├── cluster-metadata/
 │   ├── raycluster/
 │   │   └── <namespace>_<cluster_name>/
@@ -300,10 +300,10 @@ gcloud storage ls --recursive gs://${GCS_BUCKET}
 ```
 
 ```text
-gs://BUCKET/log/cluster-metadata/raycluster/NAMESPACE_raycluster-historyserver/session_2026-02-20_13-03-16_320452_1
-gs://BUCKET/log/cluster-history/raycluster/NAMESPACE/raycluster-historyserver/session_2026-02-20_13-03-16_320452_1/0a46878b6f144cdb0ed62e9871caaeb16083547bf34acb5025832ace/logs/dashboard_agent.log
-gs://BUCKET/log/cluster-history/raycluster/NAMESPACE/raycluster-historyserver/session_2026-02-20_13-03-16_320452_1/0a46878b6f144cdb0ed62e9871caaeb16083547bf34acb5025832ace/node_events/0a46878b6f144cdb0ed62e9871caaeb16083547bf34acb5025832ace-2026-02-20-13
-gs://BUCKET/log/cluster-history/raycluster/NAMESPACE/raycluster-historyserver/session_2026-02-20_13-03-16_320452_1/0a46878b6f144cdb0ed62e9871caaeb16083547bf34acb5025832ace/job_events/AQAAAA==/0a46878b6f144cdb0ed62e9871caaeb16083547bf34acb5025832ace-2026-02-20-13
+gs://BUCKET/cluster-metadata/raycluster/NAMESPACE_raycluster-historyserver/session_2026-02-20_13-03-16_320452_1
+gs://BUCKET/cluster-history/raycluster/NAMESPACE/raycluster-historyserver/session_2026-02-20_13-03-16_320452_1/0a46878b6f144cdb0ed62e9871caaeb16083547bf34acb5025832ace/logs/dashboard_agent.log
+gs://BUCKET/cluster-history/raycluster/NAMESPACE/raycluster-historyserver/session_2026-02-20_13-03-16_320452_1/0a46878b6f144cdb0ed62e9871caaeb16083547bf34acb5025832ace/node_events/0a46878b6f144cdb0ed62e9871caaeb16083547bf34acb5025832ace-2026-02-20-13
+gs://BUCKET/cluster-history/raycluster/NAMESPACE/raycluster-historyserver/session_2026-02-20_13-03-16_320452_1/0a46878b6f144cdb0ed62e9871caaeb16083547bf34acb5025832ace/job_events/AQAAAA==/0a46878b6f144cdb0ed62e9871caaeb16083547bf34acb5025832ace-2026-02-20-13
 ```
 
 ## Access a terminated RayCluster from the Ray Dashboard


### PR DESCRIPTION
## Description
https://github.com/ray-project/kuberay/pull/5121 updated the env var from `RAY_ROOT_DIR` to `STORAGE_ROOT_DIR`. The default storage root dir is now the bucket root itself, so updated example and file structure in the documentation.

## Related issues
Related to https://github.com/ray-project/kuberay/pull/5121

## Additional information


(cherry picked from commit 97f7eec5345d58677b832573af6b5e4946d744ef)

> Thank you for contributing to Ray! 🚀
> Please review the [Ray Contribution Guide](https://docs.ray.io/en/master/ray-contribute/getting-involved.html) before opening a pull request.

> ⚠️ Remove these instructions before submitting your PR.

> 💡 Tip: Mark as draft if you want early feedback, or ready for review when it's complete.

## Description
> Briefly describe what this PR accomplishes and why it's needed.

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
