### PR TITLE
[Doc] Fix docs for KubeRay v1.7

### DIFF
--- a/doc/source/cluster/kubernetes/user-guides/k8s-events.md
+++ b/doc/source/cluster/kubernetes/user-guides/k8s-events.md
@@ -13,7 +13,7 @@ This guide describes how to enable and use platform events in the Ray Dashboard 
 ## Prerequisites
 
 * **Ray version**: Ray 2.56.0 or later.
-* **Kubernetes Python client**: Install the `kubernetes` Python package in the Ray head pod's Python environment. The official `rayproject/ray` images include it. Add it to custom images.
+* **Kubernetes Python client**: Install the `kubernetes` Python package (`pip install kubernetes`) in the Ray head pod's Python environment. The official `rayproject/ray` images don't include it.
 * **Kubernetes cluster**: A Kubernetes cluster where you can deploy Ray workloads.
 
 ## Configure RBAC permissions

--- a/doc/source/cluster/kubernetes/user-guides/network-policy.md
+++ b/doc/source/cluster/kubernetes/user-guides/network-policy.md
@@ -202,18 +202,21 @@ For `HTTPMode` and `SidecarMode`, there is no standalone submitter pod, so no ad
 
 When a `RayJob` targets a pre-existing cluster with `clusterSelector`, the cluster has no `RayJob` owner reference. The operator can't automatically add a submitter ingress rule. To allow the submitter pod to reach the head dashboard port, add an opt-in label to both the `RayCluster` ingress rule and the `RayJob` submitter pod template.
 
-On the `RayCluster`, add an ingress rule under `networkIsolation` that matches the opt-in label:
+On the `RayCluster`, add an ingress rule under `head.ingressRules` that matches the opt-in label:
 
 ```yaml
 spec:
-  networkIsolation:
+  networkPolicy:
     mode: DenyAll
-    ingressRules:
-    - from:
-      - podSelector:
-          matchLabels:
-            ray.io/allow-head-access: "true"
-      ports: [ { protocol: TCP, port: 8265 } ]
+    head:
+      ingressRules:
+      - from:
+        - podSelector:
+            matchLabels:
+              ray.io/allow-head-access: "true"
+        ports:
+        - port: 8265
+          protocol: TCP
 ```
 
 On the `RayJob`, set the same label on the submitter pod via `submitterPodTemplate`:


### PR DESCRIPTION
## Description
Found some bug in the docs while testing with `v1.7.0-rc.0`. This is the PR updating those docs.

1. `doc/source/cluster/kubernetes/user-guides/k8s-events.md`: official ray image does not include `kubernetes` Python package
2. `doc/source/cluster/kubernetes/user-guides/network-policy.md`: set a wrong field, should be `networkPolicy`

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
