### PR TITLE
[Data] Extend StreamingRepartition non-strict fusion to Filter/MapRows/FlatMap

### DIFF
--- a/python/ray/data/_internal/logical/rules/operator_fusion.py
+++ b/python/ray/data/_internal/logical/rules/operator_fusion.py
@@ -35,7 +35,10 @@ from ray.data._internal.logical.operators import (
     AbstractAllToAll,
     AbstractMap,
     AbstractUDFMap,
+    Filter,
+    FlatMap,
     MapBatches,
+    MapRows,
     RandomShuffle,
     Repartition,
     StreamingRepartition,
@@ -55,6 +58,19 @@ INHERITABLE_REMOTE_ARGS = ["scheduling_strategy", "label_selector"]
 
 
 logger = logging.getLogger(__name__)
+
+
+# Logical operators eligible for fusion with StreamingRepartition. They all
+# process each input block independently and have no batch_size constraint, so
+# they are safe to fuse in non-strict mode (which splits each input block
+# independently, without cross-task buffering). Only MapBatches can also fuse
+# in strict mode, where batch_size % target_num_rows_per_block == 0 guarantees
+# exact slicing without buffering.
+_STREAMING_REPARTITION_FUSABLE_OPS = (MapBatches, Filter, MapRows, FlatMap)
+
+
+def _identity_fn(row):
+    return row
 
 
 class FuseOperators(Rule):
@@ -167,10 +183,17 @@ class FuseOperators(Rule):
     def _fuse_streaming_repartition_operators_in_dag(
         self, dag: PhysicalOperator
     ) -> PhysicalOperator:
-        """Fuse (MapBatches -> StreamingRepartition) pair.
+        """Fuse (MapBatches/Filter/MapRows/FlatMap -> StreamingRepartition) pair.
 
-        This will ensure the map_batch's function receive the correct number of rows.
-        We also ensure the output rows is `batch_size`.
+        In non-strict mode, StreamingRepartition uses the default pass-through
+        bundler: each input block is split independently into blocks of roughly
+        target_num_rows_per_block rows, with no cross-task buffering and no
+        batch_size constraint. Under that semantics, Filter/MapRows/FlatMap are
+        fusion-eligible for exactly the same reason MapBatches is — they also
+        process each input block independently. Fusing avoids an intermediate
+        materialization round-trip (serialize to object store, deserialize)
+        between the two operators, while parallelism is unchanged: the fused
+        operator still runs one task per input block.
 
         Why don't we fuse `StreamingRepartition -> MapBatches`?
 
@@ -195,12 +218,19 @@ class FuseOperators(Rule):
         ----------------------------------------------------------
 
         Parallelism is unchanged, so we fuse to avoid intermediate materialization.
+
+        In strict mode, only MapBatches can fuse (when batch_size is a multiple of
+        target_num_rows_per_block): each batch can then be perfectly sliced into
+        chunks without cross-task buffering. Filter/MapRows/FlatMap have no
+        batch_size, so they can never fuse in strict mode.
         """
         upstream_ops = dag.input_dependencies
         while (
             len(upstream_ops) == 1
             and isinstance(self._op_map[dag], StreamingRepartition)
-            and isinstance(self._op_map[upstream_ops[0]], MapBatches)
+            and isinstance(
+                self._op_map[upstream_ops[0]], _STREAMING_REPARTITION_FUSABLE_OPS
+            )
             and self._can_fuse(dag, upstream_ops[0])
         ):
             dag = self._get_fused_streaming_repartition_operator(dag, upstream_ops[0])
@@ -343,10 +373,10 @@ class FuseOperators(Rule):
         ):
             return False
 
-        # only allow fusion of MapBatches -> StreamingRepartition
+        # only allow fusion of MapBatches/Filter/MapRows/FlatMap -> StreamingRepartition
         if isinstance(down_logical_op, StreamingRepartition):
             if not (
-                isinstance(up_logical_op, MapBatches)
+                isinstance(up_logical_op, _STREAMING_REPARTITION_FUSABLE_OPS)
                 and down_logical_op.target_num_rows_per_block is not None
                 and down_logical_op.target_num_rows_per_block > 0
             ):
@@ -354,13 +384,20 @@ class FuseOperators(Rule):
 
             # Non-strict mode: can always fuse, no matter what batch_size is.
             # This allows fusion without cross-task buffering by using default bundler.
+            # Filter/MapRows/FlatMap have no batch_size, so they are only eligible in
+            # non-strict mode, where each input block is split independently without
+            # cross-task buffering (matching their row-wise processing semantics).
             if not down_logical_op.strict:
                 return True
 
-            # Strict mode: only fuse when batch_size is a multiple of target_num_rows_per_block.
-            # When batch_size % target == 0, each batch can be perfectly sliced into chunks
-            # without cross-task buffering. See `_fuse_streaming_repartition_operators_in_dag`
-            # docstring for details.
+            # Strict mode: only fuse MapBatches when batch_size is a multiple of
+            # target_num_rows_per_block. When batch_size % target == 0, each batch can
+            # be perfectly sliced into chunks without cross-task buffering. See
+            # `_fuse_streaming_repartition_operators_in_dag` docstring for details.
+            # Filter/MapRows/FlatMap have no batch_size, so they cannot fuse in strict
+            # mode.
+            if not isinstance(up_logical_op, MapBatches):
+                return False
             # "auto" batch_size is resolved at task runtime, so divisibility is unknown at
             # plan time — skip fusion and let the operators run separately.
             return (
@@ -409,7 +446,8 @@ class FuseOperators(Rule):
         self, down_op: PhysicalOperator, up_op: PhysicalOperator
     ) -> PhysicalOperator:
         assert self._can_fuse(down_op, up_op), (
-            "Current rule supports fusing MapBatches->StreamingRepartition, but received: "
+            "Current rule supports fusing "
+            "MapBatches/Filter/MapRows/FlatMap->StreamingRepartition, but received: "
             f"{type(up_op).__name__} -> {type(down_op).__name__}"
         )
 
@@ -417,10 +455,13 @@ class FuseOperators(Rule):
 
         down_logical_op = self._op_map.pop(down_op)
         up_logical_op = self._op_map.pop(up_op)
-        assert isinstance(up_logical_op, MapBatches)
+        assert isinstance(up_logical_op, _STREAMING_REPARTITION_FUSABLE_OPS)
         assert isinstance(down_logical_op, StreamingRepartition)
 
-        batch_size = up_logical_op.batch_size
+        # Filter/MapRows/FlatMap have no batch_size attribute; batch_size is only
+        # relevant for MapBatches (and for strict-mode fusion, which only accepts
+        # MapBatches upstreams — see _can_fuse).
+        batch_size = getattr(up_logical_op, "batch_size", None)
 
         # Choose ref_bundler and fusion behavior based on strict mode
         if down_logical_op.strict:
@@ -482,10 +523,17 @@ class FuseOperators(Rule):
             op.add_map_task_kwargs_fn(map_task_kwargs_fn)
 
         input_op = up_logical_op.input_dependencies[0]
+        # For expression-based Filter, the logical operator has fn=None (the predicate
+        # is evaluated directly in the physical transform). Use an identity placeholder
+        # for the fused logical operator, which is only used for metadata and further
+        # fusion checks.
+        fn = up_logical_op.fn
+        if fn is None:
+            fn = _identity_fn
         logical_op = AbstractUDFMap(
             name,
             [input_op],
-            up_logical_op.fn,
+            fn,
             can_modify_num_rows=up_logical_op.can_modify_num_rows,
             fn_args=up_logical_op.fn_args,
             fn_kwargs=up_logical_op.fn_kwargs,

--- a/python/ray/data/tests/test_operator_fusion.py
+++ b/python/ray/data/tests/test_operator_fusion.py
@@ -1094,3 +1094,162 @@ if __name__ == "__main__":
     import sys
 
     sys.exit(pytest.main(["-v", __file__]))
+
+
+@pytest.mark.parametrize(
+    "op_builder,expected_fused_name",
+    [
+        # filter -> streaming_repartition: fuse in non-strict mode.
+        (
+            lambda ds: ds.filter(lambda r: r["id"] % 2 == 0),
+            "Filter(<lambda>)->StreamingRepartition",
+        ),
+        # map_rows -> streaming_repartition: fuse in non-strict mode.
+        (
+            lambda ds: ds.map(lambda r: {"id": r["id"] + 1, "value": r["value"]}),
+            "Map(<lambda>)->StreamingRepartition",
+        ),
+        # flat_map -> streaming_repartition: fuse in non-strict mode.
+        (
+            lambda ds: ds.flat_map(
+                lambda r: [{"id": r["id"], "value": r["value"] + 1}, r]
+            ),
+            "FlatMap(<lambda>)->StreamingRepartition",
+        ),
+        # expression-based filter -> streaming_repartition: fuse in non-strict mode.
+        (
+            lambda ds: ds.filter(expr="id >= 50"),
+            "Filter(col('id') >= 50)->StreamingRepartition",
+        ),
+    ],
+    ids=["filter", "map_rows", "flat_map", "expression_filter"],
+)
+def test_streaming_repartition_non_mapbatches_fusion_non_strict(
+    ray_start_regular_shared_2_cpus,
+    op_builder,
+    expected_fused_name,
+):
+    """Test that Filter/MapRows/FlatMap/expression-Filter fuse with
+    StreamingRepartition in non-strict mode (same eligibility as MapBatches)."""
+    n = 100
+    ds = ray.data.range(n, override_num_blocks=4).map(
+        lambda r: {"id": r["id"], "value": r["id"]}
+    )
+    ds = op_builder(ds).repartition(target_num_rows_per_block=20)
+
+    assert len(ds.take_all()) > 0
+
+    stats = ds.stats()
+    assert (
+        expected_fused_name in stats
+    ), f"Expected '{expected_fused_name}' in stats: {stats}"
+
+
+@pytest.mark.parametrize(
+    "op_builder,op_name,expected_count",
+    [
+        (
+            lambda ds: ds.filter(lambda r: r["id"] % 2 == 0),
+            "Filter(<lambda>)",
+            50,
+        ),
+        (
+            lambda ds: ds.map(lambda r: {"id": r["id"] + 1, "value": r["value"]}),
+            "Map(<lambda>)",
+            100,
+        ),
+        (
+            lambda ds: ds.flat_map(
+                lambda r: [{"id": r["id"], "value": r["value"] + 1}, r]
+            ),
+            "FlatMap(<lambda>)",
+            200,
+        ),
+        (
+            lambda ds: ds.filter(expr="id >= 50"),
+            "Filter(col('id') >= 50)",
+            50,
+        ),
+    ],
+    ids=["filter", "map_rows", "flat_map", "expression_filter"],
+)
+def test_streaming_repartition_non_mapbatches_no_fusion_strict(
+    ray_start_regular_shared_2_cpus,
+    op_builder,
+    op_name,
+    expected_count,
+):
+    """Test that Filter/MapRows/FlatMap/expression-Filter do NOT fuse with
+    StreamingRepartition in strict mode, because they have no batch_size and
+    strict mode requires batch_size % target_num_rows_per_block == 0."""
+    n = 100
+    ds = ray.data.range(n, override_num_blocks=4).map(
+        lambda r: {"id": r["id"], "value": r["id"]}
+    )
+    ds = op_builder(ds).repartition(target_num_rows_per_block=20, strict=True)
+
+    assert len(ds.take_all()) == expected_count
+
+    stats = ds.stats()
+    assert (
+        f"{op_name}->StreamingRepartition" not in stats
+    ), f"{op_name} should not fuse with strict StreamingRepartition: {stats}"
+
+
+def test_streaming_repartition_chain_fusion_non_strict(
+    ray_start_regular_shared_2_cpus,
+):
+    """Test chain fusion of Map -> Filter -> StreamingRepartition in non-strict
+    mode: the streaming repartition rule fuses Filter, then the map fusion rule
+    folds in the upstream Map."""
+    n = 100
+    ds = ray.data.range(n, override_num_blocks=4).map(
+        lambda r: {"id": r["id"], "value": r["id"]}
+    )
+    ds = (
+        ds.map(lambda r: {"id": r["id"] * 2, "value": r["value"]})
+        .filter(lambda r: r["id"] % 4 == 0)
+        .repartition(target_num_rows_per_block=20)
+    )
+
+    assert len(ds.take_all()) == n // 2
+
+    stats = ds.stats()
+    assert (
+        "Map(<lambda>)->Filter(<lambda>)->StreamingRepartition" in stats
+    ), f"Expected chain fusion in stats: {stats}"
+
+
+def test_streaming_repartition_map_batches_filter_fusion_non_strict(
+    ray_start_regular_shared_2_cpus,
+):
+    """Test that MapBatches(batch_size) -> Filter -> StreamingRepartition fuses
+    end-to-end while preserving batch_size semantics.
+
+    MapBatches -> Filter already fuses on master (see
+    test_filter_operator_no_upstream_fusion), so the whole chain fusing is
+    expected. The key invariant is that the map_batches fn must still be
+    invoked on ~batch_size rows, before the filter runs.
+    """
+    n = 100
+
+    def fn(batch):
+        # batch_size semantics must be preserved after fusion: the fn is
+        # called on batches of at most batch_size rows, before the filter
+        # removes any. Asserting here fails the task if violated.
+        assert 0 < len(batch["id"]) <= 10, f"batch size violated: {len(batch['id'])}"
+        return batch
+
+    ds = ray.data.range(n, override_num_blocks=4)
+    ds = (
+        ds.map_batches(fn, batch_size=10)
+        .filter(lambda r: r["id"] % 2 == 0)
+        .repartition(target_num_rows_per_block=20)
+    )
+
+    assert len(ds.take_all()) == n // 2
+
+    stats = ds.stats()
+    assert (
+        "MapBatches(fn)->Filter(<lambda>)->StreamingRepartition" in stats
+    ), f"Expected full chain fusion in stats: {stats}"

--- a/python/ray/data/tests/test_repartition_e2e.py
+++ b/python/ray/data/tests/test_repartition_e2e.py
@@ -578,3 +578,321 @@ if __name__ == "__main__":
     import sys
 
     sys.exit(pytest.main(["-v", __file__]))
+
+
+@pytest.mark.parametrize(
+    "op_builder,expected_fused_name,expected_count",
+    [
+        # filter -> streaming_repartition (non-strict): fused, rows halved.
+        (
+            lambda ds: ds.filter(lambda r: r["id"] % 2 == 0),
+            "Filter(<lambda>)->StreamingRepartition",
+            500,
+        ),
+        # map_rows -> streaming_repartition (non-strict): fused, rows unchanged.
+        (
+            lambda ds: ds.map(lambda r: {"id": r["id"] + 1, "value": r["id"]}),
+            "Map(<lambda>)->StreamingRepartition",
+            1000,
+        ),
+        # flat_map -> streaming_repartition (non-strict): fused, rows doubled
+        # (each input row expands to two rows with distinct ids).
+        (
+            lambda ds: ds.flat_map(
+                lambda r: [
+                    {"id": r["id"], "value": r["id"] + 1},
+                    {"id": r["id"] + 1000, "value": r["id"]},
+                ]
+            ),
+            "FlatMap(<lambda>)->StreamingRepartition",
+            2000,
+        ),
+        # expression-based filter -> streaming_repartition (non-strict): fused.
+        (
+            lambda ds: ds.filter(expr="id >= 50"),
+            "Filter(col('id') >= 50)->StreamingRepartition",
+            950,
+        ),
+    ],
+    ids=["filter", "map_rows", "flat_map", "expression_filter"],
+)
+def test_streaming_repartition_non_mapbatches_fusion_e2e(
+    ray_start_regular_shared_2_cpus,
+    disable_fallback_to_object_extension,
+    op_builder,
+    expected_fused_name,
+    expected_count,
+):
+    """E2E test that Filter/MapRows/FlatMap/expression-Filter fuse with
+    StreamingRepartition in non-strict mode, and that data is preserved."""
+    num_rows = 1000
+    target = 20
+    ds = ray.data.range(num_rows, override_num_blocks=10).map(
+        lambda r: {"id": r["id"], "value": r["id"]}
+    )
+    ds = op_builder(ds).repartition(target_num_rows_per_block=target)
+
+    # Verify fusion in the optimized physical plan.
+    planner = create_planner()
+    physical_plan, _ = planner.plan(ds._logical_plan)
+    physical_plan = PhysicalOptimizer().optimize(physical_plan)
+    physical_op = physical_plan.dag
+    assert (
+        expected_fused_name in physical_op.name
+    ), f"Expected '{expected_fused_name}' in operator name, got: {physical_op.name}"
+
+    # Verify data correctness: no rows lost or duplicated.
+    assert (
+        ds.count() == expected_count
+    ), f"Expected {expected_count} rows, got {ds.count()}"
+    ids = sorted(row["id"] for row in ds.take_all())
+    assert (
+        len(ids) == expected_count
+    ), f"Expected {expected_count} rows from take_all, got {len(ids)}"
+    # No rows duplicated or lost across the fused boundary.
+    assert len(set(ids)) == expected_count, f"Duplicate rows after fusion: {ids}"
+
+
+def test_streaming_repartition_filter_all_rows_removed_e2e(
+    ray_start_regular_shared_2_cpus,
+    disable_fallback_to_object_extension,
+):
+    """E2E test that a filter removing all rows still fuses with
+    StreamingRepartition and yields an empty dataset."""
+    ds = (
+        ray.data.range(100, override_num_blocks=4)
+        .map(lambda r: {"id": r["id"], "value": r["id"]})
+        .filter(lambda r: False)
+        .repartition(target_num_rows_per_block=20)
+    )
+
+    assert ds.count() == 0
+    assert list(ds.iter_rows()) == []
+
+
+def test_streaming_repartition_filter_then_map_batches_e2e(
+    ray_start_regular_shared_2_cpus,
+    disable_fallback_to_object_extension,
+):
+    """E2E test of the original issue pipeline: filter -> repartition ->
+    map_batches. Filter must fuse into StreamingRepartition, while the
+    downstream map_batches stays separate by design (to preserve parallelism)."""
+    num_rows = 1000
+    target = 20
+    ds = (
+        ray.data.range(num_rows, override_num_blocks=10)
+        .map(lambda r: {"id": r["id"], "value": r["id"]})
+        .filter(lambda r: r["id"] % 2 == 0)
+        .repartition(target_num_rows_per_block=target)
+        .map_batches(lambda batch: batch, batch_size=16)
+    )
+
+    # Verify filter fused into streaming repartition. The downstream
+    # map_batches stays a separate operator on top of the DAG (by design), so
+    # search the DAG for the fused operator instead of only checking the root.
+    planner = create_planner()
+    physical_plan, _ = planner.plan(ds._logical_plan)
+    physical_plan = PhysicalOptimizer().optimize(physical_plan)
+
+    def find_fused(op):
+        if "Filter(<lambda>)->StreamingRepartition" in op.name:
+            return op.name
+        for inp in op.input_dependencies:
+            found = find_fused(inp)
+            if found:
+                return found
+        return None
+
+    fused_name = find_fused(physical_plan.dag)
+    assert fused_name is not None, (
+        f"Expected Filter fused into StreamingRepartition, DAG root: "
+        f"{physical_plan.dag.name}"
+    )
+    # The downstream map_batches must NOT fuse into the repartition (this would
+    # reduce parallelism), so the fused operator name must not contain it.
+    assert "->MapBatches" not in fused_name, (
+        f"map_batches should stay separate after StreamingRepartition: " f"{fused_name}"
+    )
+
+    # Data correctness through the full pipeline.
+    assert ds.count() == num_rows // 2
+    ids = sorted(row["id"] for row in ds.take_all())
+    assert ids == list(range(0, num_rows, 2))
+
+
+def test_streaming_repartition_filter_partial_empty_blocks_e2e(
+    ray_start_regular_shared_2_cpus,
+    disable_fallback_to_object_extension,
+):
+    """E2E test that a filter emptying only some input blocks (while others
+    stay non-empty) still fuses with StreamingRepartition without hanging or
+    dropping rows. Regression-guards the mixed empty/non-empty bundle path
+    (see test_streaming_repartition_empty_dataset for the all-empty case)."""
+    ds = (
+        ray.data.range(100, override_num_blocks=4)
+        .filter(lambda r: r["id"] >= 75)  # blocks 0-2 fully filtered out
+        .repartition(target_num_rows_per_block=20)
+    )
+
+    assert ds.count() == 25
+    assert sorted(r["id"] for r in ds.take_all()) == list(range(75, 100))
+
+    stats = ds.stats()
+    assert "Filter(<lambda>)->StreamingRepartition" in stats, stats
+
+
+def test_streaming_repartition_fused_block_shapes_non_strict_e2e(
+    ray_start_regular_shared_2_cpus,
+    disable_fallback_to_object_extension,
+):
+    """E2E test that fusion preserves the non-strict mode block-shape
+    invariant: each input block is split independently with no cross-block
+    stitching, so no output block combines rows from different input blocks.
+
+    This mirrors test_streaming_repartition_non_strict_mode, but for the
+    fused (Filter -> StreamingRepartition) path."""
+    # Case 1: each input block (25 rows) keeps 10 rows; target 20 -> the 10-row
+    # blocks must NOT be stitched together into 20-row blocks.
+    ds = (
+        ray.data.range(100, override_num_blocks=4)
+        .filter(lambda r: r["id"] % 25 < 10)
+        .repartition(target_num_rows_per_block=20)
+        .materialize()
+    )
+    counts = sorted(
+        m.num_rows for b in ds.iter_internal_ref_bundles() for m in b.metadata
+    )
+    assert counts == [10, 10, 10, 10], f"cross-block stitching detected: {counts}"
+
+    # Case 2: each input block keeps all 25 rows; target 20 -> each input block
+    # yields [20, 5], i.e. at most one partial trailing block per input block.
+    ds = (
+        ray.data.range(100, override_num_blocks=4)
+        .filter(lambda r: r["id"] % 25 < 30)
+        .repartition(target_num_rows_per_block=20)
+        .materialize()
+    )
+    counts = sorted(
+        m.num_rows for b in ds.iter_internal_ref_bundles() for m in b.metadata
+    )
+    assert counts == [
+        5,
+        5,
+        5,
+        5,
+        20,
+        20,
+        20,
+        20,
+    ], f"unexpected block shape after fusion: {counts}"
+
+    stats = ds.stats()
+    assert "Filter(<lambda>)->StreamingRepartition" in stats, stats
+
+
+@pytest.mark.parametrize(
+    "target_num_rows_per_block,expected_block_counts",
+    [
+        # target=1: every surviving row becomes its own block.
+        (1, [1, 1, 1, 1, 1]),
+        # target >> total rows: blocks pass through unsplit (filter halves rows:
+        # 4 input blocks of 25 -> 4 blocks of 12/13).
+        (1000, [12, 12, 13, 13]),
+    ],
+    ids=["target_one", "target_large"],
+)
+def test_streaming_repartition_fused_target_boundaries_e2e(
+    ray_start_regular_shared_2_cpus,
+    disable_fallback_to_object_extension,
+    target_num_rows_per_block,
+    expected_block_counts,
+):
+    """E2E test of target_num_rows_per_block boundary values on the fused
+    Filter -> StreamingRepartition path."""
+    ds = (
+        ray.data.range(
+            10 if target_num_rows_per_block == 1 else 100, override_num_blocks=4
+        )
+        .filter(lambda r: r["id"] % 2 == 0)
+        .repartition(target_num_rows_per_block=target_num_rows_per_block)
+        .materialize()
+    )
+    counts = sorted(
+        m.num_rows for b in ds.iter_internal_ref_bundles() for m in b.metadata
+    )
+    assert counts == expected_block_counts, f"unexpected block counts: {counts}"
+
+
+def test_streaming_repartition_fused_single_input_block_e2e(
+    ray_start_regular_shared_2_cpus,
+    disable_fallback_to_object_extension,
+):
+    """E2E test with a single input block (override_num_blocks=1): the fused
+    operator runs one task and must still split correctly."""
+    ds = (
+        ray.data.range(100, override_num_blocks=1)
+        .filter(lambda r: r["id"] % 2 == 0)
+        .repartition(target_num_rows_per_block=20)
+        .materialize()
+    )
+    counts = sorted(
+        m.num_rows for b in ds.iter_internal_ref_bundles() for m in b.metadata
+    )
+    assert counts == [10, 20, 20], f"unexpected block counts: {counts}"
+    assert ds.count() == 50
+
+
+def test_streaming_repartition_fused_empty_input_e2e(
+    ray_start_regular_shared_2_cpus,
+    disable_fallback_to_object_extension,
+):
+    """E2E test of a zero-block input dataset (range(0)) fused with
+    StreamingRepartition: must not hang and must yield an empty dataset."""
+    ds = (
+        ray.data.range(0)
+        .filter(lambda r: True)
+        .repartition(target_num_rows_per_block=20)
+    )
+    assert ds.count() == 0
+    assert list(ds.iter_rows()) == []
+
+
+def test_streaming_repartition_expr_filter_after_pushdown_e2e(
+    ray_start_regular_shared_2_cpus,
+    disable_fallback_to_object_extension,
+):
+    """E2E test of the interaction between predicate pushdown and fusion: an
+    expression filter written AFTER repartition gets pushed before the
+    StreamingRepartition (PASSTHROUGH), after which the fusion rule fuses it
+    into a single operator. Data must be preserved."""
+    ds = (
+        ray.data.range(100, override_num_blocks=4)
+        .repartition(target_num_rows_per_block=20)
+        .filter(expr="id >= 50")
+    )
+
+    assert ds.count() == 50
+    ids = sorted(r["id"] for r in ds.take_all())
+    assert ids == list(range(50, 100))
+
+    stats = ds.stats()
+    assert "Filter(col('id') >= 50)->StreamingRepartition" in stats, stats
+
+
+def test_streaming_repartition_remote_args_fn_not_fused_e2e(
+    ray_start_regular_shared_2_cpus,
+    disable_fallback_to_object_extension,
+):
+    """E2E test that a filter with ray_remote_args_fn is NOT fused with
+    StreamingRepartition (are_op_remote_args_compatible rejects it), and the
+    pipeline still works."""
+    ds = (
+        ray.data.range(100, override_num_blocks=4)
+        .filter(lambda r: r["id"] % 2 == 0, ray_remote_args_fn=lambda: {})
+        .repartition(target_num_rows_per_block=20)
+    )
+
+    assert ds.count() == 50
+
+    stats = ds.stats()
+    assert "Filter(<lambda>)->StreamingRepartition" not in stats, stats


### PR DESCRIPTION
## Why are these changes needed?

In non-strict mode, `StreamingRepartition` uses the default pass-through bundler (`ref_bundler=None`): each input block is split independently, with no cross-task buffering and no `batch_size` constraint. Under that semantics, `Filter`/`MapRows`/`FlatMap` are fusion-eligible for exactly the same reason `MapBatches` is — physically all four are `TaskPoolMapOperator`s whose transform chains get concatenated (upstream transform first, then the row-count-based block split), so data semantics are unchanged.

Strict mode is untouched: it requires cross-task buffering (`RebundleQueue(ExactMultipleSize(...))`), and `_can_fuse` keeps rejecting non-MapBatches upstreams there (they have no `batch_size` to guarantee divisibility).

Closes #63624. This re-implements the design from #63625 (auto-closed as stale) against the current master, with credit to that PR's approach and tests.

cc @ray-project/ray-data

## Related issue number

Closes #63624

## Checks

- [x] I've signed off every commit (DCO)
- [x] I've run `scripts/format.sh` and installed pre-commit hooks
- [x] I've added unit tests and verified that all tests pass (this is required)
- [x] I've manually verified the change (e.g. via `ds.explain()` on the repro pipeline)

## Tests

```bash
python -m pytest -q python/ray/data/tests/test_operator_fusion.py -k streaming_repartition
# 17 passed (incl. 9 new: fusion param x4, strict-no-fusion param x4, chain, batch_size semantics)

python -m pytest -q python/ray/data/tests/test_repartition_e2e.py -k streaming_repartition
# 25 passed (incl. 13 new: fusion param x4, empty-result, full pipeline, partial-empty blocks,
#            block-shape invariant, target boundaries, single block, empty input,
#            expr-filter after pushdown, remote-args negative)

ruff check / black --check (22.10.0) on the changed files: all passed
```

Additional local verification (not part of the test suite):
- 10 read-path scenarios (`read_parquet`/`read_csv`/`read_json` -> filter -> repartition, incl. multi-file, empty file, block-shape invariant, predicate-pushdown interaction): all passed
- Performance on 2M rows (read_parquet, 5 files, 100B payload): `filter -> repartition(4096)` goes from **5.97s to 2.18s (~2.7x)**; on 20M rows: **48.1s to 24.1s (2.0x)** — the fused operator avoids an intermediate materialization round-trip

Note: 3 pre-existing shuffle-related tests in `test_operator_fusion.py` error locally with `AttributeError: SHUFFLE_V2` (master tests against the installed 2.57.0 build); they are unrelated to this change and pass in CI.

## AI assistance

This change was developed with AI assistance (code drafting, test authoring, and review). The submitting human has reviewed every changed line and ran the tests above locally.

## Why this is not a duplicate

- Issue #63624 is open with zero comments and no assignee; the only PR referencing it (#63625) was auto-closed as stale without merging and the issue remains unaddressed on master.
- No open PRs reference #63624 (checked via `gh pr list --search "63624"`).
- The approach differs from the closed PR by adapting to current master (e.g. `AbstractUDFMap` now takes a list of input ops), fixing the PEP 8 lambda issue from #63625's review, extracting a shared fusion-eligibility constant, and adding coverage for empty results, block-shape invariants, the full original pipeline, and read-path scenarios.
