### PR TITLE
[build] Retry PyPI 502s when fetching pip dependencies

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -62,6 +62,96 @@ python_register_toolchains(
 load("@python3_10//:defs.bzl", python310 = "interpreter")
 load("@rules_python//python/pip_install:repositories.bzl", "pip_install_dependencies")
 
+# rules_python's whl_library shells out to pip rather than using Bazel's downloader, so
+# wheel fetches are invisible to Bazel's retry and mirroring settings. The pip that
+# rules_python pins (22.0.4) leaves 502 out of urllib3's status_forcelist, so a
+# transient PyPI/Fastly 502 fails a repository fetch on the first try with no retry at
+# all, breaking the whole build. pip 24.0 added 502 to that list upstream.
+#
+# pip 24 also drops pip._internal.cli.progress_bars.BAR_TYPES, which the pip-tools 6.6.0
+# that rules_python pins alongside it imports, so pip-tools moves to 7.4.1 here as well.
+# 7.4.1 replaced pep517 with build + pyproject_hooks and needs packaging, none of which
+# rules_python provides, so those three are declared below too and wired into
+# //release:requirements_py310.update via _requirements_py310_deps. Versions are the set
+# rules_python itself pairs with pip 24.0 / pip-tools 7.4.1 upstream, rather than an
+# ad-hoc combination.
+#
+# The pypi__pip and pypi__pip_tools entries are declared before
+# pip_install_dependencies() so that its maybe() calls become no-ops and these win. Keep
+# the url/sha256 pairs in sync with _RULE_DEPS in
+# @rules_python//python/pip_install:repositories.bzl.
+#
+# All five entries exist only because rules_python here is 0.9.0, from July 2022, which
+# is where the pip 22.0.4 pin comes from. Ray never declares rules_python: it arrives
+# transitively via ray_deps_build_all() -> rules_foreign_cc_dependencies(), which pins it
+# at rules_foreign_cc/foreign_cc/repositories.bzl:85. That is also a maybe(), so pinning
+# rules_python explicitly before ray_deps_build_all() would take precedence and is the
+# real fix - a modern rules_python pins pip 24.0 itself, making all five entries below
+# unnecessary, and adds the experimental_index_url path that fetches wheels through
+# Bazel's downloader, where --experimental_repository_downloader_retries and downloader
+# URL rewriting would finally apply to them. That upgrade rewrites whl_library, repo
+# naming and the generated requirements.bzl, so it needs to be its own change; delete
+# this block as part of it.
+#
+# Note that upgrading pip for the hermetic interpreter is not an alternative. The
+# python_register_toolchains() CPython build ships its own pip (also 22.0.4), but
+# whl_library puts the pypi__* repositories on PYTHONPATH, which precedes site-packages
+# on sys.path, so pypi__pip shadows it and the interpreter's copy is never used.
+_PYPI_WHEEL_BUILD_FILE = """\
+package(default_visibility = ["//visibility:public"])
+
+load("@rules_python//python:defs.bzl", "py_library")
+
+py_library(
+    name = "lib",
+    srcs = glob(["**/*.py"]),
+    data = glob(["**/*"], exclude=["**/*.py", "**/* *", "BUILD", "WORKSPACE"]),
+    # This makes this directory a top-level in the python import
+    # search path for anything that depends on this.
+    imports = ["."],
+)
+"""
+
+http_archive(
+    name = "pypi__pip",
+    build_file_content = _PYPI_WHEEL_BUILD_FILE,
+    sha256 = "ba0d021a166865d2265246961bec0152ff124de910c5cc39f1156ce3fa7c69dc",
+    type = "zip",
+    url = "https://files.pythonhosted.org/packages/8a/6a/19e9fe04fca059ccf770861c7d5721ab4c2aebc539889e97c7977528a53b/pip-24.0-py3-none-any.whl",
+)
+
+http_archive(
+    name = "pypi__pip_tools",
+    build_file_content = _PYPI_WHEEL_BUILD_FILE,
+    sha256 = "4c690e5fbae2f21e87843e89c26191f0d9454f362d8acdbd695716493ec8b3a9",
+    type = "zip",
+    url = "https://files.pythonhosted.org/packages/0d/dc/38f4ce065e92c66f058ea7a368a9c5de4e702272b479c0992059f7693941/pip_tools-7.4.1-py3-none-any.whl",
+)
+
+http_archive(
+    name = "pypi__build",
+    build_file_content = _PYPI_WHEEL_BUILD_FILE,
+    sha256 = "75e10f767a433d9a86e50d83f418e83efc18ede923ee5ff7df93b6cb0306c5d4",
+    type = "zip",
+    url = "https://files.pythonhosted.org/packages/e2/03/f3c8ba0a6b6e30d7d18c40faab90807c9bb5e9a1e3b2fe2008af624a9c97/build-1.2.1-py3-none-any.whl",
+)
+
+http_archive(
+    name = "pypi__packaging",
+    build_file_content = _PYPI_WHEEL_BUILD_FILE,
+    sha256 = "2ddfb553fdf02fb784c234c7ba6ccc288296ceabec964ad2eae3777778130bc5",
+    type = "zip",
+    url = "https://files.pythonhosted.org/packages/49/df/1fceb2f8900f8639e278b056416d49134fb8d84c5942ffaa01ad34782422/packaging-24.0-py3-none-any.whl",
+)
+
+http_archive(
+    name = "pypi__pyproject_hooks",
+    build_file_content = _PYPI_WHEEL_BUILD_FILE,
+    sha256 = "7ceeefe9aec63a1064c18d939bdc3adf2d8aa1988a510afec15151578b232aa2",
+    type = "zip",
+    url = "https://files.pythonhosted.org/packages/ae/f3/431b9d5fe7d14af7a32340792ef43b8a714e7726f1d7b69cc4e8e7a3f1d7/pyproject_hooks-1.1.0-py3-none-any.whl",
+)
+
 pip_install_dependencies()
 
 load("@rules_python//python:pip.bzl", "pip_parse")
@@ -69,6 +159,21 @@ load("@rules_python//python:pip.bzl", "pip_parse")
 # For CI scripts use only; not for ray testing.
 pip_parse(
     name = "py_deps_py310",
+    # pip retries 5 times by default with backoff_factor=0.25, and urllib3 doubles the
+    # delay each round, so it gives up after only ~8 seconds (0, 0.5, 1, 2, 4). Nine
+    # retries widens that to ~2 minutes (0, 0.5, 1, 2, 4, 8, 16, 32, 64), which is long
+    # enough to ride out a brief files.pythonhosted.org outage instead of failing the
+    # whole build. Nine is also the last round before urllib3's 120s per-sleep cap
+    # kicks in, so going higher buys progressively coarser waits.
+    #
+    # Both settings are needed because two different pip processes fetch from PyPI
+    # here. PIP_RETRIES covers the pip that setuptools spawns for setup_requires when
+    # a locked package ships only an sdist; that one is not isolated, so it reads the
+    # environment. --retries covers this pip invocation, which runs with --isolated
+    # and therefore ignores PIP_* variables. Neither helps unless 502 is retryable in
+    # the first place, which is what the pip 24.0 pin above provides.
+    environment = {"PIP_RETRIES": "9"},
+    extra_pip_args = ["--retries=9"],
     python_interpreter_target = python310,
     requirements_lock = "//release:requirements_py310.txt",
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -117,13 +117,21 @@ http_archive(
     name = "pypi__pip",
     build_file_content = _PYPI_WHEEL_BUILD_FILE,
     patch_args = ["-p1"],
-    # pip hardcodes backoff_factor=0.25 when it builds its urllib3.Retry and exposes
-    # no flag or environment variable for the shape of the retry schedule, and the
-    # urllib3 it vendors (1.26.17) implements exponential backoff only - jitter arrived
-    # in urllib3 2.x. The patch swaps in a constant, jittered schedule so that the
-    # --retries count below translates into a predictable amount of wall-clock. See
-    # the comment on pip_parse's extra_pip_args for why that shape is the one wanted.
-    patches = ["//thirdparty/patches:pip-constant-jittered-retry-backoff.patch"],
+    # The patch changes two things pip does not let a caller configure, which between
+    # them decide whether retrying can succeed at all.
+    #
+    # When to retry. pip hardcodes backoff_factor=0.25 where it builds its urllib3.Retry
+    # and exposes no flag or environment variable for the shape of the backoff, and the
+    # urllib3 it vendors (1.26.17) implements exponential only - jitter arrived in
+    # urllib3 2.x. A constant jittered schedule goes in instead, so the --retries count
+    # below buys a predictable amount of wall-clock; see the comment on extra_pip_args.
+    #
+    # Where to retry. urllib3 drains a failed response specifically in order to keep the
+    # socket alive, and Fastly selects the edge node per connection, so every retry is
+    # pinned to the node that just failed. Sending Connection: close makes each attempt
+    # redial and re-draw a node. Without it no retry count helps against a single bad
+    # node, which is the failure mode described in pypi/support#11876.
+    patches = ["//thirdparty/patches:pip-retry-backoff-and-redial.patch"],
     sha256 = "ba0d021a166865d2265246961bec0152ff124de910c5cc39f1156ce3fa7c69dc",
     type = "zip",
     url = "https://files.pythonhosted.org/packages/8a/6a/19e9fe04fca059ccf770861c7d5721ab4c2aebc539889e97c7977528a53b/pip-24.0-py3-none-any.whl",
@@ -168,6 +176,14 @@ load("@rules_python//python:pip.bzl", "pip_parse")
 # For CI scripts use only; not for ray testing.
 pip_parse(
     name = "py_deps_py310",
+    # The retries above are only usable if the fetch is allowed to last long enough to
+    # spend them. timeout defaults to 600s and pip_parse forwards it to every generated
+    # whl_library, so it bounds each package's pip invocation, not just this rule. The
+    # retry budget alone reaches 588s at worst, and each of the 50 attempts can burn up
+    # to pip's 15s socket timeout on top of that when the failure mode is a hang rather
+    # than a fast 502, so the default cannot hold the schedule. 1800s covers the full
+    # backoff, the per-attempt timeouts and a slow transfer afterwards.
+    timeout = 1800,
     # pip retries 5 times by default, and the schedule is exponential, so it gives up
     # after ~8 seconds (0, 0.5, 1, 2, 4). That is far shorter than a PyPI incident,
     # and simply raising the count does not fix it: exponential backoff doubles until
@@ -191,14 +207,6 @@ pip_parse(
     extra_pip_args = ["--retries=50"],
     python_interpreter_target = python310,
     requirements_lock = "//release:requirements_py310.txt",
-    # The retries above are only usable if the fetch is allowed to last long enough to
-    # spend them. timeout defaults to 600s and pip_parse forwards it to every generated
-    # whl_library, so it bounds each package's pip invocation, not just this rule. The
-    # retry budget alone reaches 588s at worst, and each of the 50 attempts can burn up
-    # to pip's 15s socket timeout on top of that when the failure mode is a hang rather
-    # than a fast 502, so the default cannot hold the schedule. 1800s covers the full
-    # backoff, the per-attempt timeouts and a slow transfer afterwards.
-    timeout = 1800,
 )
 
 load("@py_deps_py310//:requirements.bzl", install_py_deps_py310 = "install_deps")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -91,7 +91,8 @@ load("@rules_python//python/pip_install:repositories.bzl", "pip_install_dependen
 # Bazel's downloader, where --experimental_repository_downloader_retries and downloader
 # URL rewriting would finally apply to them. That upgrade rewrites whl_library, repo
 # naming and the generated requirements.bzl, so it needs to be its own change; delete
-# this block as part of it.
+# this block as part of it, including the pip patch - once Bazel does the fetching,
+# pip's own retry schedule stops being what governs a wheel download.
 #
 # Note that upgrading pip for the hermetic interpreter is not an alternative. The
 # python_register_toolchains() CPython build ships its own pip (also 22.0.4), but
@@ -115,6 +116,14 @@ py_library(
 http_archive(
     name = "pypi__pip",
     build_file_content = _PYPI_WHEEL_BUILD_FILE,
+    patch_args = ["-p1"],
+    # pip hardcodes backoff_factor=0.25 when it builds its urllib3.Retry and exposes
+    # no flag or environment variable for the shape of the retry schedule, and the
+    # urllib3 it vendors (1.26.17) implements exponential backoff only - jitter arrived
+    # in urllib3 2.x. The patch swaps in a constant, jittered schedule so that the
+    # --retries count below translates into a predictable amount of wall-clock. See
+    # the comment on pip_parse's extra_pip_args for why that shape is the one wanted.
+    patches = ["//thirdparty/patches:pip-constant-jittered-retry-backoff.patch"],
     sha256 = "ba0d021a166865d2265246961bec0152ff124de910c5cc39f1156ce3fa7c69dc",
     type = "zip",
     url = "https://files.pythonhosted.org/packages/8a/6a/19e9fe04fca059ccf770861c7d5721ab4c2aebc539889e97c7977528a53b/pip-24.0-py3-none-any.whl",
@@ -159,12 +168,18 @@ load("@rules_python//python:pip.bzl", "pip_parse")
 # For CI scripts use only; not for ray testing.
 pip_parse(
     name = "py_deps_py310",
-    # pip retries 5 times by default with backoff_factor=0.25, and urllib3 doubles the
-    # delay each round, so it gives up after only ~8 seconds (0, 0.5, 1, 2, 4). Nine
-    # retries widens that to ~2 minutes (0, 0.5, 1, 2, 4, 8, 16, 32, 64), which is long
-    # enough to ride out a brief files.pythonhosted.org outage instead of failing the
-    # whole build. Nine is also the last round before urllib3's 120s per-sleep cap
-    # kicks in, so going higher buys progressively coarser waits.
+    # pip retries 5 times by default, and the schedule is exponential, so it gives up
+    # after ~8 seconds (0, 0.5, 1, 2, 4). That is far shorter than a PyPI incident,
+    # and simply raising the count does not fix it: exponential backoff doubles until
+    # it saturates urllib3's 120s per-sleep cap, so most of a larger budget is spent
+    # asleep in 2-minute blocks rather than covering the outage. At 50 retries the
+    # upstream schedule would run for ~5050s, which no sane fetch timeout accommodates.
+    #
+    # The patch on pypi__pip above replaces that with a constant schedule jittered over
+    # 6-12s per sleep, which makes the count buy wall-clock linearly: 50 retries is 49
+    # sleeps, so 294-588s, ~440s typical, bounded under 600s. The jitter also spreads
+    # out the many wheel fetches Bazel runs in parallel, which would otherwise retry in
+    # lockstep and hit an already-degraded origin all at once.
     #
     # Both settings are needed because two different pip processes fetch from PyPI
     # here. PIP_RETRIES covers the pip that setuptools spawns for setup_requires when
@@ -172,17 +187,17 @@ pip_parse(
     # environment. --retries covers this pip invocation, which runs with --isolated
     # and therefore ignores PIP_* variables. Neither helps unless 502 is retryable in
     # the first place, which is what the pip 24.0 pin above provides.
-    environment = {"PIP_RETRIES": "9"},
-    extra_pip_args = ["--retries=9"],
+    environment = {"PIP_RETRIES": "50"},
+    extra_pip_args = ["--retries=50"],
     python_interpreter_target = python310,
     requirements_lock = "//release:requirements_py310.txt",
     # The retries above are only usable if the fetch is allowed to last long enough to
     # spend them. timeout defaults to 600s and pip_parse forwards it to every generated
-    # whl_library, so it bounds each package's pip invocation, not just this rule. Nine
-    # retries can spend ~2 minutes sleeping before the download itself starts making
-    # progress, and a degraded PyPI is slow as well as flaky, so 600s can expire
-    # mid-retry and fail the fetch that the retries were meant to save. 1800s leaves
-    # room for the full backoff plus a slow transfer.
+    # whl_library, so it bounds each package's pip invocation, not just this rule. The
+    # retry budget alone reaches 588s at worst, and each of the 50 attempts can burn up
+    # to pip's 15s socket timeout on top of that when the failure mode is a hang rather
+    # than a fast 502, so the default cannot hold the schedule. 1800s covers the full
+    # backoff, the per-attempt timeouts and a slow transfer afterwards.
     timeout = 1800,
 )
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -176,6 +176,14 @@ pip_parse(
     extra_pip_args = ["--retries=9"],
     python_interpreter_target = python310,
     requirements_lock = "//release:requirements_py310.txt",
+    # The retries above are only usable if the fetch is allowed to last long enough to
+    # spend them. timeout defaults to 600s and pip_parse forwards it to every generated
+    # whl_library, so it bounds each package's pip invocation, not just this rule. Nine
+    # retries can spend ~2 minutes sleeping before the download itself starts making
+    # progress, and a degraded PyPI is slow as well as flaky, so 600s can expire
+    # mid-retry and fail the fetch that the retries were meant to save. 1800s leaves
+    # room for the full backoff plus a slow transfer.
+    timeout = 1800,
 )
 
 load("@py_deps_py310//:requirements.bzl", install_py_deps_py310 = "install_deps")

--- a/release/BUILD.bazel
+++ b/release/BUILD.bazel
@@ -22,12 +22,17 @@ _requirements_py310_data = [
     ":requirements_py310.txt",
 ]
 
+# pip-tools 7.4.1 replaced its pep517 dependency with build + pyproject_hooks, and
+# build additionally needs packaging. Those three repositories are declared in
+# //:WORKSPACE because rules_python does not provide them.
 _requirements_py310_deps = [
+    "@pypi__build//:lib",
     "@pypi__click//:lib",
     "@pypi__colorama//:lib",
-    "@pypi__pep517//:lib",
+    "@pypi__packaging//:lib",
     "@pypi__pip//:lib",
     "@pypi__pip_tools//:lib",
+    "@pypi__pyproject_hooks//:lib",
     "@pypi__setuptools//:lib",
     "@pypi__tomli//:lib",
 ]

--- a/thirdparty/patches/pip-constant-jittered-retry-backoff.patch
+++ b/thirdparty/patches/pip-constant-jittered-retry-backoff.patch
@@ -1,0 +1,88 @@
+--- a/pip/_internal/network/session.py
++++ b/pip/_internal/network/session.py
+@@ -10,11 +10,13 @@
+ import mimetypes
+ import os
+ import platform
++import random
+ import shutil
+ import subprocess
+ import sys
+ import urllib.parse
+ import warnings
++from itertools import takewhile
+ from typing import (
+     TYPE_CHECKING,
+     Any,
+@@ -315,6 +317,50 @@
+         super().cert_verify(conn=conn, url=url, verify=False, cert=cert)
+ 
+ 
++class _ConstantJitteredRetry(urllib3.Retry):
++    """A ``Retry`` policy with constant, jittered backoff.
++
++    urllib3 1.26 -- the version pip 24.0 vendors -- implements only exponential
++    backoff (``backoff_factor * 2 ** (n - 1)``) and offers no jitter at all;
++    ``Retry.backoff_jitter`` exists only in urllib3 2.x. Neither the shape of
++    the schedule nor ``backoff_factor`` is reachable from pip's command line,
++    so this subclass replaces ``get_backoff_time`` outright.
++
++    Exponential backoff is the wrong shape for riding out a PyPI outage. It
++    spends its early retries before the outage has plausibly cleared and its
++    late ones sleeping for minutes at a time, so a given retry count covers far
++    less wall-clock than a flat schedule of the same length would, and the part
++    of the budget that lands inside the recovery window is small. A constant
++    schedule turns the retry count into a predictable amount of wall-clock:
++    ``n`` retries cover roughly ``n`` times the nominal wait.
++
++    The jitter matters because Bazel fetches many wheels concurrently, each in
++    its own pip process. Without it, all of them fail at the same instant,
++    sleep for identical durations and re-converge on the origin together,
++    turning every retry round into a thundering herd against a service that is
++    already degraded.
++    """
++
++    #: Bounds on a single sleep, in seconds -- equal jitter around a 12s
++    #: nominal wait, meaning half the interval is fixed and half is random.
++    BACKOFF_FLOOR = 6.0
++    BACKOFF_CEILING = 12.0
++
++    def get_backoff_time(self) -> float:
++        # urllib3 does not sleep before the first retry of a sequence. Keep
++        # that, so a lone blip is recovered from immediately rather than
++        # costing a full sleep.
++        consecutive_errors = len(
++            list(
++                takewhile(lambda x: x.redirect_location is None, reversed(self.history))
++            )
++        )
++        if consecutive_errors <= 1:
++            return 0.0
++
++        return random.uniform(self.BACKOFF_FLOOR, self.BACKOFF_CEILING)
++
++
+ class PipSession(requests.Session):
+     timeout: Optional[int] = None
+ 
+@@ -346,7 +392,7 @@
+ 
+         # Create our urllib3.Retry instance which will allow us to customize
+         # how we handle retries.
+-        retries = urllib3.Retry(
++        retries = _ConstantJitteredRetry(
+             # Set the total number of retries that a particular request can
+             # have.
+             total=retries,
+@@ -358,9 +404,8 @@
+             # A 502 may be a transient error from a CDN like CloudFlare or CloudFront
+             # A 520 or 527 - may indicate transient error in CloudFlare
+             status_forcelist=[500, 502, 503, 520, 527],
+-            # Add a small amount of back off between failed requests in
+-            # order to prevent hammering the service.
+-            backoff_factor=0.25,
++            # backoff_factor is deliberately not passed: _ConstantJitteredRetry
++            # replaces get_backoff_time() entirely, so it would have no effect.
+         )  # type: ignore
+ 
+         # Our Insecure HTTPAdapter disables HTTPS validation. It does not

--- a/thirdparty/patches/pip-retry-backoff-and-redial.patch
+++ b/thirdparty/patches/pip-retry-backoff-and-redial.patch
@@ -65,7 +65,26 @@
  class PipSession(requests.Session):
      timeout: Optional[int] = None
  
-@@ -346,7 +392,7 @@
+@@ -341,12 +387,26 @@
+         # Attach our User Agent to the request
+         self.headers["User-Agent"] = user_agent()
+ 
++        # Force a new TCP connection for every request, and so for every retry.
++        # Fastly selects the edge node per connection, and urllib3's retry path
++        # deliberately drains a failed response in order to keep the socket
++        # alive, which pins every retry to the node that just failed -- against
++        # one bad node no retry count helps, because the requests never go
++        # anywhere else. Redialling re-draws the node instead: measured against
++        # files.pythonhosted.org, eight separate connections to a single pinned
++        # address reached seven distinct edge nodes, while six requests sent
++        # over one kept-alive socket all landed on the same one.
++        #
++        # The cost is a TLS handshake per request, which is minor next to a
++        # wheel download and only paid on this CI-scripts pip.
++        self.headers["Connection"] = "close"
++
+         # Attach our Authentication handler to the session
+         self.auth = MultiDomainBasicAuth(index_urls=index_urls)
  
          # Create our urllib3.Retry instance which will allow us to customize
          # how we handle retries.
@@ -74,7 +93,7 @@
              # Set the total number of retries that a particular request can
              # have.
              total=retries,
-@@ -358,9 +404,8 @@
+@@ -358,9 +418,8 @@
              # A 502 may be a transient error from a CDN like CloudFlare or CloudFront
              # A 520 or 527 - may indicate transient error in CloudFlare
              status_forcelist=[500, 502, 503, 520, 527],


### PR DESCRIPTION
## Description

`rules_python`'s `whl_library` shells out to pip rather than using Bazel's downloader, so wheel fetches bypass Bazel's retry settings entirely — `--experimental_repository_downloader_retries` never sees them. The pip that `rules_python` pins (22.0.4) leaves `502` out of urllib3's `status_forcelist`:

```python
status_forcelist=[500, 503, 520, 527],
```

so a transient `files.pythonhosted.org` 502 fails a repository fetch on the **first attempt with zero retries**, and one failed wheel takes down the whole build through the dependency cascade. Recent examples on `ray-project/release`: builds [104355](https://buildkite.com/ray-project/release/builds/104355) and [104354](https://buildkite.com/ray-project/release/builds/104354), both dying on `whl_library py_deps_py310_googleapis_common_protos failed: ... HTTP error 502`.

pip 24.0 added 502 to that list upstream. But making 502 retryable is not sufficient on its own, because pip retries down the connection it already holds and Fastly picks the edge node per connection, so every retry lands on the node that just failed. This PR therefore does three things: makes 502 retryable, makes the retry schedule usable, and makes the retries go somewhere else.

- **`WORKSPACE`** — pins `pypi__pip` 24.0 and `pypi__pip_tools` 7.4.1, declared before `pip_install_dependencies()` so `rules_python`'s `maybe()` calls no-op and these win.
- **`WORKSPACE`** — adds `pypi__build`, `pypi__packaging`, `pypi__pyproject_hooks`, which pip-tools 7.4.1 needs and `rules_python` does not provide.
- **`thirdparty/patches/pip-retry-backoff-and-redial.patch`** (new) — two changes to pip's retry behaviour, applied to `pypi__pip` via `patches`/`patch_args`: a constant schedule jittered over 6–12s in place of the exponential one, and `Connection: close` so every attempt redials and re-draws a CDN node.
- **`WORKSPACE`** — raises retries from the default 5 to 50 on `pip_parse`, and the fetch timeout from 600s to 1800s so the schedule can actually be spent.
- **`release/BUILD.bazel`** — wires the three new repositories into `_requirements_py310_deps`.

Every version pin is an unmodified upstream wheel. The one modification to a third-party dependency is the retry patch above, which touches a single pip file and is explained in detail below.

## Related issues

No Ray issue. The upstream cause is tracked at [pypi/support#11876](https://github.com/pypi/support/issues/11876) — a bad node in the CDN fronting `files.pythonhosted.org` — which is what the redial half of this change is aimed at.

I searched for prior art before opening this: open PRs matching `pypi__pip`, `status_forcelist`, `pip retries 502`, `whl_library 502`, and `WORKSPACE pip`, plus open issues matching `pip 502 pythonhosted`. The only open PRs touching pip dependencies are unrelated dependabot version bumps (#65465, #63734, #62380, #61887), so this is not duplicating work already in flight.

## Additional information

### Why pip-tools moves too

pip 24 drops `pip._internal.cli.progress_bars.BAR_TYPES`, which pip-tools 6.6.0 imports at module scope in `piptools/repositories/pypi.py`, so `//release:requirements_py310.update` and `//release:requirements_py310_test` would fail to import. pip-tools 7.4.1 fixes that.

I checked whether `BAR_TYPES` was merely the first of many breaks. It is not. Of the 36 `pip._internal` symbols pip-tools touches, only three flag on pip 24.0 and two are non-issues:

- `req_tracker` — pip-tools already gates this itself (`if PIP_VERSION[:2] <= (22, 0)`), so pip 24 correctly takes the `build_tracker` branch.
- `DEV_PKGS` — only in `piptools/sync.py` (`pip-sync`), which this compile path never imports.
- `BAR_TYPES` — the only real blocker.

pip-tools 7.4.1 replaced its `pep517` dependency with `build` + `pyproject_hooks`, and `build` needs `packaging`, hence the three added repositories. All five versions are the set `rules_python` itself pairs with pip 24.0 / pip-tools 7.4.1 upstream, rather than an ad-hoc combination.

### Why an override rather than upgrading pip

`pypi__pip`'s version is a hardcoded entry in rules_python's `_RULE_DEPS` (`python/pip_install/repositories.bzl`); no attribute on `pip_parse` or `pip_install_dependencies()` exposes it, so shadowing the repository before `pip_install_dependencies()` runs is the only lever short of changing rules_python.

Upgrading pip for the hermetic interpreter is not an alternative. The `python_register_toolchains()` CPython build ships its own pip (also 22.0.4), but `whl_library` puts the `pypi__*` repositories on `PYTHONPATH`, which precedes `site-packages` on `sys.path`, so `pypi__pip` shadows it and the interpreter's copy is never used. The failure tracebacks show this directly — they resolve `setuptools/installer.py` out of `external/pypi__setuptools`, not the interpreter's bundled setuptools.

The underlying cause is that **rules_python here is 0.9.0, from July 2022**, which is where the pip 22.0.4 pin comes from. Ray never declares rules_python; it arrives transitively via `ray_deps_build_all()` → `rules_foreign_cc_dependencies()`, pinned at `rules_foreign_cc/foreign_cc/repositories.bzl:85`. That is also a `maybe()`, so pinning rules_python explicitly before `ray_deps_build_all()` would take precedence and is the real fix: a modern rules_python pins pip 24.0 itself, making all five entries here unnecessary, and adds the `experimental_index_url` path that fetches wheels through Bazel's downloader — where `--experimental_repository_downloader_retries` and downloader URL rewriting would finally apply to them, and where pip's own retry schedule stops governing a wheel download at all, so the patch goes away with it.

That upgrade rewrites `whl_library`, repository naming and the generated `requirements.bzl`, and interacts with the `__PYTHON_RULES_MIGRATION_DO_NOT_USE_WILL_BREAK__` tags already on Ray's Python targets, so it needs to be its own change. The WORKSPACE comment records this and says to delete the block as part of it.

### Why retrying in place cannot work

pip retries down the connection it already has, so every attempt reaches the same CDN node. urllib3's status-retry path calls `response.drain_conn()` — whose docstring says *"Unread data in the HTTPResponse connection blocks the connection from being released back to the pool"* — then recurses into `self.urlopen` on the same `HTTPConnectionPool`, whose `_get_conn()` hands back the pooled connection. A 502 is a successful connect and a valid HTTP response, so nothing ever marks that socket bad.

That is fatal here, because the failure is a **single bad edge node** ([pypi/support#11876](https://github.com/pypi/support/issues/11876)) and Fastly draws the node per connection. 20 fresh connections to one address, reading Fastly's `x-served-by`:

| result | count | served by |
|---|---|---|
| `200` | 18 | `cache-pae2080021`, `…22`, `…23`, `…25`, `…26`, `…27` |
| `502` | 2 | `cache-pae2080020` — and only ever this node |

The failures are also missing the shield hop the successes carry — `cache-iad-kcgs7200167-IAD, cache-pae20800NN-PAE` against a bare `cache-pae2080020` — so that edge node is answering 502 without the request reaching the shield at all.

The node is therefore roughly a 1-in-10 draw, and the two behaviours diverge completely:

| | outcome when the bad node is drawn |
|---|---|
| keep-alive, as pip ships | the draw happens once and every retry reuses that socket, so **all 50 attempts fail** |
| redial per attempt | each attempt re-draws, so P(all 50 hit the bad node) ≈ 10⁻⁵⁰ |

That is the observed CI failure in one line: a ~10% unhealthy-node rate becomes a *certain* build failure purely because pip pins itself to the first draw. `Connection: close` turns it back into a coin flip that retrying can actually resolve.

**Why not pin a "good" address instead.** Address choice does matter — the addresses behind `files.pythonhosted.org` map to different POPs, and in the run above only `199.232.184.223` reached PAE, where the bad node lives, while the other five reached BFI and were clean on every request. So an `/etc/hosts` or `--add-host` pin would have dodged this particular incident. It is the more fragile lever, though: the DNS answer set rotates — three different sets inside an hour while investigating this (`146.75.40.223`, four `151.101.x.223` addresses, and `199.232.184.223`) — the address-to-POP mapping is Fastly's to change, and a pin has to be revisited whenever either moves. Redialling needs no knowledge of which address, POP or node is unhealthy.

urllib3's own address failover substitutes for neither: `create_connection` does iterate every `getaddrinfo` result, but only advances inside `except socket.error`, which a 502 never raises, so the first address in the list is used for every attempt.

### Why the retry schedule is patched, and why 50 retries

Raising `--retries` alone does not buy coverage, because pip's schedule is exponential and urllib3 caps a single sleep at 120s. Computed against the vendored urllib3 1.26.17:

```
retries=5:   [0, 0.5, 1, 2, 4]                       =    7.5s   (pip's default)
retries=9:   [0, 0.5, 1, 2, 4, 8, 16, 32, 64]        =  127.5s
retries=50:  ... saturating at 120s per sleep ...    = ~5050s    (~84 minutes)
```

So the count mostly buys longer sleeps rather than more coverage, and at 50 the schedule runs for ~84 minutes — longer than any fetch timeout can accommodate. The shape is wrong for this failure mode in both directions: the early retries are spent before an outage has plausibly cleared, and the late ones sleep in 2-minute blocks, so only a small part of the budget lands inside the recovery window.

Neither the shape nor `backoff_factor` is reachable from pip's command line. pip hardcodes `backoff_factor=0.25` where it builds its `urllib3.Retry` (`pip/_internal/network/session.py`), and the urllib3 it vendors is **1.26.17**, which implements exponential backoff only — `Retry.backoff_jitter` exists only in urllib3 2.x. `--retries` sets `total` and nothing else. Hence the patch, which subclasses `urllib3.Retry` and overrides `get_backoff_time()` to return `random.uniform(6.0, 12.0)` — equal jitter around a 12s nominal wait. It preserves urllib3's "no sleep before the first retry of a sequence" semantics, so a lone blip still recovers immediately at no cost.

That makes the retry count buy wall-clock linearly: **50 retries is 49 sleeps, so 294–588s, ~440s typical, bounded under 600s.**

The jitter is not cosmetic. Bazel fetches many wheels concurrently, each in its own pip process. On a fixed schedule they fail at the same instant, sleep for identical durations and re-converge on the origin together, so every retry round is a thundering herd against a service that is already degraded.

Measured against a local index that always returns 502, same interpreter, `--retries=4`, gaps between requests as observed server-side:

| | gap 1 | gap 2 | gap 3 | total |
|---|---|---|---|---|
| stock pip 24.0 | 0.51s | 1.00s | 2.01s | 3.5s |
| patched | 9.39s | 8.26s | 6.48s | 24.1s |

And simulated against pip's real vendored urllib3, 2000 draws per retry index: constant 6.00–12.00s at retry #2, #10 and #49 alike, where upstream gives 0.5s / 120s / 120s. All 2000 draws distinct. Over a full 50-retry budget, 500 trials span 408–480s (mean 441s) against upstream's flat 5048s.

### Why the timeout is raised

`timeout` is in `common_attrs`, which both `pip_repository_attrs` and `whl_library_attrs` merge in, and `pip_repository.bzl:156` forwards it explicitly (`# pass quiet and timeout args through to child repos.` → `"--timeout", str(rctx.attr.timeout)`). It is also passed as the `rctx.execute` timeout in `_whl_library_impl`, so it is a wall-clock bound on every generated `whl_library`'s pip invocation, not just on the parse step.

The retry budget alone reaches 588s at worst, and each of the 50 attempts can additionally burn pip's 15s socket timeout when the failure mode is a hang rather than a fast 502. So the 600s default cannot hold the schedule, and 1800s covers the full backoff, the per-attempt timeouts, and a slow transfer afterwards.

### Lock file impact

None in this PR. Compiling the same inputs under pip 22.0.4 / pip-tools 6.6.0 and pip 24.0 / pip-tools 7.4.1, through the same `piptools.scripts.compile:cli` entrypoint `rules_python`'s `pip_compile.py` uses, produces **byte-identical pins**. Only the generated header comment differs:

```diff
-# This file is autogenerated by pip-compile with python 3.10
-# To update, run:
+# This file is autogenerated by pip-compile with Python 3.10
+# by the following command:
```

so `release/requirements_py310.txt` will pick up a cosmetic header change the next time it is regenerated. `release/ray_release/byod/requirements_byod_3.1{1,2}.txt` carry similar headers but are not affected — the `.update` targets their headers reference no longer exist, and raydepsets generates from the `.in` files via `uv pip compile`. The retry patch cannot affect lock output at all: it changes only how long pip waits between failed requests.

### Scope

This is a mitigation, not a complete fix, and the remaining gaps are worth naming.

It now covers the two failure modes that have actually been breaking builds: a transient 502, retryable at all only since the pip 24.0 pin, and a single bad CDN node, escapable only since the redial. What it still does not cover:

- **A degraded POP, or a PyPI-wide incident.** Redialling re-draws from the same pool, so if the pool is the problem all you get is ~10 minutes of trying.
- **sdist-only locked packages**, whose `setup_requires` build dependencies are still fetched live from PyPI, unpinned and unhashed. Wheels-only locking would be the structural fix and is out of scope here.

Both premerge runs on this branch walked into real outages, which is where several of the measurements above came from. [72008](https://buildkite.com/ray-project/premerge/builds/72008) (nine exponential retries, ~2 minutes of budget) lost 33 jobs. [72031](https://buildkite.com/ray-project/premerge/builds/72031) (fifty jittered retries, ~7 minutes, but still retrying in place) lost fewer and died the same way, on `async_timeout` with `too many 502 error responses`. In both, the retries were demonstrably spent — urllib3 emits that message only when 502 is in the forcelist and the budget is exhausted, where pip 22.0.4 would have failed on the first response — and in 72031 the fetch sat silent for 410s beforehand, against a predicted 294–588s. 72031 is what prompted looking at *where* the retries were going rather than only how many there were.

### Tests run

| Command | Result |
|---|---|
| Patch applies `-p1` to pristine pip 24.0, `py_compile`, no line over 88 chars | passed — regenerated from pristine rather than hand-edited, so hunk offsets are honest |
| Patched pip vs stock pip 24.0 against a local always-502 index, `--retries=4` | gaps of 9.39/8.26/6.48s vs 0.51/1.00/2.01s — see table above |
| Patched pip against a local always-502 index speaking **HTTP/1.1 keep-alive**, `--retries=5` | every attempt from a new source port (6 of 6 distinct); jittered 6–12s spacing preserved. Before the redial change the same test reused one port for all attempts |
| 8 separate connections vs 1 kept-alive connection to a pinned Fastly address, reading `x-served-by` | 7 distinct edge nodes vs the same node 6 times — the node is drawn per connection |
| 20 fresh connections to `199.232.184.223`, across two packages | 18 × 200 from six distinct PAE nodes; 2 × 502, both from `cache-pae2080020` and nothing else |
| Six addresses × 6 requests each, pinned with `curl --resolve` | only `199.232.184.223` (PAE) returned any 502; the other five (BFI) were 6/6 clean, TLS valid throughout |
| `_ConstantJitteredRetry.get_backoff_time()` against pip's real vendored urllib3, 2000 draws at retry #2/#10/#49 | constant 6.00–12.00s at every index, all draws distinct; `Retry.sleep()` routes through the override |
| `bazel fetch @pypi__pip//:lib` | passed — fetched tree is pip 24.0 with `status_forcelist=[500, 502, 503, 520, 527]` and Bazel applied the patch. Run against the previous commit; since then only the patch's contents and filename changed, and the label form matches the other `//thirdparty/patches:` entries already in `bazel/ray_deps_setup.bzl` |
| `bazel sync --only=py_deps_py310` + regenerated `@py_deps_py310//:requirements.bzl` | `'extra_pip_args': ['--retries=50']`, `'environment': {'PIP_RETRIES': '50'}`, `'timeout': 1800`, splatted into every `whl_library` by `install_deps()` |
| `bazel fetch @py_deps_py310_pybuildkite//:pkg`, with the repo deleted first to force a real pip run (this is the repo that 502'd in premerge 72008) | passed — rebuilt from scratch through the patched pip with `--retries=50` |
| `bazel build //release:requirements_py310.update` | passed |
| `pip-compile` on identical inputs under both pip/pip-tools pairs | byte-identical pins; header comment differs as shown above |
| `bazel test //release:requirements_py310_test` | **fails**, pre-existing — see below |
| `pre-commit run --files WORKSPACE release/BUILD.bazel thirdparty/patches/pip-retry-backoff-and-redial.patch` | passed |
| `buildifier --mode=check --lint=warn WORKSPACE` | exit 0. Run directly because pre-commit's buildifier hook matches only `BUILD`/`BUILD.bazel`, so `WORKSPACE` is never linted by it |

`//release:requirements_py310_test` fails locally both before and after this change, because `release/requirements-doc.txt` pins `sphinx==8.2.3` and `sphinx_design==0.7.0`, both of which declare `Requires-Python: >=3.11`, while this lock targets Python 3.10. The checked-in lock still has the older `sphinx==7.3.7` / `sphinx-design==0.5.0`, so it is stale and cannot be regenerated at 3.10 under any pip-tools version. The reported symptom differs between versions only because pip-tools 6.6.0 uses pip's legacy resolver and 7.4.1 uses the backtracking resolver, so they name a different first-unsatisfiable pin (`sphinx_design==0.7.0` vs `sphinx==8.2.3`). This looks like a genuine pre-existing inconsistency worth fixing separately; it is out of scope here.

## AI assistance

This change was developed with AI assistance (Claude Code). The investigation — identifying the missing 502 in the forcelist, pinning the pip 24.0 boundary, auditing pip-tools' `pip._internal` usage to size the upgrade, establishing that the backoff shape is unreachable from pip's CLI, working out that retries were pinned to a single CDN node and measuring the node diversity that fixes it, and confirming lock output is unchanged — was AI-assisted and then verified with the commands above.

