### PR TITLE
[core][rdt] Make the NIXL agent configurable via env vars; default to 8 transfer threads

### DIFF
--- a/python/ray/_private/ray_constants.py
+++ b/python/ray/_private/ray_constants.py
@@ -651,5 +651,26 @@ NIXL_REMOTE_AGENT_CACHE_MAXSIZE = env_integer(
     "RAY_NIXL_REMOTE_AGENT_CACHE_MAXSIZE", 1000
 )
 
+# Comma-separated list of NIXL backends to create for the RDT NIXL agent,
+# e.g. "UCX" or "UCX,GDS". When empty (the default), the backend is
+# auto-detected from the hardware (LIBFABRIC on EFA, UCX otherwise).
+NIXL_AGENT_BACKENDS = os.environ.get("RAY_NIXL_BACKENDS", "")
+
+# Number of threads used by the NIXL agent for transfers. For the UCX backend,
+# each thread gets its own UCX worker (and its own set of QPs), which can
+# significantly improve transfer throughput on high-bandwidth NICs. Requires a
+# NIXL version whose nixl_agent_config supports `num_threads`; ignored (with a
+# warning) on older versions. Set to 0 to fall back to the NIXL default
+# (a single worker). Default: 8, since a single worker/QP cannot saturate
+# modern RDMA NICs.
+NIXL_AGENT_NUM_THREADS = env_integer("RAY_NIXL_NUM_THREADS", 8)
+
+# JSON dict mapping a NIXL backend name to its init params, e.g.
+# '{"UCX": {"num_workers": "8"}}'. Backends listed here are created via
+# nixl_agent.create_backend(backend, init_params) instead of through
+# nixl_agent_config, which also works on older NIXL versions that don't
+# support `num_threads` in nixl_agent_config.
+NIXL_AGENT_BACKEND_INIT_PARAMS = os.environ.get("RAY_NIXL_BACKEND_INIT_PARAMS", "")
+
 # Name of the environment variable for the Redis password.
 RAY_REDIS_PASSWORD_ENV = "RAY_REDIS_PASSWORD"

--- a/python/ray/experimental/rdt/nixl_tensor_transport.py
+++ b/python/ray/experimental/rdt/nixl_tensor_transport.py
@@ -1,5 +1,7 @@
 import functools
 import glob
+import inspect
+import json
 import logging
 import os
 import threading
@@ -11,6 +13,9 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 import ray
 from ray._private.ray_constants import (
+    NIXL_AGENT_BACKEND_INIT_PARAMS,
+    NIXL_AGENT_BACKENDS,
+    NIXL_AGENT_NUM_THREADS,
     NIXL_REMOTE_AGENT_CACHE_MAXSIZE,
 )
 from ray.experimental.rdt.nixl_memory_pool import MemoryPoolManager
@@ -25,6 +30,66 @@ if TYPE_CHECKING:
     import torch
 
 logger = logging.getLogger(__name__)
+
+
+def _parse_nixl_backend_init_params(raw: str) -> Dict[str, Dict[str, str]]:
+    """Parses the RAY_NIXL_BACKEND_INIT_PARAMS JSON string into a dict mapping
+    backend name to its init params. NIXL backend init params are string-to-string
+    maps, so all keys and values are stringified.
+    """
+    if not raw:
+        return {}
+    try:
+        params = json.loads(raw)
+        if not isinstance(params, dict) or not all(
+            init is None or isinstance(init, dict) for init in params.values()
+        ):
+            raise ValueError("expected a dict mapping backend name to a params dict")
+    except ValueError as e:
+        raise ValueError(
+            "Invalid RAY_NIXL_BACKEND_INIT_PARAMS value "
+            f"{raw!r}, expected a JSON dict like "
+            '\'{"UCX": {"num_workers": "8"}}\''
+        ) from e
+    return {
+        backend: {str(k): str(v) for k, v in (init or {}).items()}
+        for backend, init in params.items()
+    }
+
+
+def _build_nixl_agent_config_kwargs(
+    nixl_agent_config_cls,
+    backends: List[str],
+    num_threads: int,
+    backend_init_params: Dict[str, Dict[str, str]],
+) -> Dict[str, Any]:
+    """Builds the kwargs for nixl_agent_config from the Ray NIXL env vars.
+
+    Backends with custom init params are excluded from the config's backend
+    list since nixl_agent_config doesn't accept per-backend init params; they
+    are created separately via nixl_agent.create_backend().
+
+    Config options unsupported by the installed NIXL version are dropped with
+    a warning instead of failing agent creation.
+    """
+    config_kwargs: Dict[str, Any] = {
+        "backends": [b for b in backends if b not in backend_init_params]
+    }
+    if num_threads > 0:
+        config_kwargs["num_threads"] = num_threads
+    supported_params = inspect.signature(nixl_agent_config_cls.__init__).parameters
+    unsupported = {k for k in config_kwargs if k not in supported_params}
+    if unsupported:
+        logger.warning(
+            "The installed NIXL version does not support the agent config "
+            f"option(s) {sorted(unsupported)}; ignoring them. Consider "
+            "upgrading NIXL, or pass equivalent backend init params via "
+            "RAY_NIXL_BACKEND_INIT_PARAMS."
+        )
+        config_kwargs = {
+            k: v for k, v in config_kwargs.items() if k in supported_params
+        }
+    return config_kwargs
 
 
 @functools.lru_cache(maxsize=1)
@@ -225,11 +290,26 @@ class NixlTensorTransport(TensorTransportManager):
         """
         return "LIBFABRIC" if _is_efa_available() else "UCX"
 
-    def _make_nixl_agent(self, backend: str):
-        """Creates a NIXL agent configured with the given backend."""
+    def _make_nixl_agent(self, backends: List[str]):
+        """Creates a NIXL agent configured with the given backends.
+
+        The agent can be tuned via environment variables:
+
+        - RAY_NIXL_NUM_THREADS: number of threads the agent uses for
+          transfers. For UCX each thread gets its own worker/QPs, which can
+          significantly improve throughput.
+        - RAY_NIXL_BACKEND_INIT_PARAMS: JSON dict mapping a backend name to
+          its init params, e.g. '{"UCX": {"num_workers": "8"}}'.
+        """
         from nixl._api import nixl_agent, nixl_agent_config
 
-        agent_config = nixl_agent_config(backends=[backend])
+        backend_init_params = _parse_nixl_backend_init_params(
+            NIXL_AGENT_BACKEND_INIT_PARAMS
+        )
+        config_kwargs = _build_nixl_agent_config_kwargs(
+            nixl_agent_config, backends, NIXL_AGENT_NUM_THREADS, backend_init_params
+        )
+        agent_config = nixl_agent_config(**config_kwargs)
         ctx = ray.get_runtime_context()
         actor_id = ctx.get_actor_id()
         if actor_id is None:
@@ -237,7 +317,13 @@ class NixlTensorTransport(TensorTransportManager):
             import uuid
 
             actor_id = f"RAY-DRIVER-{uuid.uuid4()}"
-        return nixl_agent(actor_id, agent_config)
+        agent = nixl_agent(actor_id, agent_config)
+        # Backends with custom init params are created here since
+        # nixl_agent_config doesn't accept per-backend init params.
+        for backend in backends:
+            if backend in backend_init_params:
+                agent.create_backend(backend, backend_init_params[backend])
+        return agent
 
     def get_nixl_agent(self):
         """Returns the NIXL agent, building it once on first use."""
@@ -246,11 +332,19 @@ class NixlTensorTransport(TensorTransportManager):
         return self._nixl_agent
 
     def _init_nixl_agent(self):
-        """Builds the NIXL agent for the selected backend."""
-        backend = self.select_backend()
-        agent = self._make_nixl_agent(backend)
-        self._backend = backend
-        logger.info("Using NIXL backend: %s", backend)
+        """Builds the NIXL agent for the configured or auto-detected backends.
+
+        RAY_NIXL_BACKENDS (comma-separated) explicitly selects the backends;
+        when unset, the backend is auto-detected via select_backend().
+        """
+        backends = [b.strip() for b in NIXL_AGENT_BACKENDS.split(",") if b.strip()]
+        if not backends:
+            backends = [self.select_backend()]
+        agent = self._make_nixl_agent(backends)
+        # The primary backend, used for backend-specific error guidance in
+        # _add_tensor_descs.
+        self._backend = backends[0]
+        logger.info("Using NIXL backend(s): %s", ", ".join(backends))
         return agent
 
     def actor_has_tensor_transport(self, actor: "ray.actor.ActorHandle") -> bool:

--- a/python/ray/tests/rdt/test_nixl_backend_selection.py
+++ b/python/ray/tests/rdt/test_nixl_backend_selection.py
@@ -1,9 +1,9 @@
 """CPU-only unit tests for NIXL backend selection.
 
-These tests cover the backend-selection logic in
+These tests cover the backend-selection and agent-configuration logic in
 ``ray.experimental.rdt.nixl_tensor_transport`` without requiring a GPU, NIXL, or
 EFA hardware. They exercise the hardware-to-backend mapping (host vs. container
-EFA layouts and non-EFA RDMA).
+EFA layouts and non-EFA RDMA) and the RAY_NIXL_* env var plumbing.
 """
 
 import sys
@@ -13,8 +13,10 @@ import pytest
 from ray.experimental.rdt import nixl_tensor_transport as ntt
 from ray.experimental.rdt.nixl_tensor_transport import (
     NixlTensorTransport,
+    _build_nixl_agent_config_kwargs,
     _is_efa_available,
     _nixl_transport_available_in_process,
+    _parse_nixl_backend_init_params,
 )
 
 
@@ -89,6 +91,120 @@ def test_nixl_transport_available_in_process_returns_false_on_init_failure(
 
     monkeypatch.setattr(NixlTensorTransport, "get_nixl_agent", fail_init)
     assert _nixl_transport_available_in_process() is False
+
+
+def test_parse_nixl_backend_init_params():
+    """Init params are parsed from JSON and stringified for NIXL."""
+    assert _parse_nixl_backend_init_params("") == {}
+    assert _parse_nixl_backend_init_params('{"UCX": {"num_workers": 8}}') == {
+        "UCX": {"num_workers": "8"}
+    }
+    assert _parse_nixl_backend_init_params('{"UCX": null}') == {"UCX": {}}
+    for bad in ("not-json", '{"UCX": "num_workers=8"}', "[1, 2]"):
+        with pytest.raises(ValueError, match="RAY_NIXL_BACKEND_INIT_PARAMS"):
+            _parse_nixl_backend_init_params(bad)
+
+
+def test_build_nixl_agent_config_kwargs():
+    """Config kwargs honor num_threads and drop options unsupported by the
+    installed NIXL version instead of failing agent creation."""
+
+    # A config class supporting num_threads (recent NIXL).
+    class NewConfig:
+        def __init__(self, backends=None, num_threads=0):
+            pass
+
+    assert _build_nixl_agent_config_kwargs(NewConfig, ["UCX"], 8, {}) == {
+        "backends": ["UCX"],
+        "num_threads": 8,
+    }
+    # num_threads == 0 means using the NIXL default.
+    assert _build_nixl_agent_config_kwargs(NewConfig, ["UCX"], 0, {}) == {
+        "backends": ["UCX"]
+    }
+    # Backends with custom init params are created via create_backend instead.
+    assert _build_nixl_agent_config_kwargs(
+        NewConfig, ["UCX", "GDS"], 0, {"UCX": {"num_workers": "8"}}
+    ) == {"backends": ["GDS"]}
+
+    # A config class without num_threads (older NIXL): the option is dropped.
+    class OldConfig:
+        def __init__(self, backends=None):
+            pass
+
+    assert _build_nixl_agent_config_kwargs(OldConfig, ["UCX"], 8, {}) == {
+        "backends": ["UCX"]
+    }
+
+
+def test_backends_env_override(monkeypatch):
+    """RAY_NIXL_BACKENDS overrides hardware auto-detection; the first backend
+    becomes the primary one used for error guidance."""
+    monkeypatch.setattr(ntt, "NIXL_AGENT_BACKENDS", "GDS, UCX")
+    captured = {}
+
+    def fake_make(self, backends):
+        captured["backends"] = backends
+        return object()
+
+    monkeypatch.setattr(NixlTensorTransport, "_make_nixl_agent", fake_make)
+    transport = NixlTensorTransport()
+    transport.get_nixl_agent()
+    assert captured["backends"] == ["GDS", "UCX"]
+    assert transport._backend == "GDS"
+
+
+def test_backends_default_to_auto_detection(monkeypatch):
+    """When RAY_NIXL_BACKENDS is unset, select_backend() decides."""
+    monkeypatch.setattr(ntt, "NIXL_AGENT_BACKENDS", "")
+    monkeypatch.setattr(
+        NixlTensorTransport, "select_backend", lambda self: "LIBFABRIC"
+    )
+    captured = {}
+
+    def fake_make(self, backends):
+        captured["backends"] = backends
+        return object()
+
+    monkeypatch.setattr(NixlTensorTransport, "_make_nixl_agent", fake_make)
+    transport = NixlTensorTransport()
+    transport.get_nixl_agent()
+    assert captured["backends"] == ["LIBFABRIC"]
+    assert transport._backend == "LIBFABRIC"
+
+
+def test_make_nixl_agent_with_backend_init_params(monkeypatch):
+    """Backends with init params are excluded from nixl_agent_config and
+    created via create_backend() with stringified params."""
+
+    class FakeConfig:
+        def __init__(self, backends=None, num_threads=0):
+            self.backends = backends
+            self.num_threads = num_threads
+
+    class FakeAgent:
+        def __init__(self, name, config):
+            self.name = name
+            self.config = config
+            self.created_backends = {}
+
+        def create_backend(self, backend, init_params):
+            self.created_backends[backend] = init_params
+
+    fake_api = type(
+        "fake_api", (), {"nixl_agent": FakeAgent, "nixl_agent_config": FakeConfig}
+    )
+    monkeypatch.setitem(sys.modules, "nixl._api", fake_api)
+    monkeypatch.setitem(sys.modules, "nixl", type("nixl", (), {"_api": fake_api}))
+    monkeypatch.setattr(
+        ntt, "NIXL_AGENT_BACKEND_INIT_PARAMS", '{"UCX": {"num_workers": 8}}'
+    )
+    monkeypatch.setattr(ntt, "NIXL_AGENT_NUM_THREADS", 4)
+
+    agent = NixlTensorTransport()._make_nixl_agent(["UCX", "GDS"])
+    assert agent.config.backends == ["GDS"]
+    assert agent.config.num_threads == 4
+    assert agent.created_backends == {"UCX": {"num_workers": "8"}}
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

The RDT NIXL agent is created with a hard-coded `nixl_agent_config`: a single backend and no thread/worker tuning. With NIXL's defaults the UCX backend runs a single worker (`num_workers=1`), i.e. a single set of QPs per agent. A single QP cannot saturate modern high-bandwidth RDMA NICs, so RDT transfer throughput stays far below line rate. Our benchmarks confirmed that raising the worker/thread count per agent (as e.g. Dynamo does with `nixl_agent_config(num_threads=8)`) recovers most of the missing bandwidth.

This PR makes the agent configurable through three environment variables:

- **`RAY_NIXL_BACKENDS`**: comma-separated list of NIXL backends to create, e.g. `UCX` or `UCX,GDS`. When empty (default), the existing hardware auto-detection is kept (LIBFABRIC on EFA, UCX otherwise). The first backend is treated as the primary one for backend-specific error guidance in `_add_tensor_descs`.
- **`RAY_NIXL_NUM_THREADS`**: number of transfer threads for the agent. For UCX each thread gets its own UCX worker and thus its own set of QPs. Defaults to 8 because the previous effective default of a single worker/QP measured very poor throughput on high-bandwidth NICs. Set to 0 to fall back to the NIXL default (single worker). On NIXL versions whose `nixl_agent_config` does not support `num_threads`, the option is dropped with a warning instead of failing agent creation.
- **`RAY_NIXL_BACKEND_INIT_PARAMS`**: JSON dict mapping a backend name to its init params, e.g. `{"UCX": {"num_workers": "8"}}`. Backends listed here are excluded from `nixl_agent_config` and created via `nixl_agent.create_backend(backend, init_params)` after agent creation, since `nixl_agent_config` does not accept per-backend init params. This is also the escape hatch for older NIXL versions without `num_threads` support.

## Related issues

N/A

## Additional information

Implementation notes:
- `_make_nixl_agent` now takes a list of backends; `_init_nixl_agent` resolves the list from `RAY_NIXL_BACKENDS` or falls back to `select_backend()`.
- `_build_nixl_agent_config_kwargs` uses `inspect.signature` to detect which `nixl_agent_config` options the installed NIXL version supports and drops unsupported ones with a warning, keeping agent creation working across NIXL versions.
- Invalid `RAY_NIXL_BACKEND_INIT_PARAMS` values raise a `ValueError` describing the expected format.
- Init param keys/values are stringified to match NIXL's string-to-string init param maps.

Tests: added CPU-only unit tests (no GPU/NIXL required) to `test_nixl_backend_selection.py` covering init param JSON parsing and stringification, config kwarg building including the old-NIXL fallback, `RAY_NIXL_BACKENDS` override vs. hardware auto-detection, and the `create_backend` init-params path via a fake nixl module.

Note for reviewers: defaulting `RAY_NIXL_NUM_THREADS` to 8 changes the out-of-the-box behavior for all RDT users. If a conservative default is preferred, we are happy to change the default to 0 (NIXL default) and keep this purely opt-in.
