### PR TITLE
[Data] Fix three inaccurate claims on the join and save docs

### DIFF
--- a/doc/source/data/joining-data.rst
+++ b/doc/source/data/joining-data.rst
@@ -58,9 +58,7 @@ Joins are generally memory-intensive operations that require accurate memory acc
 Ray Data provides the following levers to allow tuning the performance of joins for your workload:
 
 -   `num_partitions`: (required) specifies number of partitions both incoming datasets will be hash-partitioned into. Check out :ref:`configuring number of partitions <joins_configuring_num_partitions>` section for guidance on how to tune this up.
--   `partition_size_hint`: (optional) Hint to joining operator about the estimated avg expected size of the individual partition (in bytes). If not specified, defaults to DataContext.target_max_block_size (128Mb by default). Expect this parameter to be deprecated in 2.58.
-    -   Note that, `num_partitions * partition_size_hint` should ideally be approximating actual dataset size, ie `partition_size_hint` could be estimated as dataset size divided by `num_partitions` (assuming relatively evenly sized partitions)
-    -   However, in cases when dataset partitioning is expected to be heavily skewed `partition_size_hint` should approximate largest partition to prevent Out-of-Memory (OOM) errors
+-   `partition_size_hint`: (**deprecated**) Hint to joining operator about the estimated avg expected size of the individual partition (in bytes). Ray Data ignores this parameter and a future release removes it. Passing a value emits a `DeprecationWarning`. The join path sizes reduce-task memory from observed partition sizes instead of from a hint.
 
 .. _joins_configuring_num_partitions:
 
@@ -81,7 +79,7 @@ Configuring number of Aggregators
 
 Following are important considerations for successfully configuring number of aggregators in your pool:
 
-- Defaults to 64 or `num_partitions` (in cases when there are less than 64 partitions)
+- Defaults to the smallest of `num_partitions`, the number of CPUs in the cluster, and `DataContext.max_hash_shuffle_aggregators` (128 by default)
 - Individual Aggregators might be assigned to handle more than one partition (partitions are evenly split in round-robin fashion among the aggregators)
 - Aggregators are stateful components that hold the state (partitions) during shuffling **in memory**
 

--- a/doc/source/data/saving-data.rst
+++ b/doc/source/data/saving-data.rst
@@ -197,7 +197,7 @@ number of files & their sizes (since every block could potentially carry the row
 
     ds = ray.data.from_pandas(df)
     # Key-based repartitioning requires a hash-shuffle strategy such as Shuffle v2.
-    DataContext.shuffle_strategy=ShuffleStrategy.SHUFFLE_V2
+    DataContext.get_current().shuffle_strategy = ShuffleStrategy.SHUFFLE_V2
 
     # ── Partitioned write ──────────────────────────────────────────────────────
     # 1. Repartition so all rows with the same (city, year) land in the same


### PR DESCRIPTION
## Summary

Three claims on the Ray Data join and save pages don't match the code. This PR corrects only those claims, deliberately leaving the surrounding prose alone so the diff is small enough to review as a technical question rather than a wording one.

Each correction is cited below. I don't own Ray Data, so please check the reasoning rather than the phrasing.

## 1. `saving-data.rst` sets the shuffle strategy on the class, not the context

```python
DataContext.shuffle_strategy=ShuffleStrategy.SHUFFLE_V2   # before
DataContext.get_current().shuffle_strategy = ShuffleStrategy.SHUFFLE_V2   # after
```

`shuffle_strategy` is a `property` with a setter (`python/ray/data/context.py`, the `@property` at ~L1246 and `@shuffle_strategy.setter` at ~L1258). Assigning to it on the class object rebinds the class attribute over the descriptor instead of invoking the setter. Two consequences: the example never actually selects the strategy it says it's selecting, and `shuffle_strategy` stops working for every `DataContext` instance in that process.

This is a `testcode` block, so it runs in CI. Note that because the assignment never took effect, the block has so far only ever exercised the default `HASH_SHUFFLE`. With the fix it genuinely runs `SHUFFLE_V2` for the first time. I don't have a Ray build locally, so **please confirm that job passes** rather than taking my word for it. If `SHUFFLE_V2` isn't ready to be load-bearing in a doctest, setting `HASH_SHUFFLE` on `get_current()` would fix the descriptor bug without that exposure.

@gemini-code-assist flagged this on two separate passes (#65372); the value got updated to `SHUFFLE_V2` but the receiver didn't.

## 2. `partition_size_hint` is documented as a live tuning parameter

The page described it as `(optional)`, gave it a default of `DataContext.target_max_block_size`, and offered two bullets on how to size it for skew. But `Dataset.join` documents it as "**Deprecated** and ignored ... This parameter has no effect and will be removed in a future release" (`python/ray/data/dataset.py` ~L3601), and passing a value emits a `DeprecationWarning` (~L3712).

So the guidance told readers how to tune something inert. I removed the sizing advice rather than rewriting it, since there's nothing to tune.

The page also said "Expect this parameter to be deprecated in 2.58." That deprecation has already landed, so the sentence was predicting the past.

## 3. The aggregator pool doesn't default to 64

The page said "Defaults to 64 or `num_partitions` (in cases when there are less than 64 partitions)."

From `_derive_max_shuffle_aggregators` and its caller in `python/ray/data/_internal/execution/operators/hash_shuffle.py` (~L485 and ~L591):

```
num_aggregators = min(target_num_partitions, max_shuffle_aggregators)
max_shuffle_aggregators = min(ceil(total_cluster_cpu),
                              max_hash_shuffle_aggregators or DEFAULT_MAX_HASH_SHUFFLE_AGGREGATORS)
```

`DEFAULT_MAX_HASH_SHUFFLE_AGGREGATORS` is 128 (`context.py` ~L128). So the cap is 128 rather than 64, and there's a cluster-CPU bound the page never mentioned.

**One thing worth a maintainer's eye:** the comment on the `max_hash_shuffle_aggregators` field (`context.py` ~L886) says the unset default is the smaller of "Total # of CPUs available in the cluster * 2" and 128. The code has no `* 2`. I documented the code, not the comment, but one of the two is stale and I can't tell which is intended.

## Out of scope

These pages have wider style and prose issues, plus a genuine RST rendering bug in the join-type lists. Those are handled separately in #65374 so this PR stays reviewable as a technical correction. #65374 touches the same region of `joining-data.rst`, so whichever merges second needs a trivial rebase.
