### PR TITLE
[docs] Capitalize the term after a colon label prefix in headings

### DIFF
--- a/doc/source/cluster/configure-manage-dashboard.md
+++ b/doc/source/cluster/configure-manage-dashboard.md
@@ -256,7 +256,7 @@ When the Grafana instance requires user authentication, the following settings h
 
 #### Troubleshooting
 
-##### Dashboard message: either Prometheus or Grafana server is not detected
+##### Dashboard message: Either Prometheus or Grafana server is not detected
 If you have followed the instructions above to set up everything, run the connection checks below in your browser:
 * check Head Node connection to Prometheus server: add `api/prometheus_health` to the end of Ray Dashboard URL (for example: http://127.0.0.1:8265/api/prometheus_health)and visit it.
 * check Head Node connection to Grafana server: add `api/grafana_health` to the end of Ray Dashboard URL (for example: http://127.0.0.1:8265/api/grafana_health) and visit it.

--- a/doc/source/ray-contribute/writing-style.md
+++ b/doc/source/ray-contribute/writing-style.md
@@ -192,6 +192,14 @@ Use sentence case for every heading. Capitalize only the first word and proper n
 - Use: "Configure the runtime environment"
 - Not: "Configure the Runtime Environment"
 
+When a heading opens with a short label and a colon, capitalize the first term after the colon. The label is a prefix, not the start of the sentence, so the title that follows it begins like a title. Sentence case still governs the rest of the heading.
+
+- Use: "Example: Creating a custom mean aggregator"
+- Not: "Example: creating a custom mean aggregator"
+- Not: "Example: Creating a Custom Mean Aggregator"
+
+The same applies to "Step 2:", "Advanced:", "Guide:", and any similar prefix. The one exception is a code identifier, which keeps its real casing: "Pod configuration: headGroupSpec and workerGroupSpecs" is correct, because `headGroupSpec` is an API field name. Never capitalize an identifier to satisfy this rule.
+
 Write conceptual headings as questions and task headings as imperatives. Keep them short.
 
 - Conceptual: "What is a placement group?"

--- a/doc/source/ray-contribute/writing-style.md
+++ b/doc/source/ray-contribute/writing-style.md
@@ -194,9 +194,9 @@ Use sentence case for every heading. Capitalize only the first word and proper n
 
 When a heading opens with a short label and a colon, capitalize the first term after the colon. The label is a prefix, not the start of the sentence, so the title that follows it begins like a title. Sentence case still governs the rest of the heading.
 
-- Use: "Example: Creating a custom mean aggregator"
-- Not: "Example: creating a custom mean aggregator"
-- Not: "Example: Creating a Custom Mean Aggregator"
+- Use: "Example: Create a custom mean aggregator"
+- Not: "Example: create a custom mean aggregator"
+- Not: "Example: Create a Custom Mean Aggregator"
 
 The same applies to "Step 2:", "Advanced:", "Guide:", and any similar prefix. The one exception is a code identifier, which keeps its real casing: "Pod configuration: headGroupSpec and workerGroupSpecs" is correct, because `headGroupSpec` is an API field name. Never capitalize an identifier to satisfy this rule.
 

--- a/doc/source/ray-core/internals/rpc-fault-tolerance.rst
+++ b/doc/source/ray-core/internals/rpc-fault-tolerance.rst
@@ -52,8 +52,8 @@ which maps lease IDs to workers. If the new lease request is already present in 
 ``leased_workers`` map, the system knows this lease request is a retry and responds with the 
 already leased worker address.
 
-Hidden problem: long-polling RPCs
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Hidden problem: Long-polling RPCs
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Network transient errors can happen at any time. For most RPCs, they finish in one I/O context 
 execution, so guarding against whether the request or response failed is sufficient. 

--- a/doc/source/ray-core/runtime_env_auth.md
+++ b/doc/source/ray-core/runtime_env_auth.md
@@ -42,7 +42,7 @@ In this example, `personal_access_token` is a secret credential that authenticat
 
 In short, your remote URI is not treated as a secret, so it should not contain secret info. Instead, use a `netrc` file.
 
-## Running on VMs: the netrc File
+## Running on VMs: The netrc file
 
 The [netrc file](https://www.gnu.org/software/inetutils/manual/html_node/The-_002enetrc-file.html) contains credentials that Ray uses to automatically log into remote servers. Set your credentials in this file instead of in the remote URI:
 

--- a/doc/source/serve/production-guide/fault-tolerance.md
+++ b/doc/source/serve/production-guide/fault-tolerance.md
@@ -21,7 +21,7 @@ This section discusses concepts from:
 :::
 
 (serve-e2e-ft-guide)=
-## Guide: end-to-end fault tolerance for your Serve app
+## Guide: End-to-end fault tolerance for your Serve app
 
 Serve provides some [fault tolerance](serve-ft-detail) features out of the box. Two options to get end-to-end fault tolerance are the following:
 * tune these features and run Serve on top of [KubeRay]

--- a/doc/source/train/user-guides/asynchronous-validation.rst
+++ b/doc/source/train/user-guides/asynchronous-validation.rst
@@ -119,7 +119,7 @@ You should use ``map_batches`` if:
   aggregation manually using low-level collective operations or rely on third-party libraries
   such as `torchmetrics <https://lightning.ai/docs/torchmetrics/stable>`_.
 
-Example: validation with Ray Train TorchTrainer
+Example: Validation with Ray Train TorchTrainer
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Here is a ``validation_fn`` that uses a ``TorchTrainer`` to calculate average cross entropy
@@ -137,7 +137,7 @@ loss on a validation set. Note the following about this example:
     :start-after: __validation_fn_torch_trainer_start__
     :end-before: __validation_fn_torch_trainer_end__
 
-Example: validation with Ray Data map_batches
+Example: Validation with Ray Data map_batches
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The following is a ``validation_fn`` that uses :func:`ray.data.Dataset.map_batches` to


### PR DESCRIPTION
## Summary

Adds one rule to the writing style guide: when a heading opens with a short label and a colon, capitalize the first term after the colon. Fixes the six headings under `doc/source` that don't follow it.

```
Use:  Example: Creating a custom mean aggregator
Not:  Example: creating a custom mean aggregator
Not:  Example: Creating a Custom Mean Aggregator
```

The label before the colon is a prefix, not the start of the sentence, so the title that follows begins like a title. Sentence case still governs the rest of the heading, so this isn't a return to title case.

## This codifies existing practice

I audited every heading under `doc/source` before writing the rule, rather than asserting a preference:

| Colon-prefixed headings | Capitalized after the colon | Not capitalized |
|---|---|---|
| 708 | 664 | 6 |

(The raw scan reported 44 non-conforming, but 38 were `kubectl describe` output inside literal blocks that my heuristic mistook for RST headings. The six below are the real ones.)

So the convention is already what Ray docs overwhelmingly do. This writes it down and cleans up the stragglers.

## Headings fixed

- `train/user-guides/asynchronous-validation.rst` — "Example: validation with Ray Train TorchTrainer" and "Example: validation with Ray Data map_batches"
- `ray-core/internals/rpc-fault-tolerance.rst` — "Hidden problem: long-polling RPCs"
- `ray-core/runtime_env_auth.md` — "Running on VMs: the netrc File" (also lowercases the stray "File")
- `serve/production-guide/fault-tolerance.md` — "Guide: end-to-end fault tolerance for your Serve app"
- `cluster/configure-manage-dashboard.md` — "Dashboard message: either Prometheus or Grafana server is not detected"

## The identifier carve-out

The rule explicitly exempts code identifiers. `## Pod configuration: headGroupSpec and workerGroupSpecs` in `cluster/kubernetes/user-guides/config.md` is correct as written and is deliberately not touched here, because `headGroupSpec` is a real API field name. Without the carve-out this rule invites someone to "fix" it into `HeadGroupSpec`, which would be wrong.

## No anchor churn

Every change here is capitalization only, and both MyST and Sphinx lowercase heading text when generating anchor slugs. `#guide-end-to-end-fault-tolerance-for-your-serve-app` is the slug before and after. No inbound deep link breaks, and the one heading carrying an explicit label (`(serve-e2e-ft-guide)=`) keeps it.

## Why it's worth a rule

A naive sentence-case pass actively breaks these headings — it lowercases through the colon and makes the page read worse. That happened in #65374 and had to be reverted. Since `Google.Headings` is disabled repo-wide, heading case is a human check with no tool behind it, so the guide is the only place this can live.
