### PR TITLE
[doc] Add a standard deprecation notice template

### DIFF
--- a/doc/source/_includes/README.md
+++ b/doc/source/_includes/README.md
@@ -1,0 +1,28 @@
+# Shared documentation fragments
+
+Files here are spliced into pages with the `include` directive. They aren't pages
+themselves, and `exclude_patterns` in `conf.py` keeps Sphinx from building them.
+
+````markdown
+```{include} /_includes/_deprecation.md
+```
+````
+
+An included file renders through the parent page's renderer, so substitutions the
+parent defines in its front matter resolve inside the fragment. Front matter in the
+fragment itself is stripped and ignored, so a fragment can't carry its own defaults.
+Put defaults in the substitution value in `conf.py` instead.
+
+## Deprecation notices
+
+`_deprecation.md` and `_deprecation_planned.md` render a standard deprecation notice
+as an admonition. They wrap the `deprecation_notice` and `deprecation_planned`
+substitutions defined in `myst_substitutions` in `conf.py`, which you can also
+reference inline when the notice belongs inside a sentence or list item.
+
+The wording says "will" because a committed deprecation timeline is a real future
+event. Keeping the sentence here rather than in the pages also keeps it outside the
+paths Vale lints, so the blanket `Google.Will` rule can keep guarding ordinary prose.
+
+For the values these fragments expect and when to use each one, see the deprecation
+notices section of `../ray-contribute/writing-style.md`.

--- a/doc/source/_includes/_deprecation.md
+++ b/doc/source/_includes/_deprecation.md
@@ -1,0 +1,3 @@
+:::{warning}
+{{ deprecation_notice }}
+:::

--- a/doc/source/_includes/_deprecation_planned.md
+++ b/doc/source/_includes/_deprecation_planned.md
@@ -1,0 +1,3 @@
+:::{note}
+{{ deprecation_planned }}
+:::

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -266,9 +266,34 @@ myst_enable_extensions = [
     "colon_fence",
     "smartquotes",
     "replacements",
+    "substitution",
 ]
 
 myst_heading_anchors = 4
+
+# Reusable prose fragments for deprecation notices.
+#
+# A deprecation timeline that engineering and product have publicly committed to is a
+# real future event, so these fragments say "will". Keeping the wording here rather than
+# in the pages does three things: every notice reads the same, the phrasing changes in
+# one place, and the sentence sits outside the paths Vale lints, so the blanket
+# `Google.Will` rule can keep guarding ordinary prose.
+#
+# Pages supply the values through front matter. See doc/source/_includes/README.md.
+myst_substitutions = {
+    "deprecation_planned": (
+        "Ray will deprecate {{ deprecated_feature }} in Ray {{ deprecated_in }}."
+        '{{ " Use " + deprecation_replacement + " instead."'
+        ' if deprecation_replacement is defined else "" }}'
+    ),
+    "deprecation_notice": (
+        "Ray deprecated {{ deprecated_feature }} in Ray {{ deprecated_in }} and will "
+        'remove it in {{ ("Ray " + removed_in) if removed_in is defined'
+        ' else "a future release" }}.'
+        '{{ " Use " + deprecation_replacement + " instead."'
+        ' if deprecation_replacement is defined else "" }}'
+    ),
+}
 
 # Add these for attachment handling
 nb_render_key_pairs = {

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -425,6 +425,10 @@ autogen_files = AUTOGEN_FILES
 exclude_patterns = [
     # Committed intersphinx inventory snapshots + refresh tooling, not docs.
     "_intersphinx/**",
+    # Prose fragments spliced into pages with `include`, not pages themselves.
+    # They reference substitutions the including page supplies, so building them
+    # standalone raises an undefined-substitution error and a missing-toctree warning.
+    "_includes/**",
     "templates/*",
     "cluster/running-applications/doc/ray.*",
     "data/api/ray.data.*.rst",

--- a/doc/source/ray-contribute/writing-style.md
+++ b/doc/source/ray-contribute/writing-style.md
@@ -41,6 +41,8 @@ Describe current behavior in the present tense. Avoid "will" for things that are
 - Use: "Ray Serve routes the request to a replica."
 - Not: "Ray Serve will route the request to a replica."
 
+A committed deprecation timeline is a real future event, not a description of current behavior, so it takes "will". Write those notices with the shared fragments in [Deprecation notices](#deprecation-notices) instead of rephrasing around the word.
+
 ### Address the reader as "you"
 
 Write in second person. Don't write about "the user" or "developers" in the abstract.
@@ -230,6 +232,48 @@ Ray caches the object in the local object store.
 ````
 
 Choose the level by severity. Use `tip` for optional advice, `note` for supporting information, `caution` for something that needs care, and `warning` for an action that can lose data or break a workload. Convert a standalone caveat or limitation into the matching admonition so it stands out instead of hiding in a paragraph.
+
+### Deprecation notices
+
+Announce a deprecation with a shared fragment rather than your own wording. Ray defines the sentences once in `myst_substitutions` in `doc/source/conf.py`, so every notice reads the same and a change to the phrasing reaches every page at once.
+
+Two fragments cover the lifecycle:
+
+- `deprecation_planned` announces a deprecation that hasn't happened yet. The feature still works today.
+- `deprecation_notice` announces a deprecation that's already in effect and names the release that removes the feature.
+
+Set the values in the page's front matter, then reference the fragment:
+
+````markdown
+---
+myst:
+  substitutions:
+    deprecated_feature: "`partition_size_hint`"
+    deprecated_in: "2.58"
+---
+
+- `partition_size_hint`: Hint to the joining operator about partition size. {{ deprecation_planned }}
+````
+
+That renders as "Ray will deprecate `partition_size_hint` in Ray 2.58."
+
+The fragments take four values. `deprecated_feature` and `deprecated_in` are required, and the build fails if you leave either one out:
+
+| Value | Required | Meaning |
+|---|---|---|
+| `deprecated_feature` | Yes | The API, parameter, or setting you're deprecating. Wrap it in backticks. |
+| `deprecated_in` | Yes | The Ray version that deprecates the feature. |
+| `removed_in` | No | The Ray version that removes the feature. Without it, the notice reads "a future release." |
+| `deprecation_replacement` | No | What the reader should use instead. Adds a "Use X instead." sentence. |
+
+For a standalone notice rather than a sentence inside a list or paragraph, include the matching admonition. `_deprecation.md` renders a `warning` and `_deprecation_planned.md` renders a `note`, which matches the severity of a deprecation that's already in effect against one that's still ahead:
+
+````markdown
+```{include} /_includes/_deprecation.md
+```
+````
+
+Front matter substitutions apply to a whole page, so a page carries one set of values. When you need to document two separately versioned deprecations on the same page, write the second one out in full and leave a comment explaining why it doesn't use the fragment.
 
 ### Code blocks
 


### PR DESCRIPTION
## Why this change

Ray's style guide says to avoid "will" for things that are always true. `Google.Will` enforces that, but it's a bare `existence` check on the token at `level: error`, so it also flags a deprecation timeline that engineering and product have publicly committed to. That's a real future event, not a description of current behavior.

The result is authors rephrasing around the word to get a green build. In #65372 a reviewer's suggested wording for a `partition_size_hint` deprecation couldn't be taken for exactly this reason, and what shipped instead was "Expect this parameter to be deprecated in 2.58."

This defines the notice wording once in `myst_substitutions` and references it from pages, so every deprecation notice reads the same and the phrasing changes in one place. Because the sentence then lives outside the paths Vale lints, the blanket rule can keep guarding ordinary prose without an exemption.

## What's here

Two fragments cover the lifecycle:

- `deprecation_planned` announces a deprecation that hasn't happened yet. The feature still works.
- `deprecation_notice` announces one already in effect and names the release that removes the feature.

Both work inline, which matters because the common real case is a sentence inside a parameter bullet rather than a standalone admonition. `_includes/_deprecation.md` and `_includes/_deprecation_planned.md` wrap the same fragments in a `warning` and a `note` for standalone use.

Pages supply the values through front matter:

```markdown
---
myst:
  substitutions:
    deprecated_feature: "`partition_size_hint`"
    deprecated_in: "2.58"
---

- `partition_size_hint`: Hint to the joining operator. {{ deprecation_planned }}
```

`deprecated_feature` and `deprecated_in` are required and the build fails without them. `removed_in` and `deprecation_replacement` are optional.

This also enables the MyST `substitution` extension, which wasn't previously on.

## Testing

Built a minimal Sphinx project against the pinned `myst-parser==5.1.0` with `-W`, covering every combination:

| Case | Result |
| --- | --- |
| Substitutions resolve inside an included fragment | Pass |
| Inline and block forms both render | Pass |
| Optional replacement present and absent | Pass |
| `removed_in` absent | Degrades to "a future release" |
| Required value missing | `myst.substitution` warning, build fails under `-W` |

Checked the blast radius of enabling `substitution` repo-wide: the only four `{{ }}` occurrences in `doc/source` Markdown all sit inside code fences, and no notebooks contain any, so nothing else changes rendering.

`pre-commit run` passes, but as a **no-op**. The top-level `exclude` in `.pre-commit-config.yaml` is `doc/source/(?!data/.*[.](md|rst)$)`, so no configured hook matches any file in this PR. I'm not claiming lint coverage it didn't provide.

I have not run a full `make -C doc html`. Flagging that explicitly so a reviewer can weigh it; happy to run it if you'd like that before merge.

## Deliberately not in scope

- **Narrowing `Google.Will` itself.** Arguably the rule is just miscalibrated relative to the style guide, and that's worth a separate look. This PR doesn't touch the rule.
- **Converting existing notices.** `doc/source/data/joining-data.rst` can't adopt this, because rST substitutions are global-only and can't be parameterized. Call sites pick this up as pages move to MyST.

## Known limitation

Front matter substitutions are page-scoped, so this supports one notice per page. A page documenting two separately versioned deprecations writes the second out in full. That's documented in the style guide section. A custom Sphinx directive is the escape hatch if such pages turn up, but that seemed like over-engineering for a case that doesn't exist yet.

## Note on AI assistance

I used AI assistance for this change. I've reviewed every changed line, and the myst-parser behavior it depends on is verified by the build matrix above rather than asserted. Checked open PRs for overlapping work on `_includes`, `conf.py` substitutions, and deprecation wording before starting; found none.
