### PR TITLE
[Train] Deflaky test_experiment_restore v2

### DIFF
--- a/python/ray/air/tests/_test_experiment_restore_run.py
+++ b/python/ray/air/tests/_test_experiment_restore_run.py
@@ -2,6 +2,7 @@ import collections
 import json
 import os
 import random
+import signal
 import time
 from pathlib import Path
 from typing import Dict, List, Optional
@@ -158,6 +159,19 @@ def trainer(experiment_path: str, run_config: train.RunConfig) -> train.Result:
     return result
 
 
+def ignore_late_interrupts():
+    """Ignore SIGUSR1 once the run is done, so that a late interrupt can't kill us.
+
+    The driver test signals this script at a random time, which can land after the
+    run has already finished, while the interpreter is shutting down. Tune's SIGUSR1
+    handler is a Python-level handler, and CPython resets those to `SIG_DFL` during
+    interpreter finalization (`_PySignal_Fini`) back to a termination. This would
+    result in a nonzero return code despite completing successfully.
+    """
+    if hasattr(signal, "SIGUSR1"):
+        signal.signal(signal.SIGUSR1, signal.SIG_IGN)
+
+
 if __name__ == "__main__":
     experiment_path = os.path.join(STORAGE_PATH, EXP_NAME)
 
@@ -172,8 +186,10 @@ if __name__ == "__main__":
 
     if RUNNER_TYPE == "tuner":
         tuner(experiment_path, run_config)
+        ignore_late_interrupts()
     elif RUNNER_TYPE == "trainer":
         trainer(experiment_path, run_config)
+        ignore_late_interrupts()
     else:
         raise NotImplementedError(
             "`RUNNER_TYPE` environment var must be one of ['tuner', 'trainer']"

--- a/python/ray/air/tests/test_experiment_restore.py
+++ b/python/ray/air/tests/test_experiment_restore.py
@@ -53,14 +53,14 @@ def test_experiment_restore(tmp_path, runner_type):
         - Each round of 2 trials should take 4 seconds
         - Without any interrupts/restoration:
             - Minimum runtime: 4 rounds * 4 seconds / round = 16 seconds
-        - The test will stop the script with a SIGINT at a random time between
+        - The test will stop the script with a SIGUSR1 at a random time between
         6-10 iterations each restore.
 
     - For Trainer.restore:
         - 1 trial with 4 workers
         - Each iteration takes 0.5 seconds
         - Runs for 32 iterations --> Minimum runtime = 16 seconds
-        - The test will stop the script with a SIGINT at a random time between
+        - The test will stop the script with a SIGUSR1 at a random time between
         6-10 iterations after each restore.
 
     Requirements:
@@ -156,7 +156,7 @@ def test_experiment_restore(tmp_path, runner_type):
             total_runtime += time.monotonic() - start_time
 
             if run.poll() is None:
-                # Send "SIGINT" to stop the run
+                # Send "SIGUSR1" to stop the run
                 _print_message(f"Sending SIGUSR1 to run #{run_iter} w/ PID = {run.pid}")
                 run.send_signal(signal.SIGUSR1)
                 interrupted = True

--- a/python/ray/air/tests/test_experiment_restore.py
+++ b/python/ray/air/tests/test_experiment_restore.py
@@ -114,6 +114,7 @@ def test_experiment_restore(tmp_path, runner_type):
             "NUM_TRIALS": str(num_trials),
             "MAX_CONCURRENT_TRIALS": str(max_concurrent),
             "CSV_DATA_FILE": csv_file,
+            "TUNE_WARN_EXCESSIVE_EXPERIMENT_CHECKPOINT_SYNC_THRESHOLD_S": "0",
         }
     )
 


### PR DESCRIPTION
## Description
https://github.com/ray-project/ray/pull/65212 first deflaked this test, however, it now failing after Ray Tune / Train complete and the next process starts. The challenge is that the test is chaotic, possibly failing at any point, not just during Training but afterwards as well. 
Reviewing flaky logs, all cases had `Return code = -10` which means that the failure occurs outside of the Ray process. Therefore, to fix the issue, I've added a `signal.signal(signal.SIGUSR1, signal.SIG_IGN)` to ignore when the testing process tries to kill the training process after the training is complete. 