### PR TITLE
[ci] Slow dependabot churn: quarterly cadence, cooldown, grouped PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,43 +1,70 @@
 version: 2
 updates:
-  # ML Requirements.
+  # ML Requirements — the only directory with scheduled version updates.
+  # Deliberately low-churn: quarterly checks (roughly the SPEC 0 release
+  # cadence, https://scientific-python.org/specs/spec-0000/), a cooldown so we
+  # never pick up a release until it has baked, and a single grouped PR per
+  # run instead of one PR per package. Dependabot updates can still be
+  # manually triggered via GitHub at any time.
   - package-ecosystem: "pip"
-    # If we want to add more requirements here (Core, Serve, etc.), then we should
-    # make additional subdirectories for each one.
     directory: "/python/requirements/ml"
     schedule:
-      # Automatic upgrade checks Saturday at 12 AM.
-      # Dependabot updates can still be manually triggered via Github at any time.
-      interval: "weekly"
-      day: "saturday"
-      # 12 AM
+      interval: "quarterly"
       time: "00:00"
-      # Use Pacific Standard Time.
       timezone: "America/Los_Angeles"
+    # Minimum age of a release before dependabot proposes it (days, max 90).
+    cooldown:
+      default-days: 30
+      semver-major-days: 90
+      semver-minor-days: 60
+      semver-patch-days: 14
+    groups:
+      ml-requirements:
+        applies-to: version-updates
+        patterns:
+          - "*"
+      # Batch advisory-driven PRs for this directory into one PR as well.
+      ml-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
     commit-message:
       prefix: "[air]"
       include: "scope"
-    # Only 5 upgrade PRs open at a time.
+    # Reviewer routing comes from CODEOWNERS; the old `reviewers` key was
+    # removed from the dependabot config schema in 2025.
     open-pull-requests-limit: 5
-    reviewers:
-      - "ray-project/ray-tune"
-  # Data Requirements.
+
+  # The entries below do NOT enable scheduled version updates
+  # (open-pull-requests-limit: 0). They exist only so that security updates —
+  # which ignore schedules and open a PR per advisory by default — get
+  # grouped into one PR per directory instead of flooding the repo.
   - package-ecosystem: "pip"
-    directory: "/python/requirements/data_processing"
+    directories:
+      - "/python"
+      - "/python/requirements"
+      - "/python/requirements/serve"
+      - "/release"
+      - "/doc"
+      - "/ci/raydepsets/tests/test_data"
+      - "/doc/source/templates/05_dreambooth_finetuning/dreambooth"
+      - "/doc/source/templates/testing/docker/03_serving_stable_diffusion"
     schedule:
-      # Automatic upgrade checks Saturday at 12 AM.
-      # Dependabot updates can still be manually triggered via Github at any time.
-      interval: "weekly"
-      day: "saturday"
-      # 12 AM
-      time: "00:00"
-      # Use Pacific Standard Time.
-      timezone: "America/Los_Angeles"
-    commit-message:
-      prefix: "[data]"
-      include: "scope"
-    # Only 5 upgrade PRs open at a time.
-    open-pull-requests-limit: 5
-    reviewers:
-      - "scv119"
-      - "clarkzinzow"
+      interval: "quarterly"
+    open-pull-requests-limit: 0
+    groups:
+      pip-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
+
+  - package-ecosystem: "npm"
+    directory: "/python/ray/dashboard/client"
+    schedule:
+      interval: "quarterly"
+    open-pull-requests-limit: 0
+    groups:
+      dashboard-security:
+        applies-to: security-updates
+        patterns:
+          - "*"


### PR DESCRIPTION
## Why are these changes needed?

The repo currently has ~97 open dependabot PRs (99 created since May 2026 alone) — almost all of them singleton advisory-driven security bumps that nobody merges, plus weekly `[air]` version-update PRs. This PR reworks `.github/dependabot.yml` to cut that churn:

- **Quarterly version updates with cooldown + grouping** for `/python/requirements/ml` (the only directory with scheduled version updates): `interval: quarterly` roughly matches the [SPEC 0](https://scientific-python.org/specs/spec-0000/) support cadence; the `cooldown` block (30 default / 90 major / 60 minor / 14 patch days) keeps dependabot from proposing releases before they've baked; and a `groups` block batches each run into a single `[air]` PR instead of up to five singletons.
- **Grouped security updates** for the directories that generate the advisory-PR flood (`/python`, `/python/requirements`, `/python/requirements/serve`, `/release`, `/doc`, `/ci/raydepsets/tests/test_data`, the two template docker dirs, and the dashboard npm client). These entries set `open-pull-requests-limit: 0`, so they enable **no** new version updates — their only effect is that future security PRs arrive as one grouped PR per directory instead of one PR per CVE.
- **Drop the dead Data entry**: `/python/requirements/data_processing` no longer exists (its successor `python/requirements/data` only holds pyarrow pin-variant files we don't want auto-bumped), so the entry has been silently doing nothing.
- **Remove the `reviewers` key**: GitHub removed it from the dependabot config schema in 2025 (it is ignored; review routing is CODEOWNERS-based). The schema validator rejects the file while it's present.

Notes:
- Grouping only affects future security PRs; the existing open backlog needs a one-time sweep separately.
- Grouped PRs still land on `dependabot/pip/**` branches, so the recompile-deplocks workflow (`.github/workflows/dependabot_recompile_deps.yml`) keeps working unchanged — one grouped PR now means one recompile run per batch.

**Duplicate check:** no open PR modifies `.github/dependabot.yml` (searched open PRs for "dependabot.yml" / "dependabot config"; only dependabot's own bump PRs match).

**Testing:**
```
uvx check-jsonschema --builtin-schema vendor.dependabot .github/dependabot.yml
# ok -- validation done
```
Pre-commit hooks (yaml/whitespace/semgrep) passed on commit.

AI assistance (Claude Code) was used for this change; I've reviewed every line.

## Related issue number

N/A

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR. (pre-commit hooks ran on commit)
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/. N/A
- [x] I've added any new APIs to the API Reference. N/A
- [x] I've made sure the tests are passing. Config validated against the official dependabot JSON schema (no runtime tests apply).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
