### PR TITLE
[core] Add public actor_id property to ActorHandle

### DIFF
--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -2283,6 +2283,10 @@ class ActorHandle(Generic[T]):
     cloudpickle).
 
     Attributes:
+        actor_id: The actor's ID in hex format. This is only set when the actor
+            class does not define a method named ``actor_id``; otherwise that
+            method takes precedence and the ID remains available via
+            ``_actor_id``.
         _ray_actor_language: The actor language.
         _ray_actor_id: Actor ID.
         _ray_enable_task_events: The default value of whether task events is
@@ -2463,6 +2467,14 @@ class ActorHandle(Generic[T]):
                     method_name
                 ),
             )
+
+        # Expose the actor ID as a public attribute (see #32638). This is set as
+        # an instance attribute rather than a class-level property so that an
+        # actor defining its own `actor_id` method is never shadowed: in that
+        # case the attribute is not set, normal lookup fails, and `__getattr__`
+        # resolves the name to the user's ActorMethod as it always has.
+        if "actor_id" not in self._method_shells:
+            self.actor_id = self._ray_actor_id.hex()
 
     def __del__(self):
         # Weak references don't count towards the distributed ref count, so no
@@ -2703,15 +2715,6 @@ class ActorHandle(Generic[T]):
     @property
     def _actor_id(self):
         return self._ray_actor_id
-
-    @property
-    def actor_id(self) -> str:
-        """Return the hex ID of the actor.
-
-        Returns:
-            The actor ID of this actor handle, in hex format.
-        """
-        return self._ray_actor_id.hex()
 
     def _get_local_state(self):
         """Get the local actor state.

--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -2704,6 +2704,15 @@ class ActorHandle(Generic[T]):
     def _actor_id(self):
         return self._ray_actor_id
 
+    @property
+    def actor_id(self) -> str:
+        """Return the hex ID of the actor.
+
+        Returns:
+            The actor ID of this actor handle, in hex format.
+        """
+        return self._ray_actor_id.hex()
+
     def _get_local_state(self):
         """Get the local actor state.
 

--- a/python/ray/tests/test_actor.py
+++ b/python/ray/tests/test_actor.py
@@ -368,6 +368,23 @@ def test_actor_handle_actor_id(ray_start_regular_shared):
     assert isinstance(foo.actor_id, str)
     assert foo.actor_id == foo._actor_id.hex()
 
+    # The ID survives serialization of the handle.
+    assert pickle.loads(pickle.dumps(foo)).actor_id == foo.actor_id
+
+
+def test_actor_handle_actor_id_does_not_shadow_method(ray_start_regular_shared):
+    """An actor defining `actor_id` keeps its own method (see #32638)."""
+
+    @ray.remote
+    class Bar:
+        def actor_id(self):
+            return "user-defined"
+
+    bar = Bar.remote()
+    assert ray.get(bar.actor_id.remote()) == "user-defined"
+    # The ID is still reachable through the private attribute.
+    assert isinstance(bar._actor_id.hex(), str)
+
 
 def test_actor_exit_from_task(ray_start_regular_shared):
     @ray.remote

--- a/python/ray/tests/test_actor.py
+++ b/python/ray/tests/test_actor.py
@@ -359,6 +359,16 @@ def test_actor_class_name(ray_start_regular):
     assert "test_actor" in actor_class_info["module"]
 
 
+def test_actor_handle_actor_id(ray_start_regular_shared):
+    @ray.remote
+    class Foo:
+        pass
+
+    foo = Foo.remote()
+    assert isinstance(foo.actor_id, str)
+    assert foo.actor_id == foo._actor_id.hex()
+
+
 def test_actor_exit_from_task(ray_start_regular_shared):
     @ray.remote
     class Actor:


### PR DESCRIPTION
Promote ActorHandle._actor_id to a public API. Previously the only way to get an actor's ID from a handle was the private, undocumented _actor_id property, which returns a raw ActorID object rather than the hex string used elsewhere (e.g. State API, ray.runtime_context). This adds ActorHandle.actor_id, returning the hex-encoded actor ID, matching the existing convention (e.g. get_actor_id() in runtime_context.py).

Closes #32638 