### PR TITLE
[serve] Deflake test_recursive_cancellation_during_execution

### DIFF
--- a/python/ray/serve/tests/test_handle_cancellation.py
+++ b/python/ray/serve/tests/test_handle_cancellation.py
@@ -372,14 +372,11 @@ def test_recursive_cancellation_during_assignment(serve_instance):
     # Counter is only 1.
     tlog("Sending two requests to Ingress.")
     resp1 = h.remote()
+    with pytest.raises(TimeoutError):
+        resp1.result(timeout_s=0.5)
     resp2 = h.remote()
-
-    # Each Ingress call awaits the signal only after sending its downstream
-    # request, so three waiters (both Ingress calls plus the single admitted
-    # Counter call) means resp2's Counter request is pending assignment.
-    wait_for_condition(
-        lambda: ray.get(signal.cur_num_waiters.remote()) == 3, timeout=20
-    )
+    with pytest.raises(TimeoutError):
+        resp2.result(timeout_s=0.5)
 
     # Cancel second request, which should be pending assignment.
     tlog("Canceling second request.")

--- a/python/ray/serve/tests/test_handle_cancellation.py
+++ b/python/ray/serve/tests/test_handle_cancellation.py
@@ -297,11 +297,12 @@ def test_out_of_band_task_is_not_cancelled(serve_instance):
 def test_recursive_cancellation_during_execution(serve_instance):
     inner_signal_actor = SignalActor.remote()
     outer_signal_actor = SignalActor.remote()
+    inner_running_signal_actor = SignalActor.remote()
 
     @serve.deployment
     async def inner():
         async with send_signal_on_cancellation(inner_signal_actor):
-            pass
+            await inner_running_signal_actor.send.remote()
 
     @serve.deployment
     class Ingress:
@@ -319,9 +320,13 @@ def test_recursive_cancellation_during_execution(serve_instance):
     with pytest.raises(TimeoutError):
         resp.result(timeout_s=0.5)
 
+    # Cancelling while `inner` is still pending assignment tears down its
+    # assignment task rather than its execution, so it would never signal.
+    ray.get(inner_running_signal_actor.wait.remote(), timeout=20)
+
     resp.cancel()
-    ray.get(inner_signal_actor.wait.remote(), timeout=10)
-    ray.get(outer_signal_actor.wait.remote(), timeout=10)
+    ray.get(inner_signal_actor.wait.remote(), timeout=20)
+    ray.get(outer_signal_actor.wait.remote(), timeout=20)
 
 
 @pytest.mark.skipif(
@@ -367,11 +372,14 @@ def test_recursive_cancellation_during_assignment(serve_instance):
     # Counter is only 1.
     tlog("Sending two requests to Ingress.")
     resp1 = h.remote()
-    with pytest.raises(TimeoutError):
-        resp1.result(timeout_s=0.5)
     resp2 = h.remote()
-    with pytest.raises(TimeoutError):
-        resp2.result(timeout_s=0.5)
+
+    # Each Ingress call awaits the signal only after sending its downstream
+    # request, so three waiters (both Ingress calls plus the single admitted
+    # Counter call) means resp2's Counter request is pending assignment.
+    wait_for_condition(
+        lambda: ray.get(signal.cur_num_waiters.remote()) == 3, timeout=20
+    )
 
     # Cancel second request, which should be pending assignment.
     tlog("Canceling second request.")


### PR DESCRIPTION
This PR addresses a flake in `test_recursive_cancellation_during_execution` which synchronizes on a fixed 0.5s sleep instead of on the state it requires.

`Replica._on_request_cancelled` only cancels child requests that are pending assignment, so the test needs `inner` to be executing when the cancel lands. If `inner` is still pending assignment, its assignment task is torn down, so it never enters `send_signal_on_cancellation`, causing the test to fail with `GetTimeoutError`. Holding the only slot of `inner` to delay its assignment shows the margin is under half a second, the test passes with a 0.1s delay and fails at 0.45s, 1.0s and 2.0s.

The fix is to have `inner` signal from inside its cancel-catching block and wait for that before cancelling, the same method that `test_cancel_sync_handle_call_during_execution` already uses. Its three `ray.get` waits also go from 10s to 20s.

Test-only change.