### PR TITLE
[Data] Fix Dataset.summary() crash on boolean columns

### DIFF
--- a/python/ray/data/stats.py
+++ b/python/ray/data/stats.py
@@ -233,6 +233,37 @@ def _numerical_aggregators(column: str) -> List[AggregateFnV2]:
     ]
 
 
+def _boolean_aggregators(column: str) -> List[AggregateFnV2]:
+    """Generate default metrics for boolean columns.
+
+    This function returns a list of aggregators that compute the following metrics:
+    - count
+    - mean (the fraction of true values)
+    - min
+    - max
+    - missing_value_percentage
+    - approximate_top_k (true/false value counts)
+
+    ``Std``, ``ApproximateQuantile``, and ``ZeroPercentage`` are omitted: the
+    PyArrow kernels they rely on (e.g. ``subtract``) are not implemented for
+    boolean arrays.
+
+    Args:
+        column: The name of the boolean column to compute metrics for.
+
+    Returns:
+        A list of AggregateFnV2 instances that can be used with Dataset.aggregate()
+    """
+    return [
+        Count(on=column, ignore_nulls=False),
+        Mean(on=column, ignore_nulls=True),
+        Min(on=column, ignore_nulls=True),
+        Max(on=column, ignore_nulls=True),
+        MissingValuePercentage(on=column),
+        ApproximateTopK(on=column, k=2),
+    ]
+
+
 def _temporal_aggregators(column: str) -> List[AggregateFnV2]:
     """Generate default metrics for temporal columns.
 
@@ -310,7 +341,7 @@ def _default_dtype_aggregators() -> Dict[
         DataType.uint64(): _numerical_aggregators,
         DataType.float32(): _numerical_aggregators,
         DataType.float64(): _numerical_aggregators,
-        DataType.bool(): _numerical_aggregators,
+        DataType.bool(): _boolean_aggregators,
         # String and binary types
         DataType.string(): _basic_aggregators,
         DataType.binary(): _basic_aggregators,
@@ -337,6 +368,8 @@ def _get_fallback_aggregators(column: str, dtype: "DataType") -> List[AggregateF
         # Check for null type first
         if dtype.is_arrow_type() and pa.types.is_null(dtype._physical_dtype):
             return [Count(on=column, ignore_nulls=False)]
+        elif dtype.is_boolean_type():
+            return _boolean_aggregators(column)
         elif dtype.is_numerical_type():
             return _numerical_aggregators(column)
         elif dtype.is_temporal_type():

--- a/python/ray/data/tests/test_dataset_stats.py
+++ b/python/ray/data/tests/test_dataset_stats.py
@@ -21,6 +21,7 @@ from ray.data.datatype import DataType
 from ray.data.stats import (
     DatasetSummary,
     _basic_aggregators,
+    _boolean_aggregators,
     _default_dtype_aggregators,
     _dtype_aggregators_for_dataset,
     _numerical_aggregators,
@@ -49,14 +50,14 @@ class TestDtypeAggregatorsForDataset:
                 {"num": "DataType(arrow:int64)", "str": "DataType(arrow:string)"},
                 11,  # 1 numerical * 8 + 1 string * 3
             ),
-            # Boolean treated as numerical
+            # Boolean uses boolean aggregators
             (
                 [{"bool_col": True, "int_col": 1}],
                 {
                     "bool_col": "DataType(arrow:bool)",
                     "int_col": "DataType(arrow:int64)",
                 },
-                16,  # 2 columns * 8 aggregators each
+                14,  # 1 boolean * 6 + 1 numerical * 8
             ),
         ],
     )
@@ -194,6 +195,21 @@ class TestIndividualAggregatorFunctions:
             ZeroPercentage,
         ]
 
+    def test_boolean_aggregators(self):
+        """Test _boolean_aggregators function."""
+        aggs = _boolean_aggregators("test_col")
+
+        assert len(aggs) == 6
+        assert all(agg.get_target_column() == "test_col" for agg in aggs)
+        assert [type(agg) for agg in aggs] == [
+            Count,
+            Mean,
+            Min,
+            Max,
+            MissingValuePercentage,
+            ApproximateTopK,
+        ]
+
     def test_temporal_aggregators(self):
         """Test _temporal_aggregators function."""
         aggs = _temporal_aggregators("test_col")
@@ -260,13 +276,11 @@ class TestDefaultDtypeAggregators:
                     Mean,
                     Min,
                     Max,
-                    Std,
-                    ApproximateQuantile,
                     MissingValuePercentage,
-                    ZeroPercentage,
+                    ApproximateTopK,
                 ],
                 False,
-            ),  # Numerical
+            ),  # Boolean
             (
                 DataType.string,
                 [Count, MissingValuePercentage, ApproximateTopK],
@@ -360,6 +374,32 @@ class TestDatasetSummary:
         )
 
         assert rows_same(actual_subset, expected)
+
+    def test_summary_boolean_column(self):
+        """Boolean columns must not crash summary() (issue #62235).
+
+        Std/ApproximateQuantile/ZeroPercentage rely on PyArrow kernels (e.g.
+        ``subtract``) that are not implemented for boolean arrays.
+        """
+        ds = ray.data.from_items(
+            [
+                {"flag": True, "age": 25},
+                {"flag": False, "age": 30},
+                {"flag": True, "age": 35},
+                {"flag": None, "age": 40},
+            ]
+        )
+
+        summary = ds.summary()
+        actual = summary.to_pandas()
+        assert "flag" in actual.columns
+
+        stats = dict(zip(actual["statistic"], actual["flag"]))
+        assert stats["count"] == 4
+        assert stats["mean"] == pytest.approx(2 / 3)
+        assert stats["min"] is False
+        assert stats["max"] is True
+        assert stats["missing_pct"] == pytest.approx(25.0)
 
     def test_summary_with_column_filter(self):
         """Test summary with specific columns."""


### PR DESCRIPTION
## Why are these changes needed?

`Dataset.summary()` crashes with `ArrowNotImplementedError` on any boolean column:

```python
import ray
ds = ray.data.from_items([{"b": True}, {"b": False}, {"b": True}])
ds.summary()
# pyarrow.lib.ArrowNotImplementedError:
#   Function 'subtract' has no kernel matching input types (bool, double)
```

`DataType.bool()` was mapped to `_numerical_aggregators`, but `Std`, `ApproximateQuantile`, and `ZeroPercentage` rely on PyArrow kernels with no boolean implementation. I probed each default aggregator individually against a bool column on master: `Count`, `Mean`, `Min`, `Max`, `MissingValuePercentage`, and `ApproximateTopK` all work; `Std` and `ZeroPercentage` raise `ArrowNotImplementedError` (and a boolean quantile is not meaningful).

This PR gives boolean columns a dedicated `_boolean_aggregators` set — count, mean (= fraction of true values), min, max, missing-value percentage, and approximate top-k with k=2 (true/false counts) — and routes boolean dtypes to it in the heuristic fallback path as well.

## Related issue number

Fixes #62235

## Checks

- [x] I've signed off every commit (DCO).
- [x] Formatting checked with the repo-pinned `black==22.10.0`.
- [x] Testing strategy:
  - Added `test_summary_boolean_column` (end-to-end regression: `summary()` on a bool column with nulls, asserting count/mean/min/max/missing_pct values).
  - Added `test_boolean_aggregators` unit test; updated the two existing expectations that encoded "boolean is numerical".
  - `pytest python/ray/data/tests/test_dataset_stats.py` → 39 passed (run locally against master via Ray nightly wheel + `setup-dev.py` symlinks).

### Notes for reviewers / AI-assistance disclosure

- This PR was prepared with AI assistance; I have reviewed every changed line and run the tests above locally.
- Duplicate-work check: no open PR references #62235. @jiangxt2 commented intent to work on this on Jul 2 with the same root-cause diagnosis, but no PR has appeared in the ~7 weeks since; happy to defer or hand off if one is in progress.
