### PR TITLE
[dashboard] GPU metric reporting for unified memory architectures

### DIFF
--- a/python/ray/dashboard/client/src/pages/node/AcceleratorMemoryColumn.tsx
+++ b/python/ray/dashboard/client/src/pages/node/AcceleratorMemoryColumn.tsx
@@ -107,11 +107,18 @@ const getMemDisplayRatioNoPercent = (used: number, total: number) => {
   return `${memoryConverter(usedBytes)}/${memoryConverter(totalBytes)}`;
 };
 
+// Accelerators may report memory as null (GPUs with no separate memory pool, such
+// as unified-memory parts) or NaN (TPU generations that omit the absolute
+// metrics). Both mean "unknown" and must not be rendered as a quantity.
+const isKnownMemoryValue = (
+  value: number | null | undefined,
+): value is number => value !== null && value !== undefined && !isNaN(value);
+
 type AcceleratorMemoryEntryProps = {
   gpuName: string;
   slot: number;
-  utilization: number;
-  total: number;
+  utilization: number | null;
+  total: number | null;
   utilPercent?: number;
 };
 
@@ -122,14 +129,44 @@ const AcceleratorMemoryEntry: React.FC<AcceleratorMemoryEntryProps> = ({
   total,
   utilPercent,
 }) => {
-  let ratioStr = getMemDisplayRatioNoPercent(utilization, total);
+  let used = utilization;
+  let capacity = total;
+  let ratioStr: string | undefined;
+
   // When the utilization percentage is present but absolute usage is missing
   // (as is the case on some TPU generations), spoof the bar with just a percentage.
-  if (utilPercent !== undefined && (total === 0 || isNaN(total))) {
+  if (
+    utilPercent !== undefined &&
+    (capacity === 0 || !isKnownMemoryValue(capacity))
+  ) {
     ratioStr = `${utilPercent.toFixed(1)}%`;
-    utilization = utilPercent;
-    total = 100;
+    used = utilPercent;
+    capacity = 100;
   }
+
+  let body: React.ReactNode;
+  if (isKnownMemoryValue(used) && isKnownMemoryValue(capacity)) {
+    body = (
+      <PercentageBar num={used} total={capacity}>
+        {ratioStr ?? getMemDisplayRatioNoPercent(used, capacity)}
+      </PercentageBar>
+    );
+  } else if (isKnownMemoryValue(used)) {
+    // Usage is known but capacity is not, so there is no ratio to draw. Show the
+    // absolute usage rather than discarding a real measurement.
+    body = (
+      <Typography component="span" variant="inherit">
+        {memoryConverter(used * 1024 * 1024)}
+      </Typography>
+    );
+  } else {
+    body = (
+      <Typography color="textSecondary" component="span" variant="inherit">
+        N/A
+      </Typography>
+    );
+  }
+
   return (
     <Box display="flex" flexWrap="nowrap" style={{ minWidth: GRAM_COL_WIDTH }}>
       <Tooltip title={gpuName}>
@@ -137,9 +174,7 @@ const AcceleratorMemoryEntry: React.FC<AcceleratorMemoryEntryProps> = ({
           <RightPaddedTypography variant="body1">
             [{slot}]:{" "}
           </RightPaddedTypography>
-          <PercentageBar num={utilization} total={total}>
-            {ratioStr}
-          </PercentageBar>
+          {body}
         </Box>
       </Tooltip>
     </Box>

--- a/python/ray/dashboard/client/src/type/node.d.ts
+++ b/python/ray/dashboard/client/src/type/node.d.ts
@@ -66,8 +66,10 @@ export type GPUStats = {
   index: number;
   name: string;
   utilizationGpu?: number;
-  memoryUsed: number;
-  memoryTotal: number;
+  /** null when the device reports no separate GPU memory pool (unknown, not zero) */
+  memoryUsed: number | null;
+  /** null when the device reports no separate GPU memory pool (unknown, not zero) */
+  memoryTotal: number | null;
   processesPids?: ProcessGPUUsage[];
   /** Current power draw in milliwatts (e.g. NVIDIA, AMD) */
   powerMw?: number;

--- a/python/ray/dashboard/client/src/util/accelerator.test.ts
+++ b/python/ray/dashboard/client/src/util/accelerator.test.ts
@@ -61,6 +61,28 @@ describe("normalizeAccelerators", () => {
     });
   });
 
+  it("preserves null memory metrics for gpus", () => {
+    // Devices with no separate GPU memory pool (e.g. unified-memory parts such
+    // as GB10) report null. The GPU must survive normalization so the rest of
+    // its stats are still shown.
+    const gpus: GPUStats[] = [
+      {
+        uuid: "gpu-1",
+        name: "GB10",
+        index: 0,
+        utilizationGpu: 30,
+        memoryUsed: null,
+        memoryTotal: null,
+      },
+    ];
+
+    const result = normalizeAccelerators(gpus, undefined);
+    expect(result).toHaveLength(1);
+    expect(result[0].utilization).toEqual(30);
+    expect(result[0].memoryUsed).toBeNull();
+    expect(result[0].memoryTotal).toBeNull();
+  });
+
   it("does not filter out tpus with <= 0 memoryTotal", () => {
     const tpus: TPUStats[] = [
       {

--- a/python/ray/dashboard/client/src/util/accelerator.ts
+++ b/python/ray/dashboard/client/src/util/accelerator.ts
@@ -11,8 +11,10 @@ export type UnifiedAcceleratorStat = {
   index: number;
   type: "GPU" | "TPU";
   utilization?: number;
-  memoryUsed: number;
-  memoryTotal: number;
+  // null for GPUs that report no separate memory pool; NaN for TPU generations
+  // that omit the absolute memory metrics. Both mean "unknown", not zero.
+  memoryUsed: number | null;
+  memoryTotal: number | null;
   processesPids?: UnifiedProcessAcceleratorUsage[];
   rawGpu?: GPUStats;
   rawTpu?: TPUStats;

--- a/python/ray/dashboard/modules/reporter/gpu_providers.py
+++ b/python/ray/dashboard/modules/reporter/gpu_providers.py
@@ -51,8 +51,10 @@ class GpuUtilizationInfo(TypedDict):
     name: str
     uuid: str
     utilization_gpu: Optional[Percentage]
-    memory_used: Megabytes
-    memory_total: Megabytes
+    # None when the device does not report a separate GPU memory pool
+    # (e.g. unified-memory parts such as GB10). This means "unknown", not zero.
+    memory_used: Optional[Megabytes]
+    memory_total: Optional[Megabytes]
     processes_pids: Optional[Dict[int, ProcessGPUInfo]]
     # Optional: power in milliwatts, temperature in Celsius (e.g. from NVIDIA/AMD)
     power_mw: NotRequired[Optional[int]]
@@ -237,7 +239,15 @@ class NvidiaGpuProvider(GpuProvider):
     ) -> Optional[GpuUtilizationInfo]:
         """Get utilization info for a single MIG device."""
         try:
-            memory_info = self._pynvml.nvmlDeviceGetMemoryInfo(mig_handle)
+            memory_info = None
+            try:
+                memory_info = self._pynvml.nvmlDeviceGetMemoryInfo(mig_handle)
+            except self._pynvml.NVMLError as e:
+                if log_once("mig_memory_info"):
+                    logger.info(
+                        "Failed to retrieve MIG device memory info via "
+                        f"`nvmlDeviceGetMemoryInfo`: {e}"
+                    )
 
             # Get MIG device utilization
             utilization = -1
@@ -296,8 +306,12 @@ class NvidiaGpuProvider(GpuProvider):
                 name=mig_name,
                 uuid=mig_uuid,
                 utilization_gpu=utilization,
-                memory_used=int(memory_info.used) // MB,
-                memory_total=int(memory_info.total) // MB,
+                memory_used=(
+                    int(memory_info.used) // MB if memory_info is not None else None
+                ),
+                memory_total=(
+                    int(memory_info.total) // MB if memory_info is not None else None
+                ),
                 processes_pids=processes_pids,
                 power_mw=None,  # MIG devices don't expose per-slice power in NVML
                 temperature_c=None,
@@ -310,7 +324,17 @@ class NvidiaGpuProvider(GpuProvider):
     def _get_gpu_info(self, gpu_handle, gpu_index: int) -> Optional[GpuUtilizationInfo]:
         """Get utilization info for a regular (non-MIG) GPU."""
         try:
-            memory_info = self._pynvml.nvmlDeviceGetMemoryInfo(gpu_handle)
+            # Some devices (e.g. unified-memory parts such as GB10) do not expose a
+            # separate GPU memory pool; NVML returns NVML_ERROR_NOT_SUPPORTED here.
+            memory_info = None
+            try:
+                memory_info = self._pynvml.nvmlDeviceGetMemoryInfo(gpu_handle)
+            except self._pynvml.NVMLError as e:
+                if log_once("gpu_memory_info"):
+                    logger.info(
+                        "Failed to retrieve GPU memory info via "
+                        f"`nvmlDeviceGetMemoryInfo`: {e}"
+                    )
 
             # Get GPU utilization
             utilization = -1
@@ -403,8 +427,12 @@ class NvidiaGpuProvider(GpuProvider):
                 name=self._decode(self._pynvml.nvmlDeviceGetName(gpu_handle)),
                 uuid=self._decode(self._pynvml.nvmlDeviceGetUUID(gpu_handle)),
                 utilization_gpu=utilization,
-                memory_used=int(memory_info.used) // MB,
-                memory_total=int(memory_info.total) // MB,
+                memory_used=(
+                    int(memory_info.used) // MB if memory_info is not None else None
+                ),
+                memory_total=(
+                    int(memory_info.total) // MB if memory_info is not None else None
+                ),
                 processes_pids=processes_pids,
                 power_mw=power_mw,
                 temperature_c=temperature_c,

--- a/python/ray/dashboard/modules/reporter/reporter_agent.py
+++ b/python/ray/dashboard/modules/reporter/reporter_agent.py
@@ -1668,15 +1668,21 @@ class ReporterAgent(
                 # Consume GPU may not report its utilization.
                 if gpu["utilization_gpu"] is not None:
                     gpus_utilization += gpu["utilization_gpu"]
-                gram_used += gpu["memory_used"]
-                gram_total += gpu["memory_total"]
+                # Some devices (e.g. unified-memory parts such as GB10) do not
+                # report a separate GPU memory pool. Leave the GRAM metrics
+                # unreported in that case: a 0 would be indistinguishable from an
+                # idle GPU and would skew cluster-wide sums.
+                gram_known = (
+                    gpu["memory_used"] is not None and gpu["memory_total"] is not None
+                )
+                if gram_known:
+                    gram_used = gpu["memory_used"]
+                    gram_total = gpu["memory_total"]
                 gpu_index = gpu.get("index")
                 gpu_name = gpu.get("name")
                 gpu_uuid = gpu.get("uuid")
                 gpu_power_mw = gpu.get("power_mw")
                 gpu_temperature_c = gpu.get("temperature_c")
-
-                gram_available = gram_total - gram_used
 
                 if gpu_index is not None:
                     gpu_tags = {**node_tags, "GpuIndex": str(gpu_index)}
@@ -1696,22 +1702,25 @@ class ReporterAgent(
                         value=gpus_utilization,
                         tags=gpu_tags,
                     )
-                    gram_used_record = Record(
-                        gauge=METRICS_GAUGES["node_gram_used"],
-                        value=gram_used,
-                        tags=gpu_tags,
-                    )
-                    gram_available_record = Record(
-                        gauge=METRICS_GAUGES["node_gram_available"],
-                        value=gram_available,
-                        tags=gpu_tags,
-                    )
                     gpu_records_to_add = [
                         gpus_available_record,
                         gpus_utilization_record,
-                        gram_used_record,
-                        gram_available_record,
                     ]
+                    if gram_known:
+                        gpu_records_to_add.append(
+                            Record(
+                                gauge=METRICS_GAUGES["node_gram_used"],
+                                value=gram_used,
+                                tags=gpu_tags,
+                            )
+                        )
+                        gpu_records_to_add.append(
+                            Record(
+                                gauge=METRICS_GAUGES["node_gram_available"],
+                                value=gram_total - gram_used,
+                                tags=gpu_tags,
+                            )
+                        )
                     # Optional GPU power and temperature (e.g. NVIDIA, AMD)
                     if gpu_power_mw is not None:
                         gpu_records_to_add.append(

--- a/python/ray/dashboard/modules/reporter/reporter_models.py
+++ b/python/ray/dashboard/modules/reporter/reporter_models.py
@@ -32,8 +32,10 @@ if PYDANTIC_INSTALLED:
         name: str
         uuid: str
         utilizationGpu: Optional[int] = None  # percentage
-        memoryUsed: int  # in MB
-        memoryTotal: int  # in MB
+        # None when the device does not report a separate GPU memory pool
+        # (e.g. unified-memory parts such as GB10). This means "unknown", not zero.
+        memoryUsed: Optional[int] = None  # in MB
+        memoryTotal: Optional[int] = None  # in MB
         processesPids: Optional[
             List[ProcessGPUInfo]
         ] = None  # converted to list in _compose_stats_payload

--- a/python/ray/dashboard/modules/reporter/tests/test_gpu_providers.py
+++ b/python/ray/dashboard/modules/reporter/tests/test_gpu_providers.py
@@ -389,6 +389,112 @@ class TestNvidiaGpuProvider(unittest.TestCase):
         self.assertEqual(gpu_info["memory_total"], 4 * 1024)  # 4GB in MB
         self.assertEqual(gpu_info["processes_pids"], {})
 
+    @patch("ray._private.thirdparty.pynvml", create=True)
+    def test_get_gpu_utilization_memory_not_supported(self, mock_pynvml):
+        """Devices with no separate memory pool still report everything else.
+
+        Unified-memory parts (e.g. GB10) raise NVML_ERROR_NOT_SUPPORTED from
+        `nvmlDeviceGetMemoryInfo`. The GPU should still be reported, with memory
+        left as None rather than dropping the device entirely.
+        """
+        mock_handle = Mock()
+
+        class MockNVMLError(Exception):
+            pass
+
+        mock_pynvml.NVMLError = MockNVMLError
+
+        mock_utilization_info = Mock()
+        mock_utilization_info.gpu = 42
+
+        mock_process = Mock()
+        mock_process.pid = 1234
+        mock_process.usedGpuMemory = 256 * MB
+
+        mock_pynvml.nvmlInit.return_value = None
+        mock_pynvml.nvmlDeviceGetCount.return_value = 1
+        mock_pynvml.nvmlDeviceGetHandleByIndex.return_value = mock_handle
+        # Take the regular (non-MIG) code path.
+        mock_pynvml.nvmlDeviceGetMigMode.return_value = (False, False)
+        mock_pynvml.nvmlDeviceGetMemoryInfo.side_effect = MockNVMLError("Not Supported")
+        mock_pynvml.nvmlDeviceGetUtilizationRates.return_value = mock_utilization_info
+        mock_pynvml.nvmlDeviceGetComputeRunningProcesses.return_value = [mock_process]
+        mock_pynvml.nvmlDeviceGetGraphicsRunningProcesses.return_value = []
+        mock_pynvml.nvmlDeviceGetPowerUsage.return_value = 100000
+        mock_pynvml.nvmlDeviceGetTemperature.return_value = 60
+        mock_pynvml.nvmlDeviceGetName.return_value = b"NVIDIA GB10"
+        mock_pynvml.nvmlDeviceGetUUID.return_value = (
+            b"GPU-12345678-1234-1234-1234-123456789abc"
+        )
+        mock_pynvml.nvmlShutdown.return_value = None
+
+        self.provider._pynvml = mock_pynvml
+        self.provider._initialized = True
+
+        result = self.provider.get_gpu_utilization()
+
+        self.assertEqual(len(result), 1)
+        gpu_info = result[0]
+
+        # Memory is unknown, not zero.
+        self.assertIsNone(gpu_info["memory_used"])
+        self.assertIsNone(gpu_info["memory_total"])
+
+        # Everything else is still reported.
+        self.assertEqual(gpu_info["index"], 0)
+        self.assertEqual(gpu_info["name"], "NVIDIA GB10")
+        self.assertEqual(gpu_info["uuid"], "GPU-12345678-1234-1234-1234-123456789abc")
+        self.assertEqual(gpu_info["utilization_gpu"], 42)
+        self.assertEqual(gpu_info["power_mw"], 100000)
+        self.assertEqual(gpu_info["temperature_c"], 60)
+        self.assertEqual(gpu_info["processes_pids"][1234]["gpu_memory_usage"], 256)
+
+    @patch("ray._private.thirdparty.pynvml", create=True)
+    def test_get_gpu_utilization_mig_memory_not_supported(self, mock_pynvml):
+        """A MIG device is still reported when its memory query is unsupported."""
+        mock_gpu_handle = Mock()
+        mock_mig_handle = Mock()
+
+        class MockNVMLError(Exception):
+            pass
+
+        mock_pynvml.NVMLError = MockNVMLError
+
+        mock_mig_utilization_info = Mock()
+        mock_mig_utilization_info.gpu = 80
+
+        mock_pynvml.nvmlInit.return_value = None
+        mock_pynvml.nvmlDeviceGetCount.return_value = 1
+        mock_pynvml.nvmlDeviceGetHandleByIndex.return_value = mock_gpu_handle
+        mock_pynvml.nvmlDeviceGetMigMode.return_value = (True, True)
+        mock_pynvml.nvmlDeviceGetMaxMigDeviceCount.return_value = 1
+        mock_pynvml.nvmlDeviceGetMigDeviceHandleByIndex.return_value = mock_mig_handle
+        mock_pynvml.nvmlDeviceGetMemoryInfo.side_effect = MockNVMLError("Not Supported")
+        mock_pynvml.nvmlDeviceGetUtilizationRates.return_value = (
+            mock_mig_utilization_info
+        )
+        mock_pynvml.nvmlDeviceGetComputeRunningProcesses.return_value = []
+        mock_pynvml.nvmlDeviceGetGraphicsRunningProcesses.return_value = []
+        mock_pynvml.nvmlDeviceGetName.return_value = b"NVIDIA A100-SXM4-40GB MIG 1g.5gb"
+        mock_pynvml.nvmlDeviceGetUUID.return_value = (
+            b"MIG-12345678-1234-1234-1234-123456789abc"
+        )
+        mock_pynvml.nvmlShutdown.return_value = None
+
+        self.provider._pynvml = mock_pynvml
+        self.provider._initialized = True
+
+        result = self.provider.get_gpu_utilization()
+
+        self.assertEqual(len(result), 1)
+        gpu_info = result[0]
+
+        self.assertIsNone(gpu_info["memory_used"])
+        self.assertIsNone(gpu_info["memory_total"])
+        self.assertEqual(gpu_info["index"], 0)
+        self.assertEqual(gpu_info["name"], "NVIDIA A100-SXM4-40GB MIG 1g.5gb")
+        self.assertEqual(gpu_info["utilization_gpu"], 80)
+
 
 class TestAmdGpuProvider(unittest.TestCase):
     """Test AmdGpuProvider class."""

--- a/python/ray/dashboard/modules/reporter/tests/test_reporter.py
+++ b/python/ray/dashboard/modules/reporter/tests/test_reporter.py
@@ -706,6 +706,59 @@ def test_report_stats_gpu_without_power_temperature(tmp_path):
     assert len(temp_records) == 0
 
 
+def test_report_stats_gpu_without_memory_info(tmp_path):
+    """GPUs that report no memory pool skip GRAM metrics but keep the rest.
+
+    Unified-memory parts (e.g. GB10) leave memory_used/memory_total as None.
+    Emitting 0 would be indistinguishable from an idle GPU, so no GRAM record
+    should be produced at all.
+    """
+    dashboard_agent = MagicMock()
+    dashboard_agent.gcs_address = build_address("127.0.0.1", 6379)
+    dashboard_agent.session_dir = str(tmp_path)
+    dashboard_agent.node_id = ray.NodeID.from_random().hex()
+    raylet_client = MagicMock()
+    agent = ReporterAgent(dashboard_agent, raylet_client)
+    agent._is_head_node = True
+
+    stats = copy.deepcopy(STATS_TEMPLATE)
+    stats["gpus"] = [
+        {
+            "index": 0,
+            "uuid": "GPU-ddd",
+            "name": "NVIDIA GB10",
+            "utilization_gpu": 30,
+            "memory_used": None,
+            "memory_total": None,
+            "processes": [],
+        },
+    ]
+
+    records = agent._to_records(stats, {})
+
+    gram_records = [
+        r for r in records if r.gauge.name in ("node_gram_used", "node_gram_available")
+    ]
+    assert len(gram_records) == 0
+
+    # The GPU itself is still reported.
+    available_records = [r for r in records if r.gauge.name == "node_gpus_available"]
+    utilization_records = [
+        r for r in records if r.gauge.name == "node_gpus_utilization"
+    ]
+    assert len(available_records) == 1
+    assert available_records[0].value == 1
+    assert len(utilization_records) == 1
+    assert utilization_records[0].value == 30
+
+    # Regression test: the stats payload is validated against a pydantic model,
+    # so a None memory value must not break serialization for the whole node.
+    stats_payload = agent._generate_stats_payload(stats)
+    assert stats_payload is not None
+    assert isinstance(stats_payload, str)
+    assert json.loads(stats_payload)["gpus"][0]["memoryTotal"] is None
+
+
 def test_get_tpu_usage(tmp_path):
     dashboard_agent = MagicMock()
     dashboard_agent.gcs_address = build_address("127.0.0.1", 6379)


### PR DESCRIPTION
## Description

On GPUs with no separate memory pool, `nvmlDeviceGetMemoryInfo` raises
`NVML_ERROR_NOT_SUPPORTED`. That escapes to the catch-all in
`NvidiaGpuProvider._get_gpu_info`, so the **whole GPU is dropped**, no utilization,
power, temperature or per-process stats. Found on an NVIDIA GB10 (DGX Spark).

This makes the unsupported memory query a per-field condition instead of a fatal one:

- `NvidiaGpuProvider` guards the call (regular + MIG paths) and reports memory as `None`,
  matching how the neighbouring utilization/power/temperature calls already degrade.
- `reporter_models.GpuUtilizationInfo` widens `memoryUsed`/`memoryTotal` to
  `Optional[int]`. Load-bearing: that model is validated every cycle in two unguarded
  call sites, so a `None` against the old required `int` raised `ValidationError` and the
  node published *no stats at all*.
- `_to_records` omits `node_gram_used`/`node_gram_available` when memory is unknown
  rather than exporting `0`, which is indistinguishable from an idle GPU. Mirrors the
  `power_mw`/`temperature_c` handling below it.
- The UI shows N/A instead of `0B/0B`; `GPUStats.memoryUsed` becomes `number | null`, a
  deliberate compile-time break so the null has to be handled.

**Why not fall back to host memory:** `NVML_ERROR_NOT_SUPPORTED` isn't proof of a
unified-memory architecture so reporting host RAM as GRAM could be silently
wrong. NVML has no reliable "integrated" predicate (that's CUDA's
`cudaDeviceProp.integrated`), so this reports "unknown" instead.

No runtime regression: `null` only appears where the payload previously failed to
serialize entirely, so no consumer had a value to depend on.

## Related issues

None. Found on hardware rather than filed first. Not a duplicate: the nearest open work
is #65417, which hardens `_get_gpu_info` against a different NVML call and doesn't touch
the models, the agent or the frontend. Happy to rebase on whichever lands first.

## Additional information

Follow-up, deliberately separate: `python/ray/train/v2/_internal/state/schema.py` has a
second `GPUStats` (`@DeveloperAPI`) with the same required fields, so the Train dashboard
API still 500s on this hardware. Not a regression, but it needs the same widening.

### Tests

```
pytest python/ray/dashboard/modules/reporter/tests/test_gpu_providers.py   # 37 passed
pytest python/ray/dashboard/modules/reporter/tests/test_reporter.py        # 27 passed
cd python/ray/dashboard/client && npx tsc --noEmit && npm test  # clean; 17 passed
```

Pinned `black==22.10.0` and `ruff==0.8.4` clean on all changed files.

Verified on a DGX Spark (GB10, driver 580.159.03), where `nvidia-smi` also reports
`memory.total [N/A]`. Before: no `ray_node_gpus_*` series at all. After:

```
$ curl -s localhost:8080/metrics | grep -E "ray_node_gpu|ray_node_gram"
ray_node_gpus_available{GpuDeviceName="NVIDIA GB10",GpuIndex="0",...} 1.0
ray_node_gpus_utilization{...} 0.0
ray_node_gpu_power_milliwatts{...} 4991.0
ray_node_gpu_temperature_celsius{...} 40.0
```

No GRAM series, and the new log line appears exactly once.

Cluster tab screenshots, same node

before:
<img width="3412" height="1289" alt="Screenshot 2026-08-17 at 10 56 25 PM" src="https://github.com/user-attachments/assets/a37adcbd-9fe8-4c28-81e4-90c19f7cc26b" />

after:
<img width="3419" height="1294" alt="Screenshot 2026-08-17 at 10 55 04 PM" src="https://github.com/user-attachments/assets/5ec10824-624b-4a5f-b9e6-ca37783a209d" />


---

AI assistance was used. I reviewed every changed line and ran the tests above locally.