### PR TITLE
[core][docs] Make benchmark snippet copy-paste proof in gentle_walkthrough

### DIFF
--- a/doc/source/ray-core/examples/gentle_walkthrough.ipynb
+++ b/doc/source/ray-core/examples/gentle_walkthrough.ipynb
@@ -303,6 +303,7 @@
     }
    ],
    "source": [
+    "ray.init(ignore_reinit_error=True)\n",
     "start = time.time()\n",
     "object_references = [\n",
     "    retrieve_task.remote(item) for item in range(8)\n",


### PR DESCRIPTION
## Summary of Changes
This PR updates the Ray Core `gentle_walkthrough.ipynb` notebook by adding `ray.init(ignore_reinit_error=True)` to the benchmark snippet.

## Why this change is needed
As discussed in issue #40653, the benchmark snippet was not 'copy-paste proof'. Beginners often copy the code snippet into a standalone script and miss the `ray.init()` call. This leads to Ray auto-initializing when `ray_retrieve.remote()` is called, which secretly hides the cluster startup time inside the performance timer, giving misleading benchmark results. Adding the initialization check makes the snippet robust and beginner-friendly.

## How this change was tested
1. **Local Validation:** I tested the modified code snippet locally with both `range(8)` and `range(100)` workloads. 
2. **Performance Verification:** I verified that with the added initialization check, the benchmark correctly measures task execution time without being skewed by the Ray cluster startup overhead.
3. **CI Checks:** The PR has passed all automated CI tests (including DCO and Docs build) in the Ray project's pipeline.

## Related issues
Closes #40653
Supplement to PR #64529



This change is a supplement to the fix implemented in PR #64529.


Thank you for the guidance!