### PR TITLE
[ci] Let the environment choose the Python package index

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -13,12 +13,15 @@ build --action_env=RAY_BUILD_ENV
 
 # Let the invoking environment pick the Python package index that repository
 # rules resolve from, e.g. to point a CI fleet at a caching mirror instead of
-# pypi.org. Both are deliberately valueless, so bazel inherits whatever the
-# client environment holds and pins nothing here. rules_python runs
-# whl_library's pip with --isolated, which makes pip ignore every PIP_*
-# variable, so RULES_PYTHON_PIP_ISOLATED=0 is what lets PIP_INDEX_URL through.
-# Neither is set in a plain checkout, and then pip resolves from PyPI as before.
+# pypi.org. All of these are deliberately valueless, so bazel inherits whatever
+# the client environment holds and pins nothing here. rules_python runs
+# whl_library's pip with --isolated, which makes pip ignore every PIP_* variable,
+# so RULES_PYTHON_PIP_ISOLATED=0 is what lets the others through. PIP_TRUSTED_HOST
+# is here because a mirror reached over plain HTTP is otherwise refused. None of
+# them is set in a plain checkout, and then pip resolves from PyPI as before.
 common --repo_env=PIP_INDEX_URL
+common --repo_env=PIP_EXTRA_INDEX_URL
+common --repo_env=PIP_TRUSTED_HOST
 common --repo_env=RULES_PYTHON_PIP_ISOLATED
 
 ###############################################################################

--- a/.bazelrc
+++ b/.bazelrc
@@ -11,6 +11,16 @@ build:linux --workspace_status_command="bash ./bazel/workspace_status.sh"
 # To distinguish different incompatible environments.
 build --action_env=RAY_BUILD_ENV
 
+# Let the invoking environment pick the Python package index that repository
+# rules resolve from, e.g. to point a CI fleet at a caching mirror instead of
+# pypi.org. Both are deliberately valueless, so bazel inherits whatever the
+# client environment holds and pins nothing here. rules_python runs
+# whl_library's pip with --isolated, which makes pip ignore every PIP_*
+# variable, so RULES_PYTHON_PIP_ISOLATED=0 is what lets PIP_INDEX_URL through.
+# Neither is set in a plain checkout, and then pip resolves from PyPI as before.
+common --repo_env=PIP_INDEX_URL
+common --repo_env=RULES_PYTHON_PIP_ISOLATED
+
 ###############################################################################
 # On       Windows, provide: BAZEL_SH, and BAZEL_LLVM (if using clang-cl)
 # On all platforms, provide: PYTHON3_BIN_PATH=python

--- a/ci/ray_ci/container.py
+++ b/ci/ray_ci/container.py
@@ -50,7 +50,11 @@ _DOCKER_ENV = [
     # .bazelrc. Docker passes nothing through for a variable that is unset, which
     # is the case in a plain checkout, and then pip and uv resolve from PyPI.
     "PIP_INDEX_URL",
+    "PIP_EXTRA_INDEX_URL",
+    "PIP_TRUSTED_HOST",
     "UV_INDEX_URL",
+    "UV_EXTRA_INDEX_URL",
+    "UV_INSECURE_HOST",
     "RULES_PYTHON_PIP_ISOLATED",
 ]
 _RAYCI_BUILD_ID = os.environ.get("RAYCI_BUILD_ID", "")

--- a/ci/ray_ci/container.py
+++ b/ci/ray_ci/container.py
@@ -45,6 +45,13 @@ _DOCKER_ENV = [
     "BUILDKITE_PULL_REQUEST",
     "BUILDKITE_BAZEL_CACHE_URL",
     "BUILDKITE_CACHE_READONLY",
+    # Package index configuration, so a nested container resolves from the same
+    # index as the step that started it; see the --repo_env passthrough in
+    # .bazelrc. Docker passes nothing through for a variable that is unset, which
+    # is the case in a plain checkout, and then pip and uv resolve from PyPI.
+    "PIP_INDEX_URL",
+    "UV_INDEX_URL",
+    "RULES_PYTHON_PIP_ISOLATED",
 ]
 _RAYCI_BUILD_ID = os.environ.get("RAYCI_BUILD_ID", "")
 

--- a/ci/ray_ci/test_linux_tester_container.py
+++ b/ci/ray_ci/test_linux_tester_container.py
@@ -102,7 +102,8 @@ def test_run_tests_in_docker() -> None:
         # invocation inside it reads the --repo_env passthrough from the repo's
         # .bazelrc, which only has an effect on variables that container has.
         assert (
-            "--env PIP_INDEX_URL --env UV_INDEX_URL "
+            "--env PIP_INDEX_URL --env PIP_EXTRA_INDEX_URL --env PIP_TRUSTED_HOST "
+            "--env UV_INDEX_URL --env UV_EXTRA_INDEX_URL --env UV_INSECURE_HOST "
             "--env RULES_PYTHON_PIP_ISOLATED" in input_str
         )
         assert "--network host" in input_str

--- a/ci/ray_ci/test_linux_tester_container.py
+++ b/ci/ray_ci/test_linux_tester_container.py
@@ -98,6 +98,13 @@ def test_run_tests_in_docker() -> None:
         )._run_tests_in_docker(["t1", "t2"], [0, 1], "/tmp", ["v=k"], "flag")
         input_str = inputs[-1]
         assert "--env ENV_01 --env ENV_02 --env BUILDKITE" in input_str
+        # The index configuration has to reach the nested container: the bazel
+        # invocation inside it reads the --repo_env passthrough from the repo's
+        # .bazelrc, which only has an effect on variables that container has.
+        assert (
+            "--env PIP_INDEX_URL --env UV_INDEX_URL "
+            "--env RULES_PYTHON_PIP_ISOLATED" in input_str
+        )
         assert "--network host" in input_str
         assert '--gpus "device=0,1"' in input_str
         assert "--volume /tmp:/tmp/bazel_event_logs" in input_str


### PR DESCRIPTION
## Description

CI's Python package index is effectively hardwired to the default at every point
where it resolves packages, so pointing a fleet at a caching mirror instead of
`pypi.org` cannot be done without patching `WORKSPACE` and every step that runs
pip, uv or bazel. That matters while `files.pythonhosted.org` returns
intermittent 502s (pypi/support#11895): `rules_python` shells out to pip inside
`whl_library`, so one 502 fails the repository rule and takes the build with it.

This makes the index a property of the environment. Two pieces are needed, and
neither pins a value:

- **`.bazelrc`** forwards `PIP_INDEX_URL` and `RULES_PYTHON_PIP_ISOLATED` to
  repository rules as **valueless** `--repo_env`, so bazel inherits them from the
  invoking environment. The second one is load-bearing: `rules_python` runs
  `whl_library`'s pip with `--isolated`, which makes pip ignore every `PIP_*`
  variable, and `pip_repository.bzl` checks `RULES_PYTHON_PIP_ISOLATED` before
  adding that flag. Without it, `PIP_INDEX_URL` is silently discarded and pip
  resolves from PyPI while looking configured.
- **`ci/ray_ci/container.py`** forwards `PIP_INDEX_URL`, `UV_INDEX_URL` and
  `RULES_PYTHON_PIP_ISOLATED` into the nested test containers, because the bazel
  invocation in there needs the variables in its own environment for the
  passthrough above to have anything to inherit.

**Why the repo's `.bazelrc` rather than a generated one.** Every bazel invocation
reads the workspace `.bazelrc`, including the nested ones that a `--config` flag
on a step's command line never reaches. Writing the same flags into a per-job
`~/.bazelrc` looks equivalent and is not: a container started from that step gets
its image's copy of that file, so the flags are there for the outer invocation and
gone for the inner one, and the only symptom is pip going back to PyPI.

**Nothing changes for a plain checkout.** Both variables are unset, docker passes
nothing through for an unset `--env`, bazel inherits nothing, and pip and uv
resolve from PyPI exactly as they do today.

## Related issues

Upstream cause: pypi/support#11895.

Complementary, no file overlap with either:

- #65518 raises pip's retry tolerance for the same 502s inside `whl_library`.
- #65538 adds retries to the release pipeline bootstrap.

Not a duplicate: `gh pr list --repo ray-project/ray --state open --search
"PIP_INDEX_URL"` / `"repo_env in:body"` / `"pypi index mirror"` return only those
two PRs of mine, and neither makes the index configurable.

## Additional information

### What this deliberately does not cover

- **Image builds.** The `pip install` invocations in `ci/docker/*.Dockerfile` run
  in a separate BuildKit context and are unaffected by a variable exported in a
  step. They are also cache-key sensitive, so wiring them needs its own change.
- **The committed lock files.** `raydepsets` generates with uv's
  `--emit-index-url`, so 97 of the 99 files under `python/deplocks` carry
  `--index-url https://pypi.org/simple` on line 1, and a requirements file's
  embedded index URL beats both the environment and the command line. Dropping
  just that line (the default index, so removing it changes nothing for anyone
  installing normally) while keeping the `--extra-index-url` and `--find-links`
  entries for PyTorch, TPU and PyG intact is a follow-up.

### Testing

Duplicate check as above. Every claim below was run, not assumed.

**1. Unit tests.**

```
$ PYTHONPATH=.:release python -m pytest -q ci/ray_ci/test_linux_tester_container.py \
    ci/ray_ci/test_container.py ci/ray_ci/test_windows_container.py \
    ci/ray_ci/test_linux_container.py
15 passed in 1.23s
```

**2. Valueless `--repo_env` really reaches a repository rule** (bazel 7.5.0, the
version in `.bazelversion`). Scratch workspace with a `repository_rule` that
writes `rctx.os.environ` to a file, and the two `common --repo_env` lines from
this change in its `.bazelrc`:

```
$ PIP_INDEX_URL=http://127.0.0.1:35999/simple RULES_PYTHON_PIP_ISOLATED=0 bazel build @probe//:out.txt
PIP_INDEX_URL=http://127.0.0.1:35999/simple RULES_PYTHON_PIP_ISOLATED=0

$ bazel clean --expunge && bazel build @probe//:out.txt      # both variables unset
PIP_INDEX_URL=<unset> RULES_PYTHON_PIP_ISOLATED=<unset>
```

**3. `common` is safe for the commands that do not accept `--repo_env`** — no
unsupported-option error from `bazel info release`, `bazel query //...` or
`bazel version` in that workspace.

**4. An unset variable is not forwarded as empty**, which is what keeps the
default path unchanged:

```
$ docker run --rm --env FOO_UNSET_PROBE --env BAR_SET_PROBE=x alpine:latest \
    sh -c 'echo "FOO present: ${FOO_UNSET_PROBE+yes}${FOO_UNSET_PROBE-no}"; echo "BAR=$BAR_SET_PROBE"'
FOO present: no
BAR=x
```

**5. Lint.** `pre-commit run --files .bazelrc ci/ray_ci/container.py
ci/ray_ci/test_linux_tester_container.py` — all applicable hooks pass (ruff,
black, semgrep, import order, docstyle).

AI assistance (Claude Code) was used for this change.
