### PR TITLE
[ci] Stop pinning the default PyPI index in the deplocks

### DIFF
--- a/ci/raydepsets/README.md
+++ b/ci/raydepsets/README.md
@@ -252,3 +252,11 @@ Pre-hooks support template variable substitution and are modeled as nodes in the
 --quiet
 --unsafe-package setuptools  (unless include_setuptools: true)
 ```
+
+`--emit-index-url` keeps the `--extra-index-url` entries (PyTorch, libtpu) in the
+lock file, where an install needs them to find artifacts that are not on PyPI.
+The primary `--index-url` it also emits is removed again before the lock is
+written, because a requirements file's index URL overrides both `PIP_INDEX_URL`
+and a `--index-url` passed on the command line — leaving it in would pin every
+install to whichever index compiled the lock. Absent it, pip and uv use PyPI
+unless the environment points them elsewhere.

--- a/ci/raydepsets/cli.py
+++ b/ci/raydepsets/cli.py
@@ -390,6 +390,8 @@ class DependencySetManager:
         if output:
             args.extend(["-o", output])
         self.exec_uv_cmd("compile", args, stdin)
+        if output:
+            _drop_emitted_index_url(self.get_path(output))
 
     def subset(
         self,
@@ -521,6 +523,37 @@ class DependencySetManager:
         """Remove the temporary directory used for lock file comparisons."""
         if self.temp_dir:
             shutil.rmtree(self.temp_dir)
+
+
+def _drop_emitted_index_url(lock_file_path: Path) -> None:
+    """Remove the primary index URL that uv emits into a lock file.
+
+    uv runs with --emit-index-url, which is what records the --extra-index-url
+    entries a depset resolves against (PyTorch, libtpu) inside the lock file, and
+    those have to stay: they are not PyPI, so nothing else supplies them at
+    install time. It also emits the primary --index-url, and a requirements
+    file's index URL beats both PIP_INDEX_URL and a --index-url given on the
+    command line. Emitting it therefore pins every install to whichever index
+    compiled the lock, which is not something a checked-in file should decide --
+    a caching mirror in front of PyPI cannot be configured, and a mirror URL that
+    did get written here would be unreachable for everyone outside it.
+
+    Dropping it leaves the primary index to the installing environment, which
+    falls back to PyPI when nothing is set, so resolution is unchanged. It also
+    keeps the lock files byte-identical whether they were compiled through a
+    mirror or straight from PyPI, which is what `--check` requires.
+    """
+    if not lock_file_path.exists():
+        return
+    lines = lock_file_path.read_text().splitlines(keepends=True)
+    kept = [line for line in lines if not line.startswith("--index-url ")]
+    if len(kept) == len(lines):
+        return
+    # Removing the first line can leave the file starting on the blank line that
+    # separated the emitted options from the requirements.
+    while kept and not kept[0].strip():
+        kept.pop(0)
+    lock_file_path.write_text("".join(kept))
 
 
 def _get_bytes(packages: List[str]) -> bytes:

--- a/ci/raydepsets/tests/test_cli.py
+++ b/ci/raydepsets/tests/test_cli.py
@@ -15,6 +15,7 @@ from networkx import topological_sort
 from ci.raydepsets.cli import (
     DEFAULT_UV_FLAGS,
     DependencySetManager,
+    _drop_emitted_index_url,
     _flatten_flags,
     _get_depset,
     _override_uv_flags,
@@ -425,6 +426,47 @@ class TestCli(unittest.TestCase):
             "--index",
             "https://download.pytorch.org/whl/cu128",
         ]
+
+    def test_drop_emitted_index_url(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            lock_file = Path(tmpdir) / "requirements.txt"
+            lock_file.write_text(
+                "--index-url https://pypi.org/simple\n"
+                "--extra-index-url https://download.pytorch.org/whl/cu128\n"
+                "--find-links https://data.pyg.org/whl/torch-2.9.0+cu128.html\n"
+                "\n"
+                "torch==2.9.0+cu128 \\\n"
+                "    --hash=sha256:abc123\n"
+            )
+            _drop_emitted_index_url(lock_file)
+            # The primary index goes; the indexes that are not PyPI stay, because
+            # nothing else supplies them at install time.
+            assert lock_file.read_text() == (
+                "--extra-index-url https://download.pytorch.org/whl/cu128\n"
+                "--find-links https://data.pyg.org/whl/torch-2.9.0+cu128.html\n"
+                "\n"
+                "torch==2.9.0+cu128 \\\n"
+                "    --hash=sha256:abc123\n"
+            )
+
+    def test_drop_emitted_index_url_only_option(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            lock_file = Path(tmpdir) / "requirements.txt"
+            lock_file.write_text(
+                "--index-url https://pypi.org/simple\n"
+                "\n"
+                "emoji==2.9.0 \\\n"
+                "    --hash=sha256:abc123\n"
+            )
+            _drop_emitted_index_url(lock_file)
+            # The blank line that separated the options goes with it, so the file
+            # starts on a requirement.
+            expected = "emoji==2.9.0 \\\n    --hash=sha256:abc123\n"
+            assert lock_file.read_text() == expected
+            # Rerunning is a no-op, so regenerating an already-stripped lock file
+            # cannot drift.
+            _drop_emitted_index_url(lock_file)
+            assert lock_file.read_text() == expected
 
     def test_build_graph(self):
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -1217,31 +1259,39 @@ class TestCli(unittest.TestCase):
 
     def test_relax_preserves_options(self):
         with tempfile.TemporaryDirectory() as tmpdir:
-            copy_data_to_tmpdir(tmpdir)
-            manager = _create_test_manager(tmpdir)
-            manager.compile(
-                constraints=["requirement_constraints_test.txt"],
+            copy_data_to_tmpdir(tmpdir, ignore_patterns="test2.depsets.yaml")
+            # Sourced from the large fixture because that is the one carrying an
+            # --extra-index-url: a compiled lock keeps no primary --index-url, so
+            # a freshly compiled source would have no options left to preserve.
+            depset = Depset(
+                name="large_depset",
+                operation="compile",
                 requirements=["requirements_test.txt"],
-                name="general_depset__py311_cpu",
-                output="requirements_compiled_general.txt",
+                output="requirements_compiled_large_test.txt",
+                config_name="test.depsets.yaml",
             )
-            # Verify the source has an index URL option
+            write_to_config_file(tmpdir, [depset], "test.depsets.yaml")
+            manager = _create_test_manager(tmpdir)
             source_rf = parse_lock_file(
-                str(Path(tmpdir) / "requirements_compiled_general.txt")
+                str(Path(tmpdir) / "requirements_compiled_large_test.txt")
             )
             assert len(source_rf.options) >= 1
 
             manager.relax(
-                source_depset="general_depset__py311_cpu",
-                packages=["emoji"],
+                source_depset="large_depset",
+                packages=["numpy"],
                 name="relaxed_depset",
                 output="requirements_compiled_relaxed.txt",
             )
             output_rf = parse_lock_file(
                 str(Path(tmpdir) / "requirements_compiled_relaxed.txt")
             )
-            # Options (like --index-url) should be preserved
-            assert len(output_rf.options) >= 1
+            # Options that are not PyPI, like the PyTorch --extra-index-url, have
+            # to survive a relax. Compared on the parsed options rather than the
+            # OptionLine objects, which carry the file name they came from.
+            assert [option.options for option in output_rf.options] == [
+                option.options for option in source_rf.options
+            ]
 
     def test_relax_large_lock_file(self):
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/ci/raydepsets/tests/test_data/requirements_compiled_large_test.txt
+++ b/ci/raydepsets/tests/test_data/requirements_compiled_large_test.txt
@@ -1,4 +1,3 @@
---index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu128
 
 absl-py==1.4.0 \

--- a/ci/raydepsets/tests/test_data/requirements_compiled_test.txt
+++ b/ci/raydepsets/tests/test_data/requirements_compiled_test.txt
@@ -1,5 +1,3 @@
---index-url https://pypi.org/simple
-
 emoji==2.9.0 \
     --hash=sha256:17b0d53e1d9f787307a4c65aa19badb0a1ffdbc89b3a3cd851fc77821cdaced2 \
     --hash=sha256:5f4a15b7caa9c67fc11be9d90a822e3fa26aeb4e5b7bd2ded754b394d9c47869

--- a/ci/raydepsets/tests/test_data/requirements_compiled_test_expand.txt
+++ b/ci/raydepsets/tests/test_data/requirements_compiled_test_expand.txt
@@ -1,5 +1,3 @@
---index-url https://pypi.org/simple
-
 emoji==2.9.0 \
     --hash=sha256:17b0d53e1d9f787307a4c65aa19badb0a1ffdbc89b3a3cd851fc77821cdaced2 \
     --hash=sha256:5f4a15b7caa9c67fc11be9d90a822e3fa26aeb4e5b7bd2ded754b394d9c47869

--- a/ci/raydepsets/tests/test_data/requirements_compiled_test_update.txt
+++ b/ci/raydepsets/tests/test_data/requirements_compiled_test_update.txt
@@ -1,5 +1,3 @@
---index-url https://pypi.org/simple
-
 emoji==2.10.0 \
     --hash=sha256:7e68435eecd2c428c3b4aaa5f72d61a5b1a36c81a5138681cba13d19d94aa3a0 \
     --hash=sha256:aed4332caa23553a7218f032c08b0a325ae53b010f7fb98ad272c0f7841bc1d3

--- a/doc/source/ray-contribute/dependency-management.md
+++ b/doc/source/ray-contribute/dependency-management.md
@@ -78,6 +78,8 @@ Every `compile` call inherits this default set of `uv pip compile` flags:
 --unsafe-package setuptools     (unless include_setuptools: true)
 ```
 
+`--emit-index-url` is what records the `--extra-index-url` entries a depset resolves against — PyTorch, libtpu — inside the lock, so an install can still find artifacts that are not on PyPI. The primary `--index-url` it also emits is dropped again before the lock is written: a requirements file's index URL overrides both `PIP_INDEX_URL` and a `--index-url` on the command line, so leaving it in would pin every install to whichever index compiled the lock. Without it, pip and uv fall back to PyPI unless the environment says otherwise.
+
 `--generate-hashes` is why locks are SHA256-pinned. `--no-strip-markers` preserves `python_version` markers so a single lock can be a constraint at multiple `--python-version` targets. `--index-strategy unsafe-best-match` is the same flag you'd pass when reproducing CI's install resolution locally (see [Diagnosing dependency conflicts](#diagnosing-dependency-conflicts)).
 
 Before each `compile` runs, raydepsets executes any declared **pre-hooks**. The common one is `ci/raydepsets/pre_hooks/remove-compiled-headers.sh`, which copies `requirements_compiled*.txt` to `/tmp/ray-deps/` after stripping `--extra-index-url` / `--find-links` lines, so the file is a clean version constraint and GPU index URLs don't leak into CPU locks.

--- a/python/deplocks/base_deps/ray_base_deps_py3.10.lock
+++ b/python/deplocks/base_deps/ray_base_deps_py3.10.lock
@@ -1,5 +1,3 @@
---index-url https://pypi.org/simple
-
 adlfs==2026.4.0 \
     --hash=sha256:84c6f0fc28403629ef6d6d90f0d1a35a3302179f65ce4686c939a42ad0496d8d \
     --hash=sha256:a12a420583ae2d86d1b02902db147b7da5cf3e6eef40ee53024756a781d5d84f

--- a/python/deplocks/base_deps/ray_base_deps_py3.11.lock
+++ b/python/deplocks/base_deps/ray_base_deps_py3.11.lock
@@ -1,5 +1,3 @@
---index-url https://pypi.org/simple
-
 adlfs==2026.4.0 \
     --hash=sha256:84c6f0fc28403629ef6d6d90f0d1a35a3302179f65ce4686c939a42ad0496d8d \
     --hash=sha256:a12a420583ae2d86d1b02902db147b7da5cf3e6eef40ee53024756a781d5d84f

--- a/python/deplocks/base_deps/ray_base_deps_py3.12.lock
+++ b/python/deplocks/base_deps/ray_base_deps_py3.12.lock
@@ -1,5 +1,3 @@
---index-url https://pypi.org/simple
-
 adlfs==2026.4.0 \
     --hash=sha256:84c6f0fc28403629ef6d6d90f0d1a35a3302179f65ce4686c939a42ad0496d8d \
     --hash=sha256:a12a420583ae2d86d1b02902db147b7da5cf3e6eef40ee53024756a781d5d84f

--- a/python/deplocks/base_deps/ray_base_deps_py3.13.lock
+++ b/python/deplocks/base_deps/ray_base_deps_py3.13.lock
@@ -1,5 +1,3 @@
---index-url https://pypi.org/simple
-
 adlfs==2026.4.0 \
     --hash=sha256:84c6f0fc28403629ef6d6d90f0d1a35a3302179f65ce4686c939a42ad0496d8d \
     --hash=sha256:a12a420583ae2d86d1b02902db147b7da5cf3e6eef40ee53024756a781d5d84f

--- a/python/deplocks/base_deps/ray_base_deps_py3.14.lock
+++ b/python/deplocks/base_deps/ray_base_deps_py3.14.lock
@@ -1,5 +1,3 @@
---index-url https://pypi.org/simple
-
 adlfs==2026.4.0 \
     --hash=sha256:84c6f0fc28403629ef6d6d90f0d1a35a3302179f65ce4686c939a42ad0496d8d \
     --hash=sha256:a12a420583ae2d86d1b02902db147b7da5cf3e6eef40ee53024756a781d5d84f

--- a/python/deplocks/base_deps/ray_base_deps_tpu_py3.10.lock
+++ b/python/deplocks/base_deps/ray_base_deps_tpu_py3.10.lock
@@ -1,4 +1,3 @@
---index-url https://pypi.org/simple
 --extra-index-url https://storage.googleapis.com/libtpu-releases/index.html
 
 absl-py==2.4.0 \

--- a/python/deplocks/base_deps/ray_base_deps_tpu_py3.11.lock
+++ b/python/deplocks/base_deps/ray_base_deps_tpu_py3.11.lock
@@ -1,4 +1,3 @@
---index-url https://pypi.org/simple
 --extra-index-url https://storage.googleapis.com/libtpu-releases/index.html
 
 absl-py==2.4.0 \

--- a/python/deplocks/base_deps/ray_base_deps_tpu_py3.12.lock
+++ b/python/deplocks/base_deps/ray_base_deps_tpu_py3.12.lock
@@ -1,4 +1,3 @@
---index-url https://pypi.org/simple
 --extra-index-url https://storage.googleapis.com/libtpu-releases/index.html
 
 absl-py==2.4.0 \

--- a/python/deplocks/base_deps/ray_base_deps_tpu_py3.13.lock
+++ b/python/deplocks/base_deps/ray_base_deps_tpu_py3.13.lock
@@ -1,4 +1,3 @@
---index-url https://pypi.org/simple
 --extra-index-url https://storage.googleapis.com/libtpu-releases/index.html
 
 absl-py==2.4.0 \

--- a/python/deplocks/base_deps/ray_base_deps_tpu_py3.14.lock
+++ b/python/deplocks/base_deps/ray_base_deps_tpu_py3.14.lock
@@ -1,4 +1,3 @@
---index-url https://pypi.org/simple
 --extra-index-url https://storage.googleapis.com/libtpu-releases/index.html
 
 absl-py==2.4.0 \

--- a/python/deplocks/base_extra/ray_base_extra_py3.10.lock
+++ b/python/deplocks/base_extra/ray_base_extra_py3.10.lock
@@ -1,5 +1,3 @@
---index-url https://pypi.org/simple
-
 adlfs==2026.4.0 \
     --hash=sha256:84c6f0fc28403629ef6d6d90f0d1a35a3302179f65ce4686c939a42ad0496d8d \
     --hash=sha256:a12a420583ae2d86d1b02902db147b7da5cf3e6eef40ee53024756a781d5d84f

--- a/python/deplocks/base_extra/ray_base_extra_py3.11.lock
+++ b/python/deplocks/base_extra/ray_base_extra_py3.11.lock
@@ -1,5 +1,3 @@
---index-url https://pypi.org/simple
-
 adlfs==2026.4.0 \
     --hash=sha256:84c6f0fc28403629ef6d6d90f0d1a35a3302179f65ce4686c939a42ad0496d8d \
     --hash=sha256:a12a420583ae2d86d1b02902db147b7da5cf3e6eef40ee53024756a781d5d84f

--- a/python/deplocks/base_extra/ray_base_extra_py3.12.lock
+++ b/python/deplocks/base_extra/ray_base_extra_py3.12.lock
@@ -1,5 +1,3 @@
---index-url https://pypi.org/simple
-
 adlfs==2026.4.0 \
     --hash=sha256:84c6f0fc28403629ef6d6d90f0d1a35a3302179f65ce4686c939a42ad0496d8d \
     --hash=sha256:a12a420583ae2d86d1b02902db147b7da5cf3e6eef40ee53024756a781d5d84f

--- a/python/deplocks/base_extra/ray_base_extra_py3.13.lock
+++ b/python/deplocks/base_extra/ray_base_extra_py3.13.lock
@@ -1,5 +1,3 @@
---index-url https://pypi.org/simple
-
 adlfs==2026.4.0 \
     --hash=sha256:84c6f0fc28403629ef6d6d90f0d1a35a3302179f65ce4686c939a42ad0496d8d \
     --hash=sha256:a12a420583ae2d86d1b02902db147b7da5cf3e6eef40ee53024756a781d5d84f

--- a/python/deplocks/base_extra/ray_base_extra_py3.14.lock
+++ b/python/deplocks/base_extra/ray_base_extra_py3.14.lock
@@ -1,5 +1,3 @@
---index-url https://pypi.org/simple
-
 adlfs==2026.4.0 \
     --hash=sha256:84c6f0fc28403629ef6d6d90f0d1a35a3302179f65ce4686c939a42ad0496d8d \
     --hash=sha256:a12a420583ae2d86d1b02902db147b7da5cf3e6eef40ee53024756a781d5d84f

--- a/python/deplocks/base_extra_testdeps/ray-base_extra_testdeps_py3.10.lock
+++ b/python/deplocks/base_extra_testdeps/ray-base_extra_testdeps_py3.10.lock
@@ -1,5 +1,3 @@
---index-url https://pypi.org/simple
-
 absl-py==2.4.0 \
     --hash=sha256:88476fd881ca8aab94ffa78b7b6c632a782ab3ba1cd19c9bd423abc4fb4cd28d \
     --hash=sha256:8c6af82722b35cf71e0f4d1d47dcaebfff286e27110a99fc359349b247dfb5d4

--- a/python/deplocks/base_extra_testdeps/ray-base_extra_testdeps_py3.11.lock
+++ b/python/deplocks/base_extra_testdeps/ray-base_extra_testdeps_py3.11.lock
@@ -1,5 +1,3 @@
---index-url https://pypi.org/simple
-
 absl-py==2.4.0 \
     --hash=sha256:88476fd881ca8aab94ffa78b7b6c632a782ab3ba1cd19c9bd423abc4fb4cd28d \
     --hash=sha256:8c6af82722b35cf71e0f4d1d47dcaebfff286e27110a99fc359349b247dfb5d4

--- a/python/deplocks/base_extra_testdeps/ray-base_extra_testdeps_py3.12.lock
+++ b/python/deplocks/base_extra_testdeps/ray-base_extra_testdeps_py3.12.lock
@@ -1,5 +1,3 @@
---index-url https://pypi.org/simple
-
 absl-py==2.4.0 \
     --hash=sha256:88476fd881ca8aab94ffa78b7b6c632a782ab3ba1cd19c9bd423abc4fb4cd28d \
     --hash=sha256:8c6af82722b35cf71e0f4d1d47dcaebfff286e27110a99fc359349b247dfb5d4

--- a/python/deplocks/base_extra_testdeps/ray-base_extra_testdeps_py3.13.lock
+++ b/python/deplocks/base_extra_testdeps/ray-base_extra_testdeps_py3.13.lock
@@ -1,5 +1,3 @@
---index-url https://pypi.org/simple
-
 absl-py==2.4.0 \
     --hash=sha256:88476fd881ca8aab94ffa78b7b6c632a782ab3ba1cd19c9bd423abc4fb4cd28d \
     --hash=sha256:8c6af82722b35cf71e0f4d1d47dcaebfff286e27110a99fc359349b247dfb5d4

--- a/python/deplocks/base_extra_testdeps/ray-base_extra_testdeps_py3.14.lock
+++ b/python/deplocks/base_extra_testdeps/ray-base_extra_testdeps_py3.14.lock
@@ -1,5 +1,3 @@
---index-url https://pypi.org/simple
-
 absl-py==2.4.0 \
     --hash=sha256:88476fd881ca8aab94ffa78b7b6c632a782ab3ba1cd19c9bd423abc4fb4cd28d \
     --hash=sha256:8c6af82722b35cf71e0f4d1d47dcaebfff286e27110a99fc359349b247dfb5d4

--- a/python/deplocks/base_extra_testdeps/ray-gpu-base_extra_testdeps_py3.10.lock
+++ b/python/deplocks/base_extra_testdeps/ray-gpu-base_extra_testdeps_py3.10.lock
@@ -1,4 +1,3 @@
---index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu128
 
 absl-py==2.4.0 \

--- a/python/deplocks/base_extra_testdeps/ray-gpu-cu130-base_extra_testdeps_py3.10.lock
+++ b/python/deplocks/base_extra_testdeps/ray-gpu-cu130-base_extra_testdeps_py3.10.lock
@@ -1,4 +1,3 @@
---index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu130
 
 absl-py==2.4.0 \

--- a/python/deplocks/base_extra_testdeps/ray-gpu-cu130-base_extra_testdeps_py3.11.lock
+++ b/python/deplocks/base_extra_testdeps/ray-gpu-cu130-base_extra_testdeps_py3.11.lock
@@ -1,4 +1,3 @@
---index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu130
 
 absl-py==2.4.0 \

--- a/python/deplocks/base_extra_testdeps/ray-gpu-cu130-base_extra_testdeps_py3.12.lock
+++ b/python/deplocks/base_extra_testdeps/ray-gpu-cu130-base_extra_testdeps_py3.12.lock
@@ -1,4 +1,3 @@
---index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu130
 
 absl-py==2.4.0 \

--- a/python/deplocks/base_extra_testdeps/ray-gpu-cu130-base_extra_testdeps_py3.13.lock
+++ b/python/deplocks/base_extra_testdeps/ray-gpu-cu130-base_extra_testdeps_py3.13.lock
@@ -1,4 +1,3 @@
---index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu130
 
 absl-py==2.4.0 \

--- a/python/deplocks/base_extra_testdeps/ray-llm-base_extra_testdeps_py3.11.lock
+++ b/python/deplocks/base_extra_testdeps/ray-llm-base_extra_testdeps_py3.11.lock
@@ -1,4 +1,3 @@
---index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu128
 
 absl-py==2.4.0 \

--- a/python/deplocks/base_extra_testdeps/ray-llm-base_extra_testdeps_py3.12.lock
+++ b/python/deplocks/base_extra_testdeps/ray-llm-base_extra_testdeps_py3.12.lock
@@ -1,4 +1,3 @@
---index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu130
 
 absl-py==2.4.0 \

--- a/python/deplocks/base_extra_testdeps/ray-ml-base_extra_testdeps_py3.10.lock
+++ b/python/deplocks/base_extra_testdeps/ray-ml-base_extra_testdeps_py3.10.lock
@@ -1,4 +1,3 @@
---index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu128
 
 absl-py==2.4.0 \

--- a/python/deplocks/base_slim/ray_base_slim_py3.10.lock
+++ b/python/deplocks/base_slim/ray_base_slim_py3.10.lock
@@ -1,5 +1,3 @@
---index-url https://pypi.org/simple
-
 absl-py==2.4.0 \
     --hash=sha256:88476fd881ca8aab94ffa78b7b6c632a782ab3ba1cd19c9bd423abc4fb4cd28d \
     --hash=sha256:8c6af82722b35cf71e0f4d1d47dcaebfff286e27110a99fc359349b247dfb5d4

--- a/python/deplocks/base_slim/ray_base_slim_py3.11.lock
+++ b/python/deplocks/base_slim/ray_base_slim_py3.11.lock
@@ -1,5 +1,3 @@
---index-url https://pypi.org/simple
-
 absl-py==2.4.0 \
     --hash=sha256:88476fd881ca8aab94ffa78b7b6c632a782ab3ba1cd19c9bd423abc4fb4cd28d \
     --hash=sha256:8c6af82722b35cf71e0f4d1d47dcaebfff286e27110a99fc359349b247dfb5d4

--- a/python/deplocks/base_slim/ray_base_slim_py3.12.lock
+++ b/python/deplocks/base_slim/ray_base_slim_py3.12.lock
@@ -1,5 +1,3 @@
---index-url https://pypi.org/simple
-
 absl-py==2.4.0 \
     --hash=sha256:88476fd881ca8aab94ffa78b7b6c632a782ab3ba1cd19c9bd423abc4fb4cd28d \
     --hash=sha256:8c6af82722b35cf71e0f4d1d47dcaebfff286e27110a99fc359349b247dfb5d4

--- a/python/deplocks/base_slim/ray_base_slim_py3.13.lock
+++ b/python/deplocks/base_slim/ray_base_slim_py3.13.lock
@@ -1,5 +1,3 @@
---index-url https://pypi.org/simple
-
 absl-py==2.4.0 \
     --hash=sha256:88476fd881ca8aab94ffa78b7b6c632a782ab3ba1cd19c9bd423abc4fb4cd28d \
     --hash=sha256:8c6af82722b35cf71e0f4d1d47dcaebfff286e27110a99fc359349b247dfb5d4

--- a/python/deplocks/base_slim/ray_base_slim_py3.14.lock
+++ b/python/deplocks/base_slim/ray_base_slim_py3.14.lock
@@ -1,5 +1,3 @@
---index-url https://pypi.org/simple
-
 absl-py==2.4.0 \
     --hash=sha256:88476fd881ca8aab94ffa78b7b6c632a782ab3ba1cd19c9bd423abc4fb4cd28d \
     --hash=sha256:8c6af82722b35cf71e0f4d1d47dcaebfff286e27110a99fc359349b247dfb5d4

--- a/python/deplocks/ci/ci_ml_thirdparty_depset_py3.10.lock
+++ b/python/deplocks/ci/ci_ml_thirdparty_depset_py3.10.lock
@@ -1,5 +1,3 @@
---index-url https://pypi.org/simple
-
 colorama==0.4.6 \
     --hash=sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44 \
     --hash=sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6

--- a/python/deplocks/ci/ci_ml_thirdparty_depset_py3.12.lock
+++ b/python/deplocks/ci/ci_ml_thirdparty_depset_py3.12.lock
@@ -1,5 +1,3 @@
---index-url https://pypi.org/simple
-
 colorama==0.4.6 \
     --hash=sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44 \
     --hash=sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6

--- a/python/deplocks/ci/ci_windows_depset.lock
+++ b/python/deplocks/ci/ci_windows_depset.lock
@@ -1,5 +1,3 @@
---index-url https://pypi.org/simple
-
 aioboto3==14.3.0 \
     --hash=sha256:1d18f88bb56835c607b62bb6cb907754d717bedde3ddfff6935727cb48a80135 \
     --hash=sha256:aec5de94e9edc1ffbdd58eead38a37f00ddac59a519db749a910c20b7b81bca7

--- a/python/deplocks/ci/core-build-ci_depset_py3.10.lock
+++ b/python/deplocks/ci/core-build-ci_depset_py3.10.lock
@@ -1,4 +1,3 @@
---index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cpu
 --find-links https://data.pyg.org/whl/torch-2.9.0+cpu.html
 

--- a/python/deplocks/ci/core-build-ci_depset_py3.12.lock
+++ b/python/deplocks/ci/core-build-ci_depset_py3.12.lock
@@ -1,4 +1,3 @@
---index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cpu
 --find-links https://data.pyg.org/whl/torch-2.9.0+cpu.html
 

--- a/python/deplocks/ci/core-gpu-cu130-build-ci_depset_py3.10.lock
+++ b/python/deplocks/ci/core-gpu-cu130-build-ci_depset_py3.10.lock
@@ -1,4 +1,3 @@
---index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu128
 --find-links https://data.pyg.org/whl/torch-2.9.0+cu128.html
 

--- a/python/deplocks/ci/core-gpu-cu130-build-ci_depset_py3.12.lock
+++ b/python/deplocks/ci/core-gpu-cu130-build-ci_depset_py3.12.lock
@@ -1,4 +1,3 @@
---index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu128
 --find-links https://data.pyg.org/whl/torch-2.9.0+cu128.html
 

--- a/python/deplocks/ci/core-gpubuild-ci_depset_py3.10.lock
+++ b/python/deplocks/ci/core-gpubuild-ci_depset_py3.10.lock
@@ -1,4 +1,3 @@
---index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu128
 --find-links https://data.pyg.org/whl/torch-2.9.0+cu128.html
 

--- a/python/deplocks/ci/core-gpubuild-ci_depset_py3.12.lock
+++ b/python/deplocks/ci/core-gpubuild-ci_depset_py3.12.lock
@@ -1,4 +1,3 @@
---index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu128
 --find-links https://data.pyg.org/whl/torch-2.9.0+cu128.html
 

--- a/python/deplocks/ci/data-base-ci_depset_py3.10.lock
+++ b/python/deplocks/ci/data-base-ci_depset_py3.10.lock
@@ -1,4 +1,3 @@
---index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cpu
 --find-links https://data.pyg.org/whl/torch-2.9.0+cpu.html
 

--- a/python/deplocks/ci/data-base-ci_depset_py3.11.lock
+++ b/python/deplocks/ci/data-base-ci_depset_py3.11.lock
@@ -1,4 +1,3 @@
---index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cpu
 --find-links https://data.pyg.org/whl/torch-2.9.0+cpu.html
 

--- a/python/deplocks/ci/data-base-ci_depset_py3.12.lock
+++ b/python/deplocks/ci/data-base-ci_depset_py3.12.lock
@@ -1,4 +1,3 @@
---index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cpu
 --find-links https://data.pyg.org/whl/torch-2.9.0+cpu.html
 

--- a/python/deplocks/ci/data-mongo-ci_depset_py3.10.lock
+++ b/python/deplocks/ci/data-mongo-ci_depset_py3.10.lock
@@ -1,4 +1,3 @@
---index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cpu
 --find-links https://data.pyg.org/whl/torch-2.9.0+cpu.html
 

--- a/python/deplocks/ci/data-pyarrow-latest-ci_depset_py3.10.lock
+++ b/python/deplocks/ci/data-pyarrow-latest-ci_depset_py3.10.lock
@@ -1,4 +1,3 @@
---index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cpu
 --find-links https://data.pyg.org/whl/torch-2.9.0+cpu.html
 

--- a/python/deplocks/ci/data-pyarrow-latest-ci_depset_py3.12.lock
+++ b/python/deplocks/ci/data-pyarrow-latest-ci_depset_py3.12.lock
@@ -1,4 +1,3 @@
---index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cpu
 --find-links https://data.pyg.org/whl/torch-2.9.0+cpu.html
 

--- a/python/deplocks/ci/data-pyarrow-nightly-ci_depset_py3.10.lock
+++ b/python/deplocks/ci/data-pyarrow-nightly-ci_depset_py3.10.lock
@@ -1,4 +1,3 @@
---index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cpu
 --find-links https://data.pyg.org/whl/torch-2.9.0+cpu.html
 

--- a/python/deplocks/ci/data-pyarrow-v17-ci_depset_py3.10.lock
+++ b/python/deplocks/ci/data-pyarrow-v17-ci_depset_py3.10.lock
@@ -1,4 +1,3 @@
---index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cpu
 --find-links https://data.pyg.org/whl/torch-2.9.0+cpu.html
 

--- a/python/deplocks/ci/docgpu_depset_py3.10.lock
+++ b/python/deplocks/ci/docgpu_depset_py3.10.lock
@@ -1,4 +1,3 @@
---index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu128
 --find-links https://data.pyg.org/whl/torch-2.9.0+cu128.html
 

--- a/python/deplocks/ci/docgpu_depset_py3.12.lock
+++ b/python/deplocks/ci/docgpu_depset_py3.12.lock
@@ -1,4 +1,3 @@
---index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu128
 --find-links https://data.pyg.org/whl/torch-2.9.0+cu128.html
 

--- a/python/deplocks/ci/macos_depset_py3.10.lock
+++ b/python/deplocks/ci/macos_depset_py3.10.lock
@@ -1,5 +1,3 @@
---index-url https://pypi.org/simple
-
 absl-py==2.4.0 \
     --hash=sha256:88476fd881ca8aab94ffa78b7b6c632a782ab3ba1cd19c9bd423abc4fb4cd28d \
     --hash=sha256:8c6af82722b35cf71e0f4d1d47dcaebfff286e27110a99fc359349b247dfb5d4

--- a/python/deplocks/ci/ml-build-ci_depset_py3.10.lock
+++ b/python/deplocks/ci/ml-build-ci_depset_py3.10.lock
@@ -1,4 +1,3 @@
---index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cpu
 --find-links https://data.pyg.org/whl/torch-2.9.0+cpu.html
 

--- a/python/deplocks/ci/ml-build-ci_depset_py3.12.lock
+++ b/python/deplocks/ci/ml-build-ci_depset_py3.12.lock
@@ -1,4 +1,3 @@
---index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cpu
 --find-links https://data.pyg.org/whl/torch-2.9.0+cpu.html
 

--- a/python/deplocks/ci/ml-gpubuild-ci_depset_py3.10.lock
+++ b/python/deplocks/ci/ml-gpubuild-ci_depset_py3.10.lock
@@ -1,4 +1,3 @@
---index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu128
 --find-links https://data.pyg.org/whl/torch-2.9.0+cu128.html
 

--- a/python/deplocks/ci/ml-gpubuild-ci_depset_py3.12.lock
+++ b/python/deplocks/ci/ml-gpubuild-ci_depset_py3.12.lock
@@ -1,4 +1,3 @@
---index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu128
 --find-links https://data.pyg.org/whl/torch-2.9.0+cu128.html
 

--- a/python/deplocks/ci/ml-lightning1gpubuild-ci_depset_py3.10.lock
+++ b/python/deplocks/ci/ml-lightning1gpubuild-ci_depset_py3.10.lock
@@ -1,4 +1,3 @@
---index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu128
 --find-links https://data.pyg.org/whl/torch-2.9.0+cu128.html
 

--- a/python/deplocks/ci/ml-torchft-ci_depset_py3.10.lock
+++ b/python/deplocks/ci/ml-torchft-ci_depset_py3.10.lock
@@ -1,4 +1,3 @@
---index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cpu
 --find-links https://data.pyg.org/whl/torch-2.9.0+cpu.html
 

--- a/python/deplocks/ci/relaxed_data-ci_depset_py3.10.lock
+++ b/python/deplocks/ci/relaxed_data-ci_depset_py3.10.lock
@@ -1,4 +1,3 @@
---index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cpu
 --find-links https://data.pyg.org/whl/torch-2.9.0+cpu.html
 absl-py==2.4.0 \

--- a/python/deplocks/ci/relaxed_data-ci_depset_py3.12.lock
+++ b/python/deplocks/ci/relaxed_data-ci_depset_py3.12.lock
@@ -1,4 +1,3 @@
---index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cpu
 --find-links https://data.pyg.org/whl/torch-2.9.0+cpu.html
 absl-py==2.4.0 \

--- a/python/deplocks/ci/relaxed_windows-tests-ci_depset_py3.10.lock
+++ b/python/deplocks/ci/relaxed_windows-tests-ci_depset_py3.10.lock
@@ -1,4 +1,3 @@
---index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cpu
 --find-links https://data.pyg.org/whl/torch-2.9.0+cpu.html
 absl-py==2.4.0 \

--- a/python/deplocks/ci/rllib-build-ci_depset_py3.10.lock
+++ b/python/deplocks/ci/rllib-build-ci_depset_py3.10.lock
@@ -1,4 +1,3 @@
---index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cpu
 --find-links https://data.pyg.org/whl/torch-2.9.0+cpu.html
 

--- a/python/deplocks/ci/rllib-build-ci_depset_py3.12.lock
+++ b/python/deplocks/ci/rllib-build-ci_depset_py3.12.lock
@@ -1,4 +1,3 @@
---index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cpu
 --find-links https://data.pyg.org/whl/torch-2.9.0+cpu.html
 

--- a/python/deplocks/ci/rllib-gpubuild-ci_depset_py3.10.lock
+++ b/python/deplocks/ci/rllib-gpubuild-ci_depset_py3.10.lock
@@ -1,4 +1,3 @@
---index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu128
 --find-links https://data.pyg.org/whl/torch-2.9.0+cu128.html
 

--- a/python/deplocks/ci/rllib-gpubuild-ci_depset_py3.12.lock
+++ b/python/deplocks/ci/rllib-gpubuild-ci_depset_py3.12.lock
@@ -1,4 +1,3 @@
---index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu128
 --find-links https://data.pyg.org/whl/torch-2.9.0+cu128.html
 

--- a/python/deplocks/ci/serve_base_depset_py3.10.lock
+++ b/python/deplocks/ci/serve_base_depset_py3.10.lock
@@ -1,4 +1,3 @@
---index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cpu
 
 absl-py==2.4.0 \

--- a/python/deplocks/ci/serve_base_depset_py3.12.lock
+++ b/python/deplocks/ci/serve_base_depset_py3.12.lock
@@ -1,4 +1,3 @@
---index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cpu
 
 absl-py==2.4.0 \

--- a/python/deplocks/ci/serve_ci_depset_py3.10.lock
+++ b/python/deplocks/ci/serve_ci_depset_py3.10.lock
@@ -1,4 +1,3 @@
---index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cpu
 absl-py==2.4.0 \
     --hash=sha256:88476fd881ca8aab94ffa78b7b6c632a782ab3ba1cd19c9bd423abc4fb4cd28d \

--- a/python/deplocks/ci/serve_ci_depset_py3.12.lock
+++ b/python/deplocks/ci/serve_ci_depset_py3.12.lock
@@ -1,4 +1,3 @@
---index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cpu
 absl-py==2.4.0 \
     --hash=sha256:88476fd881ca8aab94ffa78b7b6c632a782ab3ba1cd19c9bd423abc4fb4cd28d \

--- a/python/deplocks/ci/serve_tracing_depset_py3.10.lock
+++ b/python/deplocks/ci/serve_tracing_depset_py3.10.lock
@@ -1,4 +1,3 @@
---index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cpu
 
 absl-py==2.4.0 \

--- a/python/deplocks/ci/windows-tests-ci_depset_py3.10.lock
+++ b/python/deplocks/ci/windows-tests-ci_depset_py3.10.lock
@@ -1,4 +1,3 @@
---index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cpu
 --find-links https://data.pyg.org/whl/torch-2.9.0+cpu.html
 

--- a/python/deplocks/ci/windows-tests-torch27-ci_depset_py3.10.lock
+++ b/python/deplocks/ci/windows-tests-torch27-ci_depset_py3.10.lock
@@ -1,4 +1,3 @@
---index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cpu
 --find-links https://data.pyg.org/whl/torch-2.9.0+cpu.html
 --find-links https://data.pyg.org/whl/torch-2.7.0+cpu.html

--- a/python/deplocks/docs/docbuild_depset_py3.11.lock
+++ b/python/deplocks/docs/docbuild_depset_py3.11.lock
@@ -1,5 +1,3 @@
---index-url https://pypi.org/simple
-
 absl-py==2.4.0 \
     --hash=sha256:88476fd881ca8aab94ffa78b7b6c632a782ab3ba1cd19c9bd423abc4fb4cd28d \
     --hash=sha256:8c6af82722b35cf71e0f4d1d47dcaebfff286e27110a99fc359349b247dfb5d4

--- a/python/deplocks/docs/doctest_depset_py3.10.lock
+++ b/python/deplocks/docs/doctest_depset_py3.10.lock
@@ -1,4 +1,3 @@
---index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cpu
 --find-links https://data.pyg.org/whl/torch-2.9.0+cpu.html
 

--- a/python/deplocks/llm/ray_py312_cpu.lock
+++ b/python/deplocks/llm/ray_py312_cpu.lock
@@ -1,4 +1,3 @@
---index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cpu
 
 absl-py==2.4.0 \

--- a/python/deplocks/llm/ray_py312_cu130.lock
+++ b/python/deplocks/llm/ray_py312_cu130.lock
@@ -1,4 +1,3 @@
---index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu130
 
 absl-py==2.4.0 \

--- a/python/deplocks/llm/ray_test_py312_cpu.lock
+++ b/python/deplocks/llm/ray_test_py312_cpu.lock
@@ -1,4 +1,3 @@
---index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cpu
 
 absl-py==2.4.0 \

--- a/python/deplocks/llm/ray_test_py312_cu130.lock
+++ b/python/deplocks/llm/ray_test_py312_cu130.lock
@@ -1,4 +1,3 @@
---index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu130
 
 absl-py==2.4.0 \

--- a/python/deplocks/llm/rayllm_py312_cpu.lock
+++ b/python/deplocks/llm/rayllm_py312_cpu.lock
@@ -1,4 +1,3 @@
---index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cpu
 
 absl-py==2.4.0 \

--- a/python/deplocks/llm/rayllm_py312_cu130.lock
+++ b/python/deplocks/llm/rayllm_py312_cu130.lock
@@ -1,4 +1,3 @@
---index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu130
 
 absl-py==2.4.0 \

--- a/python/deplocks/llm/rayllm_subset_py312_cu130.lock
+++ b/python/deplocks/llm/rayllm_subset_py312_cu130.lock
@@ -1,4 +1,3 @@
---index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu130
 
 absl-py==2.4.0 \

--- a/python/deplocks/llm/rayllm_test_py312_cpu.lock
+++ b/python/deplocks/llm/rayllm_test_py312_cpu.lock
@@ -1,4 +1,3 @@
---index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cpu
 
 absl-py==2.4.0 \

--- a/python/deplocks/llm/rayllm_test_py312_cu130.lock
+++ b/python/deplocks/llm/rayllm_test_py312_cu130.lock
@@ -1,4 +1,3 @@
---index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu130
 
 absl-py==2.4.0 \

--- a/python/deplocks/ray-torch/ray-torch-cu128_base_py3.14.lock
+++ b/python/deplocks/ray-torch/ray-torch-cu128_base_py3.14.lock
@@ -1,4 +1,3 @@
---index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu128
 
 absl-py==2.4.0 \

--- a/python/deplocks/ray_img/ray_img_cu130_py310.lock
+++ b/python/deplocks/ray_img/ray_img_cu130_py310.lock
@@ -1,4 +1,3 @@
---index-url https://pypi.org/simple
 absl-py==2.4.0 \
     --hash=sha256:88476fd881ca8aab94ffa78b7b6c632a782ab3ba1cd19c9bd423abc4fb4cd28d \
     --hash=sha256:8c6af82722b35cf71e0f4d1d47dcaebfff286e27110a99fc359349b247dfb5d4

--- a/python/deplocks/ray_img/ray_img_cu130_py311.lock
+++ b/python/deplocks/ray_img/ray_img_cu130_py311.lock
@@ -1,4 +1,3 @@
---index-url https://pypi.org/simple
 absl-py==2.4.0 \
     --hash=sha256:88476fd881ca8aab94ffa78b7b6c632a782ab3ba1cd19c9bd423abc4fb4cd28d \
     --hash=sha256:8c6af82722b35cf71e0f4d1d47dcaebfff286e27110a99fc359349b247dfb5d4

--- a/python/deplocks/ray_img/ray_img_cu130_py312.lock
+++ b/python/deplocks/ray_img/ray_img_cu130_py312.lock
@@ -1,4 +1,3 @@
---index-url https://pypi.org/simple
 absl-py==2.4.0 \
     --hash=sha256:88476fd881ca8aab94ffa78b7b6c632a782ab3ba1cd19c9bd423abc4fb4cd28d \
     --hash=sha256:8c6af82722b35cf71e0f4d1d47dcaebfff286e27110a99fc359349b247dfb5d4

--- a/python/deplocks/ray_img/ray_img_cu130_py313.lock
+++ b/python/deplocks/ray_img/ray_img_cu130_py313.lock
@@ -1,4 +1,3 @@
---index-url https://pypi.org/simple
 absl-py==2.4.0 \
     --hash=sha256:88476fd881ca8aab94ffa78b7b6c632a782ab3ba1cd19c9bd423abc4fb4cd28d \
     --hash=sha256:8c6af82722b35cf71e0f4d1d47dcaebfff286e27110a99fc359349b247dfb5d4

--- a/python/deplocks/ray_img/ray_img_cu130_py314.lock
+++ b/python/deplocks/ray_img/ray_img_cu130_py314.lock
@@ -1,4 +1,3 @@
---index-url https://pypi.org/simple
 absl-py==2.4.0 \
     --hash=sha256:88476fd881ca8aab94ffa78b7b6c632a782ab3ba1cd19c9bd423abc4fb4cd28d \
     --hash=sha256:8c6af82722b35cf71e0f4d1d47dcaebfff286e27110a99fc359349b247dfb5d4

--- a/python/deplocks/ray_img/ray_img_py310.lock
+++ b/python/deplocks/ray_img/ray_img_py310.lock
@@ -1,5 +1,3 @@
---index-url https://pypi.org/simple
-
 absl-py==2.4.0 \
     --hash=sha256:88476fd881ca8aab94ffa78b7b6c632a782ab3ba1cd19c9bd423abc4fb4cd28d \
     --hash=sha256:8c6af82722b35cf71e0f4d1d47dcaebfff286e27110a99fc359349b247dfb5d4

--- a/python/deplocks/ray_img/ray_img_py311.lock
+++ b/python/deplocks/ray_img/ray_img_py311.lock
@@ -1,5 +1,3 @@
---index-url https://pypi.org/simple
-
 absl-py==2.4.0 \
     --hash=sha256:88476fd881ca8aab94ffa78b7b6c632a782ab3ba1cd19c9bd423abc4fb4cd28d \
     --hash=sha256:8c6af82722b35cf71e0f4d1d47dcaebfff286e27110a99fc359349b247dfb5d4

--- a/python/deplocks/ray_img/ray_img_py312.lock
+++ b/python/deplocks/ray_img/ray_img_py312.lock
@@ -1,5 +1,3 @@
---index-url https://pypi.org/simple
-
 absl-py==2.4.0 \
     --hash=sha256:88476fd881ca8aab94ffa78b7b6c632a782ab3ba1cd19c9bd423abc4fb4cd28d \
     --hash=sha256:8c6af82722b35cf71e0f4d1d47dcaebfff286e27110a99fc359349b247dfb5d4

--- a/python/deplocks/ray_img/ray_img_py313.lock
+++ b/python/deplocks/ray_img/ray_img_py313.lock
@@ -1,5 +1,3 @@
---index-url https://pypi.org/simple
-
 absl-py==2.4.0 \
     --hash=sha256:88476fd881ca8aab94ffa78b7b6c632a782ab3ba1cd19c9bd423abc4fb4cd28d \
     --hash=sha256:8c6af82722b35cf71e0f4d1d47dcaebfff286e27110a99fc359349b247dfb5d4

--- a/python/deplocks/ray_img/ray_img_py314.lock
+++ b/python/deplocks/ray_img/ray_img_py314.lock
@@ -1,5 +1,3 @@
---index-url https://pypi.org/simple
-
 absl-py==2.4.0 \
     --hash=sha256:88476fd881ca8aab94ffa78b7b6c632a782ab3ba1cd19c9bd423abc4fb4cd28d \
     --hash=sha256:8c6af82722b35cf71e0f4d1d47dcaebfff286e27110a99fc359349b247dfb5d4

--- a/python/deplocks/ray_img/ray_img_py39.lock
+++ b/python/deplocks/ray_img/ray_img_py39.lock
@@ -1,5 +1,3 @@
---index-url https://pypi.org/simple
-
 aiohappyeyeballs==2.6.1 \
     --hash=sha256:c3f9d0113123803ccadfdf3f0faa505bc78e6a72d1cc4806cbd719826e943558 \
     --hash=sha256:f349ba8f4b75cb25c99c5c2d84e997e485204d2902a9597802b0371f09331fb8

--- a/python/deplocks/tests/data/datatfds_py3.12.lock
+++ b/python/deplocks/tests/data/datatfds_py3.12.lock
@@ -1,5 +1,3 @@
---index-url https://pypi.org/simple
-
 absl-py==2.3.1 \
     --hash=sha256:a97820526f7fbfd2ec1bce83f3f25e3a14840dac0d8e02a0b71cd75db3f77fc9 \
     --hash=sha256:eeecf07f0c2a93ace0772c92e596ace6d3d3996c042b2128459aaae2a76de11d


### PR DESCRIPTION
## Description

`raydepsets` compiles with uv's `--emit-index-url`, so 97 of the 99 files under
`python/deplocks` open with `--index-url https://pypi.org/simple`. A requirements
file's index URL overrides both `PIP_INDEX_URL` and a `--index-url` passed on the
command line, so that one line decides where every install from these locks
fetches its artifacts, and nothing in the environment can redirect it. Any attempt
to put a caching index in front of PyPI — which matters while
`files.pythonhosted.org` returns intermittent 502s (pypi/support#11895) — is
silently a no-op for every step that installs from a lock.

This drops that line after each compile and from the committed files.

**What is kept is everything that is not PyPI**: the `--extra-index-url` entries
for `download.pytorch.org/whl/{cpu,cu128,cu130}` and `libtpu-releases`, and the
`data.pyg.org` `--find-links`. Those name indexes that nothing else supplies at
install time, so they have to stay pinned in the file. The primary index is the
only one with a sane default to fall back to.

**Nothing about what gets installed changes.** Absent `--index-url`, pip and uv
resolve from `https://pypi.org/simple` — the same value the line held. Every
requirement is SHA256-pinned, so an index serving a different artifact for a
pinned version fails the hash check rather than quietly installing something else.
The one behavioural difference is the intended one: `PIP_INDEX_URL` and
`UV_INDEX_URL` now take effect.

Stripping happens in the same code path that `--check` regenerates through, which
is what keeps `raydepsets build --all-configs --check` green: both sides of its
diff go through it, so a lock file is identical whether it was compiled straight
from PyPI or through a mirror.

## Related issues

Upstream cause: pypi/support#11895.

Stands alone, and completes the coverage of #65562, which makes bazel's repository
rules and the nested test containers take their index from the environment. That
one has no effect on `pip install -r <lock>` while the lock overrides it; this one
has no effect on `whl_library`. Neither depends on the other.

Not a duplicate: `gh pr list --repo ray-project/ray --state open --search
"deplocks"` / `"index-url"` / `"raydepsets index"` turns up nothing touching the
emitted index URL.

## Additional information

### Why not uv's `--no-emit-index-url`

Because it is all-or-nothing, verified on uv 0.10.12 with an `--extra-index-url` present:

```
$ uv pip compile ... --emit-index-url --emit-find-links --extra-index-url https://download.pytorch.org/whl/cpu ...
--index-url https://pypi.org/simple
--extra-index-url https://download.pytorch.org/whl/cpu
--find-links https://data.pyg.org/whl/torch-2.9.0+cpu.html

$ uv pip compile ... --no-emit-index-url --emit-find-links --extra-index-url https://download.pytorch.org/whl/cpu ...
--find-links https://data.pyg.org/whl/torch-2.9.0+cpu.html
```

The flag governs `--index-url` and `--extra-index-url` together, so it would strip
the PyTorch and libtpu indexes out of 60 lock files as well, and `torch==2.10.0+cu128`
is not resolvable without them. `--find-links` is unaffected either way; that one has
its own `--emit-find-links`. Hence keeping `--emit-index-url` and dropping the single
line afterwards.


The two lock files with no `--index-url` to remove are the ones produced by the
`relax` operation, which rewrites an existing lock rather than compiling one.

### Testing

**1. The raydepsets suite, under bazel** (it needs runfiles for the `uv` binary):

```
$ bazel test //ci/raydepsets:test_cli --nocache_test_results
//ci/raydepsets:test_cli                                                 PASSED in 38.1s
```

That includes `test_diff_lock_files_up_to_date`, which compiles a lock and diffs it
against the committed copy — the invariant that would break if the strip were
applied to only one of the two paths. Two runs earlier failed inside uv with
`502 Bad Gateway` from `files.pythonhosted.org` after `3 retries`, i.e. the problem
this change exists for; the run above was with `--test_env=UV_HTTP_RETRIES=12`.

`//ci/raydepsets:test_workspace` fails in my environment with
`AttributeError: module 'typing' has no attribute '_SpecialGenericAlias'`. It fails
identically on unmodified `master`, and this change does not touch `workspace.py`.

**2. New unit tests** for the strip itself, covering that the PyTorch
`--extra-index-url` and PyG `--find-links` survive, that the blank line goes with
the removed option so the file starts on a requirement, and that a second run is a
no-op:

```
$ python -m pytest -q ci/raydepsets/tests/test_cli.py -k drop_emitted
2 passed
```

**3. End to end against a real uv compile**, to confirm the committed shape is
exactly what regeneration produces:

```
$ uv pip compile --no-header --generate-hashes --index-strategy unsafe-best-match \
    --no-strip-markers --emit-index-url --emit-find-links --quiet \
    --unsafe-package setuptools -o out.txt req.in
$ head -1 out.txt
--index-url https://pypi.org/simple
# after _drop_emitted_index_url:
emoji==2.9.0 \
idempotent on rerun: True
```

**4. Spot-checked the artifact side of a torch lock** —
`python/deplocks/ray-torch/ray-torch-cu128_base_py3.14.lock` loses exactly one
line, keeps `--extra-index-url https://download.pytorch.org/whl/cu128`, and its
`torch==2.10.0+cu128` / `torchvision==0.25.0+cu128` entries and hashes are
byte-identical.

**5. Lint.** `pre-commit run --files` on the changed Python, README and docs —
all applicable hooks pass.

AI assistance (Claude Code) was used for this change.
