### PR TITLE
[ci][DO NOT MERGE] Test: full PyPI 502 mitigation stack (mirror + index plumbing + retries)

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -94,6 +94,13 @@ build --per_file_copt="-\\.(asm|S)$,external/com_github_grpc_grpc/.*@-DGRPC_BAZE
 # Ignore wchar_t -> char conversion warning on MSVC
 build:msvc-cl --per_file_copt="external/boost/libs/regex/src/wc_regex_traits\\.cpp@-wd4244"
 build --http_timeout_scaling=5.0
+# Retry repository rule HTTP downloads (e.g. http_archive) on transient failures such as
+# the 502s files.pythonhosted.org returns and the 429s github.com returns for archive
+# downloads during an incident. This is deliberately unconditional rather than scoped to
+# --config=ci: the release pipeline's init step invokes bazel directly
+# (.buildkite/release/custom-image-build-and-test-init.sh) without --config=ci, so a
+# ci-only setting leaves the step that generates the entire release pipeline unprotected.
+build --experimental_repository_downloader_retries=6
 build --verbose_failures
 build:iwyu --aspects @com_github_storypku_bazel_iwyu//bazel/iwyu:iwyu.bzl%iwyu_aspect
 build:iwyu --output_groups=report
@@ -212,8 +219,6 @@ build:ci --show_timestamps
 # Retry on CacheNotFoundException from raw-S3 remote cache (AC/CAS eviction mismatch).
 # Remove once the cache is fronted by a server that coordinates AC/CAS eviction (bazel-remote, Buildbarn, etc.).
 build:ci --experimental_remote_cache_eviction_retries=3
-# Retry repository rule HTTP downloads (e.g. http_archive) on transient failures (502/504).
-build:ci --experimental_repository_downloader_retries=3
 # Disable test result caching because py_test under Bazel can import from outside of sandbox, but Bazel only looks at
 # declared dependencies to determine if a result should be cached. More details at:
 # https://github.com/bazelbuild/bazel/issues/7091, https://github.com/bazelbuild/rules_python/issues/382

--- a/.bazelrc
+++ b/.bazelrc
@@ -13,12 +13,15 @@ build --action_env=RAY_BUILD_ENV
 
 # Let the invoking environment pick the Python package index that repository
 # rules resolve from, e.g. to point a CI fleet at a caching mirror instead of
-# pypi.org. Both are deliberately valueless, so bazel inherits whatever the
-# client environment holds and pins nothing here. rules_python runs
-# whl_library's pip with --isolated, which makes pip ignore every PIP_*
-# variable, so RULES_PYTHON_PIP_ISOLATED=0 is what lets PIP_INDEX_URL through.
-# Neither is set in a plain checkout, and then pip resolves from PyPI as before.
+# pypi.org. All of these are deliberately valueless, so bazel inherits whatever
+# the client environment holds and pins nothing here. rules_python runs
+# whl_library's pip with --isolated, which makes pip ignore every PIP_* variable,
+# so RULES_PYTHON_PIP_ISOLATED=0 is what lets the others through. PIP_TRUSTED_HOST
+# is here because a mirror reached over plain HTTP is otherwise refused. None of
+# them is set in a plain checkout, and then pip resolves from PyPI as before.
 common --repo_env=PIP_INDEX_URL
+common --repo_env=PIP_EXTRA_INDEX_URL
+common --repo_env=PIP_TRUSTED_HOST
 common --repo_env=RULES_PYTHON_PIP_ISOLATED
 
 ###############################################################################

--- a/.bazelrc
+++ b/.bazelrc
@@ -11,6 +11,16 @@ build:linux --workspace_status_command="bash ./bazel/workspace_status.sh"
 # To distinguish different incompatible environments.
 build --action_env=RAY_BUILD_ENV
 
+# Let the invoking environment pick the Python package index that repository
+# rules resolve from, e.g. to point a CI fleet at a caching mirror instead of
+# pypi.org. Both are deliberately valueless, so bazel inherits whatever the
+# client environment holds and pins nothing here. rules_python runs
+# whl_library's pip with --isolated, which makes pip ignore every PIP_*
+# variable, so RULES_PYTHON_PIP_ISOLATED=0 is what lets PIP_INDEX_URL through.
+# Neither is set in a plain checkout, and then pip resolves from PyPI as before.
+common --repo_env=PIP_INDEX_URL
+common --repo_env=RULES_PYTHON_PIP_ISOLATED
+
 ###############################################################################
 # On       Windows, provide: BAZEL_SH, and BAZEL_LLVM (if using clang-cl)
 # On all platforms, provide: PYTHON3_BIN_PATH=python

--- a/.buildkite/release/custom-image-build-and-test-init.sh
+++ b/.buildkite/release/custom-image-build-and-test-init.sh
@@ -34,14 +34,21 @@ export PATH="${PWD}/google-cloud-sdk/bin:$PATH"
 
 
 echo "--- Install Bazel"
-curl -sSfLo /tmp/bazel https://github.com/bazelbuild/bazelisk/releases/download/v1.19.0/bazelisk-linux-amd64
+# curl treats HTTP 408/429/500/502/503/504 as transient and retries them under --retry,
+# which is what this needs: github.com serves release and archive downloads at a heavily
+# degraded error rate during an incident, and an unretried failure here kills the step that
+# generates the entire release pipeline, so no release test runs at all. --retry-all-errors
+# is deliberately not used; it requires curl >= 7.71 and would be an unknown-option failure
+# on older agents, and the transient codes above are already covered.
+curl -sSfLo /tmp/bazel --retry 5 --retry-delay 2 \
+  https://github.com/bazelbuild/bazelisk/releases/download/v1.19.0/bazelisk-linux-amd64
 chmod +x /tmp/bazel
 
 
 echo "--- Install uv"
 
 UV_PYTHON_VERSION=3.10
-curl -LsSf https://astral.sh/uv/install.sh | sh
+curl -LsSf --retry 5 --retry-delay 2 https://astral.sh/uv/install.sh | sh
 UV_BIN="${HOME}/.local/bin/uv"
 "${UV_BIN}" python install "${UV_PYTHON_VERSION}"
 UV_PYTHON_BIN="$("${UV_BIN}" python find --no-project "${UV_PYTHON_VERSION}")"

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -62,6 +62,96 @@ python_register_toolchains(
 load("@python3_10//:defs.bzl", python310 = "interpreter")
 load("@rules_python//python/pip_install:repositories.bzl", "pip_install_dependencies")
 
+# rules_python's whl_library shells out to pip rather than using Bazel's downloader, so
+# wheel fetches are invisible to Bazel's retry and mirroring settings. The pip that
+# rules_python pins (22.0.4) leaves 502 out of urllib3's status_forcelist, so a
+# transient PyPI/Fastly 502 fails a repository fetch on the first try with no retry at
+# all, breaking the whole build. pip 24.0 added 502 to that list upstream.
+#
+# pip 24 also drops pip._internal.cli.progress_bars.BAR_TYPES, which the pip-tools 6.6.0
+# that rules_python pins alongside it imports, so pip-tools moves to 7.4.1 here as well.
+# 7.4.1 replaced pep517 with build + pyproject_hooks and needs packaging, none of which
+# rules_python provides, so those three are declared below too and wired into
+# //release:requirements_py310.update via _requirements_py310_deps. Versions are the set
+# rules_python itself pairs with pip 24.0 / pip-tools 7.4.1 upstream, rather than an
+# ad-hoc combination.
+#
+# The pypi__pip and pypi__pip_tools entries are declared before
+# pip_install_dependencies() so that its maybe() calls become no-ops and these win. Keep
+# the url/sha256 pairs in sync with _RULE_DEPS in
+# @rules_python//python/pip_install:repositories.bzl.
+#
+# All five entries exist only because rules_python here is 0.9.0, from July 2022, which
+# is where the pip 22.0.4 pin comes from. Ray never declares rules_python: it arrives
+# transitively via ray_deps_build_all() -> rules_foreign_cc_dependencies(), which pins it
+# at rules_foreign_cc/foreign_cc/repositories.bzl:85. That is also a maybe(), so pinning
+# rules_python explicitly before ray_deps_build_all() would take precedence and is the
+# real fix - a modern rules_python pins pip 24.0 itself, making all five entries below
+# unnecessary, and adds the experimental_index_url path that fetches wheels through
+# Bazel's downloader, where --experimental_repository_downloader_retries and downloader
+# URL rewriting would finally apply to them. That upgrade rewrites whl_library, repo
+# naming and the generated requirements.bzl, so it needs to be its own change; delete
+# this block as part of it.
+#
+# Note that upgrading pip for the hermetic interpreter is not an alternative. The
+# python_register_toolchains() CPython build ships its own pip (also 22.0.4), but
+# whl_library puts the pypi__* repositories on PYTHONPATH, which precedes site-packages
+# on sys.path, so pypi__pip shadows it and the interpreter's copy is never used.
+_PYPI_WHEEL_BUILD_FILE = """\
+package(default_visibility = ["//visibility:public"])
+
+load("@rules_python//python:defs.bzl", "py_library")
+
+py_library(
+    name = "lib",
+    srcs = glob(["**/*.py"]),
+    data = glob(["**/*"], exclude=["**/*.py", "**/* *", "BUILD", "WORKSPACE"]),
+    # This makes this directory a top-level in the python import
+    # search path for anything that depends on this.
+    imports = ["."],
+)
+"""
+
+http_archive(
+    name = "pypi__pip",
+    build_file_content = _PYPI_WHEEL_BUILD_FILE,
+    sha256 = "ba0d021a166865d2265246961bec0152ff124de910c5cc39f1156ce3fa7c69dc",
+    type = "zip",
+    url = "https://files.pythonhosted.org/packages/8a/6a/19e9fe04fca059ccf770861c7d5721ab4c2aebc539889e97c7977528a53b/pip-24.0-py3-none-any.whl",
+)
+
+http_archive(
+    name = "pypi__pip_tools",
+    build_file_content = _PYPI_WHEEL_BUILD_FILE,
+    sha256 = "4c690e5fbae2f21e87843e89c26191f0d9454f362d8acdbd695716493ec8b3a9",
+    type = "zip",
+    url = "https://files.pythonhosted.org/packages/0d/dc/38f4ce065e92c66f058ea7a368a9c5de4e702272b479c0992059f7693941/pip_tools-7.4.1-py3-none-any.whl",
+)
+
+http_archive(
+    name = "pypi__build",
+    build_file_content = _PYPI_WHEEL_BUILD_FILE,
+    sha256 = "75e10f767a433d9a86e50d83f418e83efc18ede923ee5ff7df93b6cb0306c5d4",
+    type = "zip",
+    url = "https://files.pythonhosted.org/packages/e2/03/f3c8ba0a6b6e30d7d18c40faab90807c9bb5e9a1e3b2fe2008af624a9c97/build-1.2.1-py3-none-any.whl",
+)
+
+http_archive(
+    name = "pypi__packaging",
+    build_file_content = _PYPI_WHEEL_BUILD_FILE,
+    sha256 = "2ddfb553fdf02fb784c234c7ba6ccc288296ceabec964ad2eae3777778130bc5",
+    type = "zip",
+    url = "https://files.pythonhosted.org/packages/49/df/1fceb2f8900f8639e278b056416d49134fb8d84c5942ffaa01ad34782422/packaging-24.0-py3-none-any.whl",
+)
+
+http_archive(
+    name = "pypi__pyproject_hooks",
+    build_file_content = _PYPI_WHEEL_BUILD_FILE,
+    sha256 = "7ceeefe9aec63a1064c18d939bdc3adf2d8aa1988a510afec15151578b232aa2",
+    type = "zip",
+    url = "https://files.pythonhosted.org/packages/ae/f3/431b9d5fe7d14af7a32340792ef43b8a714e7726f1d7b69cc4e8e7a3f1d7/pyproject_hooks-1.1.0-py3-none-any.whl",
+)
+
 pip_install_dependencies()
 
 load("@rules_python//python:pip.bzl", "pip_parse")
@@ -69,6 +159,21 @@ load("@rules_python//python:pip.bzl", "pip_parse")
 # For CI scripts use only; not for ray testing.
 pip_parse(
     name = "py_deps_py310",
+    # pip retries 5 times by default with backoff_factor=0.25, and urllib3 doubles the
+    # delay each round, so it gives up after only ~8 seconds (0, 0.5, 1, 2, 4). Nine
+    # retries widens that to ~2 minutes (0, 0.5, 1, 2, 4, 8, 16, 32, 64), which is long
+    # enough to ride out a brief files.pythonhosted.org outage instead of failing the
+    # whole build. Nine is also the last round before urllib3's 120s per-sleep cap
+    # kicks in, so going higher buys progressively coarser waits.
+    #
+    # Both settings are needed because two different pip processes fetch from PyPI
+    # here. PIP_RETRIES covers the pip that setuptools spawns for setup_requires when
+    # a locked package ships only an sdist; that one is not isolated, so it reads the
+    # environment. --retries covers this pip invocation, which runs with --isolated
+    # and therefore ignores PIP_* variables. Neither helps unless 502 is retryable in
+    # the first place, which is what the pip 24.0 pin above provides.
+    environment = {"PIP_RETRIES": "9"},
+    extra_pip_args = ["--retries=9"],
     python_interpreter_target = python310,
     requirements_lock = "//release:requirements_py310.txt",
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -91,7 +91,8 @@ load("@rules_python//python/pip_install:repositories.bzl", "pip_install_dependen
 # Bazel's downloader, where --experimental_repository_downloader_retries and downloader
 # URL rewriting would finally apply to them. That upgrade rewrites whl_library, repo
 # naming and the generated requirements.bzl, so it needs to be its own change; delete
-# this block as part of it.
+# this block as part of it, including the pip patch - once Bazel does the fetching,
+# pip's own retry schedule stops being what governs a wheel download.
 #
 # Note that upgrading pip for the hermetic interpreter is not an alternative. The
 # python_register_toolchains() CPython build ships its own pip (also 22.0.4), but
@@ -115,6 +116,14 @@ py_library(
 http_archive(
     name = "pypi__pip",
     build_file_content = _PYPI_WHEEL_BUILD_FILE,
+    patch_args = ["-p1"],
+    # pip hardcodes backoff_factor=0.25 when it builds its urllib3.Retry and exposes
+    # no flag or environment variable for the shape of the retry schedule, and the
+    # urllib3 it vendors (1.26.17) implements exponential backoff only - jitter arrived
+    # in urllib3 2.x. The patch swaps in a constant, jittered schedule so that the
+    # --retries count below translates into a predictable amount of wall-clock. See
+    # the comment on pip_parse's extra_pip_args for why that shape is the one wanted.
+    patches = ["//thirdparty/patches:pip-constant-jittered-retry-backoff.patch"],
     sha256 = "ba0d021a166865d2265246961bec0152ff124de910c5cc39f1156ce3fa7c69dc",
     type = "zip",
     url = "https://files.pythonhosted.org/packages/8a/6a/19e9fe04fca059ccf770861c7d5721ab4c2aebc539889e97c7977528a53b/pip-24.0-py3-none-any.whl",
@@ -159,12 +168,18 @@ load("@rules_python//python:pip.bzl", "pip_parse")
 # For CI scripts use only; not for ray testing.
 pip_parse(
     name = "py_deps_py310",
-    # pip retries 5 times by default with backoff_factor=0.25, and urllib3 doubles the
-    # delay each round, so it gives up after only ~8 seconds (0, 0.5, 1, 2, 4). Nine
-    # retries widens that to ~2 minutes (0, 0.5, 1, 2, 4, 8, 16, 32, 64), which is long
-    # enough to ride out a brief files.pythonhosted.org outage instead of failing the
-    # whole build. Nine is also the last round before urllib3's 120s per-sleep cap
-    # kicks in, so going higher buys progressively coarser waits.
+    # pip retries 5 times by default, and the schedule is exponential, so it gives up
+    # after ~8 seconds (0, 0.5, 1, 2, 4). That is far shorter than a PyPI incident,
+    # and simply raising the count does not fix it: exponential backoff doubles until
+    # it saturates urllib3's 120s per-sleep cap, so most of a larger budget is spent
+    # asleep in 2-minute blocks rather than covering the outage. At 50 retries the
+    # upstream schedule would run for ~5050s, which no sane fetch timeout accommodates.
+    #
+    # The patch on pypi__pip above replaces that with a constant schedule jittered over
+    # 6-12s per sleep, which makes the count buy wall-clock linearly: 50 retries is 49
+    # sleeps, so 294-588s, ~440s typical, bounded under 600s. The jitter also spreads
+    # out the many wheel fetches Bazel runs in parallel, which would otherwise retry in
+    # lockstep and hit an already-degraded origin all at once.
     #
     # Both settings are needed because two different pip processes fetch from PyPI
     # here. PIP_RETRIES covers the pip that setuptools spawns for setup_requires when
@@ -172,17 +187,17 @@ pip_parse(
     # environment. --retries covers this pip invocation, which runs with --isolated
     # and therefore ignores PIP_* variables. Neither helps unless 502 is retryable in
     # the first place, which is what the pip 24.0 pin above provides.
-    environment = {"PIP_RETRIES": "9"},
-    extra_pip_args = ["--retries=9"],
+    environment = {"PIP_RETRIES": "50"},
+    extra_pip_args = ["--retries=50"],
     python_interpreter_target = python310,
     requirements_lock = "//release:requirements_py310.txt",
     # The retries above are only usable if the fetch is allowed to last long enough to
     # spend them. timeout defaults to 600s and pip_parse forwards it to every generated
-    # whl_library, so it bounds each package's pip invocation, not just this rule. Nine
-    # retries can spend ~2 minutes sleeping before the download itself starts making
-    # progress, and a degraded PyPI is slow as well as flaky, so 600s can expire
-    # mid-retry and fail the fetch that the retries were meant to save. 1800s leaves
-    # room for the full backoff plus a slow transfer.
+    # whl_library, so it bounds each package's pip invocation, not just this rule. The
+    # retry budget alone reaches 588s at worst, and each of the 50 attempts can burn up
+    # to pip's 15s socket timeout on top of that when the failure mode is a hang rather
+    # than a fast 502, so the default cannot hold the schedule. 1800s covers the full
+    # backoff, the per-attempt timeouts and a slow transfer afterwards.
     timeout = 1800,
 )
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -176,6 +176,14 @@ pip_parse(
     extra_pip_args = ["--retries=9"],
     python_interpreter_target = python310,
     requirements_lock = "//release:requirements_py310.txt",
+    # The retries above are only usable if the fetch is allowed to last long enough to
+    # spend them. timeout defaults to 600s and pip_parse forwards it to every generated
+    # whl_library, so it bounds each package's pip invocation, not just this rule. Nine
+    # retries can spend ~2 minutes sleeping before the download itself starts making
+    # progress, and a degraded PyPI is slow as well as flaky, so 600s can expire
+    # mid-retry and fail the fetch that the retries were meant to save. 1800s leaves
+    # room for the full backoff plus a slow transfer.
+    timeout = 1800,
 )
 
 load("@py_deps_py310//:requirements.bzl", install_py_deps_py310 = "install_deps")

--- a/ci/docker/base.cu128.wanda.yaml
+++ b/ci/docker/base.cu128.wanda.yaml
@@ -14,5 +14,6 @@ build_args:
   - PYTHON
   - BASE_IMAGE=nvidia/cuda:12.8.1-cudnn-devel-ubuntu22.04
   - CUDA_VERSION=12.8.1
+  - RAYCI_IMAGE_PIP_INDEX_URL
 tags:
   - cr.ray.io/rayproject/oss-ci-base_cu128-py$PYTHON

--- a/ci/docker/base.cu130.wanda.yaml
+++ b/ci/docker/base.cu130.wanda.yaml
@@ -14,5 +14,6 @@ build_args:
   - PYTHON
   - BASE_IMAGE=nvidia/cuda:13.0.0-cudnn-devel-ubuntu22.04
   - CUDA_VERSION=13.0.0
+  - RAYCI_IMAGE_PIP_INDEX_URL
 tags:
   - cr.ray.io/rayproject/oss-ci-base_cu130-py$PYTHON

--- a/ci/docker/base.gpu.Dockerfile
+++ b/ci/docker/base.gpu.Dockerfile
@@ -18,6 +18,10 @@ ENV RAY_DEFAULT_BUILD=1
 ENV RAY_INSTALL_JAVA=0
 ENV BUILDKITE_BAZEL_CACHE_URL=${BUILDKITE_BAZEL_CACHE_URL}
 
+# See ci/docker/base.test.Dockerfile: retry transient files.pythonhosted.org failures.
+ENV PIP_RETRIES=9
+ENV UV_HTTP_RETRIES=9
+
 RUN <<EOF
 #!/bin/bash
 

--- a/ci/docker/base.gpu.Dockerfile
+++ b/ci/docker/base.gpu.Dockerfile
@@ -22,6 +22,16 @@ ENV BUILDKITE_BAZEL_CACHE_URL=${BUILDKITE_BAZEL_CACHE_URL}
 ENV PIP_RETRIES=9
 ENV UV_HTTP_RETRIES=9
 
+# Where pip and uv resolve from during this build. ci/pypi_proxy_profile.sh sets
+# RAYCI_IMAGE_PIP_INDEX_URL to the CI package mirror when the job can reach it and
+# leaves it empty otherwise, which is also the case for any build outside CI, and
+# then this is the index pip would have used anyway. Kept as one build arg with a
+# default rather than a bare ARG so the value stays stable across jobs: it is part
+# of the wanda cache key, and a per-job value would rebuild every image every build.
+ARG RAYCI_IMAGE_PIP_INDEX_URL=""
+ENV PIP_INDEX_URL=${RAYCI_IMAGE_PIP_INDEX_URL:-https://pypi.org/simple}
+ENV UV_INDEX_URL=${RAYCI_IMAGE_PIP_INDEX_URL:-https://pypi.org/simple}
+
 RUN <<EOF
 #!/bin/bash
 

--- a/ci/docker/base.gpu.wanda.yaml
+++ b/ci/docker/base.gpu.wanda.yaml
@@ -13,5 +13,6 @@ build_args:
   - BUILDKITE_BAZEL_CACHE_URL
   - PYTHON
   - CUDA_VERSION
+  - RAYCI_IMAGE_PIP_INDEX_URL
 tags:
   - cr.ray.io/rayproject/oss-ci-base_gpu-py$PYTHON

--- a/ci/docker/base.test.Dockerfile
+++ b/ci/docker/base.test.Dockerfile
@@ -17,6 +17,14 @@ ENV RAY_DEFAULT_BUILD=1
 ENV RAY_INSTALL_JAVA=0
 ENV BUILDKITE_BAZEL_CACHE_URL=${BUILDKITE_BAZEL_CACHE_URL}
 
+# Make PyPI fetches survive a transient files.pythonhosted.org 502, which otherwise fails
+# an image build outright. Set on the roots of the image graph so every descendant image
+# inherits them, at build time and at test time. Retrying a 502 needs pip >= 24.0 (that is
+# where 502 joined urllib3's status_forcelist); uv defaults to only 3 retries and has been
+# seen to exhaust them. Older uv releases ignore UV_HTTP_RETRIES rather than erroring.
+ENV PIP_RETRIES=9
+ENV UV_HTTP_RETRIES=9
+
 RUN <<EOF
 #!/bin/bash
 

--- a/ci/docker/base.test.Dockerfile
+++ b/ci/docker/base.test.Dockerfile
@@ -25,6 +25,16 @@ ENV BUILDKITE_BAZEL_CACHE_URL=${BUILDKITE_BAZEL_CACHE_URL}
 ENV PIP_RETRIES=9
 ENV UV_HTTP_RETRIES=9
 
+# Where pip and uv resolve from during this build. ci/pypi_proxy_profile.sh sets
+# RAYCI_IMAGE_PIP_INDEX_URL to the CI package mirror when the job can reach it and
+# leaves it empty otherwise, which is also the case for any build outside CI, and
+# then this is the index pip would have used anyway. Kept as one build arg with a
+# default rather than a bare ARG so the value stays stable across jobs: it is part
+# of the wanda cache key, and a per-job value would rebuild every image every build.
+ARG RAYCI_IMAGE_PIP_INDEX_URL=""
+ENV PIP_INDEX_URL=${RAYCI_IMAGE_PIP_INDEX_URL:-https://pypi.org/simple}
+ENV UV_INDEX_URL=${RAYCI_IMAGE_PIP_INDEX_URL:-https://pypi.org/simple}
+
 RUN <<EOF
 #!/bin/bash
 

--- a/ci/docker/base.test.aarch64.wanda.yaml
+++ b/ci/docker/base.test.aarch64.wanda.yaml
@@ -9,5 +9,6 @@ srcs:
 build_args:
   - BUILDKITE_BAZEL_CACHE_URL
   - PYTHON
+  - RAYCI_IMAGE_PIP_INDEX_URL
 tags:
   - cr.ray.io/rayproject/oss-ci-base_test-aarch64-py$PYTHON

--- a/ci/docker/base.test.wanda.yaml
+++ b/ci/docker/base.test.wanda.yaml
@@ -9,5 +9,6 @@ srcs:
 build_args:
   - BUILDKITE_BAZEL_CACHE_URL
   - PYTHON
+  - RAYCI_IMAGE_PIP_INDEX_URL
 tags:
   - cr.ray.io/rayproject/oss-ci-base_test-py$PYTHON

--- a/ci/docker/forge.Dockerfile
+++ b/ci/docker/forge.Dockerfile
@@ -9,6 +9,12 @@ ENV PATH="/home/forge/.local/bin:${PATH}"
 ENV BUILDKITE_BAZEL_CACHE_URL=${BUILDKITE_BAZEL_CACHE_URL}
 ENV RAY_BUILD_ENV=ubuntu22.04_forge
 
+# See ci/docker/base.test.Dockerfile: retry transient files.pythonhosted.org failures.
+# This image runs the CI job commands themselves, so it also covers the ad hoc pip installs
+# in ci/ scripts (e.g. the `pip install clang-format` in the clang_format lint step).
+ENV PIP_RETRIES=9
+ENV UV_HTTP_RETRIES=9
+
 RUN \
   --mount=type=bind,source=ci/k8s/install-k8s-tools.sh,target=install-k8s-tools.sh \
 <<EOF

--- a/ci/docker/forge.Dockerfile
+++ b/ci/docker/forge.Dockerfile
@@ -17,6 +17,8 @@ ENV UV_HTTP_RETRIES=9
 
 RUN \
   --mount=type=bind,source=ci/k8s/install-k8s-tools.sh,target=install-k8s-tools.sh \
+  --mount=type=bind,source=ci/pypi_index_proxy.py,target=pypi_index_proxy.py \
+  --mount=type=bind,source=ci/pypi_proxy_profile.sh,target=pypi_proxy_profile.sh \
 <<EOF
 #!/bin/bash
 
@@ -88,6 +90,31 @@ ln -s "$UV_PYTHON_BIN" /usr/local/bin/python
 # As a convention, we pin all python packages to a specific version. This
 # is to to make sure we can control version upgrades through code changes.
 uv pip install --system pip==25.0 cffi==1.16.0
+
+# The PyPI index proxy (ci/pypi_index_proxy.py), used when the CI package mirror is
+# reachable but only serves the path-prefixed byte cache: PyPI's own index pages name
+# files.pythonhosted.org for the artifacts, so an index URL alone reroutes the
+# metadata request and leaves the download on the origin. The proxy rewrites those
+# URLs. ci/pypi_proxy_profile.sh decides whether it is needed and starts it.
+#
+# It needs Python >=3.11 (asgi-cross-origin-protection) while this image's default
+# interpreter is deliberately 3.10 above and symlinked as python/python3, so install
+# a second interpreter for the proxy alone and keep it in its own venv. Nothing else
+# resolves through /opt/pypiproxy and the default python is left untouched.
+uv python install --install-dir /usr/local/python 3.12
+PROXY_PYTHON="$(uv python find --no-project 3.12)"
+"$PROXY_PYTHON" -m venv /opt/pypiproxy
+/opt/pypiproxy/bin/pip install --no-cache-dir \
+  "asgi-cross-origin-protection==0.1.1" \
+  "niquests==3.21.0" \
+  "starlette==1.6.0" \
+  "uvicorn==0.52.3"
+cp pypi_index_proxy.py /opt/pypiproxy/pypi_index_proxy.py
+
+# Sourced automatically: steps run under `bash -elic`, a login shell. zz- prefix so
+# it runs after anything else in profile.d that might set HOME or PATH.
+cp pypi_proxy_profile.sh /etc/profile.d/zz-rayci-pypi-proxy.sh
+chmod 0644 /etc/profile.d/zz-rayci-pypi-proxy.sh
 
 # Needs to be synchronized to the host group id as we map /var/run/docker.sock
 # into the container.

--- a/ci/docker/forge.Dockerfile
+++ b/ci/docker/forge.Dockerfile
@@ -15,6 +15,16 @@ ENV RAY_BUILD_ENV=ubuntu22.04_forge
 ENV PIP_RETRIES=9
 ENV UV_HTTP_RETRIES=9
 
+# Where pip and uv resolve from during this build. ci/pypi_proxy_profile.sh sets
+# RAYCI_IMAGE_PIP_INDEX_URL to the CI package mirror when the job can reach it and
+# leaves it empty otherwise, which is also the case for any build outside CI, and
+# then this is the index pip would have used anyway. Kept as one build arg with a
+# default rather than a bare ARG so the value stays stable across jobs: it is part
+# of the wanda cache key, and a per-job value would rebuild every image every build.
+ARG RAYCI_IMAGE_PIP_INDEX_URL=""
+ENV PIP_INDEX_URL=${RAYCI_IMAGE_PIP_INDEX_URL:-https://pypi.org/simple}
+ENV UV_INDEX_URL=${RAYCI_IMAGE_PIP_INDEX_URL:-https://pypi.org/simple}
+
 RUN \
   --mount=type=bind,source=ci/k8s/install-k8s-tools.sh,target=install-k8s-tools.sh \
   --mount=type=bind,source=ci/pypi_index_proxy.py,target=pypi_index_proxy.py \

--- a/ci/docker/forge.aarch64.wanda.yaml
+++ b/ci/docker/forge.aarch64.wanda.yaml
@@ -3,6 +3,7 @@ froms:
   - ubuntu:22.04
 build_args:
   - BUILDKITE_BAZEL_CACHE_URL
+  - RAYCI_IMAGE_PIP_INDEX_URL
 dockerfile: ci/docker/forge.Dockerfile
 srcs:
   - ci/k8s/install-k8s-tools.sh

--- a/ci/docker/forge.wanda.yaml
+++ b/ci/docker/forge.wanda.yaml
@@ -6,3 +6,5 @@ build_args:
 dockerfile: ci/docker/forge.Dockerfile
 srcs:
   - ci/k8s/install-k8s-tools.sh
+  - ci/pypi_index_proxy.py
+  - ci/pypi_proxy_profile.sh

--- a/ci/docker/forge.wanda.yaml
+++ b/ci/docker/forge.wanda.yaml
@@ -3,6 +3,7 @@ froms:
   - ubuntu:22.04
 build_args:
   - BUILDKITE_BAZEL_CACHE_URL
+  - RAYCI_IMAGE_PIP_INDEX_URL
 dockerfile: ci/docker/forge.Dockerfile
 srcs:
   - ci/k8s/install-k8s-tools.sh

--- a/ci/docker/manylinux-cibase.wanda.yaml
+++ b/ci/docker/manylinux-cibase.wanda.yaml
@@ -7,4 +7,5 @@ build_args:
   - BUILDKITE_BAZEL_CACHE_URL
   - RAYCI_DISABLE_JAVA
   - HOSTTYPE
+  - RAYCI_IMAGE_PIP_INDEX_URL
 dockerfile: ci/docker/manylinux.Dockerfile

--- a/ci/docker/manylinux.Dockerfile
+++ b/ci/docker/manylinux.Dockerfile
@@ -14,6 +14,12 @@ ENV RAYCI_DISABLE_JAVA=$RAYCI_DISABLE_JAVA
 ENV RAY_INSTALL_JAVA=1
 ENV BUILDKITE_BAZEL_CACHE_URL=$BUILDKITE_BAZEL_CACHE_URL
 
+# See ci/docker/base.test.Dockerfile: retry transient files.pythonhosted.org failures. This
+# is the image the wheel builds run in, where the manylinux interpreters' own pip installs
+# build dependencies such as cython and setuptools straight from PyPI.
+ENV PIP_RETRIES=9
+ENV UV_HTTP_RETRIES=9
+
 RUN yum -y install sudo
 
 RUN curl -LsSf https://astral.sh/uv/0.8.17/install.sh | \

--- a/ci/docker/manylinux.Dockerfile
+++ b/ci/docker/manylinux.Dockerfile
@@ -20,6 +20,16 @@ ENV BUILDKITE_BAZEL_CACHE_URL=$BUILDKITE_BAZEL_CACHE_URL
 ENV PIP_RETRIES=9
 ENV UV_HTTP_RETRIES=9
 
+# Where pip and uv resolve from during this build. ci/pypi_proxy_profile.sh sets
+# RAYCI_IMAGE_PIP_INDEX_URL to the CI package mirror when the job can reach it and
+# leaves it empty otherwise, which is also the case for any build outside CI, and
+# then this is the index pip would have used anyway. Kept as one build arg with a
+# default rather than a bare ARG so the value stays stable across jobs: it is part
+# of the wanda cache key, and a per-job value would rebuild every image every build.
+ARG RAYCI_IMAGE_PIP_INDEX_URL=""
+ENV PIP_INDEX_URL=${RAYCI_IMAGE_PIP_INDEX_URL:-https://pypi.org/simple}
+ENV UV_INDEX_URL=${RAYCI_IMAGE_PIP_INDEX_URL:-https://pypi.org/simple}
+
 RUN yum -y install sudo
 
 RUN curl -LsSf https://astral.sh/uv/0.8.17/install.sh | \

--- a/ci/docker/windows.build.Dockerfile
+++ b/ci/docker/windows.build.Dockerfile
@@ -5,5 +5,9 @@ ENV PYTHON=3.10
 ENV PYTHON_FULL_VERSION=3.10.19
 ENV RAY_BUILD_ENV=win_py$PYTHON_FULL_VERSION
 
+# See ci/docker/base.test.Dockerfile: retry transient files.pythonhosted.org failures.
+ENV PIP_RETRIES=9
+ENV UV_HTTP_RETRIES=9
+
 COPY . .
 RUN bash ci/ray_ci/windows/build_base.sh

--- a/ci/pypi_index_proxy.py
+++ b/ci/pypi_index_proxy.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env -S uv run
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "asgi-cross-origin-protection>=0.1",
+#     "niquests>=3",
+#     "starlette>=0.40",
+#     "uvicorn>=0.30",
+# ]
+# ///
+
+# Vendored from https://gist.github.com/thomasdesr/73abd831c1525ad75ac04d11cad3a93a
+# Re-sync by overwriting this file from the gist and re-running pre-commit, which
+# reorders the imports; no other local edits.
+# Runtime deps are pre-installed into /opt/pypiproxy by ci/docker/forge.Dockerfile,
+# so this runs under that venv rather than via the `uv run` shebang.
+"""Job-local PyPI index proxy.
+
+Serves PyPI simple-index pages fetched through the CI caching mirror, with
+every file URL rewritten to point at the mirror, so pip/uv resolve AND
+download entirely through the mirror and never contact PyPI. Wheels do not
+flow through this process: clients download them straight from the mirror at
+the rewritten URLs, and the sha256 hashes in the pages pass through the
+rewrite untouched, so artifact verification stays end to end against
+upstream bytes.
+
+Usage:
+    uv run pypi_index_proxy.py [port]
+
+Listens on 127.0.0.1, on an ephemeral port by default, and prints the bound
+address plus ready-to-eval client configuration to stdout:
+
+    listening on http://127.0.0.1:PORT
+    export PIP_INDEX_URL=http://127.0.0.1:PORT/simple
+    export UV_INDEX_URL=http://127.0.0.1:PORT/simple
+
+Stateless: all caching, deduplication, and stale-on-error availability live
+in the mirror. MIRROR_URL is env-overridable only so the proxy can be tested
+outside the CI VPC against a stand-in; CI uses the default.
+"""
+
+import os
+import socket
+import sys
+
+import niquests
+import uvicorn
+from asgi_cross_origin_protection import CrossOriginProtection
+from starlette.applications import Starlette
+from starlette.requests import Request
+from starlette.responses import PlainTextResponse, Response
+from starlette.routing import Route
+
+MIRROR_URL = os.environ.get("MIRROR_URL", "https://mirror.ci.anyscale-test.com")
+
+# PyPI serves every artifact from files.pythonhosted.org; the pages carry no
+# other artifact host. The replacement is textual on purpose: it covers both
+# simple-index representations (HTML and PEP 691 JSON) with one rule and
+# survives format additions that real parsing would trip on.
+UPSTREAM_FILES_PREFIX = b"https://files.pythonhosted.org/"
+MIRROR_FILES_PREFIX = f"{MIRROR_URL}/files.pythonhosted.org/".encode()
+
+# Redirects are followed by default: the mirror serves cache hits as 303s to
+# presigned S3 URLs. niquests auto-decompresses, so the rewrite below sees
+# plain bytes.
+client = niquests.AsyncSession()
+
+
+async def simple(request: Request) -> Response:
+    upstream = f"{MIRROR_URL}/pypi.org/simple/{request.path_params['path']}"
+    headers = {}
+    # Content negotiation happens on this header: pip/uv choose between the
+    # HTML and PEP 691 JSON index representations with it.
+    accept = request.headers.get("accept")
+    if accept:
+        headers["Accept"] = accept
+    try:
+        response = await client.get(upstream, headers=headers, timeout=60)
+    except niquests.exceptions.RequestException as e:
+        return PlainTextResponse(f"fetching {upstream} failed: {e}", status_code=502)
+    body = response.content
+    if response.status_code == 200:
+        body = body.replace(UPSTREAM_FILES_PREFIX, MIRROR_FILES_PREFIX)
+    return Response(
+        body,
+        status_code=response.status_code,
+        media_type=response.headers.get("content-type", "text/html"),
+    )
+
+
+async def healthz(_request: Request) -> Response:
+    return PlainTextResponse("ok")
+
+
+# Cross-origin protection: rejects cross-site state-changing requests via
+# Fetch Metadata. Inert for today's all-GET routes (safe methods are always
+# allowed) and starts enforcing if this proxy ever grows one that isn't.
+app = CrossOriginProtection(
+    Starlette(
+        routes=[
+            Route("/healthz", healthz),
+            Route("/simple/{path:path}", simple),
+        ]
+    )
+)
+
+if __name__ == "__main__":
+    # Bind before serving so the ephemeral port is known and announced
+    # synchronously: once the lines below are printed, the socket accepts.
+    listener = socket.create_server(
+        ("127.0.0.1", int(sys.argv[1]) if len(sys.argv) > 1 else 0)
+    )
+    base_url = "http://{}:{}".format(*listener.getsockname())
+    print(f"listening on {base_url}", flush=True)
+    print(f"export PIP_INDEX_URL={base_url}/simple", flush=True)
+    print(f"export UV_INDEX_URL={base_url}/simple", flush=True)
+    uvicorn.Server(uvicorn.Config(app, log_level="info")).run(sockets=[listener])

--- a/ci/pypi_proxy_profile.sh
+++ b/ci/pypi_proxy_profile.sh
@@ -51,6 +51,11 @@ _rayci_pypi_index_setup() {
       export PIP_INDEX_URL="${mirror}/simple"
       export UV_INDEX_URL="${mirror}/simple"
       export RULES_PYTHON_PIP_ISOLATED=0
+      # Docker builds resolve through this too, as a build arg on the roots of the
+      # image graph. Only exported in this mode: a build container cannot reach a
+      # proxy on this container's loopback, and a per-job address would change the
+      # wanda cache key on every build and rebuild every image.
+      export RAYCI_IMAGE_PIP_INDEX_URL="${mirror}/simple"
       echo "pypi index: using the mirror's rewriting simple index -> ${PIP_INDEX_URL}"
       return 0
     fi

--- a/ci/pypi_proxy_profile.sh
+++ b/ci/pypi_proxy_profile.sh
@@ -1,0 +1,115 @@
+# shellcheck shell=bash
+# Installed as /etc/profile.d/zz-rayci-pypi-proxy.sh in the forge image.
+#
+# Points pip, uv and bazel at the CI package mirror when this job can reach it, and
+# leaves them on public PyPI when it cannot. Steps run under `bash -elic`, a login
+# shell, so this is sourced automatically and every step gets it without per-step
+# wiring. The variables it exports are the ones .bazelrc forwards to repository
+# rules and ci/ray_ci/container.py forwards into nested containers.
+#
+# Which index to use is decided by probing, not by assuming, because the mirror
+# serves two different shapes and only one of them is usable directly:
+#
+#   1. A rewriting simple index at /simple. Its pages already point at the mirror
+#      for the artifacts, so pip can use it as-is. Nothing local runs and nested
+#      containers reach it by hostname.
+#   2. A path-prefixed byte cache at /pypi.org/simple. Those pages are PyPI's own,
+#      so their bodies still point at files.pythonhosted.org and using them as an
+#      index leaves every wheel download on the origin that returns the 502s. In
+#      that case start ci/pypi_index_proxy.py, which fetches those pages and
+#      rewrites the file URLs in them.
+#   3. Neither reachable: export nothing and let the retry settings carry the job.
+#
+# Fail-open is load-bearing, and it is why the probe hits the mirror rather than
+# only the local process: a healthy proxy in front of an unreachable mirror answers
+# every request with a 502, which is strictly worse than no proxy at all.
+
+_rayci_pypi_index_setup() {
+  # Off CI the mirror is unreachable by design, so leave developer machines alone.
+  [[ -n "${BUILDKITE:-}" ]] || return 0
+  # /etc/profile can be sourced more than once per job; never probe or start twice.
+  [[ -z "${RAYCI_PYPI_INDEX_MODE:-}" ]] || return 0
+
+  local mirror="${RAYCI_PYPI_MIRROR_URL:-https://mirror.ci.anyscale-test.com}"
+  local probe_pkg="pip"
+
+  # Diagnostics first: the resolved address and the reachability verdict are the
+  # only way to tell "the mirror is not deployed for this fleet" apart from "the
+  # mirror is deployed and this fleet has no route to it".
+  local resolved
+  resolved="$(getent hosts "${mirror#https://}" 2>/dev/null | awk '{print $1}' | paste -sd, -)"
+  echo "pypi index: mirror=${mirror} resolves_to=${resolved:-<unresolved>}"
+
+  local body
+  # 1. Rewriting simple index. Accepted only if the page points at the mirror for
+  #    artifacts; a page that still names files.pythonhosted.org would leave the
+  #    downloads on the origin.
+  if body="$(curl -sf -m 15 -H 'Accept: text/html' "${mirror}/simple/${probe_pkg}/" 2>/dev/null)" \
+    && [[ -n "${body}" ]]; then
+    if grep -qF "${mirror}/files.pythonhosted.org/" <<<"${body}"; then
+      export RAYCI_PYPI_INDEX_MODE="mirror-simple"
+      export PIP_INDEX_URL="${mirror}/simple"
+      export UV_INDEX_URL="${mirror}/simple"
+      export RULES_PYTHON_PIP_ISOLATED=0
+      echo "pypi index: using the mirror's rewriting simple index -> ${PIP_INDEX_URL}"
+      return 0
+    fi
+    echo "pypi index: ${mirror}/simple answers but does not rewrite artifact URLs; trying the byte cache" >&2
+  fi
+
+  # 2. Path-prefixed byte cache, which needs the local rewriting proxy in front.
+  if ! curl -sf -m 15 -o /dev/null "${mirror}/pypi.org/simple/${probe_pkg}/" 2>/dev/null; then
+    export RAYCI_PYPI_INDEX_MODE="pypi"
+    echo "pypi index: mirror unreachable from this agent; resolving from public PyPI" >&2
+    return 0
+  fi
+  if [[ ! -x /opt/pypiproxy/bin/python ]]; then
+    export RAYCI_PYPI_INDEX_MODE="pypi"
+    echo "pypi index: byte cache reachable but this image carries no proxy; resolving from public PyPI" >&2
+    return 0
+  fi
+
+  local port="${RAYCI_PYPI_PROXY_PORT:-35999}"
+  local url="http://127.0.0.1:${port}"
+  local log=/tmp/pypi_index_proxy.log
+
+  # setsid gives the proxy its own session: `bash -i` enables job control, so a
+  # plain background job shares the step shell's process group and would be
+  # signalled along with it.
+  MIRROR_URL="${mirror}" setsid /opt/pypiproxy/bin/python \
+    /opt/pypiproxy/pypi_index_proxy.py "${port}" >"${log}" 2>&1 &
+
+  local _
+  for _ in $(seq 1 60); do
+    curl -sf -m 5 -o /dev/null "${url}/healthz" 2>/dev/null && break
+    sleep 0.5
+  done
+  # Probed through the proxy rather than at /healthz, which does not touch the
+  # mirror: a process that is up but cannot reach its upstream must not be used.
+  if ! curl -sf -m 20 -o /dev/null "${url}/simple/${probe_pkg}/" 2>/dev/null; then
+    export RAYCI_PYPI_INDEX_MODE="pypi"
+    echo "pypi index: proxy did not serve an index in 30s; resolving from public PyPI" >&2
+    [[ -f "${log}" ]] && tail -n 40 "${log}" >&2
+    return 0
+  fi
+
+  export RAYCI_PYPI_INDEX_MODE="local-proxy"
+  export RAYCI_PYPI_PROXY_PORT="${port}"
+  export RAYCI_PYPI_PROXY_LOG="${log}"
+  export PIP_INDEX_URL="${url}/simple"
+  export UV_INDEX_URL="${url}/simple"
+  # rules_python passes --isolated to whl_library's pip, which makes it ignore
+  # every PIP_* variable. It reads this before deciding to pass the flag.
+  export RULES_PYTHON_PIP_ISOLATED=0
+
+  # The proxy is on this container's loopback, which a nested container does not
+  # share. Publish this container's id so ci/ray_ci/tester.py can join its network
+  # namespace; docker sets the hostname to the container's short id.
+  local container_id
+  container_id="$(cat /etc/hostname 2>/dev/null || hostname)"
+  export RAYCI_PYPI_PROXY_NETWORK="container:${container_id}"
+
+  echo "pypi index: using the local rewriting proxy over the mirror -> ${PIP_INDEX_URL}"
+}
+
+_rayci_pypi_index_setup

--- a/ci/ray_ci/container.py
+++ b/ci/ray_ci/container.py
@@ -50,7 +50,11 @@ _DOCKER_ENV = [
     # .bazelrc. Docker passes nothing through for a variable that is unset, which
     # is the case in a plain checkout, and then pip and uv resolve from PyPI.
     "PIP_INDEX_URL",
+    "PIP_EXTRA_INDEX_URL",
+    "PIP_TRUSTED_HOST",
     "UV_INDEX_URL",
+    "UV_EXTRA_INDEX_URL",
+    "UV_INSECURE_HOST",
     "RULES_PYTHON_PIP_ISOLATED",
 ]
 _RAYCI_BUILD_ID = os.environ.get("RAYCI_BUILD_ID", "")

--- a/ci/ray_ci/container.py
+++ b/ci/ray_ci/container.py
@@ -45,6 +45,13 @@ _DOCKER_ENV = [
     "BUILDKITE_PULL_REQUEST",
     "BUILDKITE_BAZEL_CACHE_URL",
     "BUILDKITE_CACHE_READONLY",
+    # Package index configuration, so a nested container resolves from the same
+    # index as the step that started it; see the --repo_env passthrough in
+    # .bazelrc. Docker passes nothing through for a variable that is unset, which
+    # is the case in a plain checkout, and then pip and uv resolve from PyPI.
+    "PIP_INDEX_URL",
+    "UV_INDEX_URL",
+    "RULES_PYTHON_PIP_ISOLATED",
 ]
 _RAYCI_BUILD_ID = os.environ.get("RAYCI_BUILD_ID", "")
 

--- a/ci/ray_ci/linux_container.py
+++ b/ci/ray_ci/linux_container.py
@@ -47,6 +47,9 @@ class LinuxContainer(Container):
         self, build_type: Optional[str] = None, mask: Optional[str] = None
     ) -> List[str]:
         cache_readonly = os.environ.get("BUILDKITE_CACHE_READONLY", "")
+        # Empty unless the CI package mirror is reachable and usable from a docker
+        # build; the Dockerfile falls back to PyPI on an empty value.
+        image_index_url = os.environ.get("RAYCI_IMAGE_PIP_INDEX_URL", "")
 
         env = os.environ.copy()
         env["DOCKER_BUILDKIT"] = "1"
@@ -63,6 +66,8 @@ class LinuxContainer(Container):
             f"BUILD_TYPE={build_type or ''}",
             "--build-arg",
             f"BUILDKITE_CACHE_READONLY={cache_readonly}",
+            "--build-arg",
+            f"RAYCI_IMAGE_PIP_INDEX_URL={image_index_url}",
         ]
 
         if not build_type or build_type in (

--- a/ci/ray_ci/test_linux_tester_container.py
+++ b/ci/ray_ci/test_linux_tester_container.py
@@ -102,7 +102,8 @@ def test_run_tests_in_docker() -> None:
         # invocation inside it reads the --repo_env passthrough from the repo's
         # .bazelrc, which only has an effect on variables that container has.
         assert (
-            "--env PIP_INDEX_URL --env UV_INDEX_URL "
+            "--env PIP_INDEX_URL --env PIP_EXTRA_INDEX_URL --env PIP_TRUSTED_HOST "
+            "--env UV_INDEX_URL --env UV_EXTRA_INDEX_URL --env UV_INSECURE_HOST "
             "--env RULES_PYTHON_PIP_ISOLATED" in input_str
         )
         assert "--network host" in input_str

--- a/ci/ray_ci/test_linux_tester_container.py
+++ b/ci/ray_ci/test_linux_tester_container.py
@@ -98,6 +98,13 @@ def test_run_tests_in_docker() -> None:
         )._run_tests_in_docker(["t1", "t2"], [0, 1], "/tmp", ["v=k"], "flag")
         input_str = inputs[-1]
         assert "--env ENV_01 --env ENV_02 --env BUILDKITE" in input_str
+        # The index configuration has to reach the nested container: the bazel
+        # invocation inside it reads the --repo_env passthrough from the repo's
+        # .bazelrc, which only has an effect on variables that container has.
+        assert (
+            "--env PIP_INDEX_URL --env UV_INDEX_URL "
+            "--env RULES_PYTHON_PIP_ISOLATED" in input_str
+        )
         assert "--network host" in input_str
         assert '--gpus "device=0,1"' in input_str
         assert "--volume /tmp:/tmp/bazel_event_logs" in input_str

--- a/ci/ray_ci/test_linux_tester_container.py
+++ b/ci/ray_ci/test_linux_tester_container.py
@@ -188,6 +188,8 @@ def test_ray_installation() -> None:
             "BUILD_TYPE=debug",
             "--build-arg",
             "BUILDKITE_CACHE_READONLY=",
+            "--build-arg",
+            "RAYCI_IMAGE_PIP_INDEX_URL=",
             "-f",
             "ci/ray_ci/tests.env.Dockerfile",
             "/ray",

--- a/ci/ray_ci/tester.py
+++ b/ci/ray_ci/tester.py
@@ -118,6 +118,13 @@ bazel_workspace_dir = os.environ.get("BUILD_WORKSPACE_DIRECTORY", "")
 @click.option(
     "--network",
     type=str,
+    # The nested test container has its own loopback, so it cannot see a PyPI index
+    # proxy bound on 127.0.0.1 in the forge container. When that proxy is what the
+    # index points at, ci/pypi_proxy_profile.sh publishes the forge container's id
+    # here so the test container joins its network namespace. Unset when the index
+    # needs no proxy or none is running, which leaves networking as it was, and an
+    # explicit --network on the command line still wins.
+    default=lambda: os.environ.get("RAYCI_PYPI_PROXY_NETWORK"),
     help="Network to use for the test.",
 )
 @click.option(

--- a/ci/ray_ci/tests.env.Dockerfile
+++ b/ci/ray_ci/tests.env.Dockerfile
@@ -15,6 +15,14 @@ ARG BUILD_TYPE
 ARG BUILDKITE_CACHE_READONLY
 ARG RAY_INSTALL_MASK=
 
+# Where pip and uv resolve from during this build. See the same block on the roots of
+# the image graph in ci/docker/: ci/pypi_proxy_profile.sh sets this to the CI package
+# mirror when the job can reach it and leaves it empty otherwise, which is also the
+# case outside CI, and then this is the index pip would have used anyway.
+ARG RAYCI_IMAGE_PIP_INDEX_URL=""
+ENV PIP_INDEX_URL=${RAYCI_IMAGE_PIP_INDEX_URL:-https://pypi.org/simple}
+ENV UV_INDEX_URL=${RAYCI_IMAGE_PIP_INDEX_URL:-https://pypi.org/simple}
+
 # Disable C++ API/worker building by default on CI.
 # To use C++ API/worker, set BUILD_TYPE to "multi-lang".
 ENV RAY_DISABLE_EXTRA_CPP=1

--- a/ci/raydepsets/README.md
+++ b/ci/raydepsets/README.md
@@ -252,3 +252,11 @@ Pre-hooks support template variable substitution and are modeled as nodes in the
 --quiet
 --unsafe-package setuptools  (unless include_setuptools: true)
 ```
+
+`--emit-index-url` keeps the `--extra-index-url` entries (PyTorch, libtpu) in the
+lock file, where an install needs them to find artifacts that are not on PyPI.
+The primary `--index-url` it also emits is removed again before the lock is
+written, because a requirements file's index URL overrides both `PIP_INDEX_URL`
+and a `--index-url` passed on the command line — leaving it in would pin every
+install to whichever index compiled the lock. Absent it, pip and uv use PyPI
+unless the environment points them elsewhere.

--- a/ci/raydepsets/cli.py
+++ b/ci/raydepsets/cli.py
@@ -390,6 +390,8 @@ class DependencySetManager:
         if output:
             args.extend(["-o", output])
         self.exec_uv_cmd("compile", args, stdin)
+        if output:
+            _drop_emitted_index_url(self.get_path(output))
 
     def subset(
         self,
@@ -521,6 +523,37 @@ class DependencySetManager:
         """Remove the temporary directory used for lock file comparisons."""
         if self.temp_dir:
             shutil.rmtree(self.temp_dir)
+
+
+def _drop_emitted_index_url(lock_file_path: Path) -> None:
+    """Remove the primary index URL that uv emits into a lock file.
+
+    uv runs with --emit-index-url, which is what records the --extra-index-url
+    entries a depset resolves against (PyTorch, libtpu) inside the lock file, and
+    those have to stay: they are not PyPI, so nothing else supplies them at
+    install time. It also emits the primary --index-url, and a requirements
+    file's index URL beats both PIP_INDEX_URL and a --index-url given on the
+    command line. Emitting it therefore pins every install to whichever index
+    compiled the lock, which is not something a checked-in file should decide --
+    a caching mirror in front of PyPI cannot be configured, and a mirror URL that
+    did get written here would be unreachable for everyone outside it.
+
+    Dropping it leaves the primary index to the installing environment, which
+    falls back to PyPI when nothing is set, so resolution is unchanged. It also
+    keeps the lock files byte-identical whether they were compiled through a
+    mirror or straight from PyPI, which is what `--check` requires.
+    """
+    if not lock_file_path.exists():
+        return
+    lines = lock_file_path.read_text().splitlines(keepends=True)
+    kept = [line for line in lines if not line.startswith("--index-url ")]
+    if len(kept) == len(lines):
+        return
+    # Removing the first line can leave the file starting on the blank line that
+    # separated the emitted options from the requirements.
+    while kept and not kept[0].strip():
+        kept.pop(0)
+    lock_file_path.write_text("".join(kept))
 
 
 def _get_bytes(packages: List[str]) -> bytes:

--- a/ci/raydepsets/tests/test_cli.py
+++ b/ci/raydepsets/tests/test_cli.py
@@ -15,6 +15,7 @@ from networkx import topological_sort
 from ci.raydepsets.cli import (
     DEFAULT_UV_FLAGS,
     DependencySetManager,
+    _drop_emitted_index_url,
     _flatten_flags,
     _get_depset,
     _override_uv_flags,
@@ -425,6 +426,47 @@ class TestCli(unittest.TestCase):
             "--index",
             "https://download.pytorch.org/whl/cu128",
         ]
+
+    def test_drop_emitted_index_url(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            lock_file = Path(tmpdir) / "requirements.txt"
+            lock_file.write_text(
+                "--index-url https://pypi.org/simple\n"
+                "--extra-index-url https://download.pytorch.org/whl/cu128\n"
+                "--find-links https://data.pyg.org/whl/torch-2.9.0+cu128.html\n"
+                "\n"
+                "torch==2.9.0+cu128 \\\n"
+                "    --hash=sha256:abc123\n"
+            )
+            _drop_emitted_index_url(lock_file)
+            # The primary index goes; the indexes that are not PyPI stay, because
+            # nothing else supplies them at install time.
+            assert lock_file.read_text() == (
+                "--extra-index-url https://download.pytorch.org/whl/cu128\n"
+                "--find-links https://data.pyg.org/whl/torch-2.9.0+cu128.html\n"
+                "\n"
+                "torch==2.9.0+cu128 \\\n"
+                "    --hash=sha256:abc123\n"
+            )
+
+    def test_drop_emitted_index_url_only_option(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            lock_file = Path(tmpdir) / "requirements.txt"
+            lock_file.write_text(
+                "--index-url https://pypi.org/simple\n"
+                "\n"
+                "emoji==2.9.0 \\\n"
+                "    --hash=sha256:abc123\n"
+            )
+            _drop_emitted_index_url(lock_file)
+            # The blank line that separated the options goes with it, so the file
+            # starts on a requirement.
+            expected = "emoji==2.9.0 \\\n    --hash=sha256:abc123\n"
+            assert lock_file.read_text() == expected
+            # Rerunning is a no-op, so regenerating an already-stripped lock file
+            # cannot drift.
+            _drop_emitted_index_url(lock_file)
+            assert lock_file.read_text() == expected
 
     def test_build_graph(self):
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -1217,31 +1259,39 @@ class TestCli(unittest.TestCase):
 
     def test_relax_preserves_options(self):
         with tempfile.TemporaryDirectory() as tmpdir:
-            copy_data_to_tmpdir(tmpdir)
-            manager = _create_test_manager(tmpdir)
-            manager.compile(
-                constraints=["requirement_constraints_test.txt"],
+            copy_data_to_tmpdir(tmpdir, ignore_patterns="test2.depsets.yaml")
+            # Sourced from the large fixture because that is the one carrying an
+            # --extra-index-url: a compiled lock keeps no primary --index-url, so
+            # a freshly compiled source would have no options left to preserve.
+            depset = Depset(
+                name="large_depset",
+                operation="compile",
                 requirements=["requirements_test.txt"],
-                name="general_depset__py311_cpu",
-                output="requirements_compiled_general.txt",
+                output="requirements_compiled_large_test.txt",
+                config_name="test.depsets.yaml",
             )
-            # Verify the source has an index URL option
+            write_to_config_file(tmpdir, [depset], "test.depsets.yaml")
+            manager = _create_test_manager(tmpdir)
             source_rf = parse_lock_file(
-                str(Path(tmpdir) / "requirements_compiled_general.txt")
+                str(Path(tmpdir) / "requirements_compiled_large_test.txt")
             )
             assert len(source_rf.options) >= 1
 
             manager.relax(
-                source_depset="general_depset__py311_cpu",
-                packages=["emoji"],
+                source_depset="large_depset",
+                packages=["numpy"],
                 name="relaxed_depset",
                 output="requirements_compiled_relaxed.txt",
             )
             output_rf = parse_lock_file(
                 str(Path(tmpdir) / "requirements_compiled_relaxed.txt")
             )
-            # Options (like --index-url) should be preserved
-            assert len(output_rf.options) >= 1
+            # Options that are not PyPI, like the PyTorch --extra-index-url, have
+            # to survive a relax. Compared on the parsed options rather than the
+            # OptionLine objects, which carry the file name they came from.
+            assert [option.options for option in output_rf.options] == [
+                option.options for option in source_rf.options
+            ]
 
     def test_relax_large_lock_file(self):
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/ci/raydepsets/tests/test_data/requirements_compiled_large_test.txt
+++ b/ci/raydepsets/tests/test_data/requirements_compiled_large_test.txt
@@ -1,4 +1,3 @@
---index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu128
 
 absl-py==1.4.0 \

--- a/ci/raydepsets/tests/test_data/requirements_compiled_test.txt
+++ b/ci/raydepsets/tests/test_data/requirements_compiled_test.txt
@@ -1,5 +1,3 @@
---index-url https://pypi.org/simple
-
 emoji==2.9.0 \
     --hash=sha256:17b0d53e1d9f787307a4c65aa19badb0a1ffdbc89b3a3cd851fc77821cdaced2 \
     --hash=sha256:5f4a15b7caa9c67fc11be9d90a822e3fa26aeb4e5b7bd2ded754b394d9c47869

--- a/ci/raydepsets/tests/test_data/requirements_compiled_test_expand.txt
+++ b/ci/raydepsets/tests/test_data/requirements_compiled_test_expand.txt
@@ -1,5 +1,3 @@
---index-url https://pypi.org/simple
-
 emoji==2.9.0 \
     --hash=sha256:17b0d53e1d9f787307a4c65aa19badb0a1ffdbc89b3a3cd851fc77821cdaced2 \
     --hash=sha256:5f4a15b7caa9c67fc11be9d90a822e3fa26aeb4e5b7bd2ded754b394d9c47869

--- a/ci/raydepsets/tests/test_data/requirements_compiled_test_update.txt
+++ b/ci/raydepsets/tests/test_data/requirements_compiled_test_update.txt
@@ -1,5 +1,3 @@
---index-url https://pypi.org/simple
-
 emoji==2.10.0 \
     --hash=sha256:7e68435eecd2c428c3b4aaa5f72d61a5b1a36c81a5138681cba13d19d94aa3a0 \
     --hash=sha256:aed4332caa23553a7218f032c08b0a325ae53b010f7fb98ad272c0f7841bc1d3

--- a/doc/source/ray-contribute/dependency-management.md
+++ b/doc/source/ray-contribute/dependency-management.md
@@ -78,6 +78,8 @@ Every `compile` call inherits this default set of `uv pip compile` flags:
 --unsafe-package setuptools     (unless include_setuptools: true)
 ```
 
+`--emit-index-url` is what records the `--extra-index-url` entries a depset resolves against — PyTorch, libtpu — inside the lock, so an install can still find artifacts that are not on PyPI. The primary `--index-url` it also emits is dropped again before the lock is written: a requirements file's index URL overrides both `PIP_INDEX_URL` and a `--index-url` on the command line, so leaving it in would pin every install to whichever index compiled the lock. Without it, pip and uv fall back to PyPI unless the environment says otherwise.
+
 `--generate-hashes` is why locks are SHA256-pinned. `--no-strip-markers` preserves `python_version` markers so a single lock can be a constraint at multiple `--python-version` targets. `--index-strategy unsafe-best-match` is the same flag you'd pass when reproducing CI's install resolution locally (see [Diagnosing dependency conflicts](#diagnosing-dependency-conflicts)).
 
 Before each `compile` runs, raydepsets executes any declared **pre-hooks**. The common one is `ci/raydepsets/pre_hooks/remove-compiled-headers.sh`, which copies `requirements_compiled*.txt` to `/tmp/ray-deps/` after stripping `--extra-index-url` / `--find-links` lines, so the file is a clean version constraint and GPU index URLs don't leak into CPU locks.

--- a/python/deplocks/base_deps/ray_base_deps_py3.10.lock
+++ b/python/deplocks/base_deps/ray_base_deps_py3.10.lock
@@ -1,5 +1,3 @@
---index-url https://pypi.org/simple
-
 adlfs==2026.4.0 \
     --hash=sha256:84c6f0fc28403629ef6d6d90f0d1a35a3302179f65ce4686c939a42ad0496d8d \
     --hash=sha256:a12a420583ae2d86d1b02902db147b7da5cf3e6eef40ee53024756a781d5d84f

--- a/python/deplocks/base_deps/ray_base_deps_py3.11.lock
+++ b/python/deplocks/base_deps/ray_base_deps_py3.11.lock
@@ -1,5 +1,3 @@
---index-url https://pypi.org/simple
-
 adlfs==2026.4.0 \
     --hash=sha256:84c6f0fc28403629ef6d6d90f0d1a35a3302179f65ce4686c939a42ad0496d8d \
     --hash=sha256:a12a420583ae2d86d1b02902db147b7da5cf3e6eef40ee53024756a781d5d84f

--- a/python/deplocks/base_deps/ray_base_deps_py3.12.lock
+++ b/python/deplocks/base_deps/ray_base_deps_py3.12.lock
@@ -1,5 +1,3 @@
---index-url https://pypi.org/simple
-
 adlfs==2026.4.0 \
     --hash=sha256:84c6f0fc28403629ef6d6d90f0d1a35a3302179f65ce4686c939a42ad0496d8d \
     --hash=sha256:a12a420583ae2d86d1b02902db147b7da5cf3e6eef40ee53024756a781d5d84f

--- a/python/deplocks/base_deps/ray_base_deps_py3.13.lock
+++ b/python/deplocks/base_deps/ray_base_deps_py3.13.lock
@@ -1,5 +1,3 @@
---index-url https://pypi.org/simple
-
 adlfs==2026.4.0 \
     --hash=sha256:84c6f0fc28403629ef6d6d90f0d1a35a3302179f65ce4686c939a42ad0496d8d \
     --hash=sha256:a12a420583ae2d86d1b02902db147b7da5cf3e6eef40ee53024756a781d5d84f

--- a/python/deplocks/base_deps/ray_base_deps_py3.14.lock
+++ b/python/deplocks/base_deps/ray_base_deps_py3.14.lock
@@ -1,5 +1,3 @@
---index-url https://pypi.org/simple
-
 adlfs==2026.4.0 \
     --hash=sha256:84c6f0fc28403629ef6d6d90f0d1a35a3302179f65ce4686c939a42ad0496d8d \
     --hash=sha256:a12a420583ae2d86d1b02902db147b7da5cf3e6eef40ee53024756a781d5d84f

--- a/python/deplocks/base_deps/ray_base_deps_tpu_py3.10.lock
+++ b/python/deplocks/base_deps/ray_base_deps_tpu_py3.10.lock
@@ -1,4 +1,3 @@
---index-url https://pypi.org/simple
 --extra-index-url https://storage.googleapis.com/libtpu-releases/index.html
 
 absl-py==2.4.0 \

--- a/python/deplocks/base_deps/ray_base_deps_tpu_py3.11.lock
+++ b/python/deplocks/base_deps/ray_base_deps_tpu_py3.11.lock
@@ -1,4 +1,3 @@
---index-url https://pypi.org/simple
 --extra-index-url https://storage.googleapis.com/libtpu-releases/index.html
 
 absl-py==2.4.0 \

--- a/python/deplocks/base_deps/ray_base_deps_tpu_py3.12.lock
+++ b/python/deplocks/base_deps/ray_base_deps_tpu_py3.12.lock
@@ -1,4 +1,3 @@
---index-url https://pypi.org/simple
 --extra-index-url https://storage.googleapis.com/libtpu-releases/index.html
 
 absl-py==2.4.0 \

--- a/python/deplocks/base_deps/ray_base_deps_tpu_py3.13.lock
+++ b/python/deplocks/base_deps/ray_base_deps_tpu_py3.13.lock
@@ -1,4 +1,3 @@
---index-url https://pypi.org/simple
 --extra-index-url https://storage.googleapis.com/libtpu-releases/index.html
 
 absl-py==2.4.0 \

--- a/python/deplocks/base_deps/ray_base_deps_tpu_py3.14.lock
+++ b/python/deplocks/base_deps/ray_base_deps_tpu_py3.14.lock
@@ -1,4 +1,3 @@
---index-url https://pypi.org/simple
 --extra-index-url https://storage.googleapis.com/libtpu-releases/index.html
 
 absl-py==2.4.0 \

--- a/python/deplocks/base_extra/ray_base_extra_py3.10.lock
+++ b/python/deplocks/base_extra/ray_base_extra_py3.10.lock
@@ -1,5 +1,3 @@
---index-url https://pypi.org/simple
-
 adlfs==2026.4.0 \
     --hash=sha256:84c6f0fc28403629ef6d6d90f0d1a35a3302179f65ce4686c939a42ad0496d8d \
     --hash=sha256:a12a420583ae2d86d1b02902db147b7da5cf3e6eef40ee53024756a781d5d84f

--- a/python/deplocks/base_extra/ray_base_extra_py3.11.lock
+++ b/python/deplocks/base_extra/ray_base_extra_py3.11.lock
@@ -1,5 +1,3 @@
---index-url https://pypi.org/simple
-
 adlfs==2026.4.0 \
     --hash=sha256:84c6f0fc28403629ef6d6d90f0d1a35a3302179f65ce4686c939a42ad0496d8d \
     --hash=sha256:a12a420583ae2d86d1b02902db147b7da5cf3e6eef40ee53024756a781d5d84f

--- a/python/deplocks/base_extra/ray_base_extra_py3.12.lock
+++ b/python/deplocks/base_extra/ray_base_extra_py3.12.lock
@@ -1,5 +1,3 @@
---index-url https://pypi.org/simple
-
 adlfs==2026.4.0 \
     --hash=sha256:84c6f0fc28403629ef6d6d90f0d1a35a3302179f65ce4686c939a42ad0496d8d \
     --hash=sha256:a12a420583ae2d86d1b02902db147b7da5cf3e6eef40ee53024756a781d5d84f

--- a/python/deplocks/base_extra/ray_base_extra_py3.13.lock
+++ b/python/deplocks/base_extra/ray_base_extra_py3.13.lock
@@ -1,5 +1,3 @@
---index-url https://pypi.org/simple
-
 adlfs==2026.4.0 \
     --hash=sha256:84c6f0fc28403629ef6d6d90f0d1a35a3302179f65ce4686c939a42ad0496d8d \
     --hash=sha256:a12a420583ae2d86d1b02902db147b7da5cf3e6eef40ee53024756a781d5d84f

--- a/python/deplocks/base_extra/ray_base_extra_py3.14.lock
+++ b/python/deplocks/base_extra/ray_base_extra_py3.14.lock
@@ -1,5 +1,3 @@
---index-url https://pypi.org/simple
-
 adlfs==2026.4.0 \
     --hash=sha256:84c6f0fc28403629ef6d6d90f0d1a35a3302179f65ce4686c939a42ad0496d8d \
     --hash=sha256:a12a420583ae2d86d1b02902db147b7da5cf3e6eef40ee53024756a781d5d84f

--- a/python/deplocks/base_extra_testdeps/ray-base_extra_testdeps_py3.10.lock
+++ b/python/deplocks/base_extra_testdeps/ray-base_extra_testdeps_py3.10.lock
@@ -1,5 +1,3 @@
---index-url https://pypi.org/simple
-
 absl-py==2.4.0 \
     --hash=sha256:88476fd881ca8aab94ffa78b7b6c632a782ab3ba1cd19c9bd423abc4fb4cd28d \
     --hash=sha256:8c6af82722b35cf71e0f4d1d47dcaebfff286e27110a99fc359349b247dfb5d4

--- a/python/deplocks/base_extra_testdeps/ray-base_extra_testdeps_py3.11.lock
+++ b/python/deplocks/base_extra_testdeps/ray-base_extra_testdeps_py3.11.lock
@@ -1,5 +1,3 @@
---index-url https://pypi.org/simple
-
 absl-py==2.4.0 \
     --hash=sha256:88476fd881ca8aab94ffa78b7b6c632a782ab3ba1cd19c9bd423abc4fb4cd28d \
     --hash=sha256:8c6af82722b35cf71e0f4d1d47dcaebfff286e27110a99fc359349b247dfb5d4

--- a/python/deplocks/base_extra_testdeps/ray-base_extra_testdeps_py3.12.lock
+++ b/python/deplocks/base_extra_testdeps/ray-base_extra_testdeps_py3.12.lock
@@ -1,5 +1,3 @@
---index-url https://pypi.org/simple
-
 absl-py==2.4.0 \
     --hash=sha256:88476fd881ca8aab94ffa78b7b6c632a782ab3ba1cd19c9bd423abc4fb4cd28d \
     --hash=sha256:8c6af82722b35cf71e0f4d1d47dcaebfff286e27110a99fc359349b247dfb5d4

--- a/python/deplocks/base_extra_testdeps/ray-base_extra_testdeps_py3.13.lock
+++ b/python/deplocks/base_extra_testdeps/ray-base_extra_testdeps_py3.13.lock
@@ -1,5 +1,3 @@
---index-url https://pypi.org/simple
-
 absl-py==2.4.0 \
     --hash=sha256:88476fd881ca8aab94ffa78b7b6c632a782ab3ba1cd19c9bd423abc4fb4cd28d \
     --hash=sha256:8c6af82722b35cf71e0f4d1d47dcaebfff286e27110a99fc359349b247dfb5d4

--- a/python/deplocks/base_extra_testdeps/ray-base_extra_testdeps_py3.14.lock
+++ b/python/deplocks/base_extra_testdeps/ray-base_extra_testdeps_py3.14.lock
@@ -1,5 +1,3 @@
---index-url https://pypi.org/simple
-
 absl-py==2.4.0 \
     --hash=sha256:88476fd881ca8aab94ffa78b7b6c632a782ab3ba1cd19c9bd423abc4fb4cd28d \
     --hash=sha256:8c6af82722b35cf71e0f4d1d47dcaebfff286e27110a99fc359349b247dfb5d4

--- a/python/deplocks/base_extra_testdeps/ray-gpu-base_extra_testdeps_py3.10.lock
+++ b/python/deplocks/base_extra_testdeps/ray-gpu-base_extra_testdeps_py3.10.lock
@@ -1,4 +1,3 @@
---index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu128
 
 absl-py==2.4.0 \

--- a/python/deplocks/base_extra_testdeps/ray-gpu-cu130-base_extra_testdeps_py3.10.lock
+++ b/python/deplocks/base_extra_testdeps/ray-gpu-cu130-base_extra_testdeps_py3.10.lock
@@ -1,4 +1,3 @@
---index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu130
 
 absl-py==2.4.0 \

--- a/python/deplocks/base_extra_testdeps/ray-gpu-cu130-base_extra_testdeps_py3.11.lock
+++ b/python/deplocks/base_extra_testdeps/ray-gpu-cu130-base_extra_testdeps_py3.11.lock
@@ -1,4 +1,3 @@
---index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu130
 
 absl-py==2.4.0 \

--- a/python/deplocks/base_extra_testdeps/ray-gpu-cu130-base_extra_testdeps_py3.12.lock
+++ b/python/deplocks/base_extra_testdeps/ray-gpu-cu130-base_extra_testdeps_py3.12.lock
@@ -1,4 +1,3 @@
---index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu130
 
 absl-py==2.4.0 \

--- a/python/deplocks/base_extra_testdeps/ray-gpu-cu130-base_extra_testdeps_py3.13.lock
+++ b/python/deplocks/base_extra_testdeps/ray-gpu-cu130-base_extra_testdeps_py3.13.lock
@@ -1,4 +1,3 @@
---index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu130
 
 absl-py==2.4.0 \

--- a/python/deplocks/base_extra_testdeps/ray-llm-base_extra_testdeps_py3.11.lock
+++ b/python/deplocks/base_extra_testdeps/ray-llm-base_extra_testdeps_py3.11.lock
@@ -1,4 +1,3 @@
---index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu128
 
 absl-py==2.4.0 \

--- a/python/deplocks/base_extra_testdeps/ray-llm-base_extra_testdeps_py3.12.lock
+++ b/python/deplocks/base_extra_testdeps/ray-llm-base_extra_testdeps_py3.12.lock
@@ -1,4 +1,3 @@
---index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu130
 
 absl-py==2.4.0 \

--- a/python/deplocks/base_extra_testdeps/ray-ml-base_extra_testdeps_py3.10.lock
+++ b/python/deplocks/base_extra_testdeps/ray-ml-base_extra_testdeps_py3.10.lock
@@ -1,4 +1,3 @@
---index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu128
 
 absl-py==2.4.0 \

--- a/python/deplocks/base_slim/ray_base_slim_py3.10.lock
+++ b/python/deplocks/base_slim/ray_base_slim_py3.10.lock
@@ -1,5 +1,3 @@
---index-url https://pypi.org/simple
-
 absl-py==2.4.0 \
     --hash=sha256:88476fd881ca8aab94ffa78b7b6c632a782ab3ba1cd19c9bd423abc4fb4cd28d \
     --hash=sha256:8c6af82722b35cf71e0f4d1d47dcaebfff286e27110a99fc359349b247dfb5d4

--- a/python/deplocks/base_slim/ray_base_slim_py3.11.lock
+++ b/python/deplocks/base_slim/ray_base_slim_py3.11.lock
@@ -1,5 +1,3 @@
---index-url https://pypi.org/simple
-
 absl-py==2.4.0 \
     --hash=sha256:88476fd881ca8aab94ffa78b7b6c632a782ab3ba1cd19c9bd423abc4fb4cd28d \
     --hash=sha256:8c6af82722b35cf71e0f4d1d47dcaebfff286e27110a99fc359349b247dfb5d4

--- a/python/deplocks/base_slim/ray_base_slim_py3.12.lock
+++ b/python/deplocks/base_slim/ray_base_slim_py3.12.lock
@@ -1,5 +1,3 @@
---index-url https://pypi.org/simple
-
 absl-py==2.4.0 \
     --hash=sha256:88476fd881ca8aab94ffa78b7b6c632a782ab3ba1cd19c9bd423abc4fb4cd28d \
     --hash=sha256:8c6af82722b35cf71e0f4d1d47dcaebfff286e27110a99fc359349b247dfb5d4

--- a/python/deplocks/base_slim/ray_base_slim_py3.13.lock
+++ b/python/deplocks/base_slim/ray_base_slim_py3.13.lock
@@ -1,5 +1,3 @@
---index-url https://pypi.org/simple
-
 absl-py==2.4.0 \
     --hash=sha256:88476fd881ca8aab94ffa78b7b6c632a782ab3ba1cd19c9bd423abc4fb4cd28d \
     --hash=sha256:8c6af82722b35cf71e0f4d1d47dcaebfff286e27110a99fc359349b247dfb5d4

--- a/python/deplocks/base_slim/ray_base_slim_py3.14.lock
+++ b/python/deplocks/base_slim/ray_base_slim_py3.14.lock
@@ -1,5 +1,3 @@
---index-url https://pypi.org/simple
-
 absl-py==2.4.0 \
     --hash=sha256:88476fd881ca8aab94ffa78b7b6c632a782ab3ba1cd19c9bd423abc4fb4cd28d \
     --hash=sha256:8c6af82722b35cf71e0f4d1d47dcaebfff286e27110a99fc359349b247dfb5d4

--- a/python/deplocks/ci/ci_ml_thirdparty_depset_py3.10.lock
+++ b/python/deplocks/ci/ci_ml_thirdparty_depset_py3.10.lock
@@ -1,5 +1,3 @@
---index-url https://pypi.org/simple
-
 colorama==0.4.6 \
     --hash=sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44 \
     --hash=sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6

--- a/python/deplocks/ci/ci_ml_thirdparty_depset_py3.12.lock
+++ b/python/deplocks/ci/ci_ml_thirdparty_depset_py3.12.lock
@@ -1,5 +1,3 @@
---index-url https://pypi.org/simple
-
 colorama==0.4.6 \
     --hash=sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44 \
     --hash=sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6

--- a/python/deplocks/ci/ci_windows_depset.lock
+++ b/python/deplocks/ci/ci_windows_depset.lock
@@ -1,5 +1,3 @@
---index-url https://pypi.org/simple
-
 aioboto3==14.3.0 \
     --hash=sha256:1d18f88bb56835c607b62bb6cb907754d717bedde3ddfff6935727cb48a80135 \
     --hash=sha256:aec5de94e9edc1ffbdd58eead38a37f00ddac59a519db749a910c20b7b81bca7

--- a/python/deplocks/ci/core-build-ci_depset_py3.10.lock
+++ b/python/deplocks/ci/core-build-ci_depset_py3.10.lock
@@ -1,4 +1,3 @@
---index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cpu
 --find-links https://data.pyg.org/whl/torch-2.9.0+cpu.html
 

--- a/python/deplocks/ci/core-build-ci_depset_py3.12.lock
+++ b/python/deplocks/ci/core-build-ci_depset_py3.12.lock
@@ -1,4 +1,3 @@
---index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cpu
 --find-links https://data.pyg.org/whl/torch-2.9.0+cpu.html
 

--- a/python/deplocks/ci/core-gpu-cu130-build-ci_depset_py3.10.lock
+++ b/python/deplocks/ci/core-gpu-cu130-build-ci_depset_py3.10.lock
@@ -1,4 +1,3 @@
---index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu128
 --find-links https://data.pyg.org/whl/torch-2.9.0+cu128.html
 

--- a/python/deplocks/ci/core-gpu-cu130-build-ci_depset_py3.12.lock
+++ b/python/deplocks/ci/core-gpu-cu130-build-ci_depset_py3.12.lock
@@ -1,4 +1,3 @@
---index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu128
 --find-links https://data.pyg.org/whl/torch-2.9.0+cu128.html
 

--- a/python/deplocks/ci/core-gpubuild-ci_depset_py3.10.lock
+++ b/python/deplocks/ci/core-gpubuild-ci_depset_py3.10.lock
@@ -1,4 +1,3 @@
---index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu128
 --find-links https://data.pyg.org/whl/torch-2.9.0+cu128.html
 

--- a/python/deplocks/ci/core-gpubuild-ci_depset_py3.12.lock
+++ b/python/deplocks/ci/core-gpubuild-ci_depset_py3.12.lock
@@ -1,4 +1,3 @@
---index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu128
 --find-links https://data.pyg.org/whl/torch-2.9.0+cu128.html
 

--- a/python/deplocks/ci/data-base-ci_depset_py3.10.lock
+++ b/python/deplocks/ci/data-base-ci_depset_py3.10.lock
@@ -1,4 +1,3 @@
---index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cpu
 --find-links https://data.pyg.org/whl/torch-2.9.0+cpu.html
 

--- a/python/deplocks/ci/data-base-ci_depset_py3.11.lock
+++ b/python/deplocks/ci/data-base-ci_depset_py3.11.lock
@@ -1,4 +1,3 @@
---index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cpu
 --find-links https://data.pyg.org/whl/torch-2.9.0+cpu.html
 

--- a/python/deplocks/ci/data-base-ci_depset_py3.12.lock
+++ b/python/deplocks/ci/data-base-ci_depset_py3.12.lock
@@ -1,4 +1,3 @@
---index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cpu
 --find-links https://data.pyg.org/whl/torch-2.9.0+cpu.html
 

--- a/python/deplocks/ci/data-mongo-ci_depset_py3.10.lock
+++ b/python/deplocks/ci/data-mongo-ci_depset_py3.10.lock
@@ -1,4 +1,3 @@
---index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cpu
 --find-links https://data.pyg.org/whl/torch-2.9.0+cpu.html
 

--- a/python/deplocks/ci/data-pyarrow-latest-ci_depset_py3.10.lock
+++ b/python/deplocks/ci/data-pyarrow-latest-ci_depset_py3.10.lock
@@ -1,4 +1,3 @@
---index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cpu
 --find-links https://data.pyg.org/whl/torch-2.9.0+cpu.html
 

--- a/python/deplocks/ci/data-pyarrow-latest-ci_depset_py3.12.lock
+++ b/python/deplocks/ci/data-pyarrow-latest-ci_depset_py3.12.lock
@@ -1,4 +1,3 @@
---index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cpu
 --find-links https://data.pyg.org/whl/torch-2.9.0+cpu.html
 

--- a/python/deplocks/ci/data-pyarrow-nightly-ci_depset_py3.10.lock
+++ b/python/deplocks/ci/data-pyarrow-nightly-ci_depset_py3.10.lock
@@ -1,4 +1,3 @@
---index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cpu
 --find-links https://data.pyg.org/whl/torch-2.9.0+cpu.html
 

--- a/python/deplocks/ci/data-pyarrow-v17-ci_depset_py3.10.lock
+++ b/python/deplocks/ci/data-pyarrow-v17-ci_depset_py3.10.lock
@@ -1,4 +1,3 @@
---index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cpu
 --find-links https://data.pyg.org/whl/torch-2.9.0+cpu.html
 

--- a/python/deplocks/ci/docgpu_depset_py3.10.lock
+++ b/python/deplocks/ci/docgpu_depset_py3.10.lock
@@ -1,4 +1,3 @@
---index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu128
 --find-links https://data.pyg.org/whl/torch-2.9.0+cu128.html
 

--- a/python/deplocks/ci/docgpu_depset_py3.12.lock
+++ b/python/deplocks/ci/docgpu_depset_py3.12.lock
@@ -1,4 +1,3 @@
---index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu128
 --find-links https://data.pyg.org/whl/torch-2.9.0+cu128.html
 

--- a/python/deplocks/ci/macos_depset_py3.10.lock
+++ b/python/deplocks/ci/macos_depset_py3.10.lock
@@ -1,5 +1,3 @@
---index-url https://pypi.org/simple
-
 absl-py==2.4.0 \
     --hash=sha256:88476fd881ca8aab94ffa78b7b6c632a782ab3ba1cd19c9bd423abc4fb4cd28d \
     --hash=sha256:8c6af82722b35cf71e0f4d1d47dcaebfff286e27110a99fc359349b247dfb5d4

--- a/python/deplocks/ci/ml-build-ci_depset_py3.10.lock
+++ b/python/deplocks/ci/ml-build-ci_depset_py3.10.lock
@@ -1,4 +1,3 @@
---index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cpu
 --find-links https://data.pyg.org/whl/torch-2.9.0+cpu.html
 

--- a/python/deplocks/ci/ml-build-ci_depset_py3.12.lock
+++ b/python/deplocks/ci/ml-build-ci_depset_py3.12.lock
@@ -1,4 +1,3 @@
---index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cpu
 --find-links https://data.pyg.org/whl/torch-2.9.0+cpu.html
 

--- a/python/deplocks/ci/ml-gpubuild-ci_depset_py3.10.lock
+++ b/python/deplocks/ci/ml-gpubuild-ci_depset_py3.10.lock
@@ -1,4 +1,3 @@
---index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu128
 --find-links https://data.pyg.org/whl/torch-2.9.0+cu128.html
 

--- a/python/deplocks/ci/ml-gpubuild-ci_depset_py3.12.lock
+++ b/python/deplocks/ci/ml-gpubuild-ci_depset_py3.12.lock
@@ -1,4 +1,3 @@
---index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu128
 --find-links https://data.pyg.org/whl/torch-2.9.0+cu128.html
 

--- a/python/deplocks/ci/ml-lightning1gpubuild-ci_depset_py3.10.lock
+++ b/python/deplocks/ci/ml-lightning1gpubuild-ci_depset_py3.10.lock
@@ -1,4 +1,3 @@
---index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu128
 --find-links https://data.pyg.org/whl/torch-2.9.0+cu128.html
 

--- a/python/deplocks/ci/ml-torchft-ci_depset_py3.10.lock
+++ b/python/deplocks/ci/ml-torchft-ci_depset_py3.10.lock
@@ -1,4 +1,3 @@
---index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cpu
 --find-links https://data.pyg.org/whl/torch-2.9.0+cpu.html
 

--- a/python/deplocks/ci/relaxed_data-ci_depset_py3.10.lock
+++ b/python/deplocks/ci/relaxed_data-ci_depset_py3.10.lock
@@ -1,4 +1,3 @@
---index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cpu
 --find-links https://data.pyg.org/whl/torch-2.9.0+cpu.html
 absl-py==2.4.0 \

--- a/python/deplocks/ci/relaxed_data-ci_depset_py3.12.lock
+++ b/python/deplocks/ci/relaxed_data-ci_depset_py3.12.lock
@@ -1,4 +1,3 @@
---index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cpu
 --find-links https://data.pyg.org/whl/torch-2.9.0+cpu.html
 absl-py==2.4.0 \

--- a/python/deplocks/ci/relaxed_windows-tests-ci_depset_py3.10.lock
+++ b/python/deplocks/ci/relaxed_windows-tests-ci_depset_py3.10.lock
@@ -1,4 +1,3 @@
---index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cpu
 --find-links https://data.pyg.org/whl/torch-2.9.0+cpu.html
 absl-py==2.4.0 \

--- a/python/deplocks/ci/rllib-build-ci_depset_py3.10.lock
+++ b/python/deplocks/ci/rllib-build-ci_depset_py3.10.lock
@@ -1,4 +1,3 @@
---index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cpu
 --find-links https://data.pyg.org/whl/torch-2.9.0+cpu.html
 

--- a/python/deplocks/ci/rllib-build-ci_depset_py3.12.lock
+++ b/python/deplocks/ci/rllib-build-ci_depset_py3.12.lock
@@ -1,4 +1,3 @@
---index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cpu
 --find-links https://data.pyg.org/whl/torch-2.9.0+cpu.html
 

--- a/python/deplocks/ci/rllib-gpubuild-ci_depset_py3.10.lock
+++ b/python/deplocks/ci/rllib-gpubuild-ci_depset_py3.10.lock
@@ -1,4 +1,3 @@
---index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu128
 --find-links https://data.pyg.org/whl/torch-2.9.0+cu128.html
 

--- a/python/deplocks/ci/rllib-gpubuild-ci_depset_py3.12.lock
+++ b/python/deplocks/ci/rllib-gpubuild-ci_depset_py3.12.lock
@@ -1,4 +1,3 @@
---index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu128
 --find-links https://data.pyg.org/whl/torch-2.9.0+cu128.html
 

--- a/python/deplocks/ci/serve_base_depset_py3.10.lock
+++ b/python/deplocks/ci/serve_base_depset_py3.10.lock
@@ -1,4 +1,3 @@
---index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cpu
 
 absl-py==2.4.0 \

--- a/python/deplocks/ci/serve_base_depset_py3.12.lock
+++ b/python/deplocks/ci/serve_base_depset_py3.12.lock
@@ -1,4 +1,3 @@
---index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cpu
 
 absl-py==2.4.0 \

--- a/python/deplocks/ci/serve_ci_depset_py3.10.lock
+++ b/python/deplocks/ci/serve_ci_depset_py3.10.lock
@@ -1,4 +1,3 @@
---index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cpu
 absl-py==2.4.0 \
     --hash=sha256:88476fd881ca8aab94ffa78b7b6c632a782ab3ba1cd19c9bd423abc4fb4cd28d \

--- a/python/deplocks/ci/serve_ci_depset_py3.12.lock
+++ b/python/deplocks/ci/serve_ci_depset_py3.12.lock
@@ -1,4 +1,3 @@
---index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cpu
 absl-py==2.4.0 \
     --hash=sha256:88476fd881ca8aab94ffa78b7b6c632a782ab3ba1cd19c9bd423abc4fb4cd28d \

--- a/python/deplocks/ci/serve_tracing_depset_py3.10.lock
+++ b/python/deplocks/ci/serve_tracing_depset_py3.10.lock
@@ -1,4 +1,3 @@
---index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cpu
 
 absl-py==2.4.0 \

--- a/python/deplocks/ci/windows-tests-ci_depset_py3.10.lock
+++ b/python/deplocks/ci/windows-tests-ci_depset_py3.10.lock
@@ -1,4 +1,3 @@
---index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cpu
 --find-links https://data.pyg.org/whl/torch-2.9.0+cpu.html
 

--- a/python/deplocks/ci/windows-tests-torch27-ci_depset_py3.10.lock
+++ b/python/deplocks/ci/windows-tests-torch27-ci_depset_py3.10.lock
@@ -1,4 +1,3 @@
---index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cpu
 --find-links https://data.pyg.org/whl/torch-2.9.0+cpu.html
 --find-links https://data.pyg.org/whl/torch-2.7.0+cpu.html

--- a/python/deplocks/docs/docbuild_depset_py3.11.lock
+++ b/python/deplocks/docs/docbuild_depset_py3.11.lock
@@ -1,5 +1,3 @@
---index-url https://pypi.org/simple
-
 absl-py==2.4.0 \
     --hash=sha256:88476fd881ca8aab94ffa78b7b6c632a782ab3ba1cd19c9bd423abc4fb4cd28d \
     --hash=sha256:8c6af82722b35cf71e0f4d1d47dcaebfff286e27110a99fc359349b247dfb5d4

--- a/python/deplocks/docs/doctest_depset_py3.10.lock
+++ b/python/deplocks/docs/doctest_depset_py3.10.lock
@@ -1,4 +1,3 @@
---index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cpu
 --find-links https://data.pyg.org/whl/torch-2.9.0+cpu.html
 

--- a/python/deplocks/llm/ray_py312_cpu.lock
+++ b/python/deplocks/llm/ray_py312_cpu.lock
@@ -1,4 +1,3 @@
---index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cpu
 
 absl-py==2.4.0 \

--- a/python/deplocks/llm/ray_py312_cu130.lock
+++ b/python/deplocks/llm/ray_py312_cu130.lock
@@ -1,4 +1,3 @@
---index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu130
 
 absl-py==2.4.0 \

--- a/python/deplocks/llm/ray_test_py312_cpu.lock
+++ b/python/deplocks/llm/ray_test_py312_cpu.lock
@@ -1,4 +1,3 @@
---index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cpu
 
 absl-py==2.4.0 \

--- a/python/deplocks/llm/ray_test_py312_cu130.lock
+++ b/python/deplocks/llm/ray_test_py312_cu130.lock
@@ -1,4 +1,3 @@
---index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu130
 
 absl-py==2.4.0 \

--- a/python/deplocks/llm/rayllm_py312_cpu.lock
+++ b/python/deplocks/llm/rayllm_py312_cpu.lock
@@ -1,4 +1,3 @@
---index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cpu
 
 absl-py==2.4.0 \

--- a/python/deplocks/llm/rayllm_py312_cu130.lock
+++ b/python/deplocks/llm/rayllm_py312_cu130.lock
@@ -1,4 +1,3 @@
---index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu130
 
 absl-py==2.4.0 \

--- a/python/deplocks/llm/rayllm_subset_py312_cu130.lock
+++ b/python/deplocks/llm/rayllm_subset_py312_cu130.lock
@@ -1,4 +1,3 @@
---index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu130
 
 absl-py==2.4.0 \

--- a/python/deplocks/llm/rayllm_test_py312_cpu.lock
+++ b/python/deplocks/llm/rayllm_test_py312_cpu.lock
@@ -1,4 +1,3 @@
---index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cpu
 
 absl-py==2.4.0 \

--- a/python/deplocks/llm/rayllm_test_py312_cu130.lock
+++ b/python/deplocks/llm/rayllm_test_py312_cu130.lock
@@ -1,4 +1,3 @@
---index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu130
 
 absl-py==2.4.0 \

--- a/python/deplocks/ray-torch/ray-torch-cu128_base_py3.14.lock
+++ b/python/deplocks/ray-torch/ray-torch-cu128_base_py3.14.lock
@@ -1,4 +1,3 @@
---index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cu128
 
 absl-py==2.4.0 \

--- a/python/deplocks/ray_img/ray_img_cu130_py310.lock
+++ b/python/deplocks/ray_img/ray_img_cu130_py310.lock
@@ -1,4 +1,3 @@
---index-url https://pypi.org/simple
 absl-py==2.4.0 \
     --hash=sha256:88476fd881ca8aab94ffa78b7b6c632a782ab3ba1cd19c9bd423abc4fb4cd28d \
     --hash=sha256:8c6af82722b35cf71e0f4d1d47dcaebfff286e27110a99fc359349b247dfb5d4

--- a/python/deplocks/ray_img/ray_img_cu130_py311.lock
+++ b/python/deplocks/ray_img/ray_img_cu130_py311.lock
@@ -1,4 +1,3 @@
---index-url https://pypi.org/simple
 absl-py==2.4.0 \
     --hash=sha256:88476fd881ca8aab94ffa78b7b6c632a782ab3ba1cd19c9bd423abc4fb4cd28d \
     --hash=sha256:8c6af82722b35cf71e0f4d1d47dcaebfff286e27110a99fc359349b247dfb5d4

--- a/python/deplocks/ray_img/ray_img_cu130_py312.lock
+++ b/python/deplocks/ray_img/ray_img_cu130_py312.lock
@@ -1,4 +1,3 @@
---index-url https://pypi.org/simple
 absl-py==2.4.0 \
     --hash=sha256:88476fd881ca8aab94ffa78b7b6c632a782ab3ba1cd19c9bd423abc4fb4cd28d \
     --hash=sha256:8c6af82722b35cf71e0f4d1d47dcaebfff286e27110a99fc359349b247dfb5d4

--- a/python/deplocks/ray_img/ray_img_cu130_py313.lock
+++ b/python/deplocks/ray_img/ray_img_cu130_py313.lock
@@ -1,4 +1,3 @@
---index-url https://pypi.org/simple
 absl-py==2.4.0 \
     --hash=sha256:88476fd881ca8aab94ffa78b7b6c632a782ab3ba1cd19c9bd423abc4fb4cd28d \
     --hash=sha256:8c6af82722b35cf71e0f4d1d47dcaebfff286e27110a99fc359349b247dfb5d4

--- a/python/deplocks/ray_img/ray_img_cu130_py314.lock
+++ b/python/deplocks/ray_img/ray_img_cu130_py314.lock
@@ -1,4 +1,3 @@
---index-url https://pypi.org/simple
 absl-py==2.4.0 \
     --hash=sha256:88476fd881ca8aab94ffa78b7b6c632a782ab3ba1cd19c9bd423abc4fb4cd28d \
     --hash=sha256:8c6af82722b35cf71e0f4d1d47dcaebfff286e27110a99fc359349b247dfb5d4

--- a/python/deplocks/ray_img/ray_img_py310.lock
+++ b/python/deplocks/ray_img/ray_img_py310.lock
@@ -1,5 +1,3 @@
---index-url https://pypi.org/simple
-
 absl-py==2.4.0 \
     --hash=sha256:88476fd881ca8aab94ffa78b7b6c632a782ab3ba1cd19c9bd423abc4fb4cd28d \
     --hash=sha256:8c6af82722b35cf71e0f4d1d47dcaebfff286e27110a99fc359349b247dfb5d4

--- a/python/deplocks/ray_img/ray_img_py311.lock
+++ b/python/deplocks/ray_img/ray_img_py311.lock
@@ -1,5 +1,3 @@
---index-url https://pypi.org/simple
-
 absl-py==2.4.0 \
     --hash=sha256:88476fd881ca8aab94ffa78b7b6c632a782ab3ba1cd19c9bd423abc4fb4cd28d \
     --hash=sha256:8c6af82722b35cf71e0f4d1d47dcaebfff286e27110a99fc359349b247dfb5d4

--- a/python/deplocks/ray_img/ray_img_py312.lock
+++ b/python/deplocks/ray_img/ray_img_py312.lock
@@ -1,5 +1,3 @@
---index-url https://pypi.org/simple
-
 absl-py==2.4.0 \
     --hash=sha256:88476fd881ca8aab94ffa78b7b6c632a782ab3ba1cd19c9bd423abc4fb4cd28d \
     --hash=sha256:8c6af82722b35cf71e0f4d1d47dcaebfff286e27110a99fc359349b247dfb5d4

--- a/python/deplocks/ray_img/ray_img_py313.lock
+++ b/python/deplocks/ray_img/ray_img_py313.lock
@@ -1,5 +1,3 @@
---index-url https://pypi.org/simple
-
 absl-py==2.4.0 \
     --hash=sha256:88476fd881ca8aab94ffa78b7b6c632a782ab3ba1cd19c9bd423abc4fb4cd28d \
     --hash=sha256:8c6af82722b35cf71e0f4d1d47dcaebfff286e27110a99fc359349b247dfb5d4

--- a/python/deplocks/ray_img/ray_img_py314.lock
+++ b/python/deplocks/ray_img/ray_img_py314.lock
@@ -1,5 +1,3 @@
---index-url https://pypi.org/simple
-
 absl-py==2.4.0 \
     --hash=sha256:88476fd881ca8aab94ffa78b7b6c632a782ab3ba1cd19c9bd423abc4fb4cd28d \
     --hash=sha256:8c6af82722b35cf71e0f4d1d47dcaebfff286e27110a99fc359349b247dfb5d4

--- a/python/deplocks/ray_img/ray_img_py39.lock
+++ b/python/deplocks/ray_img/ray_img_py39.lock
@@ -1,5 +1,3 @@
---index-url https://pypi.org/simple
-
 aiohappyeyeballs==2.6.1 \
     --hash=sha256:c3f9d0113123803ccadfdf3f0faa505bc78e6a72d1cc4806cbd719826e943558 \
     --hash=sha256:f349ba8f4b75cb25c99c5c2d84e997e485204d2902a9597802b0371f09331fb8

--- a/python/deplocks/tests/data/datatfds_py3.12.lock
+++ b/python/deplocks/tests/data/datatfds_py3.12.lock
@@ -1,5 +1,3 @@
---index-url https://pypi.org/simple
-
 absl-py==2.3.1 \
     --hash=sha256:a97820526f7fbfd2ec1bce83f3f25e3a14840dac0d8e02a0b71cd75db3f77fc9 \
     --hash=sha256:eeecf07f0c2a93ace0772c92e596ace6d3d3996c042b2128459aaae2a76de11d

--- a/release/BUILD.bazel
+++ b/release/BUILD.bazel
@@ -22,12 +22,17 @@ _requirements_py310_data = [
     ":requirements_py310.txt",
 ]
 
+# pip-tools 7.4.1 replaced its pep517 dependency with build + pyproject_hooks, and
+# build additionally needs packaging. Those three repositories are declared in
+# //:WORKSPACE because rules_python does not provide them.
 _requirements_py310_deps = [
+    "@pypi__build//:lib",
     "@pypi__click//:lib",
     "@pypi__colorama//:lib",
-    "@pypi__pep517//:lib",
+    "@pypi__packaging//:lib",
     "@pypi__pip//:lib",
     "@pypi__pip_tools//:lib",
+    "@pypi__pyproject_hooks//:lib",
     "@pypi__setuptools//:lib",
     "@pypi__tomli//:lib",
 ]

--- a/release/ray_release/byod/byod.Dockerfile
+++ b/release/ray_release/byod/byod.Dockerfile
@@ -10,6 +10,18 @@ ARG PIP_REQUIREMENTS="python/deplocks/base_extra_testdeps/${IMAGE_TYPE}-base_ext
 
 COPY "$PIP_REQUIREMENTS" extra-test-requirements.txt
 
+# Make PyPI fetches survive a transient files.pythonhosted.org failure. Declared before
+# the RUN below so the image build itself picks them up, and kept in the image so the
+# byod_*.sh scripts that pip install at cluster startup inherit them too. pip reads PIP_*
+# only when it is not run with --isolated, which is the case for every pip invocation on
+# this path. Note that retrying an HTTP 502 specifically needs pip >= 24.0, which is where
+# 502 was added to urllib3's status_forcelist; on older pip these still cover connection
+# errors and 500/503. uv defaults to only 3 retries and has been seen to exhaust them on a
+# 502, hence UV_HTTP_RETRIES; older uv releases ignore the variable rather than erroring.
+ENV \
+  PIP_RETRIES=9 \
+  UV_HTTP_RETRIES=9
+
 RUN <<EOF
 #!/bin/bash
 
@@ -34,7 +46,8 @@ sudo apt-get autoclean
 sudo rm -rf /etc/apt/sources.list.d/*
 
 sudo mkdir -p /etc/apt/keyrings
-curl -sLS https://packages.microsoft.com/keys/microsoft.asc |
+curl -sLS --retry 5 --retry-delay 2 \
+  https://packages.microsoft.com/keys/microsoft.asc |
   gpg --dearmor | sudo tee /etc/apt/keyrings/microsoft.gpg > /dev/null
 sudo chmod go+r /etc/apt/keyrings/microsoft.gpg
 

--- a/thirdparty/patches/pip-constant-jittered-retry-backoff.patch
+++ b/thirdparty/patches/pip-constant-jittered-retry-backoff.patch
@@ -1,0 +1,88 @@
+--- a/pip/_internal/network/session.py
++++ b/pip/_internal/network/session.py
+@@ -10,11 +10,13 @@
+ import mimetypes
+ import os
+ import platform
++import random
+ import shutil
+ import subprocess
+ import sys
+ import urllib.parse
+ import warnings
++from itertools import takewhile
+ from typing import (
+     TYPE_CHECKING,
+     Any,
+@@ -315,6 +317,50 @@
+         super().cert_verify(conn=conn, url=url, verify=False, cert=cert)
+ 
+ 
++class _ConstantJitteredRetry(urllib3.Retry):
++    """A ``Retry`` policy with constant, jittered backoff.
++
++    urllib3 1.26 -- the version pip 24.0 vendors -- implements only exponential
++    backoff (``backoff_factor * 2 ** (n - 1)``) and offers no jitter at all;
++    ``Retry.backoff_jitter`` exists only in urllib3 2.x. Neither the shape of
++    the schedule nor ``backoff_factor`` is reachable from pip's command line,
++    so this subclass replaces ``get_backoff_time`` outright.
++
++    Exponential backoff is the wrong shape for riding out a PyPI outage. It
++    spends its early retries before the outage has plausibly cleared and its
++    late ones sleeping for minutes at a time, so a given retry count covers far
++    less wall-clock than a flat schedule of the same length would, and the part
++    of the budget that lands inside the recovery window is small. A constant
++    schedule turns the retry count into a predictable amount of wall-clock:
++    ``n`` retries cover roughly ``n`` times the nominal wait.
++
++    The jitter matters because Bazel fetches many wheels concurrently, each in
++    its own pip process. Without it, all of them fail at the same instant,
++    sleep for identical durations and re-converge on the origin together,
++    turning every retry round into a thundering herd against a service that is
++    already degraded.
++    """
++
++    #: Bounds on a single sleep, in seconds -- equal jitter around a 12s
++    #: nominal wait, meaning half the interval is fixed and half is random.
++    BACKOFF_FLOOR = 6.0
++    BACKOFF_CEILING = 12.0
++
++    def get_backoff_time(self) -> float:
++        # urllib3 does not sleep before the first retry of a sequence. Keep
++        # that, so a lone blip is recovered from immediately rather than
++        # costing a full sleep.
++        consecutive_errors = len(
++            list(
++                takewhile(lambda x: x.redirect_location is None, reversed(self.history))
++            )
++        )
++        if consecutive_errors <= 1:
++            return 0.0
++
++        return random.uniform(self.BACKOFF_FLOOR, self.BACKOFF_CEILING)
++
++
+ class PipSession(requests.Session):
+     timeout: Optional[int] = None
+ 
+@@ -346,7 +392,7 @@
+ 
+         # Create our urllib3.Retry instance which will allow us to customize
+         # how we handle retries.
+-        retries = urllib3.Retry(
++        retries = _ConstantJitteredRetry(
+             # Set the total number of retries that a particular request can
+             # have.
+             total=retries,
+@@ -358,9 +404,8 @@
+             # A 502 may be a transient error from a CDN like CloudFlare or CloudFront
+             # A 520 or 527 - may indicate transient error in CloudFlare
+             status_forcelist=[500, 502, 503, 520, 527],
+-            # Add a small amount of back off between failed requests in
+-            # order to prevent hammering the service.
+-            backoff_factor=0.25,
++            # backoff_factor is deliberately not passed: _ConstantJitteredRetry
++            # replaces get_backoff_time() entirely, so it would have no effect.
+         )  # type: ignore
+ 
+         # Our Insecure HTTPAdapter disables HTTPS validation. It does not


### PR DESCRIPTION
**DO NOT MERGE — this is a test PR.** It stacks everything needed to get CI green
against the PyPI 502s into one branch so the whole thing can be exercised at once.
It will be split into the reviewable pieces listed below (three of them are already
open as separate PRs).

## Description

`files.pythonhosted.org` returns intermittent 502s (pypi/support#11895). Ray CI is
hit disproportionately because a single job cold-fetches ~50 wheels concurrently, so
it samples the fault dozens of times per job, and `rules_python` shells out to pip
inside `whl_library`, where one 502 fails the repository rule and the build with it.

Four layers, in dependency order:

1. **Make the index an environment property** (#65562). Valueless `--repo_env` for
   `PIP_INDEX_URL`, `PIP_EXTRA_INDEX_URL`, `PIP_TRUSTED_HOST` and
   `RULES_PYTHON_PIP_ISOLATED` in `.bazelrc`, and those plus the `UV_*` equivalents
   forwarded into nested containers by `ci/ray_ci/container.py`.
   `RULES_PYTHON_PIP_ISOLATED` is load-bearing: `whl_library` runs pip with
   `--isolated`, which otherwise makes it ignore every `PIP_*` variable.
2. **Stop the lock files overriding it** (#65563). 97 of the 99 files under
   `python/deplocks` opened with `--index-url https://pypi.org/simple`, and a
   requirements file's index URL beats both the environment and the command line.
   The `--extra-index-url` and `--find-links` entries for PyTorch, libtpu and PyG
   stay: those are not PyPI, so nothing else supplies them at install time.
3. **Retry what still goes to PyPI** (#65518 by @sai-miduthuri, and #65538). pip
   24.0 for `whl_library` so a 502 is retryable at all, jittered backoff, and
   `PIP_RETRIES` / `UV_HTTP_RETRIES` on the roots of the CI image graph.
4. **Resolve through the CI package mirror when the job can reach it** (new here).
   The forge image gets `ci/pypi_index_proxy.py` and a `profile.d` script that
   probes the mirror and picks a mode.

### What the probe is for

The mirror serves two shapes, and only one works as an index directly:

- a **rewriting simple index** at `/simple`, whose pages already point at the mirror
  for artifacts — pip can use it as-is, and nested containers reach it by hostname;
- a **path-prefixed byte cache** at `/pypi.org/simple`, which serves PyPI's own pages
  whose bodies still name `files.pythonhosted.org`. Pointing an index URL there
  reroutes only the metadata request and leaves every wheel download on the origin
  that is returning the 502s. That case needs the local proxy, which rewrites the
  file URLs in those pages.

Which one is deployed is exactly what I could not determine from outside, so the
script probes instead of assuming, logs the resolved address and the mode it chose,
and falls back to public PyPI plus layer 3 when neither answers. That fallback is
why the probe talks to the mirror rather than only checking that the proxy is up:
`/healthz` never touches the mirror, so a proxy in front of an unreachable mirror
looks healthy and then 502s every request — worse than no proxy.

**The open question this PR is meant to answer:** whether a `ray-project` premerge
agent can reach the mirror at all. Those run on `bk-runner-queue-small-pr-*` in the
Ray CI account, while the mirror's ALB is internal to a different account's CI VPC,
and the two VPCs share the `10.0.0.0/16` range so they cannot be peered. If the
logs say `mirror unreachable from this agent`, the mirror layer needs infrastructure
work first (PrivateLink, or a second deployment in the Ray CI account) and layers
1–3 are what carry CI in the meantime.

## Known gaps, deliberately not addressed here

- **Image builds still resolve from PyPI.** The `pip install` lines in
  `ci/docker/*.Dockerfile` run in a separate BuildKit context, so a variable exported
  by a step's login shell never reaches them; they rely on layer 3's retries. Wiring
  them needs the mirror URL in the image, which is cache-key sensitive.
- **The mirror hostname is a default in `ci/pypi_proxy_profile.sh`.** In the split-up
  PRs it should come from the agent environment (`RAYCI_PYPI_MIRROR_URL`, which the
  script already honours) so no internal hostname lands in this repo. It is inline
  here only so CI can exercise the path without an infrastructure change.
- `ci/pypi_index_proxy.py` is vendored from a public gist, as recorded at the top of
  the file.

## Related issues

pypi/support#11895. Supersedes nothing; #65562, #65563, #65518 and #65538 stay open
as the reviewable units.

## Testing

Local, before pushing:

- `PYTHONPATH=.:release python -m pytest -q ci/ray_ci/test_tester.py
  ci/ray_ci/test_linux_tester_container.py ci/ray_ci/test_container.py
  ci/ray_ci/test_windows_container.py` — 21 passed.
- `bazel test //ci/raydepsets:test_cli` — passed, including
  `test_diff_lock_files_up_to_date`, which is the generated-equals-committed
  invariant for layer 2.
- Bazel 7.5.0 probe workspace: a valueless `common --repo_env=NAME` does reach
  `rctx.os.environ` in a repository rule, and reads unset when the variable is unset.
- `pre-commit run --files` over every changed file, shellcheck included.

CI on this branch is the actual test, specifically the `pypi index:` lines the
profile.d script logs at the start of every step.

AI assistance (Claude Code) was used for this change.
