### PR TITLE
[ci][DO NOT MERGE] Resolve Python packages from AWS CodeArtifact instead of PyPI

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -13,12 +13,15 @@ build --action_env=RAY_BUILD_ENV
 
 # Let the invoking environment pick the Python package index that repository
 # rules resolve from, e.g. to point a CI fleet at a caching mirror instead of
-# pypi.org. Both are deliberately valueless, so bazel inherits whatever the
-# client environment holds and pins nothing here. rules_python runs
-# whl_library's pip with --isolated, which makes pip ignore every PIP_*
-# variable, so RULES_PYTHON_PIP_ISOLATED=0 is what lets PIP_INDEX_URL through.
-# Neither is set in a plain checkout, and then pip resolves from PyPI as before.
+# pypi.org. All of these are deliberately valueless, so bazel inherits whatever
+# the client environment holds and pins nothing here. rules_python runs
+# whl_library's pip with --isolated, which makes pip ignore every PIP_* variable,
+# so RULES_PYTHON_PIP_ISOLATED=0 is what lets the others through. PIP_TRUSTED_HOST
+# is here because a mirror reached over plain HTTP is otherwise refused. None of
+# them is set in a plain checkout, and then pip resolves from PyPI as before.
 common --repo_env=PIP_INDEX_URL
+common --repo_env=PIP_EXTRA_INDEX_URL
+common --repo_env=PIP_TRUSTED_HOST
 common --repo_env=RULES_PYTHON_PIP_ISOLATED
 
 ###############################################################################

--- a/.bazelrc
+++ b/.bazelrc
@@ -11,6 +11,16 @@ build:linux --workspace_status_command="bash ./bazel/workspace_status.sh"
 # To distinguish different incompatible environments.
 build --action_env=RAY_BUILD_ENV
 
+# Let the invoking environment pick the Python package index that repository
+# rules resolve from, e.g. to point a CI fleet at a caching mirror instead of
+# pypi.org. Both are deliberately valueless, so bazel inherits whatever the
+# client environment holds and pins nothing here. rules_python runs
+# whl_library's pip with --isolated, which makes pip ignore every PIP_*
+# variable, so RULES_PYTHON_PIP_ISOLATED=0 is what lets PIP_INDEX_URL through.
+# Neither is set in a plain checkout, and then pip resolves from PyPI as before.
+common --repo_env=PIP_INDEX_URL
+common --repo_env=RULES_PYTHON_PIP_ISOLATED
+
 ###############################################################################
 # On       Windows, provide: BAZEL_SH, and BAZEL_LLVM (if using clang-cl)
 # On all platforms, provide: PYTHON3_BIN_PATH=python

--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -36,3 +36,12 @@ fi
 
 RAYCI_CHECKOUT_DIR="$(pwd)"
 export RAYCI_CHECKOUT_DIR
+
+# Resolve Python packages from CodeArtifact when it is reachable from this
+# agent, so that a files.pythonhosted.org 502 cannot fail the job. Sourced, not
+# executed: the point is the exports. Fail-open -- if the index does not answer,
+# it exports nothing and the job resolves from PyPI as before.
+if [[ "${OSTYPE}" == linux* && -f "${RAYCI_CHECKOUT_DIR}/ci/codeartifact_env.sh" ]]; then
+  # shellcheck source=ci/codeartifact_env.sh
+  source "${RAYCI_CHECKOUT_DIR}/ci/codeartifact_env.sh" || true
+fi

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+# ci/ray_ci/linux_container.py builds the test image with `COPY . .` from the
+# checkout. .rayci-netrc holds a CodeArtifact bearer token, which must not end up
+# in an image layer -- it is bind-mounted into that container at run time
+# instead. The env file is excluded with it because the same settings reach the
+# container as forwarded environment variables.
+.rayci-netrc
+.rayci-codeartifact.env

--- a/.gitignore
+++ b/.gitignore
@@ -254,3 +254,8 @@ CLAUDE.local.md
 # Worktrees
 .worktrees/
 .claude/worktrees/
+
+# CodeArtifact index configuration written by .buildkite/hooks/pre-command.
+# .rayci-netrc holds a short-lived bearer token.
+.rayci-netrc
+.rayci-codeartifact.env

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -70,6 +70,14 @@ load("@rules_python//python:pip.bzl", "pip_parse")
 pip_parse(
     name = "py_deps_py310",
     python_interpreter_target = python310,
+    # TEMPORARY, REVERT BEFORE MERGE. rules_python runs whl_library's pip with
+    # quiet = True, so a fetch that succeeds prints nothing and every index URL
+    # ever seen in a CI log came from a failure path. That makes "no PyPI URLs in
+    # the log" unreadable as evidence: it looks identical whether CodeArtifact
+    # served the wheels or PyPI served them without incident. Turning it off makes
+    # pip print the index it actually resolved from, which is the only positive
+    # confirmation available short of instrumenting the fetch.
+    quiet = False,
     requirements_lock = "//release:requirements_py310.txt",
 )
 

--- a/ci/codeartifact_env.sh
+++ b/ci/codeartifact_env.sh
@@ -1,34 +1,54 @@
 #!/bin/bash
-# Point this job's Python package resolution at AWS CodeArtifact instead of
-# pypi.org, so that a files.pythonhosted.org 502 cannot fail a build.
+# Point CI's Python package resolution at AWS CodeArtifact instead of pypi.org,
+# so that a files.pythonhosted.org 502 cannot fail a build.
 #
 # CodeArtifact's simple index hands out artifact URLs relative to its own
 # endpoint, so both requests pip makes -- the project page and the wheel itself
 # -- resolve against CodeArtifact. A path-prefix byte cache only ever gets the
 # first one, because PyPI's index body names files.pythonhosted.org absolutely.
 #
-# This script must be SOURCED, not executed: its whole purpose is the exports.
+# This runs on the agent, but the fetches happen two layers in: the step's
+# command runs in a container started by the Buildkite docker plugin, whose
+# --env list is fixed and carries nothing about the index, and that container
+# starts the nested test container. Exporting here therefore cannot reach them.
+# What crosses the boundary is the checkout, which is bind-mounted into the step
+# container, so the configuration is written there as two files:
 #
-# It is deliberately fail-open. It probes the index and exports nothing unless
-# that probe succeeds, so a missing IAM permission, an expired token or an
-# unreachable endpoint leaves the job resolving from PyPI exactly as it does
-# today, with the reason printed. Nothing here makes CI depend on CodeArtifact
-# being available.
+#   .rayci-codeartifact.env  index settings, read by /etc/profile.d in the image
+#   .rayci-netrc             the credential, mode 0600
+#
+# Both are gitignored and excluded from docker build contexts, so neither is
+# committed nor baked into an image layer. The nested container gets the netrc
+# bind-mounted by ci/ray_ci/linux_container.py, since its workspace is COPYed
+# into an image rather than mounted.
+#
+# Fail-open throughout: it probes the index and writes nothing unless that probe
+# succeeds, so a missing IAM permission, an expired token or an unreachable
+# endpoint leaves the build resolving from PyPI exactly as it does today, with
+# the reason printed.
 
-# The caller (.buildkite/hooks/pre-command) runs under `set -x`, and this
-# function handles a bearer token. Keep it out of the build log.
 _rayci_codeartifact_setup() {
+  # The caller runs under `set -x` and this handles a bearer token. Keep it out
+  # of the build log.
   local had_xtrace=0
   case "$-" in *x*) had_xtrace=1; set +x ;; esac
 
+  local checkout="${RAYCI_CHECKOUT_DIR:-$PWD}"
+  local env_file="${checkout}/.rayci-codeartifact.env"
+  local netrc_file="${checkout}/.rayci-netrc"
+
   _rayci_ca_finish() {
+    # Never leave a stale credential behind for the next job on a reused agent.
+    if [[ "${1:-keep}" == "clear" ]]; then
+      rm -f "${env_file}" "${netrc_file}"
+    fi
     [[ "${had_xtrace}" == "1" ]] && set -x
     return 0
   }
 
   if [[ "${RAYCI_CODEARTIFACT_DISABLE:-0}" == "1" ]]; then
     echo "codeartifact: disabled by RAYCI_CODEARTIFACT_DISABLE, using PyPI"
-    _rayci_ca_finish; return 0
+    _rayci_ca_finish clear; return 0
   fi
 
   local domain="${RAYCI_CODEARTIFACT_DOMAIN:-ray-ci-scratch}"
@@ -38,7 +58,7 @@ _rayci_codeartifact_setup() {
 
   if ! command -v aws >/dev/null 2>&1; then
     echo "codeartifact: no aws CLI on this agent, using PyPI"
-    _rayci_ca_finish; return 0
+    _rayci_ca_finish clear; return 0
   fi
 
   local host="${domain}-${owner}.d.codeartifact.${region}.amazonaws.com"
@@ -49,50 +69,46 @@ _rayci_codeartifact_setup() {
         --domain "${domain}" --domain-owner "${owner}" --region "${region}" \
         --query authorizationToken --output text 2>&1)"; then
     echo "codeartifact: could not mint a token, using PyPI"
-    # Print why. The AWS CLI puts blank lines around its errors, so take the
-    # first line that actually says something.
+    # The AWS CLI puts blank lines around its errors; print the first line that
+    # actually says something.
     echo "${token}" | grep -m1 -v '^[[:space:]]*$' | sed 's/^/codeartifact: /' || true
-    _rayci_ca_finish; return 0
+    _rayci_ca_finish clear; return 0
   fi
 
-  # The credential goes in a netrc rather than in the URL. pip and uv both read
-  # $NETRC, which keeps the token out of the environment, out of `docker run`
-  # arguments and out of anything that echoes a command line. It also avoids
-  # depending on $HOME, which differs between the agent and the unprivileged
-  # user that Bazel runs as inside the test containers.
-  #
-  # The URL itself must carry no userinfo at all. A half-credentialled
-  # https://aws@host/ is worse than useless: requests derives the netrc lookup
-  # key as netloc.split(":")[0], which strips the port but not the userinfo, so
-  # it searches for a machine literally named "aws@<host>", misses, and pip then
-  # coerces the absent password to "" and authenticates as aws with an empty
-  # password -- a 401 that looks exactly like a bad token.
-  local dir=/tmp/rayci-codeartifact
-  local netrc="${dir}/netrc"
-  mkdir -p "${dir}"
-  chmod 700 "${dir}"
-  ( umask 077; printf 'machine %s\nlogin aws\npassword %s\n' "${host}" "${token}" > "${netrc}" )
-  chmod 600 "${netrc}"
+  ( umask 077; printf 'machine %s\nlogin aws\npassword %s\n' "${host}" "${token}" > "${netrc_file}" )
+  chmod 600 "${netrc_file}"
 
-  # Fail-open gate: only redirect the job if the index actually answers.
+  # Fail-open gate: only redirect the build if the index actually answers.
   local code
   code="$(curl -sS -o /dev/null -w '%{http_code}' --max-time 20 \
-            --netrc-file "${netrc}" \
+            --netrc-file "${netrc_file}" \
             -H 'Accept: application/vnd.pypi.simple.v1+json' \
             "${index}tabulate/" 2>/dev/null || echo 000)"
   if [[ "${code}" != "200" ]]; then
     echo "codeartifact: index probe returned HTTP ${code}, using PyPI"
-    rm -f "${netrc}"
-    _rayci_ca_finish; return 0
+    _rayci_ca_finish clear; return 0
   fi
 
-  export NETRC="${netrc}"
+  # rules_python runs whl_library's pip with --isolated, which makes pip ignore
+  # every PIP_* variable. Without RULES_PYTHON_PIP_ISOLATED=0 the index setting
+  # is silently discarded and the repository rule resolves from PyPI while
+  # looking configured.
+  #
+  # UV_INDEX_URL is set for the same reason but has the opposite precedence to
+  # pip: it overrides the --index-url embedded on line 1 of the deplock files,
+  # so uv installs are redirected as well.
+  cat > "${env_file}" <<EOF
+PIP_INDEX_URL=${index}
+UV_INDEX_URL=${index}
+RULES_PYTHON_PIP_ISOLATED=0
+EOF
+  chmod 644 "${env_file}"
+
+  # Also export on the agent, for the few steps that run outside a container.
   export PIP_INDEX_URL="${index}"
   export UV_INDEX_URL="${index}"
-  # rules_python runs whl_library's pip with --isolated, which makes pip ignore
-  # every PIP_* variable. Without this the export above is silently discarded
-  # and the repository rule resolves from PyPI while looking configured.
   export RULES_PYTHON_PIP_ISOLATED=0
+  export NETRC="${netrc_file}"
 
   echo "codeartifact: index probe OK, resolving from ${index}"
   _rayci_ca_finish; return 0

--- a/ci/codeartifact_env.sh
+++ b/ci/codeartifact_env.sh
@@ -94,19 +94,22 @@ _rayci_codeartifact_setup() {
   # is silently discarded and the repository rule resolves from PyPI while
   # looking configured.
   #
-  # UV_INDEX_URL is set for the same reason but has the opposite precedence to
-  # pip: it overrides the --index-url embedded on line 1 of the deplock files,
-  # so uv installs are redirected as well.
+  # UV_INDEX_URL is deliberately NOT set. It would work -- uv overrides the
+  # --index-url embedded in the deplock files, unlike pip -- but it also reaches
+  # the uv that Ray spawns for uv-based runtime environments, and those
+  # subprocesses do not carry the credential. They then hit an authenticated
+  # index anonymously: //python/ray/tests:test_runtime_env_uv{,_run} produced 80
+  # 401s and timed out at 915s. Redirecting uv needs the credential to follow it
+  # into the runtime env first, which is its own change. Absent the variable, uv
+  # follows the index pinned in each lock file, as it does today.
   cat > "${env_file}" <<EOF
 PIP_INDEX_URL=${index}
-UV_INDEX_URL=${index}
 RULES_PYTHON_PIP_ISOLATED=0
 EOF
   chmod 644 "${env_file}"
 
   # Also export on the agent, for the few steps that run outside a container.
   export PIP_INDEX_URL="${index}"
-  export UV_INDEX_URL="${index}"
   export RULES_PYTHON_PIP_ISOLATED=0
   export NETRC="${netrc_file}"
 

--- a/ci/codeartifact_env.sh
+++ b/ci/codeartifact_env.sh
@@ -1,0 +1,102 @@
+#!/bin/bash
+# Point this job's Python package resolution at AWS CodeArtifact instead of
+# pypi.org, so that a files.pythonhosted.org 502 cannot fail a build.
+#
+# CodeArtifact's simple index hands out artifact URLs relative to its own
+# endpoint, so both requests pip makes -- the project page and the wheel itself
+# -- resolve against CodeArtifact. A path-prefix byte cache only ever gets the
+# first one, because PyPI's index body names files.pythonhosted.org absolutely.
+#
+# This script must be SOURCED, not executed: its whole purpose is the exports.
+#
+# It is deliberately fail-open. It probes the index and exports nothing unless
+# that probe succeeds, so a missing IAM permission, an expired token or an
+# unreachable endpoint leaves the job resolving from PyPI exactly as it does
+# today, with the reason printed. Nothing here makes CI depend on CodeArtifact
+# being available.
+
+# The caller (.buildkite/hooks/pre-command) runs under `set -x`, and this
+# function handles a bearer token. Keep it out of the build log.
+_rayci_codeartifact_setup() {
+  local had_xtrace=0
+  case "$-" in *x*) had_xtrace=1; set +x ;; esac
+
+  _rayci_ca_finish() {
+    [[ "${had_xtrace}" == "1" ]] && set -x
+    return 0
+  }
+
+  if [[ "${RAYCI_CODEARTIFACT_DISABLE:-0}" == "1" ]]; then
+    echo "codeartifact: disabled by RAYCI_CODEARTIFACT_DISABLE, using PyPI"
+    _rayci_ca_finish; return 0
+  fi
+
+  local domain="${RAYCI_CODEARTIFACT_DOMAIN:-ray-ci-scratch}"
+  local owner="${RAYCI_CODEARTIFACT_OWNER:-029272617770}"
+  local repo="${RAYCI_CODEARTIFACT_REPO:-pypi-store}"
+  local region="${RAYCI_CODEARTIFACT_REGION:-us-west-2}"
+
+  if ! command -v aws >/dev/null 2>&1; then
+    echo "codeartifact: no aws CLI on this agent, using PyPI"
+    _rayci_ca_finish; return 0
+  fi
+
+  local host="${domain}-${owner}.d.codeartifact.${region}.amazonaws.com"
+  local index="https://${host}/pypi/${repo}/simple/"
+
+  local token
+  if ! token="$(aws codeartifact get-authorization-token \
+        --domain "${domain}" --domain-owner "${owner}" --region "${region}" \
+        --query authorizationToken --output text 2>&1)"; then
+    echo "codeartifact: could not mint a token, using PyPI"
+    # Print why. The AWS CLI puts blank lines around its errors, so take the
+    # first line that actually says something.
+    echo "${token}" | grep -m1 -v '^[[:space:]]*$' | sed 's/^/codeartifact: /' || true
+    _rayci_ca_finish; return 0
+  fi
+
+  # The credential goes in a netrc rather than in the URL. pip and uv both read
+  # $NETRC, which keeps the token out of the environment, out of `docker run`
+  # arguments and out of anything that echoes a command line. It also avoids
+  # depending on $HOME, which differs between the agent and the unprivileged
+  # user that Bazel runs as inside the test containers.
+  #
+  # The URL itself must carry no userinfo at all. A half-credentialled
+  # https://aws@host/ is worse than useless: requests derives the netrc lookup
+  # key as netloc.split(":")[0], which strips the port but not the userinfo, so
+  # it searches for a machine literally named "aws@<host>", misses, and pip then
+  # coerces the absent password to "" and authenticates as aws with an empty
+  # password -- a 401 that looks exactly like a bad token.
+  local dir=/tmp/rayci-codeartifact
+  local netrc="${dir}/netrc"
+  mkdir -p "${dir}"
+  chmod 700 "${dir}"
+  ( umask 077; printf 'machine %s\nlogin aws\npassword %s\n' "${host}" "${token}" > "${netrc}" )
+  chmod 600 "${netrc}"
+
+  # Fail-open gate: only redirect the job if the index actually answers.
+  local code
+  code="$(curl -sS -o /dev/null -w '%{http_code}' --max-time 20 \
+            --netrc-file "${netrc}" \
+            -H 'Accept: application/vnd.pypi.simple.v1+json' \
+            "${index}tabulate/" 2>/dev/null || echo 000)"
+  if [[ "${code}" != "200" ]]; then
+    echo "codeartifact: index probe returned HTTP ${code}, using PyPI"
+    rm -f "${netrc}"
+    _rayci_ca_finish; return 0
+  fi
+
+  export NETRC="${netrc}"
+  export PIP_INDEX_URL="${index}"
+  export UV_INDEX_URL="${index}"
+  # rules_python runs whl_library's pip with --isolated, which makes pip ignore
+  # every PIP_* variable. Without this the export above is silently discarded
+  # and the repository rule resolves from PyPI while looking configured.
+  export RULES_PYTHON_PIP_ISOLATED=0
+
+  echo "codeartifact: index probe OK, resolving from ${index}"
+  _rayci_ca_finish; return 0
+}
+
+_rayci_codeartifact_setup
+unset -f _rayci_codeartifact_setup _rayci_ca_finish

--- a/ci/codeartifact_prewarm.py
+++ b/ci/codeartifact_prewarm.py
@@ -1,0 +1,183 @@
+"""Import every pinned package version in a lock file into CodeArtifact.
+
+CodeArtifact imports a package version from pypi.org the first time something
+asks for one of its *assets*. Until that import finishes it will list the file
+in the simple index and answer the download with a 404 -- and 404 is not in
+urllib3's status_forcelist, so pip does not retry it and the build fails. The
+window is short (measured at 1.3-1.6s) but it is real, so the repository has to
+be warm before CI depends on it.
+
+Requesting the /simple/<pkg>/ listing does not import anything. One asset GET
+imports every asset of that version, so fetching the single smallest asset per
+pinned version is the cheapest complete warm-up.
+
+Usage:
+    python ci/codeartifact_prewarm.py release/requirements_py310.txt [more.lock ...]
+
+Reads the index from $PIP_INDEX_URL and credentials from the netrc at $NETRC,
+both of which ci/codeartifact_env.sh exports.
+"""
+
+import argparse
+import concurrent.futures
+import json
+import netrc
+import os
+import re
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from base64 import b64encode
+from typing import Dict, List, Optional, Set, Tuple
+
+_PIN = re.compile(r"^([A-Za-z0-9._-]+)==([^ \\\n]+)")
+_SUFFIXES = (".whl", ".tar.gz", ".zip", ".tar.bz2", ".egg")
+_JSON_ACCEPT = "application/vnd.pypi.simple.v1+json"
+
+
+def _normalize(name: str) -> str:
+    """PEP 503 normalisation: '-', '_' and '.' are interchangeable."""
+    return re.sub(r"[-_.]+", "-", name.lower())
+
+
+def _belongs_to(filename: str, name: str, version: str) -> bool:
+    """Is this distribution file the given name==version?
+
+    The version field cannot be found by splitting on '-': an sdist of a
+    hyphenated project is python-dateutil-2.9.0.tar.gz, so the name contributes
+    hyphens too. Strip the extension and match the normalised name-version
+    prefix instead.
+    """
+    for suffix in _SUFFIXES:
+        if filename.endswith(suffix):
+            filename = filename[: -len(suffix)]
+            break
+    stem = _normalize(filename)
+    prefix = _normalize(f"{name}-{version}")
+    return stem == prefix or stem.startswith(prefix + "-")
+
+
+def parse_locks(paths: List[str]) -> Dict[str, str]:
+    """Collect {package: version} from pip/uv lock files."""
+    pins: Dict[str, str] = {}
+    for path in paths:
+        with open(path) as handle:
+            for line in handle:
+                match = _PIN.match(line)
+                if match:
+                    pins[_normalize(match.group(1))] = match.group(2)
+    return pins
+
+
+class Index:
+    def __init__(self, index_url: str, netrc_path: Optional[str]) -> None:
+        self.index_url = index_url if index_url.endswith("/") else index_url + "/"
+        host = urllib.parse.urlparse(self.index_url).hostname or ""
+        self.headers = {}
+        auth = netrc.netrc(netrc_path).authenticators(host) if netrc_path else None
+        if auth:
+            login, _, password = auth
+            raw = f"{login}:{password}".encode()
+            self.headers["Authorization"] = "Basic " + b64encode(raw).decode()
+
+    def _get(self, url: str, accept: Optional[str] = None) -> Tuple[int, bytes]:
+        headers = dict(self.headers)
+        if accept:
+            headers["Accept"] = accept
+        request = urllib.request.Request(url, headers=headers)
+        try:
+            with urllib.request.urlopen(request, timeout=180) as response:
+                return response.status, response.read()
+        except urllib.error.HTTPError as error:
+            return error.code, b""
+
+    def warm(
+        self, name: str, version: str, deadline: float
+    ) -> Tuple[str, str, Optional[str], int]:
+        """Import name==version, retrying past the cold-import 404."""
+        project = self.index_url + name + "/"
+        status, body = self._get(project, _JSON_ACCEPT)
+        if status != 200:
+            return name, version, f"index HTTP {status}", 0
+
+        files = [
+            entry
+            for entry in json.loads(body).get("files", [])
+            if _belongs_to(entry["filename"], name, version)
+        ]
+        if not files:
+            return name, version, "not on the index", 0
+
+        smallest = min(files, key=lambda entry: entry.get("size") or sys.maxsize)
+        asset = urllib.parse.urljoin(project, smallest["url"])
+
+        retries = 0
+        started = time.monotonic()
+        while True:
+            status, _ = self._get(asset)
+            if status == 200:
+                return name, version, None, retries
+            if status != 404 or time.monotonic() - started > deadline:
+                return name, version, f"asset HTTP {status}", retries
+            retries += 1
+            time.sleep(1.0)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("locks", nargs="+", help="lock files to warm")
+    parser.add_argument("--index-url", default=os.environ.get("PIP_INDEX_URL", ""))
+    parser.add_argument("--netrc", default=os.environ.get("NETRC"))
+    parser.add_argument("--jobs", type=int, default=8)
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=120.0,
+        help="seconds to keep retrying one asset's cold-import 404",
+    )
+    args = parser.parse_args()
+
+    if not args.index_url or "codeartifact" not in args.index_url:
+        print(
+            "codeartifact-prewarm: PIP_INDEX_URL is not a CodeArtifact index, "
+            "nothing to warm",
+            file=sys.stderr,
+        )
+        return 0
+
+    pins = parse_locks(args.locks)
+    index = Index(args.index_url, args.netrc)
+    print(f"warming {len(pins)} package versions from {len(args.locks)} lock file(s)")
+
+    started = time.monotonic()
+    failures: List[Tuple[str, str, str]] = []
+    raced: Set[str] = set()
+    with concurrent.futures.ThreadPoolExecutor(args.jobs) as pool:
+        futures = [
+            pool.submit(index.warm, name, version, args.timeout)
+            for name, version in sorted(pins.items())
+        ]
+        for future in concurrent.futures.as_completed(futures):
+            name, version, error, retries = future.result()
+            if error:
+                failures.append((name, version, error))
+            elif retries:
+                raced.add(f"{name}=={version}")
+
+    elapsed = time.monotonic() - started
+    print(
+        f"warmed {len(pins) - len(failures)}/{len(pins)} in {elapsed:.0f}s; "
+        f"{len(raced)} hit the cold-import 404 and cleared on retry"
+    )
+    for name, version, error in failures:
+        print(f"  FAILED {name}=={version}: {error}", file=sys.stderr)
+
+    # Warming is best effort: a package that cannot be imported here is one that
+    # a build would have had to fetch from PyPI anyway.
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ci/docker/base.cu128.wanda.yaml
+++ b/ci/docker/base.cu128.wanda.yaml
@@ -2,6 +2,7 @@ name: "oss-ci-base_cu128-py$PYTHON"
 froms: ["nvidia/cuda:12.8.1-cudnn-devel-ubuntu22.04"]
 dockerfile: ci/docker/base.gpu.Dockerfile
 srcs:
+  - ci/docker/rayci-codeartifact-profile.sh
   - .bazelrc
   - .bazelversion
   - ci/env/install-dependencies.sh

--- a/ci/docker/base.cu130.wanda.yaml
+++ b/ci/docker/base.cu130.wanda.yaml
@@ -2,6 +2,7 @@ name: "oss-ci-base_cu130-py$PYTHON"
 froms: ["nvidia/cuda:13.0.0-cudnn-devel-ubuntu22.04"]
 dockerfile: ci/docker/base.gpu.Dockerfile
 srcs:
+  - ci/docker/rayci-codeartifact-profile.sh
   - .bazelrc
   - .bazelversion
   - ci/env/install-dependencies.sh

--- a/ci/docker/base.gpu.Dockerfile
+++ b/ci/docker/base.gpu.Dockerfile
@@ -70,3 +70,17 @@ COPY . .
 RUN bash --login -ie -c '\
     BUILD=1 SKIP_PYTHON_PACKAGES=1 ./ci/env/install-dependencies.sh \
 '
+
+# Package index configuration for CI, sourced by the login shell each step runs.
+# No-op unless the agent wrote the matching files into the checkout.
+RUN \
+  --mount=type=bind,source=ci/docker/rayci-codeartifact-profile.sh,target=rayci-codeartifact-profile.sh \
+<<EOF
+#!/bin/bash
+
+set -euo pipefail
+
+install -D -m 0644 rayci-codeartifact-profile.sh \
+  /etc/profile.d/zz-rayci-codeartifact.sh
+
+EOF

--- a/ci/docker/base.gpu.wanda.yaml
+++ b/ci/docker/base.gpu.wanda.yaml
@@ -2,6 +2,7 @@ name: "oss-ci-base_gpu-py$PYTHON"
 froms: ["nvidia/cuda:12.8.1-cudnn-devel-ubuntu22.04"]
 dockerfile: ci/docker/base.gpu.Dockerfile
 srcs:
+  - ci/docker/rayci-codeartifact-profile.sh
   - .bazelrc
   - .bazelversion
   - ci/env/install-dependencies.sh

--- a/ci/docker/base.test.Dockerfile
+++ b/ci/docker/base.test.Dockerfile
@@ -66,3 +66,17 @@ COPY . .
 
 RUN ./ci/env/install-miniforge.sh
 RUN ./ci/env/install-bazel.sh
+
+# Package index configuration for CI, sourced by the login shell each step runs.
+# No-op unless the agent wrote the matching files into the checkout.
+RUN \
+  --mount=type=bind,source=ci/docker/rayci-codeartifact-profile.sh,target=rayci-codeartifact-profile.sh \
+<<EOF
+#!/bin/bash
+
+set -euo pipefail
+
+install -D -m 0644 rayci-codeartifact-profile.sh \
+  /etc/profile.d/zz-rayci-codeartifact.sh
+
+EOF

--- a/ci/docker/base.test.aarch64.wanda.yaml
+++ b/ci/docker/base.test.aarch64.wanda.yaml
@@ -2,6 +2,7 @@ name: "oss-ci-base_test-aarch64-py$PYTHON"
 froms: ["ubuntu:jammy"]
 dockerfile: ci/docker/base.test.Dockerfile
 srcs:
+  - ci/docker/rayci-codeartifact-profile.sh
   - ci/env/install-bazel.sh
   - ci/env/install-miniforge.sh
   - ci/suppress_output

--- a/ci/docker/base.test.wanda.yaml
+++ b/ci/docker/base.test.wanda.yaml
@@ -2,6 +2,7 @@ name: "oss-ci-base_test-py$PYTHON"
 froms: ["ubuntu:jammy"]
 dockerfile: ci/docker/base.test.Dockerfile
 srcs:
+  - ci/docker/rayci-codeartifact-profile.sh
   - ci/env/install-bazel.sh
   - ci/env/install-miniforge.sh
   - ci/suppress_output

--- a/ci/docker/forge.Dockerfile
+++ b/ci/docker/forge.Dockerfile
@@ -128,6 +128,20 @@ curl -fsSL "https://github.com/google/go-containerregistry/releases/download/v${
 chmod +x /usr/local/bin/crane
 EOF
 
+# Package index configuration for CI, sourced by the login shell each step runs.
+# No-op unless the agent wrote the matching files into the checkout.
+RUN \
+  --mount=type=bind,source=ci/docker/rayci-codeartifact-profile.sh,target=rayci-codeartifact-profile.sh \
+<<EOF
+#!/bin/bash
+
+set -euo pipefail
+
+cp rayci-codeartifact-profile.sh /etc/profile.d/zz-rayci-codeartifact.sh
+chmod 0644 /etc/profile.d/zz-rayci-codeartifact.sh
+
+EOF
+
 USER forge
 
 RUN <<EOF
@@ -140,20 +154,6 @@ set -euo pipefail
   echo "build --announce_rc"
   echo "build --remote_cache=${BUILDKITE_BAZEL_CACHE_URL}"
 } > ~/.bazelrc
-
-EOF
-
-# Package index configuration for CI, sourced by the login shell each step runs.
-# No-op unless the agent wrote the matching files into the checkout.
-RUN \
-  --mount=type=bind,source=ci/docker/rayci-codeartifact-profile.sh,target=rayci-codeartifact-profile.sh \
-<<EOF
-#!/bin/bash
-
-set -euo pipefail
-
-cp rayci-codeartifact-profile.sh /etc/profile.d/zz-rayci-codeartifact.sh
-chmod 0644 /etc/profile.d/zz-rayci-codeartifact.sh
 
 EOF
 

--- a/ci/docker/forge.Dockerfile
+++ b/ci/docker/forge.Dockerfile
@@ -137,8 +137,8 @@ RUN \
 
 set -euo pipefail
 
-cp rayci-codeartifact-profile.sh /etc/profile.d/zz-rayci-codeartifact.sh
-chmod 0644 /etc/profile.d/zz-rayci-codeartifact.sh
+install -D -m 0644 rayci-codeartifact-profile.sh \
+  /etc/profile.d/zz-rayci-codeartifact.sh
 
 EOF
 

--- a/ci/docker/forge.Dockerfile
+++ b/ci/docker/forge.Dockerfile
@@ -143,6 +143,20 @@ set -euo pipefail
 
 EOF
 
+# Package index configuration for CI, sourced by the login shell each step runs.
+# No-op unless the agent wrote the matching files into the checkout.
+RUN \
+  --mount=type=bind,source=ci/docker/rayci-codeartifact-profile.sh,target=rayci-codeartifact-profile.sh \
+<<EOF
+#!/bin/bash
+
+set -euo pipefail
+
+cp rayci-codeartifact-profile.sh /etc/profile.d/zz-rayci-codeartifact.sh
+chmod 0644 /etc/profile.d/zz-rayci-codeartifact.sh
+
+EOF
+
 ENV DOCKER_API_VERSION=1.43
 
 CMD ["echo", "ray forge"]

--- a/ci/docker/forge.wanda.yaml
+++ b/ci/docker/forge.wanda.yaml
@@ -6,3 +6,4 @@ build_args:
 dockerfile: ci/docker/forge.Dockerfile
 srcs:
   - ci/k8s/install-k8s-tools.sh
+  - ci/docker/rayci-codeartifact-profile.sh

--- a/ci/docker/manylinux-retag.Dockerfile
+++ b/ci/docker/manylinux-retag.Dockerfile
@@ -31,6 +31,10 @@ EOF
 
 # Package index configuration for CI, sourced by the login shell each step runs.
 # No-op unless the agent wrote the matching files into the checkout.
+#
+# The base image already runs as forge (crane config reports User "forge"), and
+# /etc/profile.d is root-owned, so this has to step up and back down again.
+USER root
 RUN \
   --mount=type=bind,source=ci/docker/rayci-codeartifact-profile.sh,target=rayci-codeartifact-profile.sh \
 <<EOF
@@ -42,3 +46,5 @@ install -D -m 0644 rayci-codeartifact-profile.sh \
   /etc/profile.d/zz-rayci-codeartifact.sh
 
 EOF
+
+USER forge

--- a/ci/docker/manylinux-retag.Dockerfile
+++ b/ci/docker/manylinux-retag.Dockerfile
@@ -28,3 +28,17 @@ set -euo pipefail
 } > "$HOME"/.bazelrc
 
 EOF
+
+# Package index configuration for CI, sourced by the login shell each step runs.
+# No-op unless the agent wrote the matching files into the checkout.
+RUN \
+  --mount=type=bind,source=ci/docker/rayci-codeartifact-profile.sh,target=rayci-codeartifact-profile.sh \
+<<EOF
+#!/bin/bash
+
+set -euo pipefail
+
+install -D -m 0644 rayci-codeartifact-profile.sh \
+  /etc/profile.d/zz-rayci-codeartifact.sh
+
+EOF

--- a/ci/docker/manylinux.wanda.yaml
+++ b/ci/docker/manylinux.wanda.yaml
@@ -6,3 +6,5 @@ build_args:
   - MANYLINUX_VERSION
   - HOSTTYPE
 dockerfile: ci/docker/manylinux-retag.Dockerfile
+srcs:
+  - ci/docker/rayci-codeartifact-profile.sh

--- a/ci/docker/rayci-codeartifact-profile.sh
+++ b/ci/docker/rayci-codeartifact-profile.sh
@@ -1,0 +1,31 @@
+# shellcheck shell=sh
+# Installed as /etc/profile.d/zz-rayci-codeartifact.sh in the CI images.
+#
+# Steps run their command with `bash -elic`, a login shell, so this is sourced
+# automatically and every step picks up the package index with no per-step
+# wiring. That matters because the container is started by the Buildkite docker
+# plugin, whose --env list is fixed and carries no index configuration: exporting
+# these on the agent cannot reach the build, and bazel's --repo_env passthrough
+# then has nothing to inherit.
+#
+# The agent writes both files into the checkout, which is bind-mounted here, so
+# $PWD resolves them without either side knowing the other's mount path.
+#
+# Everything is conditional on the files existing. A plain checkout has neither,
+# nothing is exported, and pip and uv resolve from PyPI exactly as before.
+
+if [ -f "${PWD}/.rayci-codeartifact.env" ]; then
+  set -a
+  # shellcheck disable=SC1091
+  . "${PWD}/.rayci-codeartifact.env"
+  set +a
+
+  # The credential is a netrc rather than userinfo in the index URL: it keeps the
+  # token out of the environment, and a half-credentialled https://aws@host/ URL
+  # would make requests look up a machine named "aws@<host>", miss, and then
+  # authenticate with an empty password.
+  if [ -f "${PWD}/.rayci-netrc" ]; then
+    NETRC="${PWD}/.rayci-netrc"
+    export NETRC
+  fi
+fi

--- a/ci/ray_ci/container.py
+++ b/ci/ray_ci/container.py
@@ -56,10 +56,6 @@ _DOCKER_ENV = [
     "UV_EXTRA_INDEX_URL",
     "UV_INSECURE_HOST",
     "RULES_PYTHON_PIP_ISOLATED",
-    # Where the index credential lives, for an index that needs one. Both pip
-    # and uv read $NETRC, which keeps the token out of the index URL and so out
-    # of this very list. The file itself is bind-mounted in get_run_command.
-    "NETRC",
 ]
 _RAYCI_BUILD_ID = os.environ.get("RAYCI_BUILD_ID", "")
 
@@ -146,13 +142,6 @@ class Container(abc.ABC):
         ]
         for env in self.envs:
             command += ["--env", env]
-        # Forwarding $NETRC only names a path; the file has to exist inside the
-        # container too, and at the same path, since that is the value the
-        # variable carries. Read-only: nothing in a test container should be
-        # rewriting the index credential.
-        netrc = os.environ.get("NETRC")
-        if netrc and os.path.exists(netrc):
-            command += ["--volume", f"{netrc}:{netrc}:ro"]
         if network:
             command += ["--network", network]
         for volume in (volumes or []) + self.volumes:

--- a/ci/ray_ci/container.py
+++ b/ci/ray_ci/container.py
@@ -50,7 +50,11 @@ _DOCKER_ENV = [
     # .bazelrc. Docker passes nothing through for a variable that is unset, which
     # is the case in a plain checkout, and then pip and uv resolve from PyPI.
     "PIP_INDEX_URL",
+    "PIP_EXTRA_INDEX_URL",
+    "PIP_TRUSTED_HOST",
     "UV_INDEX_URL",
+    "UV_EXTRA_INDEX_URL",
+    "UV_INSECURE_HOST",
     "RULES_PYTHON_PIP_ISOLATED",
 ]
 _RAYCI_BUILD_ID = os.environ.get("RAYCI_BUILD_ID", "")

--- a/ci/ray_ci/container.py
+++ b/ci/ray_ci/container.py
@@ -56,6 +56,10 @@ _DOCKER_ENV = [
     "UV_EXTRA_INDEX_URL",
     "UV_INSECURE_HOST",
     "RULES_PYTHON_PIP_ISOLATED",
+    # Where the index credential lives, for an index that needs one. Both pip
+    # and uv read $NETRC, which keeps the token out of the index URL and so out
+    # of this very list. The file itself is bind-mounted in get_run_command.
+    "NETRC",
 ]
 _RAYCI_BUILD_ID = os.environ.get("RAYCI_BUILD_ID", "")
 
@@ -142,6 +146,13 @@ class Container(abc.ABC):
         ]
         for env in self.envs:
             command += ["--env", env]
+        # Forwarding $NETRC only names a path; the file has to exist inside the
+        # container too, and at the same path, since that is the value the
+        # variable carries. Read-only: nothing in a test container should be
+        # rewriting the index credential.
+        netrc = os.environ.get("NETRC")
+        if netrc and os.path.exists(netrc):
+            command += ["--volume", f"{netrc}:{netrc}:ro"]
         if network:
             command += ["--network", network]
         for volume in (volumes or []) + self.volumes:

--- a/ci/ray_ci/container.py
+++ b/ci/ray_ci/container.py
@@ -45,6 +45,13 @@ _DOCKER_ENV = [
     "BUILDKITE_PULL_REQUEST",
     "BUILDKITE_BAZEL_CACHE_URL",
     "BUILDKITE_CACHE_READONLY",
+    # Package index configuration, so a nested container resolves from the same
+    # index as the step that started it; see the --repo_env passthrough in
+    # .bazelrc. Docker passes nothing through for a variable that is unset, which
+    # is the case in a plain checkout, and then pip and uv resolve from PyPI.
+    "PIP_INDEX_URL",
+    "UV_INDEX_URL",
+    "RULES_PYTHON_PIP_ISOLATED",
 ]
 _RAYCI_BUILD_ID = os.environ.get("RAYCI_BUILD_ID", "")
 

--- a/ci/ray_ci/linux_container.py
+++ b/ci/ray_ci/linux_container.py
@@ -130,13 +130,22 @@ class LinuxContainer(Container):
         # way the rest of the checkout does: tests.env.Dockerfile COPYs the
         # workspace into an image, and a token does not belong in an image layer,
         # so .rayci-netrc is excluded from the build context. Bind-mount it
-        # instead, and name it at this layer's workspace path -- the agent's
-        # value points at the step container's mount, which does not exist here.
+        # instead.
+        #
+        # Both paths are needed and they are not interchangeable. $NETRC is where
+        # the file is *here*, which is what says whether there is one to mount.
+        # The mount source has to be the path on the *host*, because this docker
+        # run is served by the host daemon through the mounted socket -- passing
+        # the in-container path makes docker create a directory of that name and
+        # fail with "not a directory". RAYCI_CHECKOUT_DIR is the same checkout as
+        # the host sees it, which is how the workspace mount above is built too.
         netrc = os.environ.get("NETRC")
-        if netrc and os.path.exists(netrc):
+        checkout = os.environ.get("RAYCI_CHECKOUT_DIR")
+        if netrc and checkout and os.path.exists(netrc):
+            host_netrc = os.path.join(checkout, os.path.basename(netrc))
             extra_args += [
                 "--volume",
-                f"{netrc}:/rayci/.rayci-netrc:ro",
+                f"{host_netrc}:/rayci/.rayci-netrc:ro",
                 "--env",
                 "NETRC=/rayci/.rayci-netrc",
             ]

--- a/ci/ray_ci/linux_container.py
+++ b/ci/ray_ci/linux_container.py
@@ -126,6 +126,20 @@ class LinuxContainer(Container):
             "/rayci",
             "--shm-size=2.5gb",
         ]
+        # The index credential cannot ride the workspace into this container the
+        # way the rest of the checkout does: tests.env.Dockerfile COPYs the
+        # workspace into an image, and a token does not belong in an image layer,
+        # so .rayci-netrc is excluded from the build context. Bind-mount it
+        # instead, and name it at this layer's workspace path -- the agent's
+        # value points at the step container's mount, which does not exist here.
+        netrc = os.environ.get("NETRC")
+        if netrc and os.path.exists(netrc):
+            extra_args += [
+                "--volume",
+                f"{netrc}:/rayci/.rayci-netrc:ro",
+                "--env",
+                "NETRC=/rayci/.rayci-netrc",
+            ]
         return extra_args
 
     def get_artifact_mount(self) -> Tuple[str, str]:

--- a/ci/ray_ci/test_linux_tester_container.py
+++ b/ci/ray_ci/test_linux_tester_container.py
@@ -92,17 +92,26 @@ def test_netrc_is_mounted_into_the_container(tmp_path) -> None:
     def _mock_popen(input: List[str]) -> None:
         inputs.append(" ".join(input))
 
-    netrc = tmp_path / "netrc"
+    netrc = tmp_path / ".rayci-netrc"
     netrc.write_text("machine example.invalid\nlogin aws\npassword tok\n")
+    host_checkout = "/var/lib/buildkite-agent/builds/agent-1/ray-project/microcheck"
 
     with mock.patch("subprocess.Popen", side_effect=_mock_popen), mock.patch(
         "ci.ray_ci.linux_tester_container.LinuxTesterContainer.install_ray",
         return_value=None,
-    ), mock.patch.dict(os.environ, {"NETRC": str(netrc)}):
+    ), mock.patch.dict(
+        os.environ, {"NETRC": str(netrc), "RAYCI_CHECKOUT_DIR": host_checkout}
+    ):
         LinuxTesterContainer("team")._run_tests_in_docker(["t1"], [], "/tmp", [])
-        # Mounted at this layer's workspace path, not the agent's: the value the
-        # step container carries points at its own mount, which is not here.
-        assert f"--volume {netrc}:/rayci/.rayci-netrc:ro" in inputs[-1]
+        # The source must be the host path. This docker run is served by the host
+        # daemon through the mounted socket, so passing the path as seen inside
+        # this container makes docker create a directory of that name and fail
+        # with "not a directory".
+        assert (
+            f"--volume {host_checkout}/.rayci-netrc:/rayci/.rayci-netrc:ro"
+            in inputs[-1]
+        )
+        assert f"--volume {netrc}:" not in inputs[-1]
         assert "--env NETRC=/rayci/.rayci-netrc" in inputs[-1]
 
 
@@ -114,6 +123,7 @@ def test_netrc_is_not_mounted_when_unset() -> None:
         inputs.append(" ".join(input))
 
     environ = {k: v for k, v in os.environ.items() if k != "NETRC"}
+    environ["RAYCI_CHECKOUT_DIR"] = "/some/host/checkout"
     with mock.patch("subprocess.Popen", side_effect=_mock_popen), mock.patch(
         "ci.ray_ci.linux_tester_container.LinuxTesterContainer.install_ray",
         return_value=None,

--- a/ci/ray_ci/test_linux_tester_container.py
+++ b/ci/ray_ci/test_linux_tester_container.py
@@ -102,7 +102,8 @@ def test_run_tests_in_docker() -> None:
         # invocation inside it reads the --repo_env passthrough from the repo's
         # .bazelrc, which only has an effect on variables that container has.
         assert (
-            "--env PIP_INDEX_URL --env UV_INDEX_URL "
+            "--env PIP_INDEX_URL --env PIP_EXTRA_INDEX_URL --env PIP_TRUSTED_HOST "
+            "--env UV_INDEX_URL --env UV_EXTRA_INDEX_URL --env UV_INSECURE_HOST "
             "--env RULES_PYTHON_PIP_ISOLATED" in input_str
         )
         assert "--network host" in input_str

--- a/ci/ray_ci/test_linux_tester_container.py
+++ b/ci/ray_ci/test_linux_tester_container.py
@@ -80,6 +80,45 @@ def test_persist_test_results(
         assert mock_move_test_state.called
 
 
+def test_netrc_is_mounted_into_the_container(tmp_path) -> None:
+    """The index credential must exist inside the container, at the same path.
+
+    Forwarding $NETRC only carries the path. Without the bind mount the variable
+    names a file that is not there, pip falls back to anonymous access and an
+    index that requires auth answers 401.
+    """
+    inputs = []
+
+    def _mock_popen(input: List[str]) -> None:
+        inputs.append(" ".join(input))
+
+    netrc = tmp_path / "netrc"
+    netrc.write_text("machine example.invalid\nlogin aws\npassword tok\n")
+
+    with mock.patch("subprocess.Popen", side_effect=_mock_popen), mock.patch(
+        "ci.ray_ci.linux_tester_container.LinuxTesterContainer.install_ray",
+        return_value=None,
+    ), mock.patch.dict(os.environ, {"NETRC": str(netrc)}):
+        LinuxTesterContainer("team")._run_tests_in_docker(["t1"], [], "/tmp", [])
+        assert f"--volume {netrc}:{netrc}:ro" in inputs[-1]
+
+
+def test_netrc_is_not_mounted_when_unset() -> None:
+    """A plain checkout sets no NETRC, so nothing extra is mounted."""
+    inputs = []
+
+    def _mock_popen(input: List[str]) -> None:
+        inputs.append(" ".join(input))
+
+    environ = {k: v for k, v in os.environ.items() if k != "NETRC"}
+    with mock.patch("subprocess.Popen", side_effect=_mock_popen), mock.patch(
+        "ci.ray_ci.linux_tester_container.LinuxTesterContainer.install_ray",
+        return_value=None,
+    ), mock.patch.dict(os.environ, environ, clear=True):
+        LinuxTesterContainer("team")._run_tests_in_docker(["t1"], [], "/tmp", [])
+        assert ":ro" not in inputs[-1]
+
+
 def test_run_tests_in_docker() -> None:
     inputs = []
 
@@ -104,7 +143,7 @@ def test_run_tests_in_docker() -> None:
         assert (
             "--env PIP_INDEX_URL --env PIP_EXTRA_INDEX_URL --env PIP_TRUSTED_HOST "
             "--env UV_INDEX_URL --env UV_EXTRA_INDEX_URL --env UV_INSECURE_HOST "
-            "--env RULES_PYTHON_PIP_ISOLATED" in input_str
+            "--env RULES_PYTHON_PIP_ISOLATED --env NETRC" in input_str
         )
         assert "--network host" in input_str
         assert '--gpus "device=0,1"' in input_str

--- a/ci/ray_ci/test_linux_tester_container.py
+++ b/ci/ray_ci/test_linux_tester_container.py
@@ -98,6 +98,13 @@ def test_run_tests_in_docker() -> None:
         )._run_tests_in_docker(["t1", "t2"], [0, 1], "/tmp", ["v=k"], "flag")
         input_str = inputs[-1]
         assert "--env ENV_01 --env ENV_02 --env BUILDKITE" in input_str
+        # The index configuration has to reach the nested container: the bazel
+        # invocation inside it reads the --repo_env passthrough from the repo's
+        # .bazelrc, which only has an effect on variables that container has.
+        assert (
+            "--env PIP_INDEX_URL --env UV_INDEX_URL "
+            "--env RULES_PYTHON_PIP_ISOLATED" in input_str
+        )
         assert "--network host" in input_str
         assert '--gpus "device=0,1"' in input_str
         assert "--volume /tmp:/tmp/bazel_event_logs" in input_str

--- a/ci/ray_ci/test_linux_tester_container.py
+++ b/ci/ray_ci/test_linux_tester_container.py
@@ -100,7 +100,10 @@ def test_netrc_is_mounted_into_the_container(tmp_path) -> None:
         return_value=None,
     ), mock.patch.dict(os.environ, {"NETRC": str(netrc)}):
         LinuxTesterContainer("team")._run_tests_in_docker(["t1"], [], "/tmp", [])
-        assert f"--volume {netrc}:{netrc}:ro" in inputs[-1]
+        # Mounted at this layer's workspace path, not the agent's: the value the
+        # step container carries points at its own mount, which is not here.
+        assert f"--volume {netrc}:/rayci/.rayci-netrc:ro" in inputs[-1]
+        assert "--env NETRC=/rayci/.rayci-netrc" in inputs[-1]
 
 
 def test_netrc_is_not_mounted_when_unset() -> None:
@@ -116,7 +119,7 @@ def test_netrc_is_not_mounted_when_unset() -> None:
         return_value=None,
     ), mock.patch.dict(os.environ, environ, clear=True):
         LinuxTesterContainer("team")._run_tests_in_docker(["t1"], [], "/tmp", [])
-        assert ":ro" not in inputs[-1]
+        assert ".rayci-netrc" not in inputs[-1]
 
 
 def test_run_tests_in_docker() -> None:
@@ -143,7 +146,7 @@ def test_run_tests_in_docker() -> None:
         assert (
             "--env PIP_INDEX_URL --env PIP_EXTRA_INDEX_URL --env PIP_TRUSTED_HOST "
             "--env UV_INDEX_URL --env UV_EXTRA_INDEX_URL --env UV_INSECURE_HOST "
-            "--env RULES_PYTHON_PIP_ISOLATED --env NETRC" in input_str
+            "--env RULES_PYTHON_PIP_ISOLATED" in input_str
         )
         assert "--network host" in input_str
         assert '--gpus "device=0,1"' in input_str


### PR DESCRIPTION
## Description

CI resolves Python packages from `files.pythonhosted.org`, which returns
intermittent 502s (pypi/support#11876). Putting a byte cache in front of PyPI does
not fix this: one `pip install` is two requests, and `--index-url` governs only
the first. PyPI's simple index names `files.pythonhosted.org` **absolutely** in
the body, so the wheel bytes — where every observed 502 landed — go to origin no
matter what the index was set to.

AWS CodeArtifact does not have that shape. Verified against a live repository:

```
$ curl -H "Accept: application/vnd.pypi.simple.v1+json" .../simple/setuptools-scm/
  filename : setuptools_scm-10.2.1-py3-none-any.whl
  url      : 10.2.1/setuptools_scm-10.2.1-py3-none-any.whl     <- relative
  sha256   : b7c82f4102d389ee57dc66ccdb4f9b4bca3c40ba83b43f1f63d68ccd72db2580
```

The artifact URL is **relative**, so pip resolves it against the endpoint it
already fetched the index from. Both requests transit CodeArtifact, one credential
covers both, and a package version is *retained* once imported rather than cached
with a TTL — so a PyPI outage stops being an event rather than becoming a shorter
one.

### How the configuration reaches the fetch

This is most of the change, and the first CI run is what taught it. Exporting the
index on the agent does nothing: the step's command runs in a container started by
the Buildkite docker plugin, whose `--env` list is fixed and carries nothing about
the index, so bazel's `--repo_env` passthrough has nothing to inherit and every
`py_deps_py310_*` fetch still resolved from pypi.org.

Steps run their command with `bash -elic`, a **login** shell, so `/etc/profile.d`
in the image is sourced automatically and reaches every step with no per-step
wiring. The agent writes two files into the checkout, which is bind-mounted into
the step container, and the fragment resolves both from `$PWD` so neither side
needs to know the other's mount path:

| file | contents |
| --- | --- |
| `.rayci-codeartifact.env` | `PIP_INDEX_URL`, `UV_INDEX_URL`, `RULES_PYTHON_PIP_ISOLATED=0` |
| `.rayci-netrc` | the credential, mode 0600 |

`RULES_PYTHON_PIP_ISOLATED=0` is load-bearing: rules_python runs `whl_library`'s
pip with `--isolated`, which makes pip ignore every `PIP_*` variable, so without
it the index is silently discarded and the repository rule resolves from PyPI
while looking configured.

The **nested** test container cannot take the same route. `tests.env.Dockerfile`
COPYs the workspace into an image, and a bearer token does not belong in an image
layer, so `.rayci-netrc` is excluded from the build context and bind-mounted into
that container instead — named at its own workspace path, since the value the step
container carries points at a mount that does not exist there. Its shell is
`bash -iecuo`, not a login shell, so it takes the index settings by `--env`
forwarding rather than from profile.d.

Images wired, by root — the rest derive:

| root | covers |
| --- | --- |
| `forge` | default steps; also `forge-aarch64` (same Dockerfile) and `fossa-base` (`FROM forge`) |
| `base.test` | `oss-ci-base_{test,build,ml}` → `corebuild`, `docbuild`, `data*build`, `ml*` |
| `base.gpu` | `oss-ci-base_{gpu,cu128,cu130}` → `docgpubuild` |
| `manylinux-retag` | `manylinux-$HOSTTYPE`, what `job_env: manylinux-x86_64` resolves to |

### Why a netrc and not credentials in the URL

Besides keeping the token out of the environment and out of `docker run`
arguments, the half-credentialled form `https://aws@host/` is actively harmful.
`requests` derives the netrc lookup key as `netloc.split(":")[0]`, which strips
the port but **not** the userinfo, so it searches for a machine named
`aws@<host>`, misses, and pip then coerces the absent password to `""` and
authenticates as `aws` with an empty password. The symptom is a 401 with an
`Authorization` header present, which reads like a bad token rather than a
malformed URL.

## Related issues

Upstream cause: pypi/support#11876.

**Not a duplicate, and what it depends on.** `gh pr list --state open --search
"codeartifact"` returns nothing; `"pypi index mirror"` and `"pip_parse"` return
only the PRs below.

- **#65562 — depends on it.** Its two commits are cherry-picked here (authorship
  preserved) because the nested container takes its settings from that forwarding.
  **This should not merge before #65562; rebase onto it once that lands.**
- **#65564 — materially different approach to the same problem.** That one runs a
  rewriting index proxy on the agent in front of a byte-cache mirror. This uses a
  managed AWS index instead: no proxy process, no `WORKSPACE` change, and no cold
  fetch over the CI egress path, since CodeArtifact reaches pypi.org over the AWS
  network. Posted as an alternative to compare, **not** to compete — happy to fold
  it into that stack or close it if it is preferred.
- **#65563** (drop the emitted index URL from the deplocks) is complementary and
  not included.
- **#65518** raised pip's retry tolerance for the same 502s and is now **closed
  unmerged**, so `master` has no 502 retry protection at all and these fetches
  fail on the first 502 rather than exhausting a budget. That makes an index the
  remaining lever rather than one of two.

## Additional information

### ⚠️ Draft — not mergeable as-is

- Points at a **scratch** domain (`ray-ci-scratch` in `029272617770`). A real
  domain is a prerequisite.
- Needs an agent IAM policy. The first run proved the roles could not authenticate
  at all:
  `bk-runner-queue-small-pr-Role ... is not authorized to perform:
  codeartifact:GetAuthorizationToken`. A read-only policy is now on
  `bk-runner-queue-{small,large}-pr-Role`; `medium-pr`, `arm64-medium-pr` and the
  four `-branch-Role`s still fail open. Note a domain resource policy cannot
  substitute: `sts:GetServiceBearerToken` is also required and AWS documents that
  it has no effect in that policy.

### The failure mode this introduces

CodeArtifact lists an asset in the index *before* it has finished importing it and
answers the download with a **404**, which is not in urllib3's `status_forcelist`,
so pip does not retry it. Measured on fresh packages: 2 of 12 in one sample and 3
of 215 in another, clearing in **1.3–1.6s**. Hence `ci/codeartifact_prewarm.py`,
which is a prerequisite rather than an optimisation. Requesting `/simple/<pkg>/`
imports nothing; one *asset* GET imports every asset of that version (one wheel
request pulled all 76 assets of `aiohttp==3.9.5`), so fetching the smallest asset
per pin is the cheapest complete warm-up.

### Scope

CodeArtifact external connections are a fixed allowlist (`public:pypi`,
`public:npmjs`, …), so **`download.pytorch.org` and the libtpu index cannot be
proxied** and continue to resolve directly. That is safe here: `UV_INDEX_URL`
replaces only the *primary* index, and a lock file's `--extra-index-url` survives
it — verified by resolving one package from each in a single install.

`WINDOWS` and `MACOS` `job_env`s are untouched: neither runs a Linux container and
the Windows step shell is not a login shell, so those steps still resolve from
PyPI. Image builds run in a separate BuildKit context and are likewise unaffected.

### Testing

Every claim below was run, not assumed.

**1. All lock hashes survive the move.** All 215 pinned versions in
`release/requirements_py310.txt`, checked against the sha256 CodeArtifact reports
for each file — this is what keeps `--require-hashes` passing and is why no lock
file needs regenerating:

```
hashes verified identical: 2263 / 2263
package versions clean   : 215 / 215
```

**2. The exact CI failure chain resolves through it.** `anyscale==0.26.74` is
sdist-only, so its `setup_requires` spawns a nested pip:

```
$ pip --isolated download -r <anyscale pin + hash> --require-hashes --index-url=<codeartifact>
Downloading .../simple/anyscale/0.26.74/anyscale-0.26.74.tar.gz (1.5 MB)
  Downloading .../simple/setuptools-scm/10.2.1/setuptools_scm-10.2.1-py3-none-any.whl
Saved anyscale-0.26.74.tar.gz
exit=0
```

`setuptools_scm` and its own build dependency `vcs-versioning` came off
CodeArtifact too.

**3. Pre-warm covers the whole exposed set.** uv's precedence is the opposite of
pip's — `UV_INDEX_URL` overrides the `--index-url` on line 1 of the deplocks, so
uv installs are redirected as well and the exposed set is the deplock union, not
`release/requirements_py310.txt` alone:

```
$ python ci/codeartifact_prewarm.py release/requirements_py310.txt python/deplocks/**/*.lock
warming 891 package versions from 98 lock file(s)
warmed 879/891 in 112s; 1 hit the cold-import 404 and cleared on retry
```

The 12 not warmed are all `+cu130` / `+cpu` / `+pt29cpu` torch builds, which live
on `download.pytorch.org` and cannot be on a PyPI-backed index.

**4. The image mechanism, in a container built from this pattern.**

```
files present, bash -elic  -> PIP_INDEX_URL, UV_INDEX_URL,
                              RULES_PYTHON_PIP_ISOLATED=0, NETRC=/ray/.rayci-netrc
plain checkout, bash -elic -> everything unset          (fail-open holds)
files present, bash -iecuo -> unset                     (nested takes --env)
```

**5. `$NETRC` authenticates pip under `--isolated`, and uv, with an empty
`$HOME`** — against a purpose-built index requiring HTTP Basic that logs whether
each request carried it:

```
pip --isolated | NETRC set, HOME empty -> exit=0 Saved
    REQ auth=YES /simple/dummypkg/
    REQ auth=YES /files/dummypkg-1.0-py3-none-any.whl
pip --isolated | neither (control)     -> exit=1
uv             | NETRC set, HOME empty -> exit=0
```

**6. The userinfo trap** (pip 24.0, the version `WORKSPACE` pins):

```
https://HOST/…      netrc lookup HIT  -> sends aws / <token>
https://aws@HOST/…  netrc lookup MISS -> sends aws / ''   (401)
```

**7. Fail-open, with no usable credentials:**

```
$ source ci/codeartifact_env.sh
codeartifact: could not mint a token, using PyPI
codeartifact: ... AccessDeniedException ... not authorized to perform: codeartifact:GetAuthorizationToken
$ echo "${PIP_INDEX_URL:-<unset>}"
<unset>
```

**8. Unit tests.**

```
$ PYTHONPATH=.:release python -m pytest -q ci/ray_ci/test_container.py \
    ci/ray_ci/test_linux_tester_container.py ci/ray_ci/test_linux_container.py \
    ci/ray_ci/test_windows_container.py
17 passed
```

Two are new and cover the bind mount: the netrc is mounted read-only at the nested
container's own workspace path when `NETRC` is set, and nothing is mounted when it
is not.

**9. Lint.** `pre-commit run --files <every changed file>` — all applicable hooks
pass (ruff, black, shellcheck, semgrep, docstyle, import order).

AI assistance (Claude Code) was used for this change.

