### PR TITLE
[docs] Scope the symbol rule to symbols standing in for words

### DIFF
--- a/doc/source/ray-contribute/writing-style.md
+++ b/doc/source/ray-contribute/writing-style.md
@@ -150,11 +150,17 @@ In prose, write "ID" (or "IDs"). Reserve `id` for code, where it's a literal ide
 
 ### Use words for symbols in prose
 
-Outside code, spell out operators and separators.
+Outside code, spell out a symbol that stands in for a word.
 
 - "X + Y" → "X and Y"
 - "X vs. Y" → "X versus Y"
 - "X/Y" → "X or Y" or "X and Y"
+
+This rule is about a symbol doing a word's job. It isn't about arithmetic. Keep the symbol when it expresses a calculation, a pair of dimensions, or an established shorthand, where spelling it out is longer and harder to read:
+
+- `4 × 0.5 GPU = 2 GPUs`, and `tensor_parallel_size × pipeline_parallel_size`
+- `384×384` for a resolution, and `4 rows × 23 columns` for a shape
+- `8xH100` or `4xL4` for an accelerator count
 
 ### Don't write "etc." after "such as," "for example," or "including"
 

--- a/doc/source/ray-contribute/writing-style.md
+++ b/doc/source/ray-contribute/writing-style.md
@@ -158,8 +158,8 @@ Outside code, spell out a symbol that stands in for a word.
 
 This rule is about a symbol doing a word's job. It isn't about arithmetic. Keep the symbol when it expresses a calculation, a pair of dimensions, or an established shorthand, where spelling it out is longer and harder to read:
 
-- `4 × 0.5 GPU = 2 GPUs`, and `tensor_parallel_size × pipeline_parallel_size`
-- `384×384` for a resolution, and `4 rows × 23 columns` for a shape
+- `4 × 0.5 GPU = 2 GPUs` and `tensor_parallel_size × pipeline_parallel_size`
+- `384×384` for a resolution and `4 rows × 23 columns` for a shape
 - `8xH100` or `4xL4` for an accelerator count
 
 ### Don't write "etc." after "such as," "for example," or "including"


### PR DESCRIPTION
## Why

`Use words for symbols in prose` currently opens with "spell out operators and separators," then gives three examples that are all symbols standing in for conjunctions (`+`, `vs.`, `/`). Read literally, "operators" also covers `×`, so the rule appears to ask you to rewrite genuine arithmetic and established shorthand into words.

That reading produces worse text. It turns `4 × 0.5 GPU = 2 GPUs` into a sentence, and it argues against `8xH100`. It also contradicts what the docs already do.

## What the docs already do

Two distinct conventions are in use, and they aren't competing for the same job:

| Job | Form | Occurrences | Examples in tree |
|---|---|---|---|
| Accelerator count shorthand | ASCII `x`, no spaces | 92 across 6 files | `4xL4`, `4xT4`, `8xA100`, `8xH100`, `8xH200` |
| Calculation, dimensions, shape | `×` | 16 across 9 files | `4 × 0.5 GPU = 2 GPUs`, `tensor_parallel_size × pipeline_parallel_size`, `384×384`, `4 rows × 23 columns` |

Sources include `cluster/kubernetes/k8s-ecosystem/kai-scheduler.md`, `serve/llm/architecture/overview.md`, `serve/llm/user-guides/fractional-gpu.md`, `serve/monitoring.md`, `serve/tutorials/serve-deepseek.md`, and `serve/tutorials/video-analysis/README.md`.

## What this changes

Narrows the rule's opening sentence from "operators and separators" to "a symbol that stands in for a word," which is what the three examples actually illustrate, and adds a short carve-out naming the cases where the symbol should stay. No existing example or recommendation is removed or weakened.

## Why it's worth fixing rather than leaving to judgment

This page states that its guidance applies to AI coding agents as well as humans, and agents apply a rule as written. An over-broad "spell out operators" is exactly the kind of instruction that gets applied mechanically to `384×384`. I hit this myself while style-reviewing a docs PR: I flagged a contributor's correct `128G × 8` hardware sizing as a rule violation, and it wasn't one.

## Scope

Documentation only, and only this one subsection. No behavior change. Vale doesn't lint this page (`.vale.ini` scopes it to the Ray Data docs and the example gallery) and no pre-commit hook covers Markdown under `doc/source/`, so there's no automated check to satisfy here.

AI assistance was used to gather the occurrence counts and draft this change; I reviewed the wording and the data and stand behind both.
