### PR TITLE
[cherry-pick][2.58.0][docs] add initial documentation for Ray sandboxing (#65503)

### DIFF
--- a/doc/source/cluster/kubernetes/examples.md
+++ b/doc/source/cluster/kubernetes/examples.md
@@ -19,6 +19,7 @@ examples/rayserve-deepseek-example
 examples/verl-post-training
 examples/argocd
 examples/rayjob-agent-sandbox
+examples/ray-sandboxing
 ```
 
 
@@ -37,3 +38,4 @@ This section presents example Ray workloads to try out on your Kubernetes cluste
 - {ref}`kuberay-rayservice-deepseek-example`
 - {ref}`kuberay-verl`
 - {ref}`kuberay-agent-sandbox`
+- {ref}`kuberay-sandboxing`

--- a/doc/source/cluster/kubernetes/examples/ray-sandboxing.md
+++ b/doc/source/cluster/kubernetes/examples/ray-sandboxing.md
@@ -1,0 +1,180 @@
+---
+myst:
+  html_meta:
+    description: "Deploy Ray Sandboxes on Google Kubernetes Engine (GKE) with KubeRay for kernel-isolated, high-throughput untrusted code execution using gVisor."
+---
+
+(kuberay-sandboxing)=
+
+# Deploy Ray sandboxes with KubeRay
+
+This guide covers how to deploy and orchestrate Ray Sandboxes using Ray and KubeRay. It uses Google Kubernetes Engine (GKE) as an example, but the same principles apply to other Kubernetes distributions.
+
+Ray Sandboxes run untrusted, model-generated code safely inside lightweight, kernel-isolated environments, for reinforcement learning (RL) rollout workers and autonomous large language model (LLM) agents. Ray runs [gVisor](https://gvisor.dev/docs/) (`runsc`) directly inside Ray worker Pods, which delivers sub-100 ms startup latencies and dense bin packing of hundreds of concurrent sandboxes per node without the multi-second overhead of provisioning separate Kubernetes Pods.
+
+:::{warning}
+Ray Sandboxes (`ray.experimental.sandbox`) is an {ref}`alpha <api-stability-alpha>` library. The API can change or disappear in any release before it graduates to stable.
+:::
+
+---
+
+## Prerequisites
+
+* `kubectl` installed and configured with access to your Kubernetes cluster.
+* `gcloud` CLI installed and authenticated to your Google Cloud project.
+* [Helm](https://helm.sh/) v3 installed.
+* Ray 2.58.0 or newer with the `ray.experimental.sandbox` package.
+
+---
+
+## Step 1: Create a GKE cluster
+
+Create a GKE cluster with standard Linux worker nodes. Because gVisor runs inside the Ray container processes in rootless user space, you can use standard GKE node pools with the `containerd` container runtime.
+
+```bash
+gcloud container clusters create ray-sandbox-cluster \
+    --region=us-central1 \
+    --machine-type=e2-standard-16 \
+    --num-nodes=3
+```
+
+---
+
+## Step 2: Install the KubeRay operator
+
+Follow {ref}`KubeRay operator installation <kuberay-operator-deploy>` to install the latest stable KubeRay operator from the Helm repository.
+
+---
+
+## Step 3: Run sandboxes with a RayJob
+
+Create a RayJob that creates a RayCluster configured with `runsc` and submits a Ray job that manages Ray sandboxes:
+
+```bash
+kubectl apply -f https://raw.githubusercontent.com/ray-project/kuberay/master/ray-operator/config/samples/ray-job.sandbox.yaml
+```
+
+The RayJob is configured to do the following:
+* Create a RayCluster configured to install `runsc` at startup with the necessary `securityContext` required for gVisor
+* Submit a Ray job which will create a sandbox and execute some Python code inside it
+* Terminate sandboxes after the job is done
+
+Below is the script used for the RayJob:
+
+```python
+import ray
+from ray.experimental import sandbox
+
+ray.init()
+
+sb = sandbox.create(
+    image="python:3.12-slim",
+    workdir="/workspace",
+    cpu=1.0,
+    memory="1Gi",
+)
+
+script = """\
+import platform
+import sys
+
+print("=== Hello from inside Ray Sandbox! ===")
+print(f"Python Version : {sys.version}")
+print(f"Platform       : {platform.platform()}")
+"""
+ray.get(sb.write_file.remote("/workspace/main.py", script))
+
+result = ray.get(sb.exec.remote("python3 /workspace/main.py"))
+print(f"Exit code: {result.exit_code}")
+print("Sandbox output:")
+print(result.stdout)
+
+ray.get(sb.delete.remote())
+print("RayJob completed successfully!")
+```
+
+Monitor the status and output of the job:
+
+```bash
+# List running job pods (wait for Ray cluster to be in ready state)
+kubectl get pods -l job-name=rayjob-sandbox
+
+# Stream the demo logs
+kubectl logs -f -l job-name=rayjob-sandbox
+```
+
+The output should be similar to the following:
+
+```text
+Sandbox output:
+=== Hello from inside Ray Sandbox! ===
+Python Version : 3.12.14 (main, Aug 13 2026, 19:41:13) [GCC 14.2.0]
+Platform       : Linux-4.19.0-gvisor-x86_64-with-glibc2.41
+
+RayJob completed successfully!
+2026-08-15 17:38:41,535	INFO sdk.py:520 -- WebSocket closed for job rayjob-sandbox-gz8j6 with close code 1000
+2026-08-15 17:38:41,546	SUCC cli.py:66 -- ------------------------------------
+2026-08-15 17:38:41,546	SUCC cli.py:67 -- Job 'rayjob-sandbox-gz8j6' succeeded
+2026-08-15 17:38:41,546	SUCC cli.py:68 -- ------------------------------------
+```
+
+---
+
+## (Optional) Step 4: Verify isolation and security guarantees
+
+You can verify that untrusted code running inside an active sandbox cannot compromise the host environment or escape its sandbox boundary:
+
+### Filesystem write protection
+
+By default, base root filesystems are mounted read-only (`readonly=True`). Only the designated `workdir` is writable.
+
+```python
+# Assuming an active sandbox `sb = sandbox.create(...)`
+# Attempting to modify /etc or rootfs will fail
+res = ray.get(sb.exec.remote("touch /etc/hacked.txt"))
+print(res.exit_code)  # Non-zero exit code
+print(res.stderr)     # "Read-only file system"
+```
+
+### Network isolation
+
+With `network="none"` (the default), untrusted code cannot establish outbound connections to the internet or probe internal Kubernetes cluster services:
+
+```python
+# Attempting network egress will immediately fail
+res = ray.get(sb.exec.remote("python3 -c 'import urllib.request; urllib.request.urlopen(\"http://google.com\", timeout=2)'"))
+print(res.exit_code)  # Non-zero exit code
+```
+
+---
+
+## (Optional) Step 5: Build a custom Ray image with pre-installed `runsc`
+
+Ray Sandboxes require the `runsc` binary in the Ray worker container's `$PATH`, for example `/usr/local/bin/runsc`.
+
+The example above downloads `runsc` at Pod startup. For production, pre-install `runsc` in your container image. Pre-baking the binary eliminates runtime network dependencies, avoids external download failures or rate limits, and decreases Pod startup latency.
+
+You can build a custom Ray worker image using the following `Dockerfile`:
+
+```dockerfile
+FROM rayproject/ray:2.58.0-py312
+
+USER root
+
+# Install wget, download gVisor runsc, and install into system PATH
+RUN apt-get update && apt-get install -y --no-install-recommends wget && \
+    ARCH=$(uname -m) && \
+    wget "https://storage.googleapis.com/gvisor/releases/release/latest/${ARCH}/runsc" -O /usr/local/bin/runsc && \
+    chmod a+rx /usr/local/bin/runsc && \
+    rm -rf /var/lib/apt/lists/*
+
+USER ray
+```
+
+---
+
+## Next steps
+
+* See {ref}`ray-core-sandboxes` for API details and custom actor patterns.
+* Learn more about [gVisor](https://gvisor.dev/docs/).
+* Explore {ref}`resource-isolation-with-writable-cgroups` to configure resource isolation on Kubernetes.

--- a/doc/source/ray-core/api/index.rst
+++ b/doc/source/ray-core/api/index.rst
@@ -10,6 +10,7 @@ Ray Core API
     utility.rst
     exceptions.rst
     cli.rst
+    sandboxes.md
     ../../ray-observability/reference/cli.rst
     ../../ray-observability/reference/api.rst
     direct-transport.rst

--- a/doc/source/ray-core/api/sandboxes.md
+++ b/doc/source/ray-core/api/sandboxes.md
@@ -1,0 +1,53 @@
+---
+myst:
+  html_meta:
+    description: "API reference for Ray Sandboxes (gVisor-isolated container environments)."
+---
+
+(ray-sandbox-ref)=
+
+# Sandbox API
+
+:::{note}
+Ray Sandboxes (`ray.experimental.sandbox`) is an {ref}`alpha <api-stability-alpha>` library. The API can change before it graduates to stable.
+:::
+
+For an introduction and usage guides, see {ref}`ray-core-sandboxes`.
+
+## Sandbox lifecycle and execution
+
+```{eval-rst}
+.. autosummary::
+    :nosignatures:
+    :toctree: doc/
+
+    ray.experimental.sandbox.create
+    ray.experimental.sandbox.Sandbox
+    ray.experimental.sandbox.SandboxRuntime
+```
+
+## Data structures and status
+
+```{eval-rst}
+.. autosummary::
+    :nosignatures:
+    :toctree: doc/
+    :template: autosummary/class_without_autosummary.rst
+
+    ray.experimental.sandbox.ExecResult
+    ray.experimental.sandbox.SandboxStatus
+```
+
+## Exceptions
+
+```{eval-rst}
+.. autosummary::
+    :nosignatures:
+    :toctree: doc/
+
+    ray.experimental.sandbox.SandboxError
+    ray.experimental.sandbox.SandboxCreationError
+    ray.experimental.sandbox.SandboxTimeoutError
+    ray.experimental.sandbox.SandboxExecError
+    ray.experimental.sandbox.SandboxNotFoundError
+```

--- a/doc/source/ray-core/sandboxes.md
+++ b/doc/source/ray-core/sandboxes.md
@@ -1,0 +1,328 @@
+---
+myst:
+  html_meta:
+    description: "Execute untrusted model-generated code and agent tool calls safely with Ray Sandboxes using lightweight gVisor kernel isolation."
+---
+
+(ray-core-sandboxes)=
+
+# Ray Sandboxes
+
+Ray Sandboxes use [gVisor](https://gvisor.dev/docs/) to provide lightweight, kernel-isolated execution environments for running untrusted code and agent tool calls safely on Ray clusters.
+
+:::{warning}
+Ray Sandboxes (`ray.experimental.sandbox`) is an {ref}`alpha <api-stability-alpha>` library. The API can change or disappear in any release before it graduates to stable.
+:::
+
+## Background
+
+The ability to sandbox model-generated code is critical for agentic reinforcement learning (RL) and large language model (LLM) agents. Executing untrusted code directly in Ray worker processes or host environments introduces security and stability risks. Ray Sandboxes solve this challenge by running lightweight, kernel-isolated sandboxes directly on Ray worker nodes using [gVisor](https://gvisor.dev/docs/) (`runsc`). Scale and manage sandbox environments with familiar Ray concepts and primitives.
+
+### What is gVisor?
+
+[gVisor](https://gvisor.dev/docs/) is an open-source application kernel written in Go that provides lightweight, defense-in-depth isolation for containers. Developed by Google, gVisor implements a substantial portion of the Linux system call interface in user space, acting as an isolation barrier between untrusted applications and the host operating system kernel.
+
+Unlike standard container runtimes such as Docker or `runc`, where containers share the host Linux kernel directly, gVisor intercepts system calls made by containerized processes before they reach the host. gVisor is daemonless and runs as a non-privileged user, so you can deploy and manage it on top of existing container orchestrators such as Kubernetes.
+
+### Why gVisor?
+
+Untrusted code interacts with gVisor's user-space kernel rather than the host Linux kernel, which shrinks the attack surface for host kernel vulnerabilities and container breakout exploits. gVisor also runs entirely in user space, without host root privileges, the Docker daemon, or nested virtualization hardware extensions, so it runs inside existing Kubernetes Ray worker Pods and cloud container environments.
+
+The runtime cost is low next to full virtual machines (VMs) and MicroVMs, which boot a guest OS kernel and manage heavy disk images. A gVisor sandbox boots in tens of milliseconds, adds minimal memory overhead, and uses near-zero idle CPU, so Ray worker nodes can densely pack hundreds of concurrent sandboxes alongside standard Ray tasks and actors and sustain the high-frequency execution loops that RL rollouts and agent tool calls need.
+
+## Requirements
+
+Ray Sandboxes need the following on every Ray node that runs a sandbox:
+
+* **Linux**: x86_64 or arm64.
+* **gVisor (`runsc`)**: Install the `runsc` binary on worker nodes and make it reachable from the system `$PATH`.
+* **Ray**: version 2.58.0 or later, which includes the `ray.experimental.sandbox` package.
+
+To install `runsc` on a Linux worker node, see the [gVisor installation guide](https://gvisor.dev/docs/user_guide/install/).
+
+## Usage patterns and examples
+
+### Create a basic sandbox and run a command
+
+Use `sandbox.create()` to start an isolated environment from any container image. The function returns a Ray `ActorHandle` representing the sandbox actor.
+
+```python
+import ray
+from ray.experimental import sandbox
+
+ray.init()
+
+# Create a sandbox with 1 CPU core and 512 MiB RAM
+sb = sandbox.create(
+    image="python:3.10-slim",
+    cpu=1.0,
+    memory="512Mi",
+    workdir="/workspace",
+    timeout_seconds=30.0,
+)
+
+# Execute untrusted Python code inside the sandbox
+result = ray.get(
+    sb.exec.remote("python3 -c 'import sys; print(\"Hello from sandboxed Python:\", sys.version)'")
+)
+
+print(f"Exit Code: {result.exit_code}")
+print(f"Stdout: {result.stdout.strip()}")
+print(f"Execution Duration: {result.duration_ms:.2f} ms")
+
+# Clean up sandbox resources
+ray.get(sb.delete.remote())
+```
+
+### Read, write, upload, and download files
+
+Write source files directly into the sandbox, or upload local files from the host before execution. By default, the root filesystem is read-only and the configured `workdir`, such as `/workspace`, is the writable scratch space.
+
+```python
+import textwrap
+import ray
+from ray.experimental import sandbox
+
+ray.init()
+
+sb = sandbox.create(
+    image="python:3.10-slim",
+    workdir="/workspace",
+    memory="1Gi",
+)
+
+# 1. Write untrusted model-generated script into the sandbox
+code = textwrap.dedent("""\
+    def fibonacci(n):
+        a, b = 0, 1
+        for _ in range(n):
+            a, b = b, a + b
+        return a
+
+    with open('/workspace/output.txt', 'w') as f:
+        f.write(f"fib(30) = {fibonacci(30)}")
+""")
+ray.get(sb.write_file.remote("/workspace/solution.py", code))
+
+# 2. Execute the script inside the sandbox
+exec_res = ray.get(sb.exec.remote("python3 /workspace/solution.py"))
+print("Execution returncode:", exec_res.exit_code)
+
+# 3. Read generated output file back to the host
+output_bytes = ray.get(sb.read_file.remote("/workspace/output.txt"))
+print("Result:", output_bytes.decode("utf-8"))
+
+# 4. Alternatively, use upload_file and download_file for host files
+# ray.get(sb.upload_file.remote("local_input.json", "/workspace/input.json"))
+# ray.get(sb.download_file.remote("/workspace/output.txt", "local_output.txt"))
+
+ray.get(sb.delete.remote())
+```
+
+### Schedule a Sandbox actor with custom resources
+
+Because `Sandbox` is a standard Ray actor, you can instantiate it directly with Ray actor scheduling options such as `num_cpus`, `memory`, and custom accelerator or placement constraints.
+
+```python
+import ray
+from ray.experimental.sandbox import Sandbox
+
+ray.init()
+
+# Instantiate Sandbox actor with Ray Core resource placement options
+sandbox_actor = Sandbox.options(
+    num_cpus=2.0,
+    memory=2 * 1024 * 1024 * 1024,  # 2 GiB
+).remote(
+    image="python:3.10-slim",
+    workdir="/workspace",
+    ttl_seconds=600,  # Automatically terminate after 10 minutes
+)
+
+# Run command with a per-command execution timeout
+result = ray.get(
+    sandbox_actor.exec.remote(
+        "python3 -c 'import os; print(\"Worker PID:\", os.getpid())'",
+        timeout=5.0,  # 5 second execution timeout
+    )
+)
+
+print(result.stdout)
+ray.get(sandbox_actor.delete.remote())
+```
+
+### Manage sandboxes inside custom actors with SandboxRuntime
+
+If you're building custom RL environment actors or specialized rollout workers, embed `SandboxRuntime` directly inside your custom actors for fine-grained sandbox lifecycle control:
+
+```python
+import ray
+from ray.experimental.sandbox.runtime import SandboxRuntime
+
+@ray.remote
+class SandboxPool:
+    def __init__(self, size: int = 3, image: str = "python:3.10-slim"):
+        self.runtime = SandboxRuntime()
+        self.sandboxes = [
+            self.runtime.create(image=image, memory="512Mi")
+            for _ in range(size)
+        ]
+
+    def run_command(self, index: int, command: str):
+        return self.runtime.exec(self.sandboxes[index], command)
+
+    def close(self):
+        for sb_id in self.sandboxes:
+            self.runtime.delete(sb_id)
+
+# Deploy an actor managing a pool of local sandboxes
+pool = SandboxPool.remote(size=3)
+result = ray.get(pool.run_command.remote(0, "python3 -c 'print(\"Hello from pool!\")'"))
+print(result.stdout)
+ray.get(pool.close.remote())
+```
+
+### Pass custom OCI configurations to gVisor
+
+For advanced workloads, you might need to configure low-level runtime options such as custom host mounts, Linux capabilities, or custom network and DNS settings. Use the `_oci_spec_transform_fn` parameter to inspect and modify the generated [OCI runtime specification](https://github.com/opencontainers/runtime-spec) dictionary before Ray passes it to gVisor (`runsc`).
+
+:::{note}
+`_oci_spec_transform_fn` is an experimental hook for advanced use cases. The Ray project is designing first-class configuration APIs for Ray Sandboxes, such as higher-level volume mount and capability abstractions, and this hook is likely to change once those land. To help shape them, open an issue describing your use case.
+:::
+
+The `_oci_spec_transform_fn` callable receives the fully generated OCI specification dictionary. It can mutate the dictionary in place or return a modified one. Common use cases include the following:
+
+* **Host mounts**: Mount host directories, read-only datasets, or model weights into the sandbox container.
+* **Networking and DNS**: Set up DNS resolution by mounting host configuration files such as `/etc/resolv.conf` and `/etc/hosts`, or modify network namespace parameters when using `network="sandbox"`.
+* **Linux capabilities**: Add or restrict Linux process capabilities such as `CAP_NET_RAW` or `CAP_SYS_PTRACE` under `spec["process"]["capabilities"]`.
+
+```python
+import ray
+from ray.experimental import sandbox
+
+ray.init()
+
+
+def configure_oci_spec(spec: dict) -> dict:
+    # Add a host bind mount (e.g., read-only dataset or cache directory)
+    spec.setdefault("mounts", []).append(
+        {
+            "destination": "/mnt/dataset",
+            "source": "/path/to/host/dataset",
+            "type": "bind",
+            "options": ["rbind", "ro"],
+        }
+    )
+
+    # Configure networking and DNS resolution
+    spec["mounts"].append(
+        {
+            "destination": "/etc/resolv.conf",
+            "source": "/etc/resolv.conf",
+            "type": "bind",
+            "options": ["rbind", "ro"],
+        }
+    )
+
+    # Grant additional Linux process capabilities
+    caps = spec.setdefault("process", {}).setdefault("capabilities", {})
+    for cap_set in ["bounding", "effective", "permitted"]:
+        caps.setdefault(cap_set, [])
+        if "CAP_NET_RAW" not in caps[cap_set]:
+            caps[cap_set].append("CAP_NET_RAW")
+
+    return spec
+
+
+# Pass the transformation hook when creating the sandbox
+sb = sandbox.create(
+    image="python:3.10-slim",
+    workdir="/workspace",
+    network="sandbox",  # Enable network isolation namespace in gVisor
+    _oci_spec_transform_fn=configure_oci_spec,
+)
+
+# Execute commands within the customized sandbox
+result = ray.get(
+    sb.exec.remote(
+        "python3 -c 'print(\"Sandbox initialized with custom OCI configuration!\")'"
+    )
+)
+print(result.stdout)
+
+# Clean up resources
+ray.get(sb.delete.remote())
+```
+
+## Architecture
+
+The Ray Sandboxes subsystem has the following layers:
+
+```text
++-------------------------------------------------------------------+
+|               Ray Application / RL Framework                      |
+|           (e.g., veRL, SkyRL, RL Rollout Workers, Agents)         |
++-------------------------------------------------------------------+
+                                  |
+                                  v
++-------------------------------------------------------------------+
+|                      ray.experimental.sandbox                     |
+|           (High-level create() API & Sandbox Ray Actor)           |
++-------------------------------------------------------------------+
+                                  |
+                                  v
++-------------------------------------------------------------------+
+|                  ray.experimental.sandbox.runtime                 |
+|                      SandboxRuntime Interface                     |
++-------------------------------------------------------------------+
+                                  |
+                                  v
++-------------------------------------------------------------------+
+|                 ray.experimental.sandbox.backend                  |
+|               GVisorSandboxBackend (runsc OCI)                    |
++-------------------------------------------------------------------+
+                                  |
+                                  v
++-------------------------------------------------------------------+
+|                        Ray Worker Node                            |
+|   +-----------------------+       +-----------------------+       |
+|   |  gVisor Sandbox 1     |       |  gVisor Sandbox 2     |       |
+|   | (python:3.10-slim)    |       | (busybox:latest)      |       |
+|   |   CPU: 0.5, Mem: 256M |       |   CPU: 1.0, Mem: 512M |       |
+|   +-----------------------+       +-----------------------+       |
++-------------------------------------------------------------------+
+```
+
+### Core components
+
+* **High-level helper ({func}`~ray.experimental.sandbox.create`)**: Spawns a Ray actor that encapsulates the sandbox lifecycle and returns an `ActorHandle`.
+* **Sandbox actor ({class}`~ray.experimental.sandbox.Sandbox`)**: A Ray actor that serves as a proxy to forward command execution and file I/O to the isolated sandbox instance while managing the scheduling and lifecycle of the sandbox.
+* **Sandbox runtime ({class}`~ray.experimental.sandbox.SandboxRuntime`)**: A low-level abstraction that manages the lifecycle of local sandboxes, image pulling and caching, and interactions with the execution backend.
+* **gVisor backend (`ray.experimental.sandbox.backend.GVisorSandboxBackend`)**: Executes commands and isolates processes through gVisor's OCI runtime (`runsc`).
+* **Image manager (`ray.experimental.sandbox.image_manager.ImageManager`)**: Automatically pulls container images from sources such as Docker Hub, GHCR, or local tar archives, extracts root filesystems into `/tmp/ray/sandbox/images`, and builds OCI `config.json` runtime specifications.
+
+## Security and isolation model
+
+Ray Sandboxes implement multi-layered defense-in-depth isolation:
+
+* **System call interception**: gVisor's Sentry application kernel intercepts system calls in user space, isolating untrusted code from the host Linux kernel.
+* **Read-only root filesystem**: Ray mounts base container filesystems read-only (`readonly=True`) with an isolated copy-on-write overlay directory per sandbox.
+* **Restricted working directory**: Only the explicit `workdir`, such as `/workspace`, is mounted read-write for application artifacts.
+* **Network containment**: By default, `network="none"` disables all outbound network interfaces, which prevents untrusted code from making external API calls or scanning the internal cluster network.
+* **Resource quotas**: cgroups enforce CPU quotas and memory limits, which prevents CPU starvation and out-of-memory (OOM) conditions from affecting other Ray actors.
+
+## API reference
+
+For detailed signatures, parameters, and return types, see {ref}`ray-sandbox-ref`.
+
+## Troubleshooting
+
+* **`runsc` not found in `$PATH`**: Verify that gVisor's `runsc` binary is installed on all Ray worker nodes and sits in a directory on the system `$PATH`, such as `/usr/local/bin/runsc`.
+* **cgroup or permission errors**: In containerized environments such as Kubernetes without root permissions, keep the default `rootless=True`. Where cgroups are restricted, set `RAY_SANDBOX_IGNORE_CGROUPS=1`.
+* **Image pull failures**: Verify that the node can reach the container registry, such as Docker Hub or GHCR, or pre-populate the image cache directory at `/tmp/ray/sandbox/images`.
+
+## Next steps
+
+* See {ref}`kuberay-sandboxing` to deploy Ray Sandboxes on Kubernetes with KubeRay.
+* Learn more about [gVisor](https://gvisor.dev/docs/).
+* Explore {ref}`resource-isolation` to isolate Ray system processes from worker processes.

--- a/doc/source/ray-core/user-guide.rst
+++ b/doc/source/ray-core/user-guide.rst
@@ -23,4 +23,5 @@ If you’re brand new to Ray, we recommend starting with the :ref:`walkthrough <
     direct-transport/direct-transport
     compiled-graph/ray-compiled-graph
     resource-isolation-with-cgroupv2
+    sandboxes
     advanced-topics

--- a/python/ray/experimental/sandbox/__init__.py
+++ b/python/ray/experimental/sandbox/__init__.py
@@ -23,8 +23,10 @@ from ray.experimental.sandbox.image_manager import (
 )
 from ray.experimental.sandbox.runtime import SandboxRuntime
 from ray.experimental.sandbox.sandbox import Sandbox
+from ray.util.annotations import PublicAPI
 
 
+@PublicAPI(stability="alpha")
 def create(
     image: str,
     cpu: Optional[float] = None,
@@ -39,22 +41,31 @@ def create(
     readonly: bool = True,
     **kwargs,
 ) -> ActorHandle:
-    """Create a sandbox environment.
+    """Create a remote sandbox environment managed by a Ray actor.
+
+    Spawns a :class:`~ray.experimental.sandbox.Sandbox` actor on the Ray cluster to manage
+    the sandbox lifecycle and returns an :class:`~ray.actor.ActorHandle`. For low-level local
+    sandbox management on the current node (e.g., inside custom worker actors), use
+    :class:`~ray.experimental.sandbox.runtime.SandboxRuntime` instead.
 
     Args:
         image: Container image for the sandbox environment.
         cpu: Number of CPU cores allocated to the sandbox.
         memory: Amount of memory allocated to the sandbox (e.g. "1Gi", "512Mi").
         env: Environment variables to inject into the sandbox.
-        workdir: Default working directory inside the sandbox. Note that the
-            working directory is the only writable path in the sandbox. If not provided,
-            the container's WORKDIR is used.
+        workdir: Default working directory inside the sandbox. By default, the
+            working directory is the only writable path in the sandbox (unless
+            ``readonly=False`` is set). If not provided, the container's WORKDIR is used.
         ttl_seconds: Optional automatic cleanup time-to-live in seconds.
         timeout_seconds: Timeout in seconds for sandbox creation.
         rootless: If True, run gVisor in rootless mode.
         network: Network mode for runsc.
         resources: Custom logical resource requirements.
-        readonly: If True, mount container image rootfs in read-only mode (default: True).
+        readonly: If True (default), mount container image rootfs in read-only mode
+            such that only ``workdir`` is writable. If False, the entire root filesystem
+            is writable. Writes are isolated within a per-sandbox copy-on-write overlay
+            filesystem, ensuring multiple sandboxes running the same container image do
+            not interfere with each other or modify the base image.
         **kwargs: Additional options.
 
     Returns:

--- a/python/ray/experimental/sandbox/backend/base.py
+++ b/python/ray/experimental/sandbox/backend/base.py
@@ -4,8 +4,10 @@ from enum import Enum
 from typing import Any, Dict, List, Optional, Union
 
 from ray.experimental.sandbox.config import SandboxConfig
+from ray.util.annotations import PublicAPI
 
 
+@PublicAPI(stability="alpha")
 class SandboxStatus(Enum):
     """Operational status of a Sandbox."""
 
@@ -15,6 +17,7 @@ class SandboxStatus(Enum):
     ERROR = "ERROR"
 
 
+@PublicAPI(stability="alpha")
 @dataclass
 class ExecResult:
     """Result of executing a command inside a Sandbox.

--- a/python/ray/experimental/sandbox/config.py
+++ b/python/ray/experimental/sandbox/config.py
@@ -53,14 +53,18 @@ class SandboxConfig:
         cpu: Number of CPU cores allocated to the sandbox.
         memory: Amount of memory allocated to the sandbox (e.g. "1Gi", "512Mi").
         env: Environment variables to inject into the sandbox.
-        workdir: Default working directory inside the sandbox. Note that the
-            working directory is the only writable path in the sandbox. If not provided,
-            the container's WORKDIR is used.
+        workdir: Default working directory inside the sandbox. By default, the
+            working directory is the only writable path in the sandbox (unless
+            ``readonly=False`` is set). If not provided, the container's WORKDIR is used.
         ttl_seconds: Optional automatic cleanup time-to-live in seconds.
         timeout_seconds: Timeout in seconds for sandbox creation.
         rootless: If True, run gVisor in rootless mode (default: True).
         network: Network mode for runsc ("none", "host", "sandbox") (default: "none").
-        readonly: If True, mount container image rootfs in read-only mode (default: True).
+        readonly: If True (default), mount container image rootfs in read-only mode
+            such that only ``workdir`` is writable. If False, the entire root filesystem
+            is writable. Writes are isolated within a per-sandbox copy-on-write overlay
+            filesystem, ensuring multiple sandboxes running the same container image do
+            not interfere with each other or modify the base image.
     """
 
     image: str

--- a/python/ray/experimental/sandbox/exceptions.py
+++ b/python/ray/experimental/sandbox/exceptions.py
@@ -1,27 +1,35 @@
+from ray.util.annotations import PublicAPI
+
+
+@PublicAPI(stability="alpha")
 class SandboxError(Exception):
     """Base exception for all Ray Sandbox errors."""
 
     pass
 
 
+@PublicAPI(stability="alpha")
 class SandboxCreationError(SandboxError):
     """Raised when sandbox creation fails or times out."""
 
     pass
 
 
+@PublicAPI(stability="alpha")
 class SandboxTimeoutError(SandboxError):
     """Raised when a command execution or operation inside a sandbox times out."""
 
     pass
 
 
+@PublicAPI(stability="alpha")
 class SandboxExecError(SandboxError):
     """Raised when a command execution encounters an unexpected system/backend error."""
 
     pass
 
 
+@PublicAPI(stability="alpha")
 class SandboxNotFoundError(SandboxError):
     """Raised when a specified sandbox ID cannot be found."""
 

--- a/python/ray/experimental/sandbox/runtime.py
+++ b/python/ray/experimental/sandbox/runtime.py
@@ -9,8 +9,10 @@ from ray.experimental.sandbox.backend.base import (
 from ray.experimental.sandbox.backend.gvisor import GVisorSandboxBackend
 from ray.experimental.sandbox.config import SandboxConfig
 from ray.experimental.sandbox.image_manager import ImageManager
+from ray.util.annotations import PublicAPI
 
 
+@PublicAPI(stability="alpha")
 class SandboxRuntime:
     """Low-level interface for managing local sandbox runtime environments."""
 
@@ -63,14 +65,18 @@ class SandboxRuntime:
             cpu: Number of CPU cores allocated to the sandbox.
             memory: Amount of memory allocated to the sandbox (e.g. "1Gi", "512Mi").
             env: Environment variables to inject into the sandbox.
-            workdir: Default working directory inside the sandbox. Note that the
-                working directory is the only writable path in the sandbox. If not provided,
-                the container's WORKDIR is used.
+            workdir: Default working directory inside the sandbox. By default, the
+                working directory is the only writable path in the sandbox (unless
+                ``readonly=False`` is set). If not provided, the container's WORKDIR is used.
             ttl_seconds: Optional automatic cleanup time-to-live in seconds.
             timeout_seconds: Timeout in seconds for sandbox creation.
             rootless: If True, run gVisor in rootless mode.
             network: Network mode for runsc.
-            readonly: If True, mount container image rootfs in read-only mode (default: True).
+            readonly: If True (default), mount container image rootfs in read-only mode
+                such that only ``workdir`` is writable. If False, the entire root filesystem
+                is writable. Writes are isolated within a per-sandbox copy-on-write overlay
+                filesystem, ensuring multiple sandboxes running the same container image do
+                not interfere with each other or modify the base image.
             _oci_spec_transform_fn: PRIVATE — development/testing only. Called with the fully-built OCI
                 spec dict before it is written; may mutate in place or return a new dict. Must be
                 cloudpickle-serializable. No stability guarantees. Accepts a transform function.
@@ -106,7 +112,18 @@ class SandboxRuntime:
         cwd: Optional[str] = None,
         env: Optional[Dict[str, str]] = None,
     ) -> ExecResult:
-        """Execute a command inside the specified sandbox."""
+        """Execute a command inside the specified sandbox.
+
+        Args:
+            instance_id: Unique identifier of the sandbox instance.
+            command: Command to execute, either as a string or a list of arguments.
+            timeout: Maximum execution time in seconds.
+            cwd: Working directory inside the sandbox for command execution.
+            env: Environment variables to set for the command.
+
+        Returns:
+            ExecResult containing exit code, stdout, and stderr.
+        """
         return self._backend.exec_command(
             instance_id,
             command,
@@ -123,7 +140,18 @@ class SandboxRuntime:
         cwd: Optional[str] = None,
         env: Optional[Dict[str, str]] = None,
     ) -> ExecResult:
-        """Execute a command inside the specified sandbox asynchronously."""
+        """Execute a command inside the specified sandbox asynchronously.
+
+        Args:
+            instance_id: Unique identifier of the sandbox instance.
+            command: Command to execute, either as a string or a list of arguments.
+            timeout: Maximum execution time in seconds.
+            cwd: Working directory inside the sandbox for command execution.
+            env: Environment variables to set for the command.
+
+        Returns:
+            ExecResult containing exit code, stdout, and stderr.
+        """
         return await asyncio.to_thread(
             self.exec,
             instance_id,
@@ -134,7 +162,13 @@ class SandboxRuntime:
         )
 
     def upload_file(self, instance_id: str, local_path: str, remote_path: str) -> None:
-        """Copy local file into the sandbox."""
+        """Copy local file into the sandbox.
+
+        Args:
+            instance_id: Unique identifier of the sandbox instance.
+            local_path: Path to the source file on the local filesystem.
+            remote_path: Destination path inside the sandbox.
+        """
         with open(local_path, "rb") as f:
             content = f.read()
         self._backend.write_file(instance_id, remote_path, content)
@@ -142,7 +176,13 @@ class SandboxRuntime:
     def download_file(
         self, instance_id: str, remote_path: str, local_path: str
     ) -> None:
-        """Copy file from the sandbox to local."""
+        """Copy file from the sandbox to local.
+
+        Args:
+            instance_id: Unique identifier of the sandbox instance.
+            remote_path: Path to the source file inside the sandbox.
+            local_path: Destination path on the local filesystem.
+        """
         content = self._backend.read_file(instance_id, remote_path)
         local_dir = os.path.dirname(os.path.abspath(local_path))
         if local_dir:
@@ -153,25 +193,58 @@ class SandboxRuntime:
     def write_file(
         self, instance_id: str, path: str, content: Union[str, bytes]
     ) -> None:
-        """Write string or binary content directly to a file inside the sandbox."""
+        """Write string or binary content directly to a file inside the sandbox.
+
+        Args:
+            instance_id: Unique identifier of the sandbox instance.
+            path: Destination file path inside the sandbox.
+            content: String or binary content to write into the file.
+        """
         self._backend.write_file(instance_id, path, content)
 
     def read_file(self, instance_id: str, path: str) -> bytes:
-        """Read binary content from a file inside the sandbox."""
+        """Read binary content from a file inside the sandbox.
+
+        Args:
+            instance_id: Unique identifier of the sandbox instance.
+            path: Path to the file inside the sandbox to read.
+
+        Returns:
+            File content as bytes.
+        """
         return self._backend.read_file(instance_id, path)
 
     def get_status(self, instance_id: str) -> SandboxStatus:
-        """Query operational status of the sandbox."""
+        """Query operational status of the sandbox.
+
+        Args:
+            instance_id: Unique identifier of the sandbox instance.
+
+        Returns:
+            SandboxStatus of the sandbox instance.
+        """
         return self._backend.get_status(instance_id)
 
     def delete(self, instance_id: str) -> None:
-        """Clean up and terminate the sandbox instance."""
+        """Clean up and terminate the sandbox instance.
+
+        Args:
+            instance_id: Unique identifier of the sandbox instance.
+        """
         self._backend.delete_sandbox(instance_id)
 
     def terminate(self, instance_id: str) -> None:
-        """Clean up and terminate the sandbox instance."""
+        """Clean up and terminate the sandbox instance.
+
+        Args:
+            instance_id: Unique identifier of the sandbox instance.
+        """
         self.delete(instance_id)
 
     async def delete_async(self, instance_id: str) -> None:
-        """Clean up and terminate the sandbox instance asynchronously."""
+        """Clean up and terminate the sandbox instance asynchronously.
+
+        Args:
+            instance_id: Unique identifier of the sandbox instance.
+        """
         await asyncio.to_thread(self.delete, instance_id)

--- a/python/ray/experimental/sandbox/sandbox.py
+++ b/python/ray/experimental/sandbox/sandbox.py
@@ -12,21 +12,25 @@ from ray.experimental.sandbox.runtime import SandboxRuntime
 
 @ray.remote
 class Sandbox:
-    """Ray actor interface for managing scheduling and lifecycle of an isolated sandbox.
+    """Ray actor proxy for managing scheduling, lifecycle, command execution, and file I/O for an isolated sandbox instance.
 
     Args:
         image: Container image for the sandbox environment.
         cpu: Number of CPU cores allocated to the sandbox.
         memory: Amount of memory allocated to the sandbox (e.g. "1Gi", "512Mi").
         env: Environment variables to inject into the sandbox.
-        workdir: Default working directory inside the sandbox. Note that the
-            working directory is the only writable path in the sandbox. If not provided,
-            the container's WORKDIR is used.
+        workdir: Default working directory inside the sandbox. By default, the
+            working directory is the only writable path in the sandbox (unless
+            ``readonly=False`` is set). If not provided, the container's WORKDIR is used.
         ttl_seconds: Optional automatic cleanup time-to-live in seconds.
         timeout_seconds: Timeout in seconds for sandbox creation.
         rootless: If True, run gVisor in rootless mode.
         network: Network mode for runsc.
-        readonly: If True, mount container image rootfs in read-only mode (default: True).
+        readonly: If True (default), mount container image rootfs in read-only mode
+            such that only ``workdir`` is writable. If False, the entire root filesystem
+            is writable. Writes are isolated within a per-sandbox copy-on-write overlay
+            filesystem, ensuring multiple sandboxes running the same container image do
+            not interfere with each other or modify the base image.
         **kwargs: Additional parameters passed to runtime.
     """
 
@@ -87,11 +91,19 @@ class Sandbox:
             pass
 
     def get_instance_id(self) -> str:
-        """Get the unique instance ID for the sandbox."""
+        """Get the unique instance ID for the sandbox.
+
+        Returns:
+            The instance ID string.
+        """
         return self.instance_id
 
     def get_config(self) -> SandboxConfig:
-        """Get the sandbox configuration used by the runtime."""
+        """Get the sandbox configuration used by the runtime.
+
+        Returns:
+            SandboxConfig of the sandbox instance.
+        """
         meta = self.runtime._backend._sandbox_metadata.get(self.instance_id)
         if not meta:
             raise SandboxNotFoundError(
@@ -106,29 +118,65 @@ class Sandbox:
         cwd: Optional[str] = None,
         env: Optional[Dict[str, str]] = None,
     ) -> ExecResult:
-        """Execute a command inside the sandbox."""
+        """Execute a command inside the sandbox.
+
+        Args:
+            command: Command to execute, either as a string or a list of arguments.
+            timeout: Maximum execution time in seconds.
+            cwd: Working directory inside the sandbox for command execution.
+            env: Environment variables to set for the command.
+
+        Returns:
+            ExecResult containing exit code, stdout, and stderr.
+        """
         return self.runtime.exec(
             self.instance_id, command, timeout=timeout, cwd=cwd, env=env
         )
 
     def upload_file(self, local_path: str, remote_path: str) -> None:
-        """Copy local file into the sandbox."""
+        """Copy local file into the sandbox.
+
+        Args:
+            local_path: Path to the source file on the local filesystem.
+            remote_path: Destination path inside the sandbox.
+        """
         self.runtime.upload_file(self.instance_id, local_path, remote_path)
 
     def download_file(self, remote_path: str, local_path: str) -> None:
-        """Copy file from the sandbox to local."""
+        """Copy file from the sandbox to local.
+
+        Args:
+            remote_path: Path to the source file inside the sandbox.
+            local_path: Destination path on the local filesystem.
+        """
         self.runtime.download_file(self.instance_id, remote_path, local_path)
 
     def write_file(self, path: str, content: Union[str, bytes]) -> None:
-        """Write content directly to a file inside the sandbox."""
+        """Write content directly to a file inside the sandbox.
+
+        Args:
+            path: Destination file path inside the sandbox.
+            content: String or binary content to write into the file.
+        """
         self.runtime.write_file(self.instance_id, path, content)
 
     def read_file(self, path: str) -> bytes:
-        """Read binary content from a file inside the sandbox."""
+        """Read binary content from a file inside the sandbox.
+
+        Args:
+            path: Path to the file inside the sandbox to read.
+
+        Returns:
+            File content as bytes.
+        """
         return self.runtime.read_file(self.instance_id, path)
 
     def get_status(self) -> SandboxStatus:
-        """Query operational status of the sandbox."""
+        """Query operational status of the sandbox.
+
+        Returns:
+            SandboxStatus of the sandbox instance.
+        """
         return self.runtime.get_status(self.instance_id)
 
     def delete(self) -> None:


### PR DESCRIPTION
Cherry-pick of #65503 (merge commit d40da452efef7dfc3adfa3f17a24536de1f03222, authored by @andrewsykim) onto `releases/2.58.0`.

One conflict, resolved by hand: the PR adds `sandboxes.md` to the Ray Core API toctree in `doc/source/ray-core/api/index.md`, but that file only exists on master (the index was converted from `.rst` to `.md` after the branch cut). Applied the same one-line addition to the branch's `doc/source/ray-core/api/index.rst` instead; everything else picked clean and the commit is otherwise identical to the original (docs pages + docstring updates in `python/ray/experimental/sandbox/`, which already exists on this branch).

Not a duplicate: no existing cherry-pick PR for #65503 targets this branch.

AI assistance (Claude Code) was used to prepare this cherry-pick; reviewed by the submitter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
