### PR TITLE
[doc] Give the Read the Docs build a larger pip retry budget

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -67,6 +67,26 @@ build:
     # than "NNNN added") and stale-artifact pruning lands for PRs that rename
     # or delete sources. The rtd and rtd-fallback Makefile targets and
     # doc/load_doc_cache.py stay in the tree for that re-enable.
+    # Raise pip's retry budget for the dependency install below.
+    # files.pythonhosted.org has been returning intermittent 502s
+    # (https://github.com/pypi/support/issues/11895), and one failed wheel fetch
+    # fails the whole docs build. pip defaults to 5 retries with exponential
+    # backoff, which gives up in about 8 seconds of sleeping.
+    #
+    # Written as a config file rather than PIP_RETRIES because the install step
+    # is python.install below, run by Read the Docs rather than by us, and each
+    # job command runs in its own shell so an export here would not reach it.
+    # pip reads this path on every invocation in the build, including that one.
+    #
+    # Only the retry count is raised. The observed failures are immediate 502
+    # responses rather than hangs, so a larger timeout would only lengthen the
+    # worst case without making a fetch more likely to succeed.
+    pre_install:
+      - mkdir -p ~/.config/pip
+      - |
+        echo "[global]" > ~/.config/pip/pip.conf
+        echo "retries = 10" >> ~/.config/pip/pip.conf
+        cat ~/.config/pip/pip.conf
     build:
       html:
         - |


### PR DESCRIPTION
## Description

`files.pythonhosted.org` has been returning intermittent 502s (pypi/support#11895). The Read the Docs build installs `doc/requirements-doc.lock.txt` in a single pip invocation, so one failed wheel fetch fails the whole build. pip's default is 5 retries on an exponential backoff, which exhausts after roughly 8 seconds of sleeping — well short of the observed fault duration.

This raises it to 10 for that build only.

**Why a config file rather than `PIP_RETRIES`.** The install is `python.install`, run by Read the Docs rather than by us, so there is no command line of ours to add a flag to. Environment variables do not help either: each entry under `build.jobs` runs in its own shell, so an `export` in one does not reach the install step. pip reads `~/.config/pip/pip.conf` on every invocation in the build environment, including RTD's own, which makes it the one place that covers it.

**Why only the retry count.** Every failure observed in this family is an immediate 502 response, not a hang, so raising `timeout` would only lengthen the worst case without making any individual fetch more likely to succeed.

Worth setting expectations: this is a mitigation, not a fix. Measurements on a CI build of the same fault showed in-process retries have limited power against it — the client stays pinned to the same CDN edge across attempts — so this narrows the window rather than closing it. The structural fix is a caching index in front of PyPI, which is being wired up for CI in #65571 but cannot serve Read the Docs, since RTD builders run outside the network where that mirror lives.

## Related issues

Upstream cause: pypi/support#11895. Not a duplicate: no open PR touches `.readthedocs.yaml`; #65571 and #65518 address the same upstream fault on the CI side and do not affect RTD builds.

## Testing

- `.readthedocs.yaml` parses and the job keys are as intended: `post_checkout`, `pre_install`, `build`, with `python.install` untouched.
- The `pre_install` snippet is valid shell (`bash -n`) and deliberately avoids the constructs the RTD job runner is documented in this file as mishandling: no `printf` with escape formats, no backslash escapes, no shell comments inside the block.
- It `cat`s the file it writes, so the build log will show the effective config and confirm the step ran.
- Not verified end to end: whether RTD's install step picks the config up in their environment. That is what the first build on this PR will show, and the failure mode if it does not is simply the status quo.

AI assistance (Claude Code) was used for this change.