### PR TITLE
[ci] Resolve packages through the mirror in the manylinux image too

### DIFF
--- a/ci/docker/forge.Dockerfile
+++ b/ci/docker/forge.Dockerfile
@@ -13,6 +13,7 @@ RUN \
   --mount=type=bind,source=ci/k8s/install-k8s-tools.sh,target=install-k8s-tools.sh \
   --mount=type=bind,source=ci/pypi_index_proxy.py,target=pypi_index_proxy.py \
   --mount=type=bind,source=ci/pypi_proxy_profile.sh,target=pypi_proxy_profile.sh \
+  --mount=type=bind,source=ci/install_pypi_proxy.sh,target=install_pypi_proxy.sh \
 <<EOF
 #!/bin/bash
 
@@ -96,19 +97,7 @@ uv pip install --system pip==25.0 cffi==1.16.0
 # a second interpreter for the proxy alone and keep it in its own venv. Nothing else
 # resolves through /opt/pypiproxy and the default python is left untouched.
 uv python install --install-dir /usr/local/python 3.12
-PROXY_PYTHON="$(uv python find --no-project 3.12)"
-"$PROXY_PYTHON" -m venv /opt/pypiproxy
-/opt/pypiproxy/bin/pip install --no-cache-dir \
-  "asgi-cross-origin-protection==0.1.1" \
-  "niquests==3.21.0" \
-  "starlette==1.6.0" \
-  "uvicorn==0.52.3"
-cp pypi_index_proxy.py /opt/pypiproxy/pypi_index_proxy.py
-
-# Sourced automatically: steps run under `bash -elic`, a login shell. zz- prefix so
-# it runs after anything else in profile.d that might set HOME or PATH.
-cp pypi_proxy_profile.sh /etc/profile.d/zz-rayci-pypi-proxy.sh
-chmod 0644 /etc/profile.d/zz-rayci-pypi-proxy.sh
+bash install_pypi_proxy.sh "$(uv python find --no-project 3.12)"
 
 # Needs to be synchronized to the host group id as we map /var/run/docker.sock
 # into the container.

--- a/ci/docker/forge.wanda.yaml
+++ b/ci/docker/forge.wanda.yaml
@@ -8,3 +8,4 @@ srcs:
   - ci/k8s/install-k8s-tools.sh
   - ci/pypi_index_proxy.py
   - ci/pypi_proxy_profile.sh
+  - ci/install_pypi_proxy.sh

--- a/ci/docker/manylinux-retag.Dockerfile
+++ b/ci/docker/manylinux-retag.Dockerfile
@@ -13,6 +13,44 @@ FROM rayproject/manylinux2014:${MANYLINUX_VERSION}-jdk-${HOSTTYPE}
 ARG BUILDKITE_BAZEL_CACHE_URL
 ENV BUILDKITE_BAZEL_CACHE_URL=${BUILDKITE_BAZEL_CACHE_URL}
 
+# The PyPI index proxy, so steps that run in this image resolve through the CI
+# package mirror like the ones that run in forge. This is not a cosmetic gap:
+# `build: raydepsets: compile all dependencies` runs here, and it is the step that
+# fails on files.pythonhosted.org 502s (pypi/support#11895) because uv had no index
+# configured and went straight to the origin.
+#
+# manylinux ships a set of interpreters under /opt/python; pick the newest that
+# satisfies the proxy's >=3.11 requirement rather than naming one, since the set
+# moves with the base image. The image's default python is untouched.
+RUN \
+  --mount=type=bind,source=ci/pypi_index_proxy.py,target=pypi_index_proxy.py \
+  --mount=type=bind,source=ci/pypi_proxy_profile.sh,target=pypi_proxy_profile.sh \
+  --mount=type=bind,source=ci/install_pypi_proxy.sh,target=install_pypi_proxy.sh \
+<<EOF
+#!/bin/bash
+
+set -euo pipefail
+
+PROXY_PYTHON=""
+for candidate in /opt/python/cp313-cp313/bin/python \
+                 /opt/python/cp312-cp312/bin/python \
+                 /opt/python/cp311-cp311/bin/python; do
+  if [[ -x "${candidate}" ]]; then
+    PROXY_PYTHON="${candidate}"
+    break
+  fi
+done
+
+if [[ -z "${PROXY_PYTHON}" ]]; then
+  echo "no python >= 3.11 under /opt/python; cannot install the index proxy" >&2
+  ls -1 /opt/python >&2 || true
+  exit 1
+fi
+
+echo "installing the index proxy with ${PROXY_PYTHON}"
+bash install_pypi_proxy.sh "${PROXY_PYTHON}"
+EOF
+
 # Still keep bazelrc updates to allow BUILDKITE_BAZEL_CACHE_URL to be used.
 RUN <<EOF
 #!/bin/bash

--- a/ci/docker/manylinux.wanda.yaml
+++ b/ci/docker/manylinux.wanda.yaml
@@ -6,3 +6,7 @@ build_args:
   - MANYLINUX_VERSION
   - HOSTTYPE
 dockerfile: ci/docker/manylinux-retag.Dockerfile
+srcs:
+  - ci/pypi_index_proxy.py
+  - ci/pypi_proxy_profile.sh
+  - ci/install_pypi_proxy.sh

--- a/ci/install_pypi_proxy.sh
+++ b/ci/install_pypi_proxy.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# Install the job-local PyPI index proxy into an image.
+#
+# Shared by every image whose steps resolve Python packages, so the install lives in
+# one place rather than being copied per Dockerfile. Expects ci/pypi_index_proxy.py
+# and ci/pypi_proxy_profile.sh to be present in the working directory, which the
+# callers arrange with --mount=type=bind.
+#
+# $1 is a python >= 3.11: asgi-cross-origin-protection requires it, and images whose
+# default interpreter is older pass a second one here rather than moving their
+# default. The venv is self-contained in /opt/pypiproxy, so nothing else in the image
+# resolves through it.
+
+set -euo pipefail
+
+PROXY_PYTHON="${1:?usage: install_pypi_proxy.sh <path-to-python3.11+>}"
+
+"$PROXY_PYTHON" -m venv /opt/pypiproxy
+/opt/pypiproxy/bin/pip install --no-cache-dir \
+  "asgi-cross-origin-protection==0.1.1" \
+  "niquests==3.21.0" \
+  "starlette==1.6.0" \
+  "uvicorn==0.52.3"
+cp pypi_index_proxy.py /opt/pypiproxy/pypi_index_proxy.py
+
+# Sourced automatically: CI steps run under `bash -elic`, a login shell. The zz-
+# prefix runs it after anything else in profile.d that might set HOME or PATH.
+cp pypi_proxy_profile.sh /etc/profile.d/zz-rayci-pypi-proxy.sh
+chmod 0644 /etc/profile.d/zz-rayci-pypi-proxy.sh


### PR DESCRIPTION
**Stacked on #65571** — base branch is `elliot-barn/pypi-mirror-integration`, since the proxy and the profile.d script land there. Review after that one; GitHub will retarget this to master when it merges.

## Description

Steps whose `job_env` is `manylinux-x86_64` had none of the mirror wiring, because it lived only in `forge.Dockerfile`. Audited on premerge 72104:

| Step runs in | Mirror used? | Examples |
|---|---|---|
| forge | yes — probe logs the verdict, zero direct PyPI fetches | reef tooling, lints, test-rules, `ml: train minimal`, `serve: wheel tests` |
| manylinux-x86_64 | **no wiring at all** | **`build: raydepsets: compile all dependencies`**, `build: jar`, wheel builds |

That gap is what failed the build: uv fetched `numpy-2.2.6-…whl.metadata` straight from `files.pythonhosted.org` and took a 502, with no index configured to route it anywhere else (pypi/support#11895).

## What changed

- `ci/install_pypi_proxy.sh` — the install, extracted so forge and manylinux share it instead of carrying two copies of the same twenty lines. The next image that needs it adds one `RUN`.
- `ci/docker/manylinux-retag.Dockerfile` — installs the proxy and the `profile.d` script. Steps run under `bash -elic`, so it is sourced there exactly as in forge; the probe, the mode selection and the fail-open path are unchanged.
- The interpreter is **discovered, not named**: manylinux ships a set under `/opt/python`, so the Dockerfile picks the newest that satisfies the proxy's `>=3.11` requirement and fails loudly (listing what it found) if there is none. That keeps working when the base image's interpreter set moves. The image's default python is untouched and the venv stays in `/opt/pypiproxy`.
- Both wanda specs gain the files in `srcs`, without which the bind mounts have nothing to mount.

## What this does not cover

`docker build` — the `wanda: wheel py3.*` steps still fetch from PyPI directly, because BuildKit `RUN` steps do not inherit the step container's environment. Those five fetches per build are pip's *isolated build environment* (`setuptools`, `cython`, `wheel`, `pip`, `packaging`), unpinned because `python/` has no `pyproject.toml`. Two follow-ups are possible there and neither belongs in this PR: passing the index as a build arg, which needs a stable address so wanda's content-addressed cache key does not churn per job, or `--no-build-isolation`, which removes those fetches outright.

## Testing

- `bash -n` on the installer and on the new `RUN` block; `pre-commit` (shellcheck, semgrep, whitespace) clean over every changed file.
- Not verified locally: the image build itself, which needs the manylinux base and a wanda run. The interpreter discovery is written to fail loudly rather than silently skip, so a wrong assumption about `/opt/python` shows up as a failed image build with the directory listing attached, not as a silently unwired image.
- The real check is a build on this branch: manylinux steps should log `pypi index: …` the way forge steps already do.

AI assistance (Claude Code) was used for this change.