### PR TITLE
fix(serve): return 404 status code when application or deployment not found (#51442)

### DIFF
--- a/python/ray/dashboard/modules/serve/serve_head.py
+++ b/python/ray/dashboard/modules/serve/serve_head.py
@@ -264,7 +264,7 @@ class ServeHead(SubprocessModule):
                 return self._create_json_response({"error": str(e.cause)}, 412)
             if isinstance(e, ValueError) and "not found" in str(e):
                 return self._create_json_response(
-                    {"error": "Application or Deployment not found"}, 400
+                    {"error": "Application or Deployment not found"}, 404
                 )
             else:
                 logger.error(

--- a/python/ray/dashboard/modules/serve/tests/test_serve_dashboard.py
+++ b/python/ray/dashboard/modules/serve/tests/test_serve_dashboard.py
@@ -969,7 +969,7 @@ class TestScaleDeploymentEndpoint:
             json={"target_num_replicas": 2},
             timeout=30,
         )
-        assert error_response.status_code == 400
+        assert error_response.status_code == 404
         assert "not found" in error_response.json()["error"].lower()
 
         error_response = requests.post(


### PR DESCRIPTION
## Description
Makes the Serve dashboard scale endpoint report client errors with 404 status code instead of 400 when an application or deployment is not found.

#51417 added the `HTTPStatusCode` enum and the `rest_response(status_code=...)` plumbing, but adoption across dashboard modules is ongoing.

**Backend (`python/ray/dashboard/modules/serve/serve_head.py`):**
    - In `scale_deployment`, when `ValueError` with `"not found"` occurred (looking up a nonexistent application or deployment), the endpoint returned HTTP 400 (Bad Request). Scaling a nonexistent resource is a client error representing a missing resource, so it now returns HTTP 404 (Not Found).

## Related issues

Related to #51442 (umbrella: revisit Ray dashboard API status codes).

Since #51442 is an umbrella issue, this PR covers the `serve_head.py` scope only, allowing each dashboard module to be reviewed independently.

## Tests
Updated the existing unit test `test_error_case` in `python/ray/dashboard/modules/serve/tests/test_serve_dashboard.py`:
    - Verified that scaling a nonexistent application (`app_name="nonexistent"`) returns HTTP status code 404 instead of 400.

## Not a duplicate
Checked existing open issues and PRs for #51442. No active PR currently addresses status code fixes for `serve_head.py`. Commented on #51442 prior to working on this scope.