### PR TITLE
[Data] Track launch-time memory requests in high-memory detection

### DIFF
--- a/python/ray/data/_internal/execution/interfaces/op_runtime_metrics.py
+++ b/python/ray/data/_internal/execution/interfaces/op_runtime_metrics.py
@@ -143,6 +143,8 @@ class RunningTaskInfo:
     cum_block_gen_time_s: float
     cum_block_ser_time_s: float
     task_id: ray.TaskID
+    memory_request_bytes: Optional[float] = None
+    safe_memory_bytes: Optional[int] = None
     # Node IDs derived from the input blocks' exec_stats at task submission time.
     # Used to determine cache hits: if the task's first output block was produced
     # on a node that already held an input block, it's a "cache hit" (the task
@@ -576,6 +578,8 @@ class OpRuntimeMetrics(metaclass=OpRuntimesMetricsMeta):
         self.block_size_rows = RuntimeMetricsHistogram(histogram_bucket_rows)
         self._op_task_duration_stats = DistributionTracker()
         self._max_uss_bytes = DistributionTracker()
+        self._memory_request_bytes = DistributionTracker()
+        self._safe_memory_bytes = DistributionTracker()
 
     @property
     def extra_metrics(self) -> Dict[str, Any]:
@@ -914,6 +918,18 @@ class OpRuntimeMetrics(metaclass=OpRuntimesMetricsMeta):
             return None
         return self.max_uss_bytes.mean
 
+    @property
+    def average_memory_request_per_task(self) -> Optional[float]:
+        if self._memory_request_bytes.num_samples == 0:
+            return None
+        return self._memory_request_bytes.mean
+
+    @property
+    def average_safe_memory_per_task(self) -> Optional[float]:
+        if self._safe_memory_bytes.num_samples == 0:
+            return None
+        return self._safe_memory_bytes.mean
+
     @metric_property(
         description="Indicates if the operator is hanging.",
         metrics_group=MetricsGroup.MISC,
@@ -1001,6 +1017,8 @@ class OpRuntimeMetrics(metaclass=OpRuntimesMetricsMeta):
         task_index: int,
         inputs: RefBundle,
         task_id: Optional[ray.TaskID] = None,
+        memory_request_bytes: Optional[float] = None,
+        safe_memory_bytes: Optional[int] = None,
     ):
         """Callback when the operator submits a task."""
         self.num_tasks_submitted += 1
@@ -1020,6 +1038,8 @@ class OpRuntimeMetrics(metaclass=OpRuntimesMetricsMeta):
             cum_block_gen_time_s=0,
             cum_block_ser_time_s=0,
             task_id=ray.TaskID.nil() if task_id is None else task_id,
+            memory_request_bytes=memory_request_bytes,
+            safe_memory_bytes=safe_memory_bytes,
             input_node_ids=input_node_ids,
         )
 
@@ -1164,6 +1184,11 @@ class OpRuntimeMetrics(metaclass=OpRuntimesMetricsMeta):
 
         if task_exec_stats is not None and task_exec_stats.max_uss_bytes is not None:
             self._max_uss_bytes.add_sample(task_exec_stats.max_uss_bytes)
+            if task_info.safe_memory_bytes is not None:
+                self._memory_request_bytes.add_sample(
+                    task_info.memory_request_bytes or 0
+                )
+                self._safe_memory_bytes.add_sample(task_info.safe_memory_bytes)
 
         task_output_backpressure_s = (
             task_exec_driver_stats.task_output_backpressure_s

--- a/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
+++ b/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
@@ -58,6 +58,7 @@ from ray.data._internal.execution.node_trackers.actor_location import (
 from ray.data._internal.execution.operators.map_operator import (
     MapOperator,
     _map_task,
+    get_safe_default_logical_memory,
 )
 from ray.data._internal.execution.operators.map_transformer import MapTransformer
 from ray.data._internal.execution.util import locality_string, merge_label_selector
@@ -451,6 +452,11 @@ class ActorPoolMapOperator(MapOperator):
             self._metrics.on_input_dequeued(bundle, input_index=0)
             input_blocks = [entry.ref for entry in bundle.blocks]
             self._actor_pool.on_task_submitted(actor)
+            actor_resources = self._actor_pool.get_actor_resource_usage(actor)
+            memory_request_bytes = actor_resources.memory
+            safe_memory_bytes = get_safe_default_logical_memory(
+                {"num_cpus": actor_resources.cpu}
+            )
 
             ctx = TaskContext(
                 task_idx=self._next_data_task_idx,
@@ -478,7 +484,11 @@ class ActorPoolMapOperator(MapOperator):
             from functools import partial
 
             self._submit_data_task(
-                gen, bundle, partial(_task_done_callback, actor_to_return=actor)
+                gen,
+                bundle,
+                partial(_task_done_callback, actor_to_return=actor),
+                memory_request_bytes=memory_request_bytes,
+                safe_memory_bytes=safe_memory_bytes,
             )
 
             num_submitted_tasks += 1
@@ -1074,6 +1084,9 @@ class _ActorPool(AutoscalingActorPool):
                 node_heap[actor] = rank
 
     # === End of overriding methods of AutoscalingActorPool ===
+
+    def get_actor_resource_usage(self, actor: ActorHandle) -> ExecutionResources:
+        return self._actor_resource_usage[actor]
 
     def _get_actor_logical_id(self, actor: ActorHandle) -> LogicalActorId:
         return self._actor_to_logical_id[actor]

--- a/python/ray/data/_internal/execution/operators/map_operator.py
+++ b/python/ray/data/_internal/execution/operators/map_operator.py
@@ -607,6 +607,8 @@ class MapOperator(InternalQueueOperatorMixin, OneToOneOperator, ABC):
         gen: ObjectRefGenerator,
         inputs: RefBundle,
         task_done_callback: Optional[Callable[[], None]] = None,
+        memory_request_bytes: Optional[float] = None,
+        safe_memory_bytes: Optional[int] = None,
     ):
         """Submit a new data-handling task."""
         # TODO(hchen):
@@ -674,7 +676,11 @@ class MapOperator(InternalQueueOperatorMixin, OneToOneOperator, ABC):
             operator_name=self.name,
         )
         self._metrics.on_task_submitted(
-            task_index, inputs, task_id=data_task.get_task_id()
+            task_index,
+            inputs,
+            task_id=data_task.get_task_id(),
+            memory_request_bytes=memory_request_bytes,
+            safe_memory_bytes=safe_memory_bytes,
         )
         self._data_tasks[task_index] = data_task
 

--- a/python/ray/data/_internal/execution/operators/task_pool_map_operator.py
+++ b/python/ray/data/_internal/execution/operators/task_pool_map_operator.py
@@ -20,6 +20,7 @@ from ray.data._internal.execution.interfaces import (
 from ray.data._internal.execution.operators.map_operator import (
     MapOperator,
     _map_task,
+    get_safe_default_logical_memory,
 )
 from ray.data._internal.execution.operators.map_transformer import MapTransformer
 from ray.data._internal.remote_fn import cached_remote_fn
@@ -175,6 +176,8 @@ class TaskPoolMapOperator(MapOperator):
         dynamic_ray_remote_args = self._get_dynamic_ray_remote_args(input_bundle=bundle)
         dynamic_ray_remote_args["name"] = self.name
         logical_usage = ExecutionResources.from_resource_dict(dynamic_ray_remote_args)
+        memory_request_bytes = dynamic_ray_remote_args.get("memory")
+        safe_memory_bytes = get_safe_default_logical_memory(dynamic_ray_remote_args)
 
         if (
             "_generator_backpressure_num_objects" not in dynamic_ray_remote_args
@@ -203,7 +206,13 @@ class TaskPoolMapOperator(MapOperator):
                 logical_usage
             )
 
-        self._submit_data_task(gen, bundle, task_done_callback=task_done_callback)
+        self._submit_data_task(
+            gen,
+            bundle,
+            task_done_callback=task_done_callback,
+            memory_request_bytes=memory_request_bytes,
+            safe_memory_bytes=safe_memory_bytes,
+        )
 
     def progress_str(self) -> str:
         return ""

--- a/python/ray/data/_internal/issue_detection/detectors/high_memory_detector.py
+++ b/python/ray/data/_internal/issue_detection/detectors/high_memory_detector.py
@@ -1,11 +1,8 @@
 import textwrap
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Dict, List
+from typing import TYPE_CHECKING, List
 
-from ray.data._internal.execution.operators.map_operator import (
-    MapOperator,
-    get_safe_default_logical_memory,
-)
+from ray.data._internal.execution.operators.map_operator import MapOperator
 from ray.data._internal.execution.util import memory_string
 from ray.data._internal.issue_detection.issue_detector import (
     Issue,
@@ -21,7 +18,7 @@ if TYPE_CHECKING:
 
 HIGH_MEMORY_PERIODIC_WARNING = """
 Operator '{op_name}' uses {memory_per_task} of memory per task on average, but Ray
-only requests {initial_memory_request} per task at the start of the pipeline.
+only requested {memory_request} per task on average for those tasks.
 
 To avoid out-of-memory errors, consider setting `memory={memory_per_task}` in the
 appropriate function or method call. (This might be unnecessary if the number of
@@ -50,13 +47,6 @@ class HighMemoryIssueDetector(IssueDetector):
         self._detector_cfg = config
         self._operators = operators
 
-        self._initial_memory_requests: Dict[MapOperator, int] = {}
-        for op in operators:
-            if isinstance(op, MapOperator):
-                self._initial_memory_requests[op] = (
-                    op._get_dynamic_ray_remote_args().get("memory") or 0
-                )
-
     @classmethod
     def from_executor(cls, executor: "StreamingExecutor") -> "HighMemoryIssueDetector":
         """Factory method to create a HighMemoryIssueDetector from a StreamingExecutor.
@@ -81,22 +71,24 @@ class HighMemoryIssueDetector(IssueDetector):
             if not isinstance(op, MapOperator):
                 continue
 
-            if op.metrics.average_max_uss_per_task is None:
+            memory_per_task = op.metrics.average_max_uss_per_task
+            memory_request = op.metrics.average_memory_request_per_task
+            safe_memory_per_task = op.metrics.average_safe_memory_per_task
+            if (
+                memory_per_task is None
+                or memory_request is None
+                or safe_memory_per_task is None
+            ):
                 continue
 
-            remote_args = op._get_dynamic_ray_remote_args()
-            safe_memory_per_task = get_safe_default_logical_memory(remote_args)
-
             if (
-                op.metrics.average_max_uss_per_task > self._initial_memory_requests[op]
-                and op.metrics.average_max_uss_per_task >= safe_memory_per_task
+                memory_per_task > memory_request
+                and memory_per_task >= safe_memory_per_task
             ):
                 message = HIGH_MEMORY_PERIODIC_WARNING.format(
                     op_name=op.name,
-                    memory_per_task=memory_string(op.metrics.average_max_uss_per_task),
-                    initial_memory_request=memory_string(
-                        self._initial_memory_requests[op]
-                    ),
+                    memory_per_task=memory_string(memory_per_task),
+                    memory_request=memory_string(memory_request),
                     detection_time_interval_s=self.detection_time_interval_s(),
                 )
                 issues.append(

--- a/python/ray/data/tests/test_executor_resource_management.py
+++ b/python/ray/data/tests/test_executor_resource_management.py
@@ -244,7 +244,7 @@ def test_task_pool_resource_reporting_with_dynamic_remote_args(
     input_op = InputDataBuffer(
         DataContext.get_current(), make_ref_bundles([[SMALL_STR] for i in range(100)])
     )
-    # ray_remote_args set 1 CPU, but ray_remote_args_fn overrides memory to 500
+    dynamic_memory_request = 500
     op = MapOperator.create(
         _mul2_map_data_prcessor,
         data_context=DataContext.get_current(),
@@ -252,16 +252,20 @@ def test_task_pool_resource_reporting_with_dynamic_remote_args(
         name="TestMapper",
         compute_strategy=TaskPoolStrategy(),
         ray_remote_args={"num_cpus": 1},
-        ray_remote_args_fn=lambda: {"memory": 500},
+        ray_remote_args_fn=lambda: {"memory": dynamic_memory_request},
     )
     op.start(ExecutionOptions(), noop_counter())
 
     assert op.current_logical_usage() == ExecutionResources(cpu=0, gpu=0, memory=0)
 
     op.add_input(input_op.get_next(), 0)
+    dynamic_memory_request = 1000
     op.add_input(input_op.get_next(), 0)
-    # Should reflect actual dynamic resources: 2 tasks * (1 cpu, 500 memory)
-    assert op.current_logical_usage() == ExecutionResources(cpu=2, gpu=0, memory=1000)
+    assert op.current_logical_usage() == ExecutionResources(cpu=2, gpu=0, memory=1500)
+    assert [
+        task_info.memory_request_bytes
+        for task_info in op.metrics._running_tasks.values()
+    ] == [500, 1000]
 
     run_op_tasks_sync(op)
     assert op.current_logical_usage() == ExecutionResources(cpu=0, gpu=0, memory=0)
@@ -449,7 +453,7 @@ def test_actor_pool_resource_reporting_with_dynamic_remote_args(
     input_op = InputDataBuffer(
         DataContext.get_current(), make_ref_bundles([[SMALL_STR] for i in range(100)])
     )
-    # ray_remote_args set 1 CPU, but ray_remote_args_fn overrides memory to 500
+    dynamic_memory_request = 500
     op = MapOperator.create(
         _mul2_map_data_prcessor,
         min_rows_per_bundle=None,
@@ -458,7 +462,7 @@ def test_actor_pool_resource_reporting_with_dynamic_remote_args(
         name="TestMapper",
         compute_strategy=ActorPoolStrategy(min_size=2, max_size=2),  # Create two actors
         ray_remote_args={"num_cpus": 1},
-        ray_remote_args_fn=lambda: {"memory": 500},
+        ray_remote_args_fn=lambda: {"memory": dynamic_memory_request},
     )
 
     # Blocking until actors are fully started
@@ -467,6 +471,11 @@ def test_actor_pool_resource_reporting_with_dynamic_remote_args(
 
     # Should reflect dynamic resources: 2 actors * (1 cpu, 500 memory)
     assert op.current_logical_usage() == ExecutionResources(cpu=2, gpu=0, memory=1000)
+
+    dynamic_memory_request = 1000
+    op.add_input(input_op.get_next(), 0)
+    task_info = next(iter(op.metrics._running_tasks.values()))
+    assert task_info.memory_request_bytes == 500
 
 
 def test_actor_pool_scheduling_with_bundling(

--- a/python/ray/data/tests/test_issue_detection.py
+++ b/python/ray/data/tests/test_issue_detection.py
@@ -203,21 +203,32 @@ class TestHangingExecutionIssueDetector:
 
 
 @pytest.mark.parametrize(
-    "configured_memory, actual_memory, should_return_issue",
+    "configured_memory, dynamic_memory_request, actual_memory, should_return_issue",
     [
         # User has appropriately configured memory, so no issue.
-        (8 * GiB, 8 * GiB, False),
+        (8 * GiB, None, 8 * GiB, False),
         # User hasn't configured memory correctly and memory use is high, so issue.
-        (None, 8 * GiB, True),
-        (1 * GiB, 8 * GiB, True),
+        (None, None, 8 * GiB, True),
+        (1 * GiB, None, 8 * GiB, True),
+        # Existing workers retain the request used when they were launched.
+        (1 * GiB, 10 * GiB, 8 * GiB, True),
         # User hasn't configured memory correctly but memory use is low, so no issue.
-        (None, 1 * GiB, False),
+        (None, None, 1 * GiB, False),
     ],
 )
 def test_high_memory_detection(
-    configured_memory, actual_memory, should_return_issue, restore_data_context
+    configured_memory,
+    dynamic_memory_request,
+    actual_memory,
+    should_return_issue,
+    restore_data_context,
 ):
     ctx = DataContext.get_current()
+    ray_remote_args_fn = (
+        MagicMock(return_value={"memory": dynamic_memory_request})
+        if dynamic_memory_request is not None
+        else None
+    )
 
     input_data_buffer = InputDataBuffer(ctx, input_data=[])
     map_operator = MapOperator.create(
@@ -225,8 +236,13 @@ def test_high_memory_detection(
         input_op=input_data_buffer,
         data_context=ctx,
         ray_remote_args={"memory": configured_memory},
+        ray_remote_args_fn=ray_remote_args_fn,
     )
-    map_operator._metrics = MagicMock(average_max_uss_per_task=actual_memory)
+    map_operator._metrics = MagicMock(
+        average_max_uss_per_task=actual_memory,
+        average_memory_request_per_task=configured_memory or 0,
+        average_safe_memory_per_task=2.5 * GiB,
+    )
     topology = {input_data_buffer: MagicMock(), map_operator: MagicMock()}
 
     operators = list(topology.keys())
@@ -239,6 +255,9 @@ def test_high_memory_detection(
     issues = detector.detect()
 
     assert should_return_issue == bool(issues)
+    if ray_remote_args_fn is not None:
+        assert "requested 1.0GiB per task on average" in issues[0].message
+        ray_remote_args_fn.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/python/ray/data/tests/test_op_runtime_metrics.py
+++ b/python/ray/data/tests/test_op_runtime_metrics.py
@@ -6,9 +6,7 @@ import pytest
 
 import ray
 from ray.data._internal.execution.interfaces import BlockEntry, RefBundle
-from ray.data._internal.execution.interfaces.op_runtime_metrics import (
-    OpRuntimeMetrics,
-)
+from ray.data._internal.execution.interfaces.op_runtime_metrics import OpRuntimeMetrics
 from ray.data._internal.execution.interfaces.physical_operator import (
     TaskExecDriverStats,
 )
@@ -22,11 +20,18 @@ def test_average_max_uss_per_task():
     op.data_context.enable_get_object_locations_for_metrics = False
     metrics = OpRuntimeMetrics(op)
     assert metrics.average_max_uss_per_task is None
+    assert metrics.average_memory_request_per_task is None
+    assert metrics.average_safe_memory_per_task is None
 
     input_bundle = RefBundle([], owns_blocks=False, schema=None)
 
     # Submit and finish first task with USS of 100 bytes.
-    metrics.on_task_submitted(0, input_bundle)
+    metrics.on_task_submitted(
+        0,
+        input_bundle,
+        memory_request_bytes=100,
+        safe_memory_bytes=200,
+    )
     metrics.on_task_finished(
         0,
         None,
@@ -34,9 +39,16 @@ def test_average_max_uss_per_task():
         TaskExecDriverStats(task_output_backpressure_s=0),
     )
     assert metrics.average_max_uss_per_task == 100
+    assert metrics.average_memory_request_per_task == 100
+    assert metrics.average_safe_memory_per_task == 200
 
     # Submit and finish second task with USS of 300 bytes.
-    metrics.on_task_submitted(1, input_bundle)
+    metrics.on_task_submitted(
+        1,
+        input_bundle,
+        memory_request_bytes=500,
+        safe_memory_bytes=600,
+    )
     metrics.on_task_finished(
         1,
         None,
@@ -44,6 +56,26 @@ def test_average_max_uss_per_task():
         TaskExecDriverStats(task_output_backpressure_s=0),
     )
     assert metrics.average_max_uss_per_task == 200  # (100 + 300) / 2
+    assert metrics.average_memory_request_per_task == 300
+    assert metrics.average_safe_memory_per_task == 400
+
+    # A task without a USS sample doesn't affect any of the paired averages.
+    metrics.on_task_submitted(
+        2,
+        input_bundle,
+        memory_request_bytes=900,
+        safe_memory_bytes=1000,
+    )
+    metrics.on_task_finished(
+        2,
+        None,
+        TaskExecWorkerStats(task_wall_time_s=1.0),
+        TaskExecDriverStats(task_output_backpressure_s=0),
+    )
+
+    assert metrics.average_max_uss_per_task == 200
+    assert metrics.average_memory_request_per_task == 300
+    assert metrics.average_safe_memory_per_task == 400
 
 
 def test_task_completion_time_histogram():


### PR DESCRIPTION
## Description
Record the resolved memory request and safe-memory threshold when each map task is launched. For actor pools, use the resources recorded when the selected actor was created, so a later `ray_remote_args_fn` result does not change the configuration attributed to an existing actor.

Only sample these values when the corresponding completed task contributes a USS measurement. 

`HighMemoryIssueDetector` then compares aligned averages without invoking `ray_remote_args_fn` during detector construction or periodic detection.

This prevents a callback's current value from being incorrectly attributed to tasks or actors that launched with a different memory request.

## Related issues
closes #65551.

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
