### PR TITLE
[data] revert(test_gate): remove test gate from test_write_delta.py

### DIFF
--- a/python/ray/data/tests/datasource/test_write_delta.py
+++ b/python/ray/data/tests/datasource/test_write_delta.py
@@ -41,31 +41,6 @@ pytestmark = [
     ),
 ]
 
-# Whether ``read_delta`` gives partition columns back with their declared types.
-#
-# A Delta reader takes a partitioned column's value from metadata rather than
-# from the Parquet file (the writer omits it there), so restoring the declared
-# type is the reader's job. ``read_delta`` delegates that to PyArrow -- see the
-# comment on ``partition_columns=[]`` in ``ParquetDatasource.from_pyarrow_dataset``
-# -- and on pyarrow<19 it doesn't happen: values come back as the raw Hive path
-# strings instead, so ``2024`` reads as ``"2024"`` and a null partition as the
-# literal ``"__HIVE_DEFAULT_PARTITION__"``.
-#
-# That's a gap in the *read* path, which this file doesn't own; the writes
-# themselves are fine on every version. Rather than weaken the assertions
-# everywhere, the round-trip *value* checks below skip on old pyarrow while the
-# on-disk layout checks keep running. 19 is the lowest version observed to
-# round-trip correctly (17 fails, 19 and 20 pass); 18 is simply untested.
-_PARTITION_VALUES_ROUND_TRIP = _pa_version is not None and _pa_version >= parse_version(
-    "19.0.0"
-)
-_NO_TYPED_PARTITION_VALUES = (
-    "read_delta returns partition values as untyped Hive path strings on pyarrow<19"
-)
-_skip_without_typed_partition_values = pytest.mark.skipif(
-    not _PARTITION_VALUES_ROUND_TRIP, reason=_NO_TYPED_PARTITION_VALUES
-)
-
 
 @pytest.fixture
 def temp_delta_path(tmp_path):
@@ -197,13 +172,10 @@ def test_single_column_partition(temp_delta_path):
     ray.data.from_items(rows).write_delta(temp_delta_path, partition_by=["year"])
     assert set(os.listdir(temp_delta_path)) >= {"year=2024", "year=2025"}
 
-    if not _PARTITION_VALUES_ROUND_TRIP:
-        pytest.skip(_NO_TYPED_PARTITION_VALUES)
     out = sorted(_read_all(temp_delta_path), key=lambda r: r["id"])
     assert out == rows
 
 
-@_skip_without_typed_partition_values
 def test_multi_column_partition(temp_delta_path):
     rows = [
         {"year": 2024, "month": 1, "id": 1},
@@ -226,8 +198,6 @@ def test_null_partition_value_round_trips_as_none(temp_delta_path):
     ray.data.from_items(rows).write_delta(temp_delta_path, partition_by=["year"])
     assert "year=__HIVE_DEFAULT_PARTITION__" in os.listdir(temp_delta_path)
 
-    if not _PARTITION_VALUES_ROUND_TRIP:
-        pytest.skip(_NO_TYPED_PARTITION_VALUES)
     out = sorted(_read_all(temp_delta_path), key=lambda r: r["id"])
     assert out == rows
 
@@ -270,8 +240,6 @@ def test_append_without_partition_by_inherits_existing_partitioning(temp_delta_p
 
     assert "year=2025" in os.listdir(temp_delta_path)
 
-    if not _PARTITION_VALUES_ROUND_TRIP:
-        pytest.skip(_NO_TYPED_PARTITION_VALUES)
     out = sorted(_read_all(temp_delta_path), key=lambda r: r["id"])
     assert out == [{"year": 2024, "id": 1}, {"year": 2025, "id": 2}]
 
@@ -330,12 +298,9 @@ def test_partition_by_mismatch_rejected(
 
     # Only the baseline tables that are themselves partitioned depend on
     # partition values surviving the read; the unpartitioned case is unaffected.
-    if create_partition_by and not _PARTITION_VALUES_ROUND_TRIP:
-        pytest.skip(_NO_TYPED_PARTITION_VALUES)
     assert _read_all(temp_delta_path) == first
 
 
-@_skip_without_typed_partition_values
 def test_partition_by_matching_existing_is_allowed(temp_delta_path):
     """Passing exactly the table's own partition columns is fine."""
     ray.data.from_items([{"year": 2024, "id": 1}]).write_delta(
@@ -368,8 +333,6 @@ def test_overwrite_without_partition_by_inherits_existing_partitioning(
 
     assert "year=2025" in os.listdir(temp_delta_path)
 
-    if not _PARTITION_VALUES_ROUND_TRIP:
-        pytest.skip(_NO_TYPED_PARTITION_VALUES)
     assert _read_all(temp_delta_path) == [{"year": 2025, "id": 2}]
 
 


### PR DESCRIPTION
## Description
In the tests "test_write_delta.py", we were doing a round trip assertion on write_delta -> read_delta. These assertions were originally failing in CI with pyarrow version 17 so we added assertions to skip certain tests if pyarrow's available version was < "19.0.0".

When attempting to fix the underlying issue, it is not getting reproduced locally using pyarrow v17 or above (supported versions) on both x86_64 and arm64 machines using python 3.10/3.12; Hence I'm raising this pull request to revert the test gates.

Script used for local repro -
```python3

import os
import sys
import tempfile
import deltalake  # noqa: E402
import pyarrow  # noqa: E402

import ray  # noqa: E402

# One typed partition value and one null, which Delta stores under the
# sentinel directory name "year=__HIVE_DEFAULT_PARTITION__".
ROWS = [{"id": 1, "year": 2024}, {"id": 2, "year": None}]


def main() -> int:
    ray.data.DataContext.get_current().enable_progress_bars = False
    print(
        f"ray {ray.__version__} | "
        f"pyarrow {pyarrow.__version__} | "
        f"deltalake {deltalake.__version__}"
    )

    with tempfile.TemporaryDirectory() as tmp_dir:
        table_uri = os.path.join(tmp_dir, "delta_table")
        ray.data.from_items(ROWS).write_delta(table_uri, partition_by=["year"])

        print("on disk:  ", sorted(os.listdir(table_uri)))
        # take_all() gives no ordering guarantee across blocks; sort to compare.
        got = sorted(ray.data.read_delta(table_uri).take_all(), key=lambda r: r["id"])

    print("read back:", got)
    print("expected: ", ROWS)

    if got != ROWS:
        print(
            "FAIL: partition values did not survive the round trip",
            file=sys.stderr,
        )
        return 1
    print("OK")
    return 0


if __name__ == "__main__":
    sys.exit(main())
```

which generates the following output -
```log
ray 3.0.0.dev0 | pyarrow 17.0.0 | deltalake 1.6.2
2026-08-20 15:34:17,187 INFO worker.py:2015 -- Started a local Ray instance. View the dashboard at http://127.0.0.1:8265
2026-08-20 15:34:18,148 WARNING __init__.py:28 -- Progress bars disabled. To enable, set `ray.data.DataContext.get_current().enable_progress_bars = True`.
on disk:   ['_delta_log', 'year=2024', 'year=__HIVE_DEFAULT_PARTITION__']
read back: [{'id': 1, 'year': 2024}, {'id': 2, 'year': None}]
expected:  [{'id': 1, 'year': 2024}, {'id': 2, 'year': None}]
OK
```

## Related issues
Relates to #65143