### PR TITLE
fix(dashboard): prevent white screen crash when GPU metrics are null (#50421)

### DIFF
--- a/python/ray/dashboard/client/src/pages/node/AcceleratorColumn.component.test.tsx
+++ b/python/ray/dashboard/client/src/pages/node/AcceleratorColumn.component.test.tsx
@@ -1,0 +1,21 @@
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import { UnifiedAcceleratorStat } from "../../util/accelerator";
+import { NodeAcceleratorEntry } from "./AcceleratorColumn";
+
+describe("NodeAcceleratorEntry", () => {
+  it("renders N/A without crashing when utilization is null", () => {
+    const accelerator: UnifiedAcceleratorStat = {
+      name: "Tesla T4",
+      index: 0,
+      type: "GPU",
+      utilization: null as any,
+      memoryUsed: 0,
+      memoryTotal: 16000,
+    };
+
+    render(<NodeAcceleratorEntry slot={0} accelerator={accelerator} />);
+
+    expect(screen.getByText("N/A")).toBeInTheDocument();
+  });
+});

--- a/python/ray/dashboard/client/src/pages/node/AcceleratorColumn.tsx
+++ b/python/ray/dashboard/client/src/pages/node/AcceleratorColumn.tsx
@@ -17,12 +17,12 @@ const GpuTooltip = ({ gpu }: { gpu: GPUStats }) => {
   return (
     <Box>
       <Typography variant="body2">Name: {gpu.name}</Typography>
-      {gpu.temperatureC !== undefined && (
+      {gpu.temperatureC !== undefined && gpu.temperatureC !== null && (
         <Typography variant="body2">
           Temperature: {gpu.temperatureC}°C
         </Typography>
       )}
-      {gpu.powerMw !== undefined && (
+      {gpu.powerMw !== undefined && gpu.powerMw !== null && (
         <Typography variant="body2">
           Power Draw: {(gpu.powerMw / 1000).toFixed(1)} W
         </Typography>
@@ -67,7 +67,8 @@ export const NodeAcceleratorEntry: React.FC<NodeAcceleratorEntryProps> = ({
     <Tooltip title={title}>
       <Box sx={{ display: "flex", minWidth: 120 }}>
         <RightPaddedTypography variant="body1">[{slot}]:</RightPaddedTypography>
-        {accelerator.utilization !== undefined ? (
+        {accelerator.utilization !== undefined &&
+        accelerator.utilization !== null ? (
           <UsageBar
             percent={accelerator.utilization}
             text={`${accelerator.utilization.toFixed(1)}%`}

--- a/python/ray/dashboard/client/src/pages/node/AcceleratorMemoryColumn.tsx
+++ b/python/ray/dashboard/client/src/pages/node/AcceleratorMemoryColumn.tsx
@@ -125,7 +125,11 @@ const AcceleratorMemoryEntry: React.FC<AcceleratorMemoryEntryProps> = ({
   let ratioStr = getMemDisplayRatioNoPercent(utilization, total);
   // When the utilization percentage is present but absolute usage is missing
   // (as is the case on some TPU generations), spoof the bar with just a percentage.
-  if (utilPercent !== undefined && (total === 0 || isNaN(total))) {
+  if (
+    utilPercent !== undefined &&
+    utilPercent !== null &&
+    (total === 0 || isNaN(total))
+  ) {
     ratioStr = `${utilPercent.toFixed(1)}%`;
     utilization = utilPercent;
     total = 100;


### PR DESCRIPTION
 ## Description
Fixes an uncaught `TypeError: Cannot read properties of null (reading 'toFixed')` in Ray Dashboard node accelerator components.

### Root Cause
When GPU metrics (such as `utilization`, `powerMw`, or `temperatureC`) return `null` from the backend API, loose `!== undefined` checks evaluate to `true`. Executing `null.toFixed(1)` throws an uncaught TypeError, causing the React component tree to unmount and resulting in a white screen crash.

### Changes Proposed
- Updated loose `!== undefined` checks to `!= null` in
  `python/ray/dashboard/client/src/pages/node/AcceleratorColumn.tsx` and
  `python/ray/dashboard/client/src/pages/node/AcceleratorMemoryColumn.tsx`.
- When metric values are `null`, the UI now safely falls back to displaying `"N/A"` without crashing.

## Related issues
Resolves #50421.

## AI assistance
AI assistance was used for code investigation and testing.