### PR TITLE
[core][autoscaler][v1] Skip DEAD GCS nodes in LoadMetrics so they can not overwrite a live node's idle state by IP

### DIFF
--- a/python/ray/autoscaler/_private/monitor.py
+++ b/python/ray/autoscaler/_private/monitor.py
@@ -262,15 +262,22 @@ class Monitor:
         # from "get_cluster_resource_state"
         # ref: https://github.com/ray-project/ray/pull/48519#issuecomment-2481659346
         cluster_resource_state = get_cluster_resource_state(self.gcs_client)
-        ray_node_states = cluster_resource_state.node_states
+        # Dead raylets are included in cluster_resource_state (for v2). Skip
+        # them so they cannot overwrite live LoadMetrics by IP or appear as
+        # active in the readonly provider (ray status).
+        alive_node_states = [
+            node
+            for node in cluster_resource_state.node_states
+            if node.status != NodeStatus.DEAD
+        ]
         ray_nodes_idle_duration_ms_by_id = {
-            node.node_id: node.idle_duration_ms for node in ray_node_states
+            node.node_id: node.idle_duration_ms for node in alive_node_states
         }
 
         # Tell the readonly node provider what nodes to report.
         if self.readonly_config:
             new_nodes = []
-            for msg in list(cluster_resource_state.node_states):
+            for msg in alive_node_states:
                 node_id = msg.node_id.hex()
                 new_nodes.append((node_id, msg.node_ip_address))
             self.autoscaler.provider._set_nodes(new_nodes)
@@ -284,12 +291,7 @@ class Monitor:
         )
 
         mirror_node_types = {}
-        for resource_message in cluster_resource_state.node_states:
-            # Dead raylets still appear in cluster_resource_state with their
-            # last IP. Skip them so they cannot occupy or overwrite that IP
-            # in LoadMetrics after the node is gone.
-            if resource_message.status == NodeStatus.DEAD:
-                continue
+        for resource_message in alive_node_states:
             node_id = resource_message.node_id
             # Generate node type config based on GCS reported node list.
             if self.readonly_config:

--- a/python/ray/autoscaler/_private/monitor.py
+++ b/python/ray/autoscaler/_private/monitor.py
@@ -42,6 +42,7 @@ from ray.autoscaler._private.prom_metrics import AutoscalerPrometheusMetrics
 from ray.autoscaler._private.util import format_readonly_node_type
 from ray.autoscaler.v2.sdk import get_cluster_resource_state
 from ray.core.generated import gcs_pb2
+from ray.core.generated.autoscaler_pb2 import NodeStatus
 from ray.core.generated.event_pb2 import Event as RayEvent
 from ray.experimental.internal_kv import (
     _initialize_internal_kv,
@@ -284,6 +285,11 @@ class Monitor:
 
         mirror_node_types = {}
         for resource_message in cluster_resource_state.node_states:
+            # Dead raylets still appear in cluster_resource_state with their
+            # last IP. Skip them so they cannot occupy or overwrite that IP
+            # in LoadMetrics after the node is gone.
+            if resource_message.status == NodeStatus.DEAD:
+                continue
             node_id = resource_message.node_id
             # Generate node type config based on GCS reported node list.
             if self.readonly_config:

--- a/python/ray/tests/test_monitor.py
+++ b/python/ray/tests/test_monitor.py
@@ -132,5 +132,46 @@ def test_update_load_metrics_uses_cluster_state(monkeypatch):
     assert last_used == pytest.approx(fixed_time - 1.5)
 
 
+def test_update_load_metrics_skips_dead_nodes(monkeypatch):
+    """Dead GCS nodes must not be written into LoadMetrics by IP."""
+    monitor = monitor_module.Monitor.__new__(monitor_module.Monitor)
+    monitor.gcs_client = types.SimpleNamespace()
+    monitor.load_metrics = LoadMetrics()
+    monitor.autoscaler = types.SimpleNamespace(config={"provider": {}})
+    monitor.autoscaling_config = None
+    monitor.readonly_config = None
+    monitor.prom_metrics = None
+    monitor.event_summarizer = None
+    usage_reply = gcs_service_pb2.GetAllResourceUsageReply()
+    monitor.gcs_client.get_all_resource_usage = lambda timeout: usage_reply
+
+    reused_ip = "10.0.0.5"
+    live_node_id = bytes.fromhex("cc" * 20)
+    cluster_state = autoscaler_pb2.ClusterResourceState()
+
+    dead_node = cluster_state.node_states.add()
+    dead_node.node_id = bytes.fromhex("aa" * 20)
+    dead_node.node_ip_address = reused_ip
+    dead_node.status = autoscaler_pb2.NodeStatus.DEAD
+
+    live_node = cluster_state.node_states.add()
+    live_node.node_id = live_node_id
+    live_node.node_ip_address = reused_ip
+    live_node.status = autoscaler_pb2.NodeStatus.RUNNING
+    live_node.total_resources["CPU"] = 2.0
+    live_node.available_resources["CPU"] = 1.0
+
+    monkeypatch.setattr(
+        monitor_module, "get_cluster_resource_state", lambda gcs_client: cluster_state
+    )
+
+    monitor.update_load_metrics()
+
+    assert monitor.load_metrics.node_id_by_ip[reused_ip] == live_node_id
+    assert monitor.load_metrics.static_resources_by_ip[reused_ip][
+        "CPU"
+    ] == pytest.approx(2.0)
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main(["-sv", __file__]))

--- a/python/ray/tests/test_monitor.py
+++ b/python/ray/tests/test_monitor.py
@@ -134,12 +134,23 @@ def test_update_load_metrics_uses_cluster_state(monkeypatch):
 
 def test_update_load_metrics_skips_dead_nodes(monkeypatch):
     """Dead GCS nodes must not be written into LoadMetrics by IP."""
+
+    class FakeReadonlyProvider:
+        def __init__(self):
+            self.nodes = None
+
+        def _set_nodes(self, nodes):
+            self.nodes = nodes
+
+    provider = FakeReadonlyProvider()
     monitor = monitor_module.Monitor.__new__(monitor_module.Monitor)
     monitor.gcs_client = types.SimpleNamespace()
     monitor.load_metrics = LoadMetrics()
-    monitor.autoscaler = types.SimpleNamespace(config={"provider": {}})
+    monitor.autoscaler = types.SimpleNamespace(
+        config={"provider": {}}, provider=provider
+    )
     monitor.autoscaling_config = None
-    monitor.readonly_config = None
+    monitor.readonly_config = {"available_node_types": {}}
     monitor.prom_metrics = None
     monitor.event_summarizer = None
     usage_reply = gcs_service_pb2.GetAllResourceUsageReply()
@@ -149,17 +160,19 @@ def test_update_load_metrics_skips_dead_nodes(monkeypatch):
     live_node_id = bytes.fromhex("cc" * 20)
     cluster_state = autoscaler_pb2.ClusterResourceState()
 
-    dead_node = cluster_state.node_states.add()
-    dead_node.node_id = bytes.fromhex("aa" * 20)
-    dead_node.node_ip_address = reused_ip
-    dead_node.status = autoscaler_pb2.NodeStatus.DEAD
-
+    # Live node first, DEAD second: without the skip, last-write-wins would
+    # replace the live mapping with the dead raylet's empty metrics.
     live_node = cluster_state.node_states.add()
     live_node.node_id = live_node_id
     live_node.node_ip_address = reused_ip
     live_node.status = autoscaler_pb2.NodeStatus.RUNNING
     live_node.total_resources["CPU"] = 2.0
     live_node.available_resources["CPU"] = 1.0
+
+    dead_node = cluster_state.node_states.add()
+    dead_node.node_id = bytes.fromhex("aa" * 20)
+    dead_node.node_ip_address = reused_ip
+    dead_node.status = autoscaler_pb2.NodeStatus.DEAD
 
     monkeypatch.setattr(
         monitor_module, "get_cluster_resource_state", lambda gcs_client: cluster_state
@@ -171,6 +184,10 @@ def test_update_load_metrics_skips_dead_nodes(monkeypatch):
     assert monitor.load_metrics.static_resources_by_ip[reused_ip][
         "CPU"
     ] == pytest.approx(2.0)
+
+    readonly_ids = {node_id for node_id, _ in provider.nodes}
+    assert live_node_id.hex() in readonly_ids
+    assert dead_node.node_id.hex() not in readonly_ids
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Autoscaler v1 can fail to terminate an idle worker if GCS returned two NodeStates for the same IP: a live IDLE row with idle_duration_ms > 0, and a DEAD row with idle unset (0). This can happen when an IP is reused by a new node.

The LoadMetrics in Autoscaler v1 are keyed by IP, and last write wins, so the DEAD record with idle unset (0) stored last_used = now, and then the node with the same IP no longer looked idle, thus not being terminated.

This PR fixes this by skipping DEAD rows in LoadMetrics.
