### PR TITLE
[ci] Ask the mirror for one index representation

### DIFF
--- a/ci/pypi_index_proxy.py
+++ b/ci/pypi_index_proxy.py
@@ -69,12 +69,21 @@ client = niquests.AsyncSession()
 
 async def simple(request: Request) -> Response:
     upstream = f"{MIRROR_URL}/pypi.org/simple/{request.path_params['path']}"
-    headers = {}
-    # Content negotiation happens on this header: pip/uv choose between the
-    # HTML and PEP 691 JSON index representations with it.
-    accept = request.headers.get("accept")
-    if accept:
-        headers["Accept"] = accept
+    # Always ask upstream for HTML, ignoring what the client negotiated. The mirror
+    # caches /simple/ keyed on the URL alone with no Vary, so whichever
+    # representation is fetched first is what every later client gets. Forwarding the
+    # client's Accept therefore poisons the entry: uv asks for PEP 691 JSON, the
+    # mirror stores JSON, and then whl_library's pip -- which supports only
+    # text/html -- skips the page and reports "from versions: none". Seen on
+    # postmerge 19272:
+    #
+    #   WARNING: Skipping page .../simple/exceptiongroup/ because the GET request got
+    #   Content-Type: application/vnd.pypi.simple.v1+json. The only supported
+    #   Content-Type is text/html
+    #
+    # HTML rather than JSON because it is the representation every client here
+    # understands: that pip cannot read JSON at all, while uv reads both.
+    headers = {"Accept": "text/html"}
     try:
         response = await client.get(upstream, headers=headers, timeout=60)
     except niquests.exceptions.RequestException as e:
@@ -82,11 +91,20 @@ async def simple(request: Request) -> Response:
     body = response.content
     if response.status_code == 200:
         body = body.replace(UPSTREAM_FILES_PREFIX, MIRROR_FILES_PREFIX)
-    return Response(
-        body,
-        status_code=response.status_code,
-        media_type=response.headers.get("content-type", "text/html"),
-    )
+    content_type = response.headers.get("content-type", "text/html")
+    # Asking for HTML and getting something else means the mirror is holding a
+    # representation cached before this pinning landed. Pinning stops new entries going
+    # in but cannot evict old ones, since the Accept header is not part of the mirror's
+    # cache key -- those have to be deleted from the cache prefix. Say so, because the
+    # symptom at the client is the misleading "from versions: none".
+    if response.status_code == 200 and "html" not in content_type:
+        print(
+            f"pypi proxy: {upstream} returned {content_type} for an HTML request; "
+            "this is a stale mirror cache entry and clients that only read HTML will "
+            "skip it. Delete the cache/pypi.org/simple/ prefix to clear it.",
+            flush=True,
+        )
+    return Response(body, status_code=response.status_code, media_type=content_type)
 
 
 async def healthz(_request: Request) -> Response:

--- a/ci/pypi_index_proxy.py
+++ b/ci/pypi_index_proxy.py
@@ -91,13 +91,17 @@ async def simple(request: Request) -> Response:
     body = response.content
     if response.status_code == 200:
         body = body.replace(UPSTREAM_FILES_PREFIX, MIRROR_FILES_PREFIX)
-    content_type = response.headers.get("content-type", "text/html")
+    # `or` rather than a default: covers a header that is present but empty, which a
+    # default does not.
+    content_type = response.headers.get("content-type") or "text/html"
     # Asking for HTML and getting something else means the mirror is holding a
     # representation cached before this pinning landed. Pinning stops new entries going
     # in but cannot evict old ones, since the Accept header is not part of the mirror's
     # cache key -- those have to be deleted from the cache prefix. Say so, because the
     # symptom at the client is the misleading "from versions: none".
-    if response.status_code == 200 and "html" not in content_type:
+    # Lowercased because header values are case-insensitive, and a false positive here
+    # tells the reader to delete cache entries that are in fact fine.
+    if response.status_code == 200 and "html" not in content_type.lower():
         print(
             f"pypi proxy: {upstream} returned {content_type} for an HTML request; "
             "this is a stale mirror cache entry and clients that only read HTML will "


### PR DESCRIPTION
`reef: raydepsets tests` went red on master in postmerge 19272, and the mirror caused
it rather than failing to prevent it:

  WARNING: Skipping page http://172.16.0.2:35999/simple/exceptiongroup/ because the
  GET request got Content-Type: application/vnd.pypi.simple.v1+json. The only
  supported Content-Type is text/html
  ERROR: Could not find a version that satisfies the requirement exceptiongroup==1.3.1
         (from versions: none)

The mirror caches `/simple/` keyed on the URL alone, with no Vary, so whichever
representation is fetched first is what every later client receives. The proxy
forwarded the client's Accept, so uv asking for PEP 691 JSON stored JSON, and then
whl_library's pip -- which reads only text/html -- skipped the page entirely. The
"from versions: none" that follows looks like a bad pin, which is what makes this worth
a comment in the code: exceptiongroup 1.3.1 is the current release and is present in
PyPI's HTML index.

Pins Accept to text/html. HTML rather than the JSON that product's copy of this proxy
pins, because that pip cannot read JSON at all while uv reads both.

Pinning stops new entries going in but cannot evict the ones already cached, since
Accept is not part of the mirror's cache key. Clearing those means deleting the
cache/pypi.org/simple/ prefix from the bucket, at a cost of one re-fetch per page. So
the proxy now logs loudly when it asks for HTML and gets something else, because the
client-side symptom otherwise points at the wrong thing entirely.

Testing: started the proxy against a stub upstream that records the Accept it receives
and replies with JSON. A client requesting application/vnd.pypi.simple.v1+json results
in the upstream seeing text/html, and the stale-entry warning fires. Both asserted.

AI assistance (Claude Code) was used for this change.
