### PR TITLE
[core] Return the task reference from ActorPool.submit

### DIFF
--- a/python/ray/tests/test_actor_pool.py
+++ b/python/ray/tests/test_actor_pool.py
@@ -218,6 +218,66 @@ def test_multiple_returns(init):
         assert pool.get_next(timeout=None) == [1, 2]
 
 
+def test_submit_returns_ref_when_actor_is_idle(init):
+    @ray.remote
+    class MyActor:
+        def double(self, x):
+            return 2 * x
+
+    pool = ActorPool([MyActor.remote()])
+
+    ref = pool.submit(lambda a, v: a.double.remote(v), 1)
+    assert ray.get(ref) == 2
+    # The pool still owns the result until it is drained.
+    assert pool.get_next() == 2
+
+
+def test_submit_returns_none_when_all_actors_are_busy(init):
+    @ray.remote
+    class MyActor:
+        def double(self, x):
+            return 2 * x
+
+    pool = ActorPool([MyActor.remote()])
+
+    assert pool.submit(lambda a, v: a.double.remote(v), 1) is not None
+    # The only actor is now busy, so this submission is queued instead.
+    assert pool.submit(lambda a, v: a.double.remote(v), 2) is None
+
+    # Draining frees the actor, which dispatches the queued submission.
+    assert pool.get_next() == 2
+    assert pool.get_next() == 4
+
+
+def test_submit_return_value_does_not_disturb_ordering(init):
+    @ray.remote
+    class MyActor:
+        def double(self, x):
+            return 2 * x
+
+    pool = ActorPool([MyActor.remote() for _ in range(2)])
+
+    refs = [pool.submit(lambda a, v: a.double.remote(v), i) for i in range(2)]
+    assert all(ref is not None for ref in refs)
+
+    # Results still come back in submission order, and match the returned refs.
+    for ref in refs:
+        assert pool.get_next() == ray.get(ref)
+
+
+def test_submit_returns_multiple_returns(init):
+    @ray.remote
+    class Foo:
+        @ray.method(num_returns=2)
+        def bar(self):
+            return 1, 2
+
+    pool = ActorPool([Foo.remote()])
+
+    refs = pool.submit(lambda a, v: a.bar.remote(), None)
+    assert ray.get(refs) == [1, 2]
+
+
 def test_pop_idle(init):
     @ray.remote
     class MyActor:

--- a/python/ray/util/actor_pool.py
+++ b/python/ray/util/actor_pool.py
@@ -171,7 +171,9 @@ class ActorPool:
 
         return get_generator()
 
-    def submit(self, fn: Callable[["ray.actor.ActorHandle", V], Any], value: V):
+    def submit(
+        self, fn: Callable[["ray.actor.ActorHandle", V], Any], value: V
+    ) -> Optional["ray.ObjectRef"]:
         """Schedule a single task to run in the pool.
 
         This has the same argument semantics as map(), but takes on a single
@@ -183,6 +185,16 @@ class ActorPool:
                 returns an ObjectRef computing the result over the value. The
                 actor will be considered busy until the ObjectRef completes.
             value: Value to compute a result for.
+
+        Returns:
+            Whatever ``fn`` returned (typically an ObjectRef) if an actor was
+            idle and the task was dispatched immediately, otherwise ``None``
+            because every actor is busy and the task was only queued. Use
+            has_free() beforehand to tell the two cases apart.
+
+            Awaiting the returned reference directly does not release the actor
+            back to the pool; get_next() / get_next_unordered() must still be
+            called to mark the actor idle and to drain queued submissions.
 
         Examples:
             .. testcode::
@@ -212,8 +224,10 @@ class ActorPool:
             self._future_to_actor[future_key] = (self._next_task_index, actor)
             self._index_to_future[self._next_task_index] = future
             self._next_task_index += 1
-        else:
-            self._pending_submits.append((fn, value))
+            return future
+
+        self._pending_submits.append((fn, value))
+        return None
 
     def has_next(self):
         """Returns whether there are any pending results to return.


### PR DESCRIPTION
ActorPool.submit() previously returned nothing, so the only way to get a result was the blocking get_next() / get_next_unordered(). Callers who want to await individual submissions concurrently had no handle to do so.

submit() now returns whatever fn returned (typically an ObjectRef) when an actor was idle and the task was dispatched immediately. When every actor is busy the task is only queued and no reference exists yet, so None is returned in that case; has_free() distinguishes the two.

This is backwards compatible: the previous return value was unconditionally None.

Related to #38061
