### PR TITLE
[Data] [6/11] Add FooterFileIndexer behind an opt-in flag, with bin packing as a partitioner

### DIFF
--- a/python/ray/data/_internal/datasource_v2/chunkers/file_chunker.py
+++ b/python/ray/data/_internal/datasource_v2/chunkers/file_chunker.py
@@ -85,6 +85,13 @@ class ParquetRowGroupChunkMetadata(ChunkMetadata):
     row_group_ids: Tuple[int, ...]
     num_rows: int
     uncompressed_size: int
+    # Whether every row in these groups survives the pushed predicate. Only
+    # exact-survivor counts may drive limit push-down.
+    fully_matched: bool
+    # Per-physical-row-group breakdown, in ``row_group_ids`` order. Populated
+    # for coalesced runs so a partitioner can split at exact boundaries.
+    rg_sizes: Tuple[int, ...]
+    rg_rows: Tuple[int, ...]
 
 
 @DeveloperAPI

--- a/python/ray/data/_internal/datasource_v2/chunkers/parquet_file_chunking_utils.py
+++ b/python/ray/data/_internal/datasource_v2/chunkers/parquet_file_chunking_utils.py
@@ -1,15 +1,21 @@
-"""Parquet file-level chunking helpers for DataSourceV2.
+"""Parquet chunk helpers for DataSourceV2.
 
-Maps planner chunk metadata (``ParquetFileChunkMetadata``) to row-group
-ranges and PyArrow ``ParquetFileFragment`` subsets for parallel reads.
+Two chunking strategies live here. The size-based one maps planner chunk
+metadata (``ParquetFileChunkMetadata``) to row-group ranges. The footer-based
+one maps ``ParquetRowGroupChunkMetadata`` -- the explicit surviving row groups a
+bin assigns to a file -- straight to PyArrow ``ParquetFileFragment`` subsets.
+Both produce ``(fragment, file_row_offset)`` pairs for the reader.
 """
-from typing import List, Optional, Tuple
+from typing import Callable, Iterable, List, Optional, Tuple, TypeVar
 
 import pyarrow.dataset as pds
 
+from ray._common.retry import call_with_retry
 from ray.data._internal.datasource_v2.chunkers.file_chunker import (
     ParquetFileChunkMetadata,
 )
+
+R = TypeVar("R")
 
 
 def _calculate_row_group_range(
@@ -111,3 +117,62 @@ def _fragments_from_chunk_metadata(
         )
         file_row_offset += metadata.row_group(row_group_index).num_rows
     return sub_fragments
+
+
+def _with_io_retry(f: Callable[[], R], description: str) -> R:
+    """Run ``f``, retrying the transient IO errors configured on the context.
+
+    ``ParquetFileFragment.subset`` and ``.metadata`` both open the file to read
+    its footer, so on remote storage they fail with the same transient errors
+    (S3 timeouts, throttling) the rest of the read path already retries.
+    """
+    from ray.data.context import DataContext
+
+    return call_with_retry(
+        f,
+        description=description,
+        match=DataContext.get_current().retried_io_errors,
+    )
+
+
+def _fragments_from_row_group_ids(
+    fragment: pds.ParquetFileFragment,
+    row_group_ids: Iterable[int],
+    *,
+    per_row_group_offsets: bool,
+) -> List[Tuple[pds.ParquetFileFragment, int]]:
+    """Slice ``fragment`` to the explicit physical ``row_group_ids`` of one bin.
+
+    Used by the footer-based chunking path, where ``ParquetRowGroupChunkMetadata``
+    names the exact surviving row groups for a file (predicate pruning + bin
+    packing already happened upstream), so no size-based reconciliation is needed.
+
+    When ``per_row_group_offsets`` is False (the common case) the file's groups
+    are scanned together as a single sub-fragment with a row offset of 0 -- this
+    lets PyArrow coalesce reads across the groups. When True (``include_row_hash``
+    is on), one sub-fragment per row group is returned, each paired with its
+    cumulative pre-filter row offset within the file, so row hashes stay unique
+    and match the physical row positions even when pruned groups make the
+    surviving set non-contiguous.
+    """
+    ids = sorted(row_group_ids)
+    if not ids:
+        return []
+
+    def _subset(rg_ids: List[int]) -> pds.ParquetFileFragment:
+        return _with_io_retry(
+            lambda: fragment.subset(row_group_ids=rg_ids),
+            f"subset row groups {rg_ids} of {fragment.path}",
+        )
+
+    if not per_row_group_offsets:
+        return [(_subset(ids), 0)]
+
+    metadata = _with_io_retry(
+        lambda: fragment.metadata, f"read Parquet footer for {fragment.path}"
+    )
+    # Cumulative pre-filter row offset at the start of each physical row group.
+    prefix = [0] * (metadata.num_row_groups + 1)
+    for i in range(metadata.num_row_groups):
+        prefix[i + 1] = prefix[i] + metadata.row_group(i).num_rows
+    return [(_subset([rg_id]), prefix[rg_id]) for rg_id in ids]

--- a/python/ray/data/_internal/datasource_v2/datasource_v2.py
+++ b/python/ray/data/_internal/datasource_v2/datasource_v2.py
@@ -33,6 +33,9 @@ from ray.util.annotations import DeveloperAPI
 if TYPE_CHECKING:
     from pyarrow.fs import FileSystem
 
+    from ray.data._internal.datasource_v2.partitioners.file_partitioner import (
+        FilePartitioner,
+    )
     from ray.data._internal.datasource_v2.readers.in_memory_size_estimator import (
         InMemorySizeEstimator,
     )
@@ -71,7 +74,8 @@ class DataSourceV2(ABC, Generic[InputSplit]):
     4. Scanner creation
 
     Subclasses should implement the abstract methods and can optionally
-    override _get_file_indexer() and get_size_estimator() for file-based sources.
+    override _get_file_indexer(), get_size_estimator(), and optionally
+    get_file_partitioner() for file-based sources.
 
     Example::
 
@@ -135,6 +139,19 @@ class DataSourceV2(ABC, Generic[InputSplit]):
             FileIndexer instance, or None for non-file-based sources.
         """
         return None
+
+    def get_file_partitioner(self, **kwargs) -> Optional["FilePartitioner"]:
+        """Partitioner that groups this source's listing rows into read units.
+
+        Defaults to the size-estimating ``RoundRobinPartitioner``. Override when
+        the indexer emits rows carrying richer metadata (e.g. Parquet row-group
+        stats) that a different grouping strategy can exploit.
+        """
+        from ray.data._internal.datasource_v2.partitioners.round_robin_partitioner import (  # noqa: E501
+            RoundRobinPartitioner,
+        )
+
+        return RoundRobinPartitioner(**kwargs)
 
     def get_size_estimator(self) -> Optional[InMemorySizeEstimator]:
         """Return size estimator for this datasource.

--- a/python/ray/data/_internal/datasource_v2/listing/file_indexer.py
+++ b/python/ray/data/_internal/datasource_v2/listing/file_indexer.py
@@ -3,6 +3,7 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Callable, Iterable, List, Optional, Tuple, Union
 
+import numpy as np
 from pyarrow.fs import FileSystem
 
 from ray._common.utils import env_integer
@@ -22,6 +23,7 @@ from ray.data.block import BlockColumn
 from ray.data.datasource.path_util import _resolve_paths_and_filesystem
 
 if TYPE_CHECKING:
+    from ray.data.datasource.file_based_datasource import FileShuffleConfig
     from ray.data.expressions import Expr
 
 logger = logging.getLogger(__name__)
@@ -45,6 +47,8 @@ class FileIndexer(ABC):
         predicate: Optional["Expr"] = None,
         limit: Optional[int] = None,
         projected_columns: Optional[List[str]] = None,
+        shuffle_config: Optional["FileShuffleConfig"] = None,
+        execution_idx: int = 0,
     ) -> Iterable[FileManifest]:
         """List files and their on-disk sizes for the given path.
 
@@ -60,6 +64,11 @@ class FileIndexer(ABC):
                 early. Others ignore it.
             projected_columns: Pushed-down column projection, for metadata-aware
                 sizing. Others ignore it.
+            shuffle_config: When set, listed files are shuffled after path
+                discovery and before metadata fetch (footer reads, chunking).
+                :meth:`list_file_infos` is never shuffled.
+            execution_idx: Execution index used with ``shuffle_config`` to
+                derive a per-execution seed.
 
         Returns:
             An iterator of `FileManifest` objects, each of which contains a file path
@@ -78,10 +87,11 @@ class FileIndexer(ABC):
     ) -> Iterable["FileInfo"]:
         """List files as raw ``FileInfo``\\ s (path + on-disk size).
 
-        Unlike :meth:`list_files`, this yields the pre-chunk file stream. The
-        footer-based Parquet path consumes it directly -- it reads each file's
-        footer and bin-packs row groups itself, so it needs paths + sizes rather
-        than pre-chunked manifest rows.
+        Unlike :meth:`list_files`, this yields the pre-chunk file stream and is
+        never shuffled. The footer-based Parquet path consumes it (after an
+        optional file shuffle) -- it reads each file's footer and bin-packs
+        row groups itself, so it needs paths + sizes rather than pre-chunked
+        manifest rows.
         """
         ...
 
@@ -92,6 +102,23 @@ class FileInfo:
 
     path: str
     size: Optional[int]
+
+
+def _shuffle_file_infos(
+    file_infos: List[FileInfo], seed: Optional[int]
+) -> List[FileInfo]:
+    """Permute ``file_infos`` with the same seeded rule as ``FileManifest.shuffle``.
+
+    When ``seed`` is set, sort by path first so the permutation is independent
+    of upstream listing order (the threaded indexer does not preserve order).
+    """
+    n = len(file_infos)
+    if n <= 1:
+        return file_infos
+    if seed is not None:
+        file_infos = sorted(file_infos, key=lambda fi: fi.path)
+    permutation = np.random.default_rng(seed).permutation(n)
+    return [file_infos[i] for i in permutation]
 
 
 @dataclass(frozen=True)
@@ -210,18 +237,53 @@ class NonSamplingFileIndexer(FileIndexer):
         predicate: Optional["Expr"] = None,
         limit: Optional[int] = None,
         projected_columns: Optional[List[str]] = None,
+        shuffle_config: Optional["FileShuffleConfig"] = None,
+        execution_idx: int = 0,
     ) -> Iterable[FileManifest]:
         # This per-file listing path ignores predicate/limit/projected_columns;
         # they're consumed by metadata-aware indexers (e.g. the footer indexer).
         # ``list_file_infos`` already skips zero-size files and applies pruners,
-        # so the manifest builder only has to chunk.
+        # so the manifest builder only has to chunk. Shuffle, when requested,
+        # happens after path discovery and before chunking.
+        file_infos = self._iter_file_infos_for_list(
+            paths,
+            filesystem=filesystem,
+            pruners=pruners,
+            preserve_order=preserve_order,
+            shuffle_config=shuffle_config,
+            execution_idx=execution_idx,
+        )
+        yield from self._process_file_infos_to_manifests(file_infos)
+
+    def _iter_file_infos_for_list(
+        self,
+        paths: "BlockColumn",
+        *,
+        filesystem: "FileSystem",
+        pruners: Optional[List[FilePruner]] = None,
+        preserve_order: bool = False,
+        shuffle_config: Optional["FileShuffleConfig"] = None,
+        execution_idx: int = 0,
+    ) -> Iterable[FileInfo]:
+        """Path discovery, then optional file shuffle, before metadata fetch.
+
+        :meth:`list_file_infos` stays a pure listing stream. Shuffle, when
+        requested, materializes that stream and permutes whole files so
+        metadata-aware subclasses (footer reads) and chunking both see the
+        shuffled file order. Unshuffled listing stays streaming.
+        """
         file_infos = self.list_file_infos(
             paths,
             filesystem=filesystem,
             pruners=pruners,
             preserve_order=preserve_order,
         )
-        yield from self._process_file_infos_to_manifests(file_infos)
+        if shuffle_config is None:
+            yield from file_infos
+            return
+        yield from _shuffle_file_infos(
+            list(file_infos), seed=shuffle_config.get_seed(execution_idx)
+        )
 
     def _get_file_info_iterator(
         self,
@@ -359,12 +421,14 @@ class NonSamplingFileIndexer(FileIndexer):
     ) -> Iterable[FileInfo]:
         """Yield pruned, non-empty ``FileInfo``\\ s (path + on-disk size).
 
-        The raw file-info stream that :meth:`list_files` chunks into manifests.
-        The footer-based Parquet path consumes this directly -- it reads each
-        file's footer and bin-packs row groups itself, so it needs paths + sizes
-        rather than pre-chunked manifest rows. Zero-size files are skipped and
-        ``pruners`` (file-extension / partition filters) are applied here, so
-        both listing paths share one filtering point.
+        The raw file-info stream that :meth:`list_files` (via
+        :meth:`_iter_file_infos_for_list`) optionally shuffles, then chunks
+        into manifests. The footer-based Parquet path consumes this same
+        stream -- it reads each file's footer and bin-packs row groups
+        itself, so it needs paths + sizes rather than pre-chunked manifest
+        rows. Zero-size files are skipped and ``pruners`` (file-extension /
+        partition filters) are applied here, so both listing paths share one
+        filtering point.
         """
         pruners = pruners or []
         file_info_iterator = self._get_file_info_iterator(
@@ -411,9 +475,9 @@ class NonSamplingFileIndexer(FileIndexer):
                 if len(running_paths) >= self._max_paths_per_output:
                     manifests_count += 1
                     yield FileManifest.construct_manifest(
-                        running_paths,
-                        running_file_sizes,
-                        running_chunk_metadatas,
+                        paths=running_paths,
+                        sizes=running_file_sizes,
+                        chunk_metadatas=running_chunk_metadatas,
                     )
                     running_paths = []
                     running_file_sizes = []
@@ -422,9 +486,9 @@ class NonSamplingFileIndexer(FileIndexer):
         if running_paths:
             manifests_count += 1
             yield FileManifest.construct_manifest(
-                running_paths,
-                running_file_sizes,
-                running_chunk_metadatas,
+                paths=running_paths,
+                sizes=running_file_sizes,
+                chunk_metadatas=running_chunk_metadatas,
             )
 
         logger.debug(

--- a/python/ray/data/_internal/datasource_v2/listing/file_indexer.py
+++ b/python/ray/data/_internal/datasource_v2/listing/file_indexer.py
@@ -34,19 +34,6 @@ class FileIndexer(ABC):
         """The file chunker that this indexer uses."""
         ...
 
-    @property
-    def produces_partitioned_manifests(self) -> bool:
-        """Whether ``list_files`` already produces partitioned manifests.
-
-        ``False`` (default) means the indexer yields per-file / per-chunk
-        manifests that still need size-balanced partitioning downstream. An
-        indexer that bin-packs internally (e.g. the footer-based Parquet indexer,
-        which reads footers and packs row groups into ~one-block manifests)
-        returns ``True``; ``ListFiles`` then skips the partitioner and runs
-        listing as a single task so packing sees the whole file stream.
-        """
-        return False
-
     @abstractmethod
     def list_files(
         self,
@@ -187,6 +174,25 @@ class NonSamplingFileIndexer(FileIndexer):
         to introspect or override the chunking strategy.
         """
         return self._file_chunker
+
+    def as_whole_file_indexer(self) -> "NonSamplingFileIndexer":
+        """A plain per-file indexer sharing this one's traversal config.
+
+        Metadata-only consumers (the ``PushdownCountFiles`` rule) need a listing
+        that emits each file exactly once and does no per-file IO while listing.
+        Subclasses that override :meth:`list_files` with a metadata-aware
+        strategy -- e.g. ``FooterFileIndexer``, which footer-reads every file on
+        an actor pool and emits one manifest row per row-group run -- would both
+        duplicate that IO and emit a path more than once. So this deliberately
+        returns a base ``NonSamplingFileIndexer`` rather than ``type(self)``,
+        carrying over only the traversal settings.
+        """
+        return NonSamplingFileIndexer(
+            ignore_missing_paths=self._ignore_missing_paths,
+            num_workers=self._num_workers,
+            max_paths_per_output=self._max_paths_per_output,
+            file_chunker=WholeFileChunker(),
+        )
 
     def list_files(
         self,

--- a/python/ray/data/_internal/datasource_v2/listing/file_indexer.py
+++ b/python/ray/data/_internal/datasource_v2/listing/file_indexer.py
@@ -186,9 +186,15 @@ class NonSamplingFileIndexer(FileIndexer):
         duplicate that IO and emit a path more than once. So this deliberately
         returns a base ``NonSamplingFileIndexer`` rather than ``type(self)``,
         carrying over only the traversal settings.
+
+        ``skip_paths`` is part of that traversal config and must carry over:
+        dropping it would let excluded files back into the listing, inflating a
+        pushed-down ``count()`` and turning a skipped-but-missing path into a
+        ``FileNotFoundError``.
         """
         return NonSamplingFileIndexer(
             ignore_missing_paths=self._ignore_missing_paths,
+            skip_paths=self._skip_paths,
             num_workers=self._num_workers,
             max_paths_per_output=self._max_paths_per_output,
             file_chunker=WholeFileChunker(),

--- a/python/ray/data/_internal/datasource_v2/listing/file_manifest.py
+++ b/python/ray/data/_internal/datasource_v2/listing/file_manifest.py
@@ -125,6 +125,7 @@ class FileManifest:
     @classmethod
     def construct_manifest(
         cls,
+        *,
         paths: List[str],
         sizes: List[int],
         chunk_metadatas: List[Optional[ChunkMetadata]],

--- a/python/ray/data/_internal/datasource_v2/listing/footer_file_indexer.py
+++ b/python/ray/data/_internal/datasource_v2/listing/footer_file_indexer.py
@@ -181,7 +181,9 @@ class FooterFileIndexer(NonSamplingFileIndexer):
             self._io_concurrency,
         )
         try:
-            yield from self._read_footers(actors, file_infos, limit)
+            yield from self._read_footers(
+                actors, file_infos, limit, preserve_order=preserve_order
+            )
         finally:
             for actor in actors:
                 # ``ActorProxy`` is ``ActorHandle | type[T]``; kill wants a handle.
@@ -193,6 +195,8 @@ class FooterFileIndexer(NonSamplingFileIndexer):
         actors: List["ActorProxy[FooterReader]"],
         file_infos: "Iterable[FileInfo]",
         limit: Optional[int],
+        *,
+        preserve_order: bool = False,
     ) -> Iterator[FileManifest]:
         # Bound the number of in-flight footer batches so listing stays roughly
         # demand-driven (matters under a limit) and memory stays flat.
@@ -215,6 +219,7 @@ class FooterFileIndexer(NonSamplingFileIndexer):
             gen: ray.ObjectRefGenerator = actor.read_footers.remote(
                 batch,
                 result_batch_size=self._result_batch_size,  # pyrefly: ignore[unexpected-keyword]
+                preserve_order=preserve_order,  # pyrefly: ignore[unexpected-keyword]
             )
             pending.append(gen)
             batch_no += 1

--- a/python/ray/data/_internal/datasource_v2/listing/footer_file_indexer.py
+++ b/python/ray/data/_internal/datasource_v2/listing/footer_file_indexer.py
@@ -27,6 +27,7 @@ if TYPE_CHECKING:
     from ray.data._internal.datasource_v2.listing.file_pruners import FilePruner
     from ray.data._internal.datasource_v2.listing.footer_reader import FooterReader
     from ray.data.block import BlockColumn
+    from ray.data.datasource.file_based_datasource import FileShuffleConfig
     from ray.data.expressions import Expr
 
 logger = logging.getLogger(__name__)
@@ -53,7 +54,7 @@ _DEFAULT_MAX_INFLIGHT_BATCHES = env_integer(
 # as a ``FilePartitioner``; see ``ParquetDatasourceV2.get_file_partitioner``.
 
 
-def _manifest_of_runs(file_chunks: FileChunks) -> FileManifest:
+def _file_chunks_to_manifest(file_chunks: FileChunks) -> FileManifest:
     """One listing row per row-group run of a file.
 
     The row carries the run's exact footer stats, so a downstream partitioner
@@ -63,9 +64,9 @@ def _manifest_of_runs(file_chunks: FileChunks) -> FileManifest:
     """
     n = len(file_chunks.row_groups)
     return FileManifest.construct_manifest(
-        [file_chunks.path] * n,
-        [file_chunks.size] * n,
-        [
+        paths=[file_chunks.path] * n,
+        sizes=[file_chunks.size] * n,
+        chunk_metadatas=[
             create_chunk_metadata(
                 ParquetRowGroupChunkMetadata,
                 row_group_ids=tuple(range(rg.rg_idx, rg.rg_idx + rg.rg_count)),
@@ -85,8 +86,9 @@ class FooterFileIndexer(NonSamplingFileIndexer):
 
     Inherits directory traversal and ``list_file_infos`` from
     :class:`NonSamplingFileIndexer`; overrides :meth:`list_files` to attach exact
-    footer stats to each run instead of emitting opaque per-file chunks. Grouping
-    runs into read units is the partitioner's job -- see
+    footer stats to each run instead of emitting opaque per-file chunks. File
+    shuffle, when requested, runs after path discovery and before footer reads.
+    Grouping runs into read units is the partitioner's job -- see
     :class:`~ray.data._internal.datasource_v2.partitioners.online_bin_packer.OnlineBinPacker`.
     """
 
@@ -158,12 +160,16 @@ class FooterFileIndexer(NonSamplingFileIndexer):
         predicate: Optional["Expr"] = None,
         limit: Optional[int] = None,
         projected_columns: Optional[List[str]] = None,
+        shuffle_config: Optional["FileShuffleConfig"] = None,
+        execution_idx: int = 0,
     ) -> Iterable[FileManifest]:
-        file_infos = self.list_file_infos(
+        file_infos = self._iter_file_infos_for_list(
             paths,
             filesystem=filesystem,
             pruners=pruners,
             preserve_order=preserve_order,
+            shuffle_config=shuffle_config,
+            execution_idx=execution_idx,
         )
         actors: List[ActorProxy[FooterReader]] = [
             FooterReaderActor.options(scheduling_strategy="SPREAD").remote(
@@ -234,7 +240,7 @@ class FooterFileIndexer(NonSamplingFileIndexer):
             gen = pending.popleft()
             for ref in gen:  # blocks until this generator's next result lands
                 for file_chunks in ray.get(ref):
-                    yield _manifest_of_runs(file_chunks)
+                    yield _file_chunks_to_manifest(file_chunks)
                     if limit is not None:
                         # Count only fully-matched (exact-survivor) rows so
                         # stopping can never under-deliver under a filter.

--- a/python/ray/data/_internal/datasource_v2/listing/footer_file_indexer.py
+++ b/python/ray/data/_internal/datasource_v2/listing/footer_file_indexer.py
@@ -44,11 +44,11 @@ _DEFAULT_BATCH_SIZE = env_integer("RAY_DATA_PARQUET_FOOTER_BATCH_SIZE", 10)
 # yielded list, so a large directory costs one fetch per file at ``1``. Raising
 # it trades a little latency-to-first-chunk for far fewer driver-side fetches.
 _DEFAULT_RESULT_BATCH_SIZE = env_integer("RAY_DATA_PARQUET_FOOTER_RESULT_BATCH_SIZE", 1)
-# Max in-flight footer batches. ``0`` -> auto (``num_actors * 2``). A smaller
+# Max in-flight footer batches. ``None`` -> auto (``num_actors * 2``). A smaller
 # window reads fewer footers before an early ``limit`` stop cancels the pool, at
 # the cost of less pipelining on full reads.
-_DEFAULT_MAX_INFLIGHT_BATCHES = env_integer(
-    "RAY_DATA_PARQUET_FOOTER_MAX_INFLIGHT_BATCHES", 0
+_DEFAULT_MAX_INFLIGHT_BATCHES: Optional[int] = env_integer(
+    "RAY_DATA_PARQUET_FOOTER_MAX_INFLIGHT_BATCHES", None
 )
 # Bin sizing now belongs to ``OnlineBinPacker``, which the datasource supplies
 # as a ``FilePartitioner``; see ``ParquetDatasourceV2.get_file_partitioner``.
@@ -139,7 +139,7 @@ class FooterFileIndexer(NonSamplingFileIndexer):
                 _DEFAULT_RESULT_BATCH_SIZE,
             )
         )
-        # In-flight footer-batch window; 0/None -> auto (``num_actors * 2``).
+        # In-flight footer-batch window; ``None`` -> auto (``num_actors * 2``).
         _inflight = (
             max_inflight_batches
             if max_inflight_batches is not None
@@ -148,7 +148,9 @@ class FooterFileIndexer(NonSamplingFileIndexer):
                 _DEFAULT_MAX_INFLIGHT_BATCHES,
             )
         )
-        self._max_inflight_batches = _inflight if _inflight else self._num_actors * 2
+        self._max_inflight_batches = (
+            _inflight if _inflight is not None else self._num_actors * 2
+        )
 
     def list_files(
         self,

--- a/python/ray/data/_internal/datasource_v2/listing/footer_file_indexer.py
+++ b/python/ray/data/_internal/datasource_v2/listing/footer_file_indexer.py
@@ -6,15 +6,18 @@ from typing import TYPE_CHECKING, Deque, Iterable, Iterator, List, Optional, Tup
 
 import ray
 from ray._common.utils import env_integer
+from ray.data._internal.datasource_v2.chunkers.file_chunker import (
+    ParquetRowGroupChunkMetadata,
+    create_chunk_metadata,
+)
+from ray.data._internal.datasource_v2.chunkers.parquet_footer_types import FileChunks
 from ray.data._internal.datasource_v2.listing.file_indexer import (
     NonSamplingFileIndexer,
 )
-from ray.data._internal.datasource_v2.listing.file_manifest import FileManifest
-from ray.data._internal.datasource_v2.listing.footer_reader import FooterReaderActor
-from ray.data._internal.datasource_v2.partitioners.online_bin_packer import (
-    OnlineBinPacker,
+from ray.data._internal.datasource_v2.listing.file_manifest import (
+    FileManifest,
 )
-from ray.data._internal.util import MiB
+from ray.data._internal.datasource_v2.listing.footer_reader import FooterReaderActor
 
 if TYPE_CHECKING:
     from pyarrow.fs import FileSystem
@@ -46,51 +49,67 @@ _DEFAULT_RESULT_BATCH_SIZE = env_integer("RAY_DATA_PARQUET_FOOTER_RESULT_BATCH_S
 _DEFAULT_MAX_INFLIGHT_BATCHES = env_integer(
     "RAY_DATA_PARQUET_FOOTER_MAX_INFLIGHT_BATCHES", 0
 )
-# Bin budget: uncompressed bytes of row-group data per read task. NOTE this is
-# the sole input to read-task sizing on this path -- unlike the size-estimating
-# partitioner it replaces, it does not consult
-# ``DataContext.target_max_block_size``. Deriving it from that instead is worth
-# doing before this path becomes the default.
-_DEFAULT_BIN_PACKING_BYTES = env_integer(
-    "RAY_DATA_PARQUET_BIN_PACKING_BYTES", 128 * MiB
-)
-# Shared (mixed-colour) bins the packer keeps open at once. A wider pool packs
-# tighter; a narrower one seals bins sooner, and since each sealed bin becomes a
-# read task, that's what lets reads start before every footer has landed.
-_DEFAULT_MAX_SHARED_OPEN_BINS = env_integer(
-    "RAY_DATA_PARQUET_BIN_PACKING_MAX_SHARED_OPEN_BINS", 16
-)
+# Bin sizing now belongs to ``OnlineBinPacker``, which the datasource supplies
+# as a ``FilePartitioner``; see ``ParquetDatasourceV2.get_file_partitioner``.
+
+
+def _manifest_of_runs(file_chunks: FileChunks) -> FileManifest:
+    """One listing row per row-group run of a file.
+
+    The row carries the run's exact footer stats, so a downstream partitioner
+    can group runs into read units -- and split them at row-group boundaries --
+    without re-reading the footer. Grouping is deliberately *not* done here:
+    listing discovers, the partitioner groups.
+    """
+    n = len(file_chunks.row_groups)
+    return FileManifest.construct_manifest(
+        [file_chunks.path] * n,
+        [file_chunks.size] * n,
+        [
+            create_chunk_metadata(
+                ParquetRowGroupChunkMetadata,
+                row_group_ids=tuple(range(rg.rg_idx, rg.rg_idx + rg.rg_count)),
+                num_rows=rg.num_rows,
+                uncompressed_size=rg.uncompressed_size,
+                fully_matched=rg.fully_matched,
+                rg_sizes=rg.rg_sizes,
+                rg_rows=rg.rg_rows,
+            )
+            for rg in file_chunks.row_groups
+        ],
+    )
 
 
 class FooterFileIndexer(NonSamplingFileIndexer):
-    """Lists files, then footer-reads + bin-packs their row groups into manifests.
+    """Lists files, then footer-reads them to emit one row per row-group run.
 
     Inherits directory traversal and ``list_file_infos`` from
-    :class:`NonSamplingFileIndexer`; overrides :meth:`list_files` to emit
-    bin-packed read units instead of per-file chunks.
+    :class:`NonSamplingFileIndexer`; overrides :meth:`list_files` to attach exact
+    footer stats to each run instead of emitting opaque per-file chunks. Grouping
+    runs into read units is the partitioner's job -- see
+    :class:`~ray.data._internal.datasource_v2.partitioners.online_bin_packer.OnlineBinPacker`.
     """
 
     def __init__(
         self,
         *,
         ignore_missing_paths: bool,
+        skip_paths: Optional[Iterable[str]] = None,
         num_workers: Optional[int] = None,
         max_paths_per_output: Optional[int] = None,
         coalesce_bytes: int = 0,
-        split_coalesced: bool = False,
         io_concurrency: Optional[int] = None,
         footer_batch_size: Optional[int] = None,
         result_batch_size: Optional[int] = None,
         max_inflight_batches: Optional[int] = None,
-        max_shared_open_bins: Optional[int] = None,
     ):
         super().__init__(
             ignore_missing_paths=ignore_missing_paths,
+            skip_paths=skip_paths,
             num_workers=num_workers,
             max_paths_per_output=max_paths_per_output,
         )
         self._coalesce_bytes = coalesce_bytes
-        self._split_coalesced = split_coalesced
         # Every knob is re-read here rather than taken from the module-level
         # constant, so ``monkeypatch.setenv`` and release-test env overrides work
         # after this module has already been imported. An explicit ctor argument
@@ -128,23 +147,6 @@ class FooterFileIndexer(NonSamplingFileIndexer):
             )
         )
         self._max_inflight_batches = _inflight if _inflight else self._num_actors * 2
-        self._max_shared_open_bins = (
-            max_shared_open_bins
-            if max_shared_open_bins is not None
-            else env_integer(
-                "RAY_DATA_PARQUET_BIN_PACKING_MAX_SHARED_OPEN_BINS",
-                _DEFAULT_MAX_SHARED_OPEN_BINS,
-            )
-        )
-        self._max_bin_bytes = env_integer(
-            "RAY_DATA_PARQUET_BIN_PACKING_BYTES", _DEFAULT_BIN_PACKING_BYTES
-        )
-
-    @property
-    def produces_partitioned_manifests(self) -> bool:
-        # list_files already emits bin-packed read units, so ListFiles skips the
-        # partitioner and lists in a single task (global packing + one pool).
-        return True
 
     def list_files(
         self,
@@ -157,7 +159,6 @@ class FooterFileIndexer(NonSamplingFileIndexer):
         limit: Optional[int] = None,
         projected_columns: Optional[List[str]] = None,
     ) -> Iterable[FileManifest]:
-        max_bin_bytes = self._max_bin_bytes
         file_infos = self.list_file_infos(
             paths,
             filesystem=filesystem,
@@ -180,25 +181,19 @@ class FooterFileIndexer(NonSamplingFileIndexer):
             self._io_concurrency,
         )
         try:
-            yield from self._read_and_pack(actors, file_infos, max_bin_bytes, limit)
+            yield from self._read_footers(actors, file_infos, limit)
         finally:
             for actor in actors:
                 # ``ActorProxy`` is ``ActorHandle | type[T]``; kill wants a handle.
                 # pyrefly: ignore[bad-argument-type]
                 ray.kill(actor)
 
-    def _read_and_pack(
+    def _read_footers(
         self,
         actors: List["ActorProxy[FooterReader]"],
         file_infos: "Iterable[FileInfo]",
-        max_bin_bytes: int,
         limit: Optional[int],
     ) -> Iterator[FileManifest]:
-        packer = OnlineBinPacker(
-            max_bin_bytes,
-            max_shared_open_bins=self._max_shared_open_bins,
-            split_coalesced=self._split_coalesced,
-        )
         # Bound the number of in-flight footer batches so listing stays roughly
         # demand-driven (matters under a limit) and memory stays flat.
         window = max(1, self._max_inflight_batches)
@@ -234,7 +229,7 @@ class FooterFileIndexer(NonSamplingFileIndexer):
             gen = pending.popleft()
             for ref in gen:  # blocks until this generator's next result lands
                 for file_chunks in ray.get(ref):
-                    packer.add_file_chunks(file_chunks)
+                    yield _manifest_of_runs(file_chunks)
                     if limit is not None:
                         # Count only fully-matched (exact-survivor) rows so
                         # stopping can never under-deliver under a filter.
@@ -243,21 +238,12 @@ class FooterFileIndexer(NonSamplingFileIndexer):
                             for rg in file_chunks.row_groups
                             if rg.fully_matched
                         )
-                while packer.has_partition():
-                    yield packer.next_partition()
                 if limit is not None and delivered_fully_matched_rows >= limit:
-                    # Flush open bins so a small limit yields promptly; abandon
-                    # in-flight generators (the actor teardown cancels them).
-                    packer.finalize()
-                    while packer.has_partition():
-                        yield packer.next_partition()
+                    # Stop listing; abandon in-flight generators (the actor
+                    # teardown cancels them).
                     return
             # This generator drained; keep the window full.
             dispatch_next()
-
-        packer.finalize()
-        while packer.has_partition():
-            yield packer.next_partition()
 
     def _batches(
         self, file_infos: "Iterable[FileInfo]"

--- a/python/ray/data/_internal/datasource_v2/listing/footer_file_indexer.py
+++ b/python/ray/data/_internal/datasource_v2/listing/footer_file_indexer.py
@@ -1,0 +1,274 @@
+from __future__ import annotations
+
+import logging
+from collections import deque
+from typing import TYPE_CHECKING, Deque, Iterable, Iterator, List, Optional, Tuple
+
+import ray
+from ray._common.utils import env_integer
+from ray.data._internal.datasource_v2.listing.file_indexer import (
+    NonSamplingFileIndexer,
+)
+from ray.data._internal.datasource_v2.listing.file_manifest import FileManifest
+from ray.data._internal.datasource_v2.listing.footer_reader import FooterReaderActor
+from ray.data._internal.datasource_v2.partitioners.online_bin_packer import (
+    OnlineBinPacker,
+)
+from ray.data._internal.util import MiB
+
+if TYPE_CHECKING:
+    from pyarrow.fs import FileSystem
+
+    from ray.actor import ActorProxy
+    from ray.data._internal.datasource_v2.listing.file_indexer import FileInfo
+    from ray.data._internal.datasource_v2.listing.file_pruners import FilePruner
+    from ray.data._internal.datasource_v2.listing.footer_reader import FooterReader
+    from ray.data.block import BlockColumn
+    from ray.data.expressions import Expr
+
+logger = logging.getLogger(__name__)
+
+# A pool of footer-reading actors spread across the cluster, provisioned once
+# per ``list_files`` call. Footer reads are network-bound, so several actors each
+# driving many concurrent reads keeps IO from bottlenecking on a single node.
+_DEFAULT_NUM_ACTORS = env_integer("RAY_DATA_PARQUET_FOOTER_NUM_ACTORS", 32)
+_DEFAULT_IO_CONCURRENCY = env_integer("RAY_DATA_PARQUET_FOOTER_IO_CONCURRENCY", 128)
+# Files per ``read_footers`` call. Small footers -> batch several per task to
+# amortize the per-task and per-result object-store overhead.
+_DEFAULT_BATCH_SIZE = env_integer("RAY_DATA_PARQUET_FOOTER_BATCH_SIZE", 10)
+# ``FileChunks`` per streamed result. The driver pays one object-store fetch per
+# yielded list, so a large directory costs one fetch per file at ``1``. Raising
+# it trades a little latency-to-first-chunk for far fewer driver-side fetches.
+_DEFAULT_RESULT_BATCH_SIZE = env_integer("RAY_DATA_PARQUET_FOOTER_RESULT_BATCH_SIZE", 1)
+# Max in-flight footer batches. ``0`` -> auto (``num_actors * 2``). A smaller
+# window reads fewer footers before an early ``limit`` stop cancels the pool, at
+# the cost of less pipelining on full reads.
+_DEFAULT_MAX_INFLIGHT_BATCHES = env_integer(
+    "RAY_DATA_PARQUET_FOOTER_MAX_INFLIGHT_BATCHES", 0
+)
+# Bin budget: uncompressed bytes of row-group data per read task. NOTE this is
+# the sole input to read-task sizing on this path -- unlike the size-estimating
+# partitioner it replaces, it does not consult
+# ``DataContext.target_max_block_size``. Deriving it from that instead is worth
+# doing before this path becomes the default.
+_DEFAULT_BIN_PACKING_BYTES = env_integer(
+    "RAY_DATA_PARQUET_BIN_PACKING_BYTES", 128 * MiB
+)
+# Shared (mixed-colour) bins the packer keeps open at once. A wider pool packs
+# tighter; a narrower one seals bins sooner, and since each sealed bin becomes a
+# read task, that's what lets reads start before every footer has landed.
+_DEFAULT_MAX_SHARED_OPEN_BINS = env_integer(
+    "RAY_DATA_PARQUET_BIN_PACKING_MAX_SHARED_OPEN_BINS", 16
+)
+
+
+class FooterFileIndexer(NonSamplingFileIndexer):
+    """Lists files, then footer-reads + bin-packs their row groups into manifests.
+
+    Inherits directory traversal and ``list_file_infos`` from
+    :class:`NonSamplingFileIndexer`; overrides :meth:`list_files` to emit
+    bin-packed read units instead of per-file chunks.
+    """
+
+    def __init__(
+        self,
+        *,
+        ignore_missing_paths: bool,
+        num_workers: Optional[int] = None,
+        max_paths_per_output: Optional[int] = None,
+        coalesce_bytes: int = 0,
+        split_coalesced: bool = False,
+        io_concurrency: Optional[int] = None,
+        footer_batch_size: Optional[int] = None,
+        result_batch_size: Optional[int] = None,
+        max_inflight_batches: Optional[int] = None,
+        max_shared_open_bins: Optional[int] = None,
+    ):
+        super().__init__(
+            ignore_missing_paths=ignore_missing_paths,
+            num_workers=num_workers,
+            max_paths_per_output=max_paths_per_output,
+        )
+        self._coalesce_bytes = coalesce_bytes
+        self._split_coalesced = split_coalesced
+        # Every knob is re-read here rather than taken from the module-level
+        # constant, so ``monkeypatch.setenv`` and release-test env overrides work
+        # after this module has already been imported. An explicit ctor argument
+        # still wins over the environment.
+        self._num_actors = env_integer(
+            "RAY_DATA_PARQUET_FOOTER_NUM_ACTORS", _DEFAULT_NUM_ACTORS
+        )
+        self._io_concurrency = (
+            io_concurrency
+            if io_concurrency is not None
+            else env_integer(
+                "RAY_DATA_PARQUET_FOOTER_IO_CONCURRENCY", _DEFAULT_IO_CONCURRENCY
+            )
+        )
+        self._footer_batch_size = (
+            footer_batch_size
+            if footer_batch_size is not None
+            else env_integer("RAY_DATA_PARQUET_FOOTER_BATCH_SIZE", _DEFAULT_BATCH_SIZE)
+        )
+        self._result_batch_size = (
+            result_batch_size
+            if result_batch_size is not None
+            else env_integer(
+                "RAY_DATA_PARQUET_FOOTER_RESULT_BATCH_SIZE",
+                _DEFAULT_RESULT_BATCH_SIZE,
+            )
+        )
+        # In-flight footer-batch window; 0/None -> auto (``num_actors * 2``).
+        _inflight = (
+            max_inflight_batches
+            if max_inflight_batches is not None
+            else env_integer(
+                "RAY_DATA_PARQUET_FOOTER_MAX_INFLIGHT_BATCHES",
+                _DEFAULT_MAX_INFLIGHT_BATCHES,
+            )
+        )
+        self._max_inflight_batches = _inflight if _inflight else self._num_actors * 2
+        self._max_shared_open_bins = (
+            max_shared_open_bins
+            if max_shared_open_bins is not None
+            else env_integer(
+                "RAY_DATA_PARQUET_BIN_PACKING_MAX_SHARED_OPEN_BINS",
+                _DEFAULT_MAX_SHARED_OPEN_BINS,
+            )
+        )
+        self._max_bin_bytes = env_integer(
+            "RAY_DATA_PARQUET_BIN_PACKING_BYTES", _DEFAULT_BIN_PACKING_BYTES
+        )
+
+    @property
+    def produces_partitioned_manifests(self) -> bool:
+        # list_files already emits bin-packed read units, so ListFiles skips the
+        # partitioner and lists in a single task (global packing + one pool).
+        return True
+
+    def list_files(
+        self,
+        paths: "BlockColumn",
+        *,
+        filesystem: "FileSystem",
+        pruners: Optional[List["FilePruner"]] = None,
+        preserve_order: bool = False,
+        predicate: Optional["Expr"] = None,
+        limit: Optional[int] = None,
+        projected_columns: Optional[List[str]] = None,
+    ) -> Iterable[FileManifest]:
+        max_bin_bytes = self._max_bin_bytes
+        file_infos = self.list_file_infos(
+            paths,
+            filesystem=filesystem,
+            pruners=pruners,
+            preserve_order=preserve_order,
+        )
+        actors: List[ActorProxy[FooterReader]] = [
+            FooterReaderActor.options(scheduling_strategy="SPREAD").remote(
+                filesystem,
+                self._io_concurrency,
+                predicate,
+                projected_columns,
+                self._coalesce_bytes,
+            )
+            for _ in range(self._num_actors)
+        ]
+        logger.debug(
+            "Provisioned %d FooterReader actors (io_concurrency=%d)",
+            self._num_actors,
+            self._io_concurrency,
+        )
+        try:
+            yield from self._read_and_pack(actors, file_infos, max_bin_bytes, limit)
+        finally:
+            for actor in actors:
+                # ``ActorProxy`` is ``ActorHandle | type[T]``; kill wants a handle.
+                # pyrefly: ignore[bad-argument-type]
+                ray.kill(actor)
+
+    def _read_and_pack(
+        self,
+        actors: List["ActorProxy[FooterReader]"],
+        file_infos: "Iterable[FileInfo]",
+        max_bin_bytes: int,
+        limit: Optional[int],
+    ) -> Iterator[FileManifest]:
+        packer = OnlineBinPacker(
+            max_bin_bytes,
+            max_shared_open_bins=self._max_shared_open_bins,
+            split_coalesced=self._split_coalesced,
+        )
+        # Bound the number of in-flight footer batches so listing stays roughly
+        # demand-driven (matters under a limit) and memory stays flat.
+        window = max(1, self._max_inflight_batches)
+        batches = self._batches(file_infos)
+        # FIFO of in-flight streaming generators, one per dispatched footer batch.
+        pending: Deque[ray.ObjectRefGenerator] = deque()
+        batch_no = 0
+        delivered_fully_matched_rows = 0
+
+        def dispatch_next() -> bool:
+            nonlocal batch_no
+            batch = next(batches, None)
+            if batch is None:
+                return False
+            actor: ActorProxy[FooterReader] = actors[batch_no % len(actors)]
+            # Streaming ``@ray.method``; stub types ``.remote`` as ``ObjectRef``
+            # and don't preserve the method's keyword args.
+            # pyrefly: ignore[bad-assignment]
+            gen: ray.ObjectRefGenerator = actor.read_footers.remote(
+                batch,
+                result_batch_size=self._result_batch_size,  # pyrefly: ignore[unexpected-keyword]
+            )
+            pending.append(gen)
+            batch_no += 1
+            return True
+
+        # Prime the window.
+        for _ in range(window):
+            if not dispatch_next():
+                break
+
+        while pending:
+            gen = pending.popleft()
+            for ref in gen:  # blocks until this generator's next result lands
+                for file_chunks in ray.get(ref):
+                    packer.add_file_chunks(file_chunks)
+                    if limit is not None:
+                        # Count only fully-matched (exact-survivor) rows so
+                        # stopping can never under-deliver under a filter.
+                        delivered_fully_matched_rows += sum(
+                            rg.num_rows
+                            for rg in file_chunks.row_groups
+                            if rg.fully_matched
+                        )
+                while packer.has_partition():
+                    yield packer.next_partition()
+                if limit is not None and delivered_fully_matched_rows >= limit:
+                    # Flush open bins so a small limit yields promptly; abandon
+                    # in-flight generators (the actor teardown cancels them).
+                    packer.finalize()
+                    while packer.has_partition():
+                        yield packer.next_partition()
+                    return
+            # This generator drained; keep the window full.
+            dispatch_next()
+
+        packer.finalize()
+        while packer.has_partition():
+            yield packer.next_partition()
+
+    def _batches(
+        self, file_infos: "Iterable[FileInfo]"
+    ) -> Iterator[List[Tuple[str, int]]]:
+        batch: List[Tuple[str, int]] = []
+        for file_info in file_infos:
+            if file_info.size is None:
+                continue
+            batch.append((file_info.path, file_info.size))
+            if len(batch) >= self._footer_batch_size:
+                yield batch
+                batch = []
+        if batch:
+            yield batch

--- a/python/ray/data/_internal/datasource_v2/listing/listing_utils.py
+++ b/python/ray/data/_internal/datasource_v2/listing/listing_utils.py
@@ -14,7 +14,6 @@ from ray.data._internal.datasource_v2.listing.file_pruners import (
 from ray.data._internal.datasource_v2.partitioners.file_partitioner import (
     FilePartitioner,
 )
-from ray.data._internal.delegating_block_builder import DelegatingBlockBuilder
 from ray.data._internal.execution.interfaces.task_context import TaskContext
 from ray.data.block import Block
 
@@ -66,6 +65,8 @@ def list_files_for_each_block(
     predicate: Optional["Expr"] = None,
     limit: Optional[int] = None,
     projected_columns: Optional[List[str]] = None,
+    shuffle_config: Optional["FileShuffleConfig"] = None,
+    execution_idx: int = 0,
 ) -> Iterable[Block]:
     """Expand path blocks into ``FileManifest`` blocks.
 
@@ -80,6 +81,11 @@ def list_files_for_each_block(
     to the indexer; metadata-aware indexers (e.g. the footer-based Parquet
     indexer) use them to skip row groups, stop early, and size projected
     columns, while the plain indexer ignores them.
+
+    ``shuffle_config`` is also forwarded: the indexer shuffles listed files
+    after path discovery and before metadata fetch. Listing still runs as a
+    single task when shuffle is requested so the indexer sees the full file
+    set.
     """
     pruners = _build_pruners(file_extensions, partition_filter)
     for block in blocks:
@@ -91,38 +97,11 @@ def list_files_for_each_block(
             predicate=predicate,
             limit=limit,
             projected_columns=projected_columns,
+            shuffle_config=shuffle_config,
+            execution_idx=execution_idx,
         ):
             if len(manifest) > 0:
                 yield manifest.as_block()
-
-
-def shuffle_files(
-    blocks: Iterable[Block],
-    _: TaskContext,
-    *,
-    shuffle_config: "FileShuffleConfig",
-    execution_idx: int,
-) -> Iterable[Block]:
-    """Concatenate manifest blocks and shuffle rows with the seeded RNG.
-
-    Runs in a single task (`plan_list_files_op` sets `should_parallelize=False`
-    when shuffle is requested) so we have the full manifest before
-    shuffling. Emits one merged manifest block. Determinism comes from
-    ``FileManifest.shuffle`` which sorts by path before applying the
-    permutation — this protects against non-deterministic upstream
-    indexer yield order.
-    """
-    builder = DelegatingBlockBuilder()
-    for block in blocks:
-        if len(block) > 0:
-            builder.add_block(block)
-
-    combined = builder.build()
-    if len(combined) == 0:
-        return
-
-    seed = shuffle_config.get_seed(execution_idx)
-    yield FileManifest(combined).shuffle(seed).as_block()
 
 
 def sample_files(

--- a/python/ray/data/_internal/datasource_v2/parquet_datasource_v2.py
+++ b/python/ray/data/_internal/datasource_v2/parquet_datasource_v2.py
@@ -180,9 +180,9 @@ class ParquetDatasourceV2(DataSourceV2[FileManifest]):
 
     def _get_file_indexer(self) -> FileIndexer:
         # Opt-in footer-based indexing: reads each file's footer on a
-        # ``FooterReader`` actor pool and packs row groups with the online bin
-        # packer, so read units are row-group-accurate rather than size-estimated
-        # (and predicate / limit / projection push-down reach listing). Off by
+        # ``FooterReader`` actor pool so listing rows carry per-row-group stats
+        # (and predicate / limit / projection push-down reach listing). Grouping
+        # those rows into read units is ``get_file_partitioner``'s job. Off by
         # default while it is validated against release benchmarks; the flag and
         # the blind chunker below both go away once it is the only path.
         if env_bool("RAY_DATA_PARQUET_ENABLE_FOOTER_INDEXER", False):
@@ -192,10 +192,8 @@ class ParquetDatasourceV2(DataSourceV2[FileManifest]):
 
             return FooterFileIndexer(
                 ignore_missing_paths=self._ignore_missing_paths,
+                skip_paths=self._skip_paths,
                 coalesce_bytes=env_integer("RAY_DATA_PARQUET_FOOTER_COALESCE_BYTES", 0),
-                split_coalesced=env_bool(
-                    "RAY_DATA_PARQUET_FOOTER_SPLIT_COALESCED", False
-                ),
             )
 
         return NonSamplingFileIndexer(
@@ -203,6 +201,26 @@ class ParquetDatasourceV2(DataSourceV2[FileManifest]):
             skip_paths=self._skip_paths,
             file_chunker=self._file_chunker,
         )
+
+    def get_file_partitioner(self, **kwargs):
+        # With the footer indexer on, listing rows carry per-row-group stats, so
+        # bin-pack them into read units instead of size-estimating whole files.
+        if env_bool("RAY_DATA_PARQUET_ENABLE_FOOTER_INDEXER", False):
+            from ray.data._internal.datasource_v2.partitioners.online_bin_packer import (  # noqa: E501
+                OnlineBinPacker,
+            )
+            from ray.data._internal.util import MiB
+
+            return OnlineBinPacker(
+                env_integer("RAY_DATA_PARQUET_BIN_PACKING_BYTES", 128 * MiB),
+                max_shared_open_bins=env_integer(
+                    "RAY_DATA_PARQUET_BIN_PACKING_MAX_SHARED_OPEN_BINS", 16
+                ),
+                split_coalesced=env_bool(
+                    "RAY_DATA_PARQUET_FOOTER_SPLIT_COALESCED", False
+                ),
+            )
+        return super().get_file_partitioner(**kwargs)
 
     def get_size_estimator(self) -> ParquetInMemorySizeEstimator:
         return ParquetInMemorySizeEstimator()

--- a/python/ray/data/_internal/datasource_v2/parquet_datasource_v2.py
+++ b/python/ray/data/_internal/datasource_v2/parquet_datasource_v2.py
@@ -9,6 +9,7 @@ Constructed from `read_api.read_parquet` when
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, List, Literal, Optional, Union
 
@@ -55,6 +56,8 @@ if TYPE_CHECKING:
     from pyarrow.fs import FileSystem
 
     from ray.data.datasource.file_based_datasource import FileShuffleConfig
+
+logger = logging.getLogger(__name__)
 
 
 @DeveloperAPI
@@ -211,14 +214,22 @@ class ParquetDatasourceV2(DataSourceV2[FileManifest]):
             )
             from ray.data._internal.util import MiB
 
+            max_bin_bytes = env_integer("RAY_DATA_PARQUET_BIN_PACKING_BYTES", 128 * MiB)
+            max_shared_open_bins = env_integer(
+                "RAY_DATA_PARQUET_BIN_PACKING_MAX_SHARED_OPEN_BINS", 16
+            )
+            split_coalesced = env_bool("RAY_DATA_PARQUET_FOOTER_SPLIT_COALESCED", False)
+            logger.debug(
+                "OnlineBinPacker(max_bin_bytes=%d, max_shared_open_bins=%d, "
+                "split_coalesced=%s)",
+                max_bin_bytes,
+                max_shared_open_bins,
+                split_coalesced,
+            )
             return OnlineBinPacker(
-                env_integer("RAY_DATA_PARQUET_BIN_PACKING_BYTES", 128 * MiB),
-                max_shared_open_bins=env_integer(
-                    "RAY_DATA_PARQUET_BIN_PACKING_MAX_SHARED_OPEN_BINS", 16
-                ),
-                split_coalesced=env_bool(
-                    "RAY_DATA_PARQUET_FOOTER_SPLIT_COALESCED", False
-                ),
+                max_bin_bytes=max_bin_bytes,
+                max_shared_open_bins=max_shared_open_bins,
+                split_coalesced=split_coalesced,
             )
         return super().get_file_partitioner(**kwargs)
 

--- a/python/ray/data/_internal/datasource_v2/parquet_datasource_v2.py
+++ b/python/ray/data/_internal/datasource_v2/parquet_datasource_v2.py
@@ -15,6 +15,7 @@ from typing import TYPE_CHECKING, Any, List, Literal, Optional, Union
 import pyarrow as pa
 from typing_extensions import override
 
+from ray._common.utils import env_bool, env_integer
 from ray.data._internal.datasource.parquet_datasource import (
     ParquetDatasource,
     check_for_legacy_tensor_type,
@@ -178,6 +179,25 @@ class ParquetDatasourceV2(DataSourceV2[FileManifest]):
         return self._shuffle
 
     def _get_file_indexer(self) -> FileIndexer:
+        # Opt-in footer-based indexing: reads each file's footer on a
+        # ``FooterReader`` actor pool and packs row groups with the online bin
+        # packer, so read units are row-group-accurate rather than size-estimated
+        # (and predicate / limit / projection push-down reach listing). Off by
+        # default while it is validated against release benchmarks; the flag and
+        # the blind chunker below both go away once it is the only path.
+        if env_bool("RAY_DATA_PARQUET_ENABLE_FOOTER_INDEXER", False):
+            from ray.data._internal.datasource_v2.listing.footer_file_indexer import (
+                FooterFileIndexer,
+            )
+
+            return FooterFileIndexer(
+                ignore_missing_paths=self._ignore_missing_paths,
+                coalesce_bytes=env_integer("RAY_DATA_PARQUET_FOOTER_COALESCE_BYTES", 0),
+                split_coalesced=env_bool(
+                    "RAY_DATA_PARQUET_FOOTER_SPLIT_COALESCED", False
+                ),
+            )
+
         return NonSamplingFileIndexer(
             ignore_missing_paths=self._ignore_missing_paths,
             skip_paths=self._skip_paths,

--- a/python/ray/data/_internal/datasource_v2/partitioners/file_partitioner.py
+++ b/python/ray/data/_internal/datasource_v2/partitioners/file_partitioner.py
@@ -1,5 +1,4 @@
 from abc import ABC, abstractmethod
-from typing import ClassVar
 
 from ray.data._internal.datasource_v2.listing.file_manifest import FileManifest
 
@@ -14,12 +13,16 @@ class FilePartitioner(ABC):
     retries.
     """
 
-    #: Whether every input row must reach a single instance. ``False`` (default)
-    #: means each listing task may partition its own shard independently, so
-    #: listing can be parallelized. An implementation that packs globally --
-    #: keeping one pool of open partitions across all files -- sets ``True``,
-    #: and ``plan_list_files_op`` then runs listing as a single task.
-    requires_global_input: ClassVar[bool] = False
+    @property
+    def requires_global_input(self) -> bool:
+        """Whether every input row must reach a single instance.
+
+        ``False`` (the default) means each listing task may partition its own shard
+        independently, so listing can be parallelized. An implementation that packs
+        globally -- keeping one pool of open partitions across all files -- returns
+        ``True``, and ``plan_list_files_op`` then runs listing as a single task.
+        """
+        return False
 
     @abstractmethod
     def add_input(self, input_manifest: FileManifest):

--- a/python/ray/data/_internal/datasource_v2/partitioners/file_partitioner.py
+++ b/python/ray/data/_internal/datasource_v2/partitioners/file_partitioner.py
@@ -1,4 +1,5 @@
 from abc import ABC, abstractmethod
+from typing import ClassVar
 
 from ray.data._internal.datasource_v2.listing.file_manifest import FileManifest
 
@@ -12,6 +13,13 @@ class FilePartitioner(ABC):
     Implementations must be deterministic to ensure consistent partitioning across
     retries.
     """
+
+    #: Whether every input row must reach a single instance. ``False`` (default)
+    #: means each listing task may partition its own shard independently, so
+    #: listing can be parallelized. An implementation that packs globally --
+    #: keeping one pool of open partitions across all files -- sets ``True``,
+    #: and ``plan_list_files_op`` then runs listing as a single task.
+    requires_global_input: ClassVar[bool] = False
 
     @abstractmethod
     def add_input(self, input_manifest: FileManifest):

--- a/python/ray/data/_internal/datasource_v2/partitioners/online_bin_packer.py
+++ b/python/ray/data/_internal/datasource_v2/partitioners/online_bin_packer.py
@@ -14,9 +14,11 @@ from ray.data._internal.datasource_v2.chunkers.file_chunker import (
 from ray.data._internal.datasource_v2.chunkers.parquet_footer_types import (
     Bin,
     BinItem,
-    FileChunks,
 )
 from ray.data._internal.datasource_v2.listing.file_manifest import FileManifest
+from ray.data._internal.datasource_v2.partitioners.file_partitioner import (
+    FilePartitioner,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -237,14 +239,57 @@ class _SingleFileBinPool(_BinPool):
         self._path = None
 
 
-class OnlineBinPacker:
-    """Streaming per-file bin packer over row-group chunks.
+def _bin_items(manifest: FileManifest) -> List[BinItem]:
+    """Read a listing manifest as bin items, one per row.
 
-    Feed ``FileChunks`` via :meth:`add_file_chunks`; drain sealed bins (as
-    :class:`FileManifest` blocks) via :meth:`has_partition` / :meth:`next_partition`
-    as they become available; call :meth:`finalize` once all chunks are added to
-    flush the still-open bins.
+    A row carrying :class:`ParquetRowGroupChunkMetadata` becomes a row-group run
+    with exact stats. A row with no chunk metadata -- the plain whole-file
+    listing path -- becomes a single indivisible unit sized by the file itself,
+    which is what lets this partitioner sit behind any indexer rather than only
+    a footer-reading one.
     """
+    items: List[BinItem] = []
+    for path, file_size, md in zip(
+        manifest.paths, manifest.file_sizes, manifest.file_chunk_metadatas
+    ):
+        if md is None or "row_group_ids" not in md:
+            items.append(
+                BinItem(
+                    path=str(path),
+                    rg_idx=0,
+                    uncompressed_size=int(file_size),
+                    num_rows=0,
+                )
+            )
+            continue
+        ids = md["row_group_ids"]
+        items.append(
+            BinItem(
+                path=str(path),
+                rg_idx=ids[0],
+                uncompressed_size=md["uncompressed_size"],
+                num_rows=md["num_rows"],
+                fully_matched=md["fully_matched"],
+                rg_count=len(ids),
+                rg_sizes=tuple(md["rg_sizes"]),
+                rg_rows=tuple(md["rg_rows"]),
+            )
+        )
+    return items
+
+
+class OnlineBinPacker(FilePartitioner):
+    """Streaming coloured bin packer over listing rows.
+
+    Feed manifests via :meth:`add_input`; drain sealed bins via
+    :meth:`has_partition` / :meth:`next_partition` as they become available;
+    call :meth:`finalize` once all input is added to flush the still-open bins.
+
+    Packs globally -- one pool of open bins keyed by file -- so it needs every
+    listing row, hence ``requires_global_input``.
+    """
+
+    requires_global_input = True
 
     def __init__(
         self,
@@ -271,21 +316,9 @@ class OnlineBinPacker:
 
     # === Feeding ===
 
-    def add_file_chunks(self, file_chunks: FileChunks) -> None:
-        path = file_chunks.path
-        for row_group in file_chunks.row_groups:
-            self._place(
-                BinItem(
-                    path=path,
-                    rg_idx=row_group.rg_idx,
-                    uncompressed_size=row_group.uncompressed_size,
-                    num_rows=row_group.num_rows,
-                    fully_matched=row_group.fully_matched,
-                    rg_count=row_group.rg_count,
-                    rg_sizes=row_group.rg_sizes,
-                    rg_rows=row_group.rg_rows,
-                )
-            )
+    def add_input(self, input_manifest: FileManifest) -> None:
+        for item in _bin_items(input_manifest):
+            self._place(item)
 
     def _units(self, item: BinItem) -> List[int]:
         # The row-group boundaries an item may be cut between, as unit sizes. A
@@ -366,12 +399,16 @@ class OnlineBinPacker:
         ids_by_path: defaultdict = defaultdict(list)
         rows_by_path: defaultdict = defaultdict(int)
         size_by_path: defaultdict = defaultdict(int)
+        matched_by_path: dict = {}
         for item in bin_.items:
             ids_by_path[item.path].extend(
                 range(item.rg_idx, item.rg_idx + item.rg_count)
             )
             rows_by_path[item.path] += item.num_rows
             size_by_path[item.path] += item.uncompressed_size
+            matched_by_path[item.path] = (
+                matched_by_path.get(item.path, True) and item.fully_matched
+            )
 
         paths: List[str] = []
         sizes: List[int] = []
@@ -385,6 +422,9 @@ class OnlineBinPacker:
                     row_group_ids=tuple(sorted(ids)),
                     num_rows=rows_by_path[path],
                     uncompressed_size=size_by_path[path],
+                    fully_matched=matched_by_path[path],
+                    rg_sizes=(),
+                    rg_rows=(),
                 )
             )
         # TypedDict invariance: ``ParquetRowGroupChunkMetadata`` has extra keys

--- a/python/ray/data/_internal/datasource_v2/partitioners/online_bin_packer.py
+++ b/python/ray/data/_internal/datasource_v2/partitioners/online_bin_packer.py
@@ -289,8 +289,6 @@ class OnlineBinPacker(FilePartitioner):
     listing row, hence ``requires_global_input``.
     """
 
-    requires_global_input = True
-
     def __init__(
         self,
         max_bin_bytes: int,
@@ -313,6 +311,10 @@ class OnlineBinPacker(FilePartitioner):
             self._cap, self._output, max_shared_open_bins
         )  # non-isolated bins (mixed files)
         self._heavy = _SingleFileBinPool(self._cap, self._output)
+
+    @property
+    def requires_global_input(self) -> bool:
+        return True
 
     # === Feeding ===
 
@@ -431,5 +433,7 @@ class OnlineBinPacker(FilePartitioner):
         # beyond the empty ``ChunkMetadata`` base, so the concrete list is not
         # assignable to ``List[Optional[ChunkMetadata]]`` without a cast.
         return FileManifest.construct_manifest(
-            paths, sizes, cast(List[Optional[ChunkMetadata]], chunk_metadatas)
+            paths=paths,
+            sizes=sizes,
+            chunk_metadatas=cast(List[Optional[ChunkMetadata]], chunk_metadatas),
         )

--- a/python/ray/data/_internal/datasource_v2/partitioners/round_robin_partitioner.py
+++ b/python/ray/data/_internal/datasource_v2/partitioners/round_robin_partitioner.py
@@ -80,9 +80,9 @@ class RoundRobinPartitioner(FilePartitioner):
         partition = self._partitioner.next_partition()
         paths, file_sizes, file_chunk_metadatas = zip(*partition)
         return FileManifest.construct_manifest(
-            list(paths),
-            list(file_sizes),
-            list(file_chunk_metadatas),
+            paths=list(paths),
+            sizes=list(file_sizes),
+            chunk_metadatas=list(file_chunk_metadatas),
         )
 
     def finalize(self):

--- a/python/ray/data/_internal/datasource_v2/readers/file_reader.py
+++ b/python/ray/data/_internal/datasource_v2/readers/file_reader.py
@@ -247,7 +247,7 @@ class FileReader(Reader[FileManifest]):
             "filter": (
                 self._predicate.to_pyarrow() if self._predicate is not None else None
             ),
-            "batch_size": self._resolve_batch_size(dataset),
+            "batch_size": self._resolve_batch_size(dataset, input_split),
             "batch_readahead": _ARROW_SCANNER_BATCH_READAHEAD,
         }
         scanner_kwargs.update(self._arrow_scanner_kwargs())
@@ -326,10 +326,11 @@ class FileReader(Reader[FileManifest]):
             rows_read += len(table)
             yield table
 
-    def _resolve_batch_size(self, dataset: pds.Dataset) -> int:
+    def _resolve_batch_size(self, dataset: pds.Dataset, manifest: FileManifest) -> int:
         """Return the batch size to use for scanning.
 
-        Subclasses can override this to implement adaptive batch sizing.
+        Subclasses can override this to implement adaptive batch sizing, using
+        the ``manifest`` (e.g. footer-derived per-chunk stats) to avoid re-I/O.
         """
         return self._batch_size
 

--- a/python/ray/data/_internal/datasource_v2/readers/in_memory_size_estimator.py
+++ b/python/ray/data/_internal/datasource_v2/readers/in_memory_size_estimator.py
@@ -88,9 +88,9 @@ class SamplingInMemorySizeEstimator(InMemorySizeEstimator):
         # Use ``None`` chunk metadata: the size estimator reads the file whole
         # to estimate the encoding ratio; chunk-level splitting is irrelevant here.
         manifest = FileManifest.construct_manifest(
-            [path],
-            [file_size],
-            [None],
+            paths=[path],
+            sizes=[file_size],
+            chunk_metadatas=[None],
         )
         batches = self._reader.read(manifest)
 

--- a/python/ray/data/_internal/datasource_v2/readers/parquet_file_reader.py
+++ b/python/ray/data/_internal/datasource_v2/readers/parquet_file_reader.py
@@ -18,6 +18,7 @@ from ray.data._internal.datasource.parquet_datasource import (
 )
 from ray.data._internal.datasource_v2.chunkers.parquet_file_chunking_utils import (
     _fragments_from_chunk_metadata,
+    _fragments_from_row_group_ids,
 )
 from ray.data._internal.datasource_v2.listing.file_manifest import FileManifest
 from ray.data._internal.datasource_v2.listing.footer_reader import _leaf_matches
@@ -136,6 +137,32 @@ def _estimate_batch_size_from_metadata(
     return target_batch_size
 
 
+def _estimate_batch_size_from_chunk_stats(
+    uncompressed_size: int,
+    num_rows: int,
+    target_block_size: int,
+) -> Optional[int]:
+    """Estimate batch size from footer-derived chunk stats, without any I/O.
+
+    ``ListFiles`` already read each file's footer and recorded the
+    projection-scoped uncompressed byte size and row count of the row groups it
+    assigned to this chunk (:class:`ParquetRowGroupChunkMetadata`). Sizing from
+    those avoids the extra footer read that
+    :func:`_estimate_batch_size_from_metadata` incurs. Mirrors that function's
+    math but over the whole chunk (its row-group average) rather than the first
+    row group; the estimate is refined from real data after the first batch.
+    """
+    if num_rows <= 0 or uncompressed_size <= 0:
+        return None
+    estimated_in_mem_row_size = (
+        uncompressed_size * PARQUET_ENCODING_RATIO_ESTIMATE_DEFAULT / num_rows
+    )
+    if estimated_in_mem_row_size == 0:
+        return None
+    # Never request more rows than the chunk actually contains.
+    return min(math.ceil(target_block_size / estimated_in_mem_row_size), num_rows)
+
+
 @DeveloperAPI
 class ParquetFileReader(FileReader, SupportsMetadata):
     """Parquet-specific file reader with adaptive batch sizing.
@@ -224,7 +251,7 @@ class ParquetFileReader(FileReader, SupportsMetadata):
         return pds.ParquetFileFormat(**self._parquet_format_kwargs)
 
     @override
-    def _resolve_batch_size(self, dataset: pds.Dataset) -> int:
+    def _resolve_batch_size(self, dataset: pds.Dataset, manifest: FileManifest) -> int:
         """Determine batch size from explicit setting, metadata, or default.
 
         Priority: explicit batch_size > sampled estimate > metadata estimate > default.
@@ -233,6 +260,12 @@ class ParquetFileReader(FileReader, SupportsMetadata):
         through to the metadata estimate and seed ``_sampled_batch_size`` with
         the result.  ``_on_batch_read`` later refines it from actual data, and
         subsequent ``read()`` calls on the same instance use the refined value.
+
+        The metadata estimate prefers the footer-derived stats ``ListFiles``
+        already recorded on the manifest (:class:`ParquetRowGroupChunkMetadata`),
+        so the common footer-chunking path sizes batches without re-reading the
+        footer. It falls back to reading the first fragment's metadata only when
+        the manifest carries no such stats (e.g. the whole-file path).
         """
         if self._explicit_batch_size is not None:
             return self._explicit_batch_size
@@ -242,21 +275,40 @@ class ParquetFileReader(FileReader, SupportsMetadata):
 
         batch_size = _ARROW_DEFAULT_BATCH_SIZE
         if self._target_block_size is not None:
-            first_fragment = next(dataset.get_fragments(), None)
-            if first_fragment is not None:
-                estimated = _estimate_batch_size_from_metadata(
-                    first_fragment, self._columns, self._target_block_size
+            estimated = self._estimate_batch_size(dataset, manifest)
+            if estimated is not None:
+                logger.debug(
+                    "Estimated Parquet batch size: %d rows (target_block_size=%d)",
+                    estimated,
+                    self._target_block_size,
                 )
-                if estimated is not None:
-                    logger.debug(
-                        "Estimated Parquet batch size: %d rows (target_block_size=%d)",
-                        estimated,
-                        self._target_block_size,
-                    )
-                    batch_size = estimated
+                batch_size = estimated
 
         self._sampled_batch_size = batch_size
         return batch_size
+
+    def _estimate_batch_size(
+        self, dataset: pds.Dataset, manifest: FileManifest
+    ) -> Optional[int]:
+        assert self._target_block_size is not None
+        # Prefer footer stats already on the manifest; fall back to a footer read.
+        chunk = next(
+            (md for md in manifest.file_chunk_metadatas if md is not None), None
+        )
+        if chunk is not None and "uncompressed_size" in chunk:
+            estimated = _estimate_batch_size_from_chunk_stats(
+                chunk["uncompressed_size"],
+                chunk["num_rows"],
+                self._target_block_size,
+            )
+            if estimated is not None:
+                return estimated
+        first_fragment = next(dataset.get_fragments(), None)
+        if first_fragment is None:
+            return None
+        return _estimate_batch_size_from_metadata(
+            first_fragment, self._columns, self._target_block_size
+        )
 
     @override
     def _on_batch_read(self, table: pa.Table) -> None:
@@ -272,39 +324,47 @@ class ParquetFileReader(FileReader, SupportsMetadata):
         dataset: pds.Dataset,
         manifest: FileManifest,
     ) -> List[Tuple[pds.Fragment, int]]:
-        """Fan file fragments into chunk-level sub-fragments per manifest row.
+        """Fan file fragments into read-level sub-fragments per manifest row.
 
         For each manifest row, looks up the file's fragment by path and:
 
         - If ``chunk_metadata`` is ``None`` (whole-file case), the file
-          fragment is yielded as-is with a row offset of 0. This matches
-          ``ParquetFileChunker``'s behavior for files at or below
-          ``target_chunk_size`` and the default ``WholeFileChunker`` for
-          non-chunking callers.
-        - Otherwise the row carries a :class:`ParquetFileChunkMetadata`;
+          fragment is yielded as-is with a row offset of 0 (the default
+          ``WholeFileChunker`` for non-chunking callers).
+        - Otherwise the row carries a :class:`ParquetRowGroupChunkMetadata`
+          naming the exact physical row groups the bin assigned to this file
+          (predicate pruning + bin packing already happened in ``ListFiles``);
           we slice the fragment via
-          :func:`~ray.data._internal.datasource_v2.chunkers.parquet_file_chunking_utils._fragments_from_chunk_metadata`
-          which returns one sub-fragment per row group in the chunk's
-          row-group range, paired with the cumulative pre-filter row
-          offset of that row group within the file. The downstream
-          ``_compute_row_hashes`` call uses this offset so row hashes
-          remain unique across sub-fragments that share ``fragment.path``.
+          :func:`~ray.data._internal.datasource_v2.chunkers.parquet_file_chunking_utils._fragments_from_row_group_ids`.
+          When ``include_row_hash`` is on it fans out one sub-fragment per row
+          group, each paired with its cumulative pre-filter row offset, so the
+          downstream ``_compute_row_hashes`` call keeps hashes unique across
+          sub-fragments that share ``fragment.path``.
 
         Paths are deduped by :meth:`FileReader.read` before the dataset is
         built, so the dataset has exactly one fragment per file. The
         per-row chunk metadata drives the fan-out here, not the dataset
         itself — multiple manifest rows can share a single path with
-        different chunk indices.
+        different row-group sets.
         """
         path_to_fragment = {
             fragment.path: fragment for fragment in dataset.get_fragments()
         }
         fragments: List[Tuple[pds.Fragment, int]] = []
         for path, chunk_metadata in zip(manifest.paths, manifest.file_chunk_metadatas):
-            fragment = path_to_fragment[path]
+            fragment: pds.ParquetFileFragment = path_to_fragment[path]
             if chunk_metadata is None:
                 fragments.append((fragment, 0))
+            elif "row_group_ids" in chunk_metadata:
+                fragments.extend(
+                    _fragments_from_row_group_ids(
+                        fragment,
+                        chunk_metadata["row_group_ids"],
+                        per_row_group_offsets=self._include_row_hash,
+                    )
+                )
             else:
+                # Size-based ``ParquetFileChunkMetadata`` from the blind chunker.
                 fragments.extend(
                     _fragments_from_chunk_metadata(fragment, chunk_metadata)
                 )

--- a/python/ray/data/_internal/datasource_v2/scanners/file_scanner.py
+++ b/python/ray/data/_internal/datasource_v2/scanners/file_scanner.py
@@ -16,9 +16,10 @@ class FileScanner(Scanner[FileManifest]):
     """Base scanner for file-based datasources.
 
     Subclasses implement format-specific ``read_schema()`` and
-    ``create_reader()``. Shuffling and parallel bucketing are handled
-    upstream in the ``ListFiles`` transform chain (``shuffle_files`` +
-    ``RoundRobinPartitioner`` via ``plan_list_files_op``), not here.
+    ``create_reader()``. File shuffling is handled by the ``FileIndexer``
+    after path discovery and before metadata fetch; parallel bucketing is
+    handled upstream in the ``ListFiles`` transform chain
+    (``RoundRobinPartitioner`` via ``plan_list_files_op``), not here.
 
     PyArrow Dataset-based scanners should subclass ``ArrowFileScanner``;
     use ``FileScanner`` directly for non-Arrow file formats.

--- a/python/ray/data/_internal/datasource_v2/tests/test_footer_chunking.py
+++ b/python/ray/data/_internal/datasource_v2/tests/test_footer_chunking.py
@@ -1,0 +1,146 @@
+"""End-to-end reads through the footer-based Parquet chunking path.
+
+Drives ``FooterFileIndexer`` via ``ray.data.read_parquet`` with the opt-in flag
+on, covering predicate / limit / projection push-down. The pure-logic pieces
+(coalescing, bin packing) are unit-tested in
+``python/ray/data/tests/unit/datasource_v2/test_online_bin_packer.py``.
+"""
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# End-to-end through ray.data.read_parquet (footer path)
+# ---------------------------------------------------------------------------
+
+_N_PER_FILE = 400
+_N_FILES = 3
+
+
+@pytest.fixture
+def footer_parquet(tmp_path, monkeypatch):
+    """Write a small multi-row-group Parquet dataset; enable the footer path."""
+    import pyarrow as pa
+    import pyarrow.parquet as pq
+
+    from ray.data.context import DataContext
+
+    monkeypatch.setenv("RAY_DATA_PARQUET_ENABLE_FOOTER_INDEXER", "1")
+    monkeypatch.setenv("RAY_DATA_PARQUET_FOOTER_NUM_ACTORS", "2")
+    monkeypatch.setenv("RAY_DATA_PARQUET_FOOTER_BATCH_SIZE", "2")
+
+    ctx = DataContext.get_current()
+    prev_v2 = ctx.use_datasource_v2
+    ctx.use_datasource_v2 = True
+
+    for f in range(_N_FILES):
+        start = f * _N_PER_FILE
+        table = pa.table(
+            {
+                "id": list(range(start, start + _N_PER_FILE)),
+                "val": [f"v{i}" for i in range(_N_PER_FILE)],
+            }
+        )
+        pq.write_table(table, str(tmp_path / f"part_{f}.parquet"), row_group_size=100)
+
+    try:
+        yield str(tmp_path)
+    finally:
+        ctx.use_datasource_v2 = prev_v2
+
+
+def test_e2e_footer_read_matches_expected(footer_parquet):
+    import ray
+
+    total = _N_PER_FILE * _N_FILES
+    ds = ray.data.read_parquet(footer_parquet)
+    assert ds.count() == total
+    assert sorted(r["id"] for r in ds.take_all()) == list(range(total))
+
+
+@pytest.mark.parametrize(
+    "op, expected",
+    [
+        pytest.param(lambda ds: ds.filter(expr="id < 50").count(), 50, id="filter"),
+        pytest.param(lambda ds: ds.limit(10).count(), 10, id="limit"),
+        pytest.param(
+            lambda ds: ds.select_columns(["id"]).schema().names,
+            ["id"],
+            id="projection",
+        ),
+    ],
+)
+def test_e2e_footer_pushdowns(footer_parquet, op, expected):
+    import ray
+
+    assert op(ray.data.read_parquet(footer_parquet)) == expected
+
+
+# Filter and limit push down together: the limit stops listing early once the
+# ``num_rows`` of *fully matched* row groups reaches it, so that classification
+# has to be exact. Nulls are the interesting case -- Parquet min/max statistics
+# are computed over non-null values only, so a group whose non-null values all
+# satisfy the filter looks fully matched by bounds alone while its null rows do
+# not survive. Deliberately lopsided at 10 survivors per 100 rows: the stop is
+# evaluated per file, so a fixture with a small shortfall can pass by luck when
+# the last file's overshoot covers the deficit.
+_NULL_FILES = 20
+_NULL_ROWS_PER_FILE = 100
+_NULL_TOTAL_SURVIVORS = _NULL_FILES * 10
+
+
+@pytest.fixture
+def nullable_parquet(tmp_path, monkeypatch):
+    """Multi-file, multi-row-group data whose filtered column holds nulls."""
+    import pyarrow as pa
+    import pyarrow.parquet as pq
+
+    from ray.data.context import DataContext
+
+    monkeypatch.setenv("RAY_DATA_PARQUET_ENABLE_FOOTER_INDEXER", "1")
+    monkeypatch.setenv("RAY_DATA_PARQUET_FOOTER_NUM_ACTORS", "2")
+    monkeypatch.setenv("RAY_DATA_PARQUET_FOOTER_BATCH_SIZE", "2")
+
+    ctx = DataContext.get_current()
+    prev_v2 = ctx.use_datasource_v2
+    ctx.use_datasource_v2 = True
+
+    for f in range(_NULL_FILES):
+        ids = [
+            3 + f * 1000 + i if i % 10 == 0 else None
+            for i in range(_NULL_ROWS_PER_FILE)
+        ]
+        pq.write_table(
+            pa.table({"id": pa.array(ids, pa.int64())}),
+            str(tmp_path / f"part_{f}.parquet"),
+            row_group_size=25,
+        )
+
+    try:
+        yield str(tmp_path)
+    finally:
+        ctx.use_datasource_v2 = prev_v2
+
+
+@pytest.mark.parametrize(
+    "limit", [1, 10, 100, _NULL_TOTAL_SURVIVORS, 10 * _NULL_TOTAL_SURVIVORS]
+)
+def test_e2e_filter_then_limit_with_nulls(nullable_parquet, limit):
+    """``filter(...).limit(n)`` delivers ``n`` rows whenever ``n`` survivors exist.
+
+    If nulls were ever counted as survivors, listing would stop short and
+    ``Limit`` would return fewer rows than asked for, with no error.
+    """
+    import ray
+    from ray.data.expressions import col
+
+    ds = ray.data.read_parquet(nullable_parquet)
+    rows = ds.filter(expr=col("id") > 2).limit(limit).take_all()
+
+    assert len(rows) == min(limit, _NULL_TOTAL_SURVIVORS)
+    assert all(r["id"] is not None and r["id"] > 2 for r in rows)
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main(["-v", __file__]))

--- a/python/ray/data/_internal/datasource_v2/tests/test_parquet_datasource_v2.py
+++ b/python/ray/data/_internal/datasource_v2/tests/test_parquet_datasource_v2.py
@@ -440,6 +440,45 @@ def test_datasource_uses_footer_indexer_when_flag_is_set(tmp_path, monkeypatch):
     assert isinstance(datasource._get_file_indexer(), FooterFileIndexer)
 
 
+def test_footer_indexer_skip_paths_excludes_listed_file(tmp_path, monkeypatch):
+    """``skip_paths`` must reach ``FooterFileIndexer`` or excluded files are read."""
+    monkeypatch.setenv("RAY_DATA_PARQUET_ENABLE_FOOTER_INDEXER", "1")
+    keep = tmp_path / "keep.parquet"
+    skip = tmp_path / "skip.parquet"
+    _write_parquet(str(keep), pa.table({"a": [1]}))
+    _write_parquet(str(skip), pa.table({"a": [2]}))
+
+    datasource = ParquetDatasourceV2([str(keep), str(skip)], skip_paths=[str(skip)])
+    indexer = datasource._get_file_indexer()
+    assert isinstance(indexer, FooterFileIndexer)
+
+    infos = list(
+        indexer.list_file_infos(
+            pa.array(datasource.paths), filesystem=datasource.filesystem
+        )
+    )
+    assert [info.path for info in infos] == [datasource.paths[0]]
+
+
+def test_footer_indexer_skip_paths_ignores_missing_named_path(tmp_path, monkeypatch):
+    """A skip-only missing path must not fail listing on the footer indexer."""
+    monkeypatch.setenv("RAY_DATA_PARQUET_ENABLE_FOOTER_INDEXER", "1")
+    keep = tmp_path / "keep.parquet"
+    missing = str(tmp_path / "gone.parquet")
+    _write_parquet(str(keep), pa.table({"a": [1]}))
+
+    datasource = ParquetDatasourceV2([str(keep), missing], skip_paths=[missing])
+    indexer = datasource._get_file_indexer()
+    assert isinstance(indexer, FooterFileIndexer)
+
+    infos = list(
+        indexer.list_file_infos(
+            pa.array(datasource.paths), filesystem=datasource.filesystem
+        )
+    )
+    assert [info.path for info in infos] == [datasource.paths[0]]
+
+
 def _write_multi_row_group_parquet(path, num_rows: int, row_group_size: int):
     table = pa.table({"id": list(range(num_rows))})
     pq.write_table(table, path, row_group_size=row_group_size)
@@ -459,6 +498,9 @@ def _row_group_manifest(path, row_group_ids, num_rows):
                 # Nominal projected uncompressed size (8-byte int64 ids); only
                 # used for footer-free batch sizing, not row selection.
                 uncompressed_size=num_rows * 8,
+                fully_matched=True,
+                rg_sizes=(),
+                rg_rows=(),
             )
         ],
     )

--- a/python/ray/data/_internal/datasource_v2/tests/test_parquet_datasource_v2.py
+++ b/python/ray/data/_internal/datasource_v2/tests/test_parquet_datasource_v2.py
@@ -54,7 +54,9 @@ def _write_parquet(path: str, table: pa.Table) -> None:
 
 def _manifest_of(paths):
     sizes = [os.path.getsize(p) for p in paths]
-    return FileManifest.construct_manifest(paths, sizes, [None] * len(paths))
+    return FileManifest.construct_manifest(
+        paths=paths, sizes=sizes, chunk_metadatas=[None] * len(paths)
+    )
 
 
 def test_infer_schema_unpartitioned(tmp_path):
@@ -99,7 +101,7 @@ def test_infer_schema_with_include_paths(tmp_path):
 
 def test_infer_schema_returns_empty_schema_on_empty_manifest(tmp_path):
     datasource = ParquetDatasourceV2([str(tmp_path)])
-    empty = FileManifest.construct_manifest([], [], [])
+    empty = FileManifest.construct_manifest(paths=[], sizes=[], chunk_metadatas=[])
     schema = datasource.infer_schema(empty)
     assert schema.names == []
 
@@ -353,7 +355,9 @@ def test_parquet_file_reader_reads_chunked_manifest(tmp_path):
     file_size = os.path.getsize(file_path)
 
     reader_whole = ParquetFileReader()
-    whole_manifest = FileManifest.construct_manifest([file_path], [file_size], [None])
+    whole_manifest = FileManifest.construct_manifest(
+        paths=[file_path], sizes=[file_size], chunk_metadatas=[None]
+    )
     whole_tables = _read_via_reader(reader_whole, whole_manifest)
     whole_rows = pa.concat_tables(whole_tables).column("id").to_pylist()
 
@@ -365,7 +369,7 @@ def test_parquet_file_reader_reads_chunked_manifest(tmp_path):
     chunk_metadatas = [md for md, _ in chunks]
     chunk_sizes = [sz for _, sz in chunks]
     chunked_manifest = FileManifest.construct_manifest(
-        paths, chunk_sizes, chunk_metadatas
+        paths=paths, sizes=chunk_sizes, chunk_metadatas=chunk_metadatas
     )
 
     reader_chunked = ParquetFileReader()
@@ -397,7 +401,7 @@ def test_parquet_file_reader_chunked_row_hashes_are_unique(tmp_path):
     chunk_metadatas = [md for md, _ in chunks]
     chunk_sizes = [sz for _, sz in chunks]
     chunked_manifest = FileManifest.construct_manifest(
-        paths, chunk_sizes, chunk_metadatas
+        paths=paths, sizes=chunk_sizes, chunk_metadatas=chunk_metadatas
     )
 
     reader = ParquetFileReader(include_row_hash=True)
@@ -424,7 +428,9 @@ def test_parquet_file_reader_handles_out_of_range_chunks(tmp_path):
     paths = [file_path] * (len(chunks) - 1)
     out_of_range_metadatas = [md for md, _ in chunks[1:]]
     sizes = [sz for _, sz in chunks[1:]]
-    manifest = FileManifest.construct_manifest(paths, sizes, out_of_range_metadatas)
+    manifest = FileManifest.construct_manifest(
+        paths=paths, sizes=sizes, chunk_metadatas=out_of_range_metadatas
+    )
 
     reader = ParquetFileReader()
     tables = list(reader.read(manifest))
@@ -619,9 +625,9 @@ def _write_multi_row_group_parquet(path, num_rows: int, row_group_size: int):
 def _row_group_manifest(path, row_group_ids, num_rows):
     """A one-row footer-path manifest selecting explicit row groups of a file."""
     return FileManifest.construct_manifest(
-        [path],
-        [0],
-        [
+        paths=[path],
+        sizes=[0],
+        chunk_metadatas=[
             create_chunk_metadata(
                 ParquetRowGroupChunkMetadata,
                 row_group_ids=tuple(row_group_ids),

--- a/python/ray/data/_internal/datasource_v2/tests/test_parquet_datasource_v2.py
+++ b/python/ray/data/_internal/datasource_v2/tests/test_parquet_datasource_v2.py
@@ -22,6 +22,10 @@ from ray.data._internal.datasource_v2.chunkers.parquet_file_chunking_utils impor
     _calculate_row_group_range,
     _fragments_from_chunk_metadata,
 )
+from ray.data._internal.datasource_v2.chunkers.parquet_footer_types import (
+    FileChunks,
+    RowGroupInfo,
+)
 from ray.data._internal.datasource_v2.listing.file_indexer import (
     NonSamplingFileIndexer,
 )
@@ -477,6 +481,133 @@ def test_footer_indexer_skip_paths_ignores_missing_named_path(tmp_path, monkeypa
         )
     )
     assert [info.path for info in infos] == [datasource.paths[0]]
+
+
+class _RecordingFooterActor:
+    """Stands in for a ``FooterReaderActor`` handle, recording call kwargs.
+
+    Lets the wiring be asserted without spinning up Ray: ``read_footers.remote``
+    returns the batch's chunks inline, shaped like the streaming generator the
+    driver expects (an iterable of refs, each resolving to a list of
+    ``FileChunks``).
+    """
+
+    def __init__(self, calls):
+        self._calls = calls
+        self.read_footers = self
+
+    def remote(self, batch, *, result_batch_size, preserve_order):
+        self._calls.append(preserve_order)
+        # Mimic the real ``read_footers``: honoring the flag yields in ``batch``
+        # order, otherwise in completion order -- stubbed as reversed, standing in
+        # for any IO-timing permutation.
+        ordered = batch if preserve_order else list(reversed(batch))
+        return [
+            [
+                FileChunks(
+                    path=path,
+                    size=size,
+                    row_groups=(
+                        RowGroupInfo(rg_idx=0, uncompressed_size=size, num_rows=1),
+                    ),
+                )
+            ]
+            for path, size in ordered
+        ]
+
+
+@pytest.fixture
+def recorded_preserve_order_flags(monkeypatch):
+    """Yield the ``preserve_order`` flags ``read_footers`` was invoked with."""
+    import ray
+    from ray.data._internal.datasource_v2.listing import footer_file_indexer
+
+    calls = []
+
+    class _FakeActorClass:
+        @staticmethod
+        def options(**_kwargs):
+            class _Builder:
+                @staticmethod
+                def remote(*_args):
+                    return _RecordingFooterActor(calls)
+
+            return _Builder
+
+    monkeypatch.setattr(footer_file_indexer, "FooterReaderActor", _FakeActorClass)
+    # The driver resolves refs and tears the pool down; neither needs a real Ray.
+    monkeypatch.setattr(ray, "get", lambda ref: ref)
+    monkeypatch.setattr(ray, "kill", lambda _actor: None)
+    return calls
+
+
+@pytest.mark.parametrize("preserve_order", [True, False])
+def test_footer_indexer_forwards_preserve_order_to_footer_reads(
+    tmp_path, monkeypatch, recorded_preserve_order_flags, preserve_order
+):
+    """``preserve_order`` must reach ``read_footers``, not just path discovery.
+
+    ``read_footers`` yields in completion order by default, so a dropped flag
+    leaves manifest order -- and therefore bin packing and downstream read-task
+    order -- dependent on footer IO timing.
+    """
+    monkeypatch.setenv("RAY_DATA_PARQUET_ENABLE_FOOTER_INDEXER", "1")
+    monkeypatch.setenv("RAY_DATA_PARQUET_FOOTER_NUM_ACTORS", "2")
+    # More files than one footer batch holds, so several dispatches are recorded.
+    monkeypatch.setenv("RAY_DATA_PARQUET_FOOTER_BATCH_SIZE", "2")
+    paths = []
+    for i in range(5):
+        path = tmp_path / f"f{i}.parquet"
+        _write_parquet(str(path), pa.table({"a": [i]}))
+        paths.append(str(path))
+
+    datasource = ParquetDatasourceV2(paths)
+    indexer = datasource._get_file_indexer()
+    assert isinstance(indexer, FooterFileIndexer)
+
+    manifests = list(
+        indexer.list_files(
+            pa.array(datasource.paths),
+            filesystem=datasource.filesystem,
+            preserve_order=preserve_order,
+        )
+    )
+
+    assert manifests, "expected the footer path to emit manifests"
+    # 5 files at a batch size of 2 -> 3 dispatched batches.
+    assert recorded_preserve_order_flags == [preserve_order] * 3
+
+
+def test_footer_indexer_preserves_listing_order_across_batches(
+    tmp_path, monkeypatch, recorded_preserve_order_flags
+):
+    """Order must hold across footer batches, not only within one.
+
+    ``read_footers`` orders a single batch; the driver's FIFO drain of dispatched
+    batches is what makes the overall manifest order the listing order.
+    """
+    monkeypatch.setenv("RAY_DATA_PARQUET_ENABLE_FOOTER_INDEXER", "1")
+    monkeypatch.setenv("RAY_DATA_PARQUET_FOOTER_NUM_ACTORS", "3")
+    monkeypatch.setenv("RAY_DATA_PARQUET_FOOTER_BATCH_SIZE", "2")
+    paths = []
+    for i in range(6):
+        path = tmp_path / f"f{i}.parquet"
+        _write_parquet(str(path), pa.table({"a": [i]}))
+        paths.append(str(path))
+
+    datasource = ParquetDatasourceV2(paths)
+    indexer = datasource._get_file_indexer()
+
+    manifests = list(
+        indexer.list_files(
+            pa.array(datasource.paths),
+            filesystem=datasource.filesystem,
+            preserve_order=True,
+        )
+    )
+
+    listed = [str(p) for m in manifests for p in m.paths]
+    assert listed == datasource.paths
 
 
 def _write_multi_row_group_parquet(path, num_rows: int, row_group_size: int):

--- a/python/ray/data/_internal/datasource_v2/tests/test_parquet_datasource_v2.py
+++ b/python/ray/data/_internal/datasource_v2/tests/test_parquet_datasource_v2.py
@@ -14,6 +14,7 @@ import pytest
 from ray.data._internal.datasource_v2.chunkers.file_chunker import (
     ParquetFileChunker,
     ParquetFileChunkMetadata,
+    ParquetRowGroupChunkMetadata,
     WholeFileChunker,
     create_chunk_metadata,
 )
@@ -21,7 +22,13 @@ from ray.data._internal.datasource_v2.chunkers.parquet_file_chunking_utils impor
     _calculate_row_group_range,
     _fragments_from_chunk_metadata,
 )
+from ray.data._internal.datasource_v2.listing.file_indexer import (
+    NonSamplingFileIndexer,
+)
 from ray.data._internal.datasource_v2.listing.file_manifest import FileManifest
+from ray.data._internal.datasource_v2.listing.footer_file_indexer import (
+    FooterFileIndexer,
+)
 from ray.data._internal.datasource_v2.parquet_datasource_v2 import (
     ParquetDatasourceV2,
 )
@@ -419,3 +426,73 @@ def test_parquet_file_reader_handles_out_of_range_chunks(tmp_path):
     tables = list(reader.read(manifest))
     # All sub-fragments are out-of-range -> 0 tables emitted.
     assert sum(t.num_rows for t in tables) == 0
+
+
+def test_datasource_uses_footer_indexer_when_flag_is_set(tmp_path, monkeypatch):
+    """The footer-based indexer is opt-in; the blind chunker stays the default."""
+    file_path = tmp_path / "data.parquet"
+    _write_parquet(str(file_path), pa.table({"a": [1, 2, 3]}))
+    datasource = ParquetDatasourceV2([str(file_path)])
+
+    assert isinstance(datasource._get_file_indexer(), NonSamplingFileIndexer)
+
+    monkeypatch.setenv("RAY_DATA_PARQUET_ENABLE_FOOTER_INDEXER", "1")
+    assert isinstance(datasource._get_file_indexer(), FooterFileIndexer)
+
+
+def _write_multi_row_group_parquet(path, num_rows: int, row_group_size: int):
+    table = pa.table({"id": list(range(num_rows))})
+    pq.write_table(table, path, row_group_size=row_group_size)
+    return table
+
+
+def _row_group_manifest(path, row_group_ids, num_rows):
+    """A one-row footer-path manifest selecting explicit row groups of a file."""
+    return FileManifest.construct_manifest(
+        [path],
+        [0],
+        [
+            create_chunk_metadata(
+                ParquetRowGroupChunkMetadata,
+                row_group_ids=tuple(row_group_ids),
+                num_rows=num_rows,
+                # Nominal projected uncompressed size (8-byte int64 ids); only
+                # used for footer-free batch sizing, not row selection.
+                uncompressed_size=num_rows * 8,
+            )
+        ],
+    )
+
+
+def test_parquet_file_reader_reads_selected_row_groups(tmp_path):
+    """The reader reads exactly the row groups named by the footer metadata."""
+    file_path = str(tmp_path / "data.parquet")
+    # 200 rows, 10 row groups of 20 rows each.
+    _write_multi_row_group_parquet(file_path, num_rows=200, row_group_size=20)
+
+    # Select row groups 0, 2, 5 -> rows [0,20) + [40,60) + [100,120).
+    manifest = _row_group_manifest(file_path, row_group_ids=[0, 2, 5], num_rows=60)
+    tables = list(ParquetFileReader().read(manifest))
+    rows = sorted(pa.concat_tables(tables).column("id").to_pylist())
+    expected = list(range(0, 20)) + list(range(40, 60)) + list(range(100, 120))
+    assert rows == sorted(expected)
+
+
+def test_parquet_file_reader_row_group_row_hashes_are_unique(tmp_path):
+    """Row hashes stay unique across per-row-group sub-fragments of one file.
+
+    With ``include_row_hash`` the footer path fans one sub-fragment per row
+    group, each seeded with its cumulative file row offset, so hashes can't
+    collide across row groups that share ``fragment.path``.
+    """
+    file_path = str(tmp_path / "data.parquet")
+    expected_rows = 200
+    _write_multi_row_group_parquet(file_path, num_rows=expected_rows, row_group_size=20)
+
+    manifest = _row_group_manifest(
+        file_path, row_group_ids=range(10), num_rows=expected_rows
+    )
+    reader = ParquetFileReader(include_row_hash=True)
+    hashes = pa.concat_tables(reader.read(manifest)).column("row_hash").to_pylist()
+    assert len(hashes) == expected_rows
+    assert len(set(hashes)) == expected_rows

--- a/python/ray/data/_internal/logical/operators/read_operator.py
+++ b/python/ray/data/_internal/logical/operators/read_operator.py
@@ -428,8 +428,9 @@ class ReadFiles(
 class ListFiles(LogicalOperator, SourceOperator):
     """Logical source op that lists files and yields ``FileManifest`` blocks.
 
-    Extracted from the prior monolithic ``ReadFiles`` so listing, shuffling,
-    and size-balanced bucketing live in one place (see
+    Extracted from the prior monolithic ``ReadFiles`` so listing, file shuffle
+    (applied by the ``FileIndexer`` after path discovery and before metadata
+    fetch), and size-balanced bucketing live in one place (see
     :func:`ray.data._internal.planner.plan_list_files_op.plan_list_files_op`).
     Downstream, ``ReadFiles`` consumes the manifest blocks produced here.
     """

--- a/python/ray/data/_internal/logical/rules/pushdown_count_files.py
+++ b/python/ray/data/_internal/logical/rules/pushdown_count_files.py
@@ -1,10 +1,7 @@
-import copy
 import dataclasses
+import logging
 from typing import TYPE_CHECKING, Optional
 
-from ray.data._internal.datasource_v2.chunkers.file_chunker import (
-    WholeFileChunker,
-)
 from ray.data._internal.datasource_v2.listing.file_indexer import (
     NonSamplingFileIndexer,
 )
@@ -27,6 +24,8 @@ from ray.data._internal.logical.operators.read_operator import ListFiles, ReadFi
 if TYPE_CHECKING:
     import pyarrow as pa
 
+logger = logging.getLogger(__name__)
+
 
 class PushdownCountFiles(Rule):
     """Answer ``Dataset.count()`` from file metadata instead of reading data.
@@ -39,9 +38,15 @@ class PushdownCountFiles(Rule):
         Count(ReadFiles(ListFiles))  ->  MapBatches(count_rows, ListFiles)
 
     ``count_rows`` sums ``read_metadata()`` (e.g. Parquet-footer row counts),
-    so no data columns are read. The upstream ``ListFiles`` is rebuilt to list
-    each file exactly once (``WholeFileChunker``, no partitioner) so footers are
-    read once, in the parallel count pass rather than during listing.
+    so no data columns are read. The upstream ``ListFiles`` is rebuilt with a
+    plain whole-file indexer and no partitioner, so (a) each file appears in
+    exactly one manifest row -- no over-counting -- and (b) listing does no
+    metadata IO of its own: footers are read once, in the parallel count pass.
+
+    Note this *replaces* metadata-aware indexers such as the footer-based
+    Parquet one, rather than reconfiguring them: those override ``list_files``
+    outright, so reconfiguring is a silent no-op and they would footer-sweep
+    every file during listing and pack them into a single read unit.
     """
 
     # Default CPU allocation per task is 1; lower it so at least 2 footer-read
@@ -91,16 +96,27 @@ class PushdownCountFiles(Rule):
         assert isinstance(list_files, ListFiles), list_files
 
         # Rebuild ``ListFiles`` to list each file exactly once: disable
-        # partitioning and use the ``WholeFileChunker`` (otherwise a file could
-        # appear once per chunk, in different batches, and be over-counted).
-        # ``ListFiles`` is frozen, so ``replace`` a copy with a fresh indexer.
-        count_indexer = copy.deepcopy(list_files.file_indexer)
-        assert isinstance(count_indexer, NonSamplingFileIndexer), type(count_indexer)
-        count_indexer._file_chunker = WholeFileChunker()
+        # partitioning and swap in a plain whole-file indexer. Mutating the
+        # existing indexer's chunker isn't enough -- a metadata-aware indexer
+        # (e.g. the footer-based Parquet one) overrides ``list_files`` outright
+        # and ignores its chunker, so it would keep footer-sweeping during
+        # listing and could emit a path once per bin, over-counting it.
+        base_indexer = list_files.file_indexer
+        if not isinstance(base_indexer, NonSamplingFileIndexer):
+            # A third-party indexer may chunk files or do its own metadata IO;
+            # we can't prove one-row-per-file, so leave the plan alone and let
+            # ``count()`` fall back to the regular read path.
+            logger.debug(
+                "Skipping count pushdown: %s is not a NonSamplingFileIndexer",
+                type(base_indexer).__name__,
+            )
+            return plan
+
+        # ``ListFiles`` is frozen, so ``replace`` it with a fresh indexer.
         list_files = dataclasses.replace(
             list_files,
             file_partitioner=None,
-            file_indexer=count_indexer,
+            file_indexer=base_indexer.as_whole_file_indexer(),
         )
 
         # ``reader`` is narrowed to ``SupportsMetadata`` by the guard above, but

--- a/python/ray/data/_internal/planner/plan_list_files_op.py
+++ b/python/ray/data/_internal/planner/plan_list_files_op.py
@@ -70,11 +70,6 @@ def plan_list_files_op(
 
     shuffle_config = op.shuffle_config_factory()
 
-    # Some indexers (e.g. the footer-based Parquet indexer) already emit
-    # bin-packed read units from ``list_files`` -- they need the whole file
-    # stream on one task to pack globally, and there's nothing left to partition.
-    produces_partitioned_manifests = indexer.produces_partitioned_manifests
-
     transform_fns: List[MapTransformFn] = [
         BlockMapTransformFn(
             partial(
@@ -107,7 +102,7 @@ def plan_list_files_op(
             )
         )
 
-    if partitioner is not None and not produces_partitioned_manifests:
+    if partitioner is not None:
         transform_fns.append(
             BlockMapTransformFn(
                 partial(partition_files, partitioner=partitioner),
@@ -123,10 +118,12 @@ def plan_list_files_op(
             op,
             data_context,
             # A single task is required when shuffle needs one global RNG over
-            # the full listing, or when the indexer bin-packs read units itself
-            # (it must see the whole file stream to pack globally).
-            should_parallelize=shuffle_config is None
-            and not produces_partitioned_manifests,
+            # the full listing, or when the partitioner packs globally (it must
+            # see every listing row, not just this shard's).
+            should_parallelize=(
+                shuffle_config is None
+                and not (partitioner is not None and partitioner.requires_global_input)
+            ),
         ),
         data_context,
         name="ListFiles",

--- a/python/ray/data/_internal/planner/plan_list_files_op.py
+++ b/python/ray/data/_internal/planner/plan_list_files_op.py
@@ -1,9 +1,13 @@
 """Physical planner for the V2 ``ListFiles`` source operator.
 
 Emits ``FileManifest`` blocks by (a) sharding user-supplied paths into
-parallel listing tasks, (b) invoking the configured ``FileIndexer``, and
-optionally (c) globally shuffling + size-balanced bucketing before the
-downstream ``ReadFiles`` physical op consumes them.
+parallel listing tasks, (b) invoking the configured ``FileIndexer`` (which
+shuffles listed files after path discovery and before metadata fetch when a
+shuffle config is set), and optionally (c) size-balanced bucketing before
+the downstream ``ReadFiles`` physical op consumes them.
+
+A later FileDiscovery physical step will split path listing from metadata
+fetch; this planner only relocates shuffle into the indexer.
 
 Checkpoint filtering is not attached here — it's wrapped around the
 downstream ``ReadFiles`` physical op by
@@ -26,7 +30,6 @@ from ray.data._internal.datasource_v2.listing.file_manifest import (
 from ray.data._internal.datasource_v2.listing.listing_utils import (
     list_files_for_each_block,
     partition_files,
-    shuffle_files,
 )
 from ray.data._internal.execution.interfaces import (
     BlockEntry,
@@ -84,23 +87,13 @@ def plan_list_files_op(
                 predicate=op.predicate,
                 limit=op.limit,
                 projected_columns=op.projected_columns,
+                shuffle_config=shuffle_config,
+                execution_idx=data_context._execution_idx,
             ),
             # Disable block-shaping: produce manifest blocks as-is.
             disable_block_shaping=True,
         ),
     ]
-
-    if shuffle_config is not None:
-        transform_fns.append(
-            BlockMapTransformFn(
-                partial(
-                    shuffle_files,
-                    shuffle_config=shuffle_config,
-                    execution_idx=data_context._execution_idx,
-                ),
-                disable_block_shaping=True,
-            )
-        )
 
     if partitioner is not None:
         transform_fns.append(
@@ -118,8 +111,9 @@ def plan_list_files_op(
             op,
             data_context,
             # A single task is required when shuffle needs one global RNG over
-            # the full listing, or when the partitioner packs globally (it must
-            # see every listing row, not just this shard's).
+            # the full listing (the indexer shuffles after path discovery), or
+            # when the partitioner packs globally (it must see every listing
+            # row, not just this shard's).
             should_parallelize=(
                 shuffle_config is None
                 and not (partitioner is not None and partitioner.requires_global_input)

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -449,7 +449,8 @@ def _read_datasource_v2(
     Wires a ``ListFiles → ReadFiles`` logical chain:
 
     - :class:`ListFiles` owns listing (via the datasource's ``FileIndexer``),
-      optional global shuffle (``FileShuffleConfig``), and size-balanced
+      optional file shuffle (``FileShuffleConfig``, applied after path
+      discovery and before metadata fetch), and size-balanced
       bucketing (``RoundRobinPartitioner``). Its physical planner
       parallelizes listing across path shards and emits manifest blocks.
     - :class:`ReadFiles` consumes the manifest blocks and reads each bucket

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -464,9 +464,6 @@ def _read_datasource_v2(
         _build_pruners,
         sample_files,
     )
-    from ray.data._internal.datasource_v2.partitioners.round_robin_partitioner import (
-        RoundRobinPartitioner,
-    )
     from ray.data.datasource.file_based_datasource import FileShuffleConfig
 
     ctx = DataContext.get_current()
@@ -543,17 +540,14 @@ def _read_datasource_v2(
     # (``-1`` when unset). Honoring it here per-read avoids mutating the
     # process-global ``DataContext.read_op_min_num_blocks``.
     num_buckets = parallelism if parallelism != -1 else ctx.read_op_min_num_blocks
-    # An indexer that already emits bin-packed read units (e.g. the footer-based
-    # Parquet indexer) doesn't use the size-estimate ``RoundRobinPartitioner``.
-    partitioner = (
-        None
-        if indexer.produces_partitioned_manifests
-        else RoundRobinPartitioner(
-            in_memory_size_estimator=datasource.get_size_estimator(),
-            min_bucket_size=min_bucket_size,
-            max_bucket_size=max_bucket_size,
-            num_buckets=num_buckets,
-        )
+    # The datasource chooses how listing rows are grouped into read units. The
+    # default is the size-estimate ``RoundRobinPartitioner``; a datasource whose
+    # listing carries richer metadata can supply a partitioner that uses it.
+    partitioner = datasource.get_file_partitioner(
+        in_memory_size_estimator=datasource.get_size_estimator(),
+        min_bucket_size=min_bucket_size,
+        max_bucket_size=max_bucket_size,
+        num_buckets=num_buckets,
     )
 
     # NOTE: We're using shuffle config factory to fix the seed at the planning

--- a/python/ray/data/tests/datasource/test_read_parquet_v2.py
+++ b/python/ray/data/tests/datasource/test_read_parquet_v2.py
@@ -11,6 +11,9 @@ import pyarrow.parquet as pq
 import pytest
 
 import ray
+from ray.data._internal.datasource_v2.listing.footer_file_indexer import (
+    FooterFileIndexer,
+)
 from ray.data._internal.datasource_v2.partitioners.round_robin_partitioner import (
     RoundRobinPartitioner,
 )
@@ -314,17 +317,17 @@ def test_read_parquet_v1_empty_skip_paths_is_noop(tmp_path, restore_ctx):
     assert _rows(ds) == [1, 2]
 
 
-def test_read_parquet_v2_uses_footer_indexer_without_partitioner(
+def test_read_parquet_v2_uses_footer_indexer_with_bin_packer(
     tmp_path, restore_ctx, monkeypatch
 ):
-    """With the footer indexer on, ``ListFiles`` carries no partitioner.
+    """With the footer indexer on, ``ListFiles`` pairs it with the bin packer.
 
-    The indexer bin-packs read units itself, so ``override_num_blocks`` no
-    longer drives a partitioner bucket count for Parquet. The global
+    The packer sizes read units from footer stats, so ``override_num_blocks``
+    no longer drives a partitioner bucket count for Parquet. The global
     ``DataContext`` must still not be mutated.
     """
-    from ray.data._internal.datasource_v2.listing.footer_file_indexer import (
-        FooterFileIndexer,
+    from ray.data._internal.datasource_v2.partitioners.online_bin_packer import (
+        OnlineBinPacker,
     )
 
     _write(tmp_path / "data.parquet", pa.table({"a": [1, 2, 3]}))
@@ -337,8 +340,149 @@ def test_read_parquet_v2_uses_footer_indexer_without_partitioner(
     list_files_op = ds._logical_plan.dag.input_dependencies[0]
     assert isinstance(list_files_op, ListFiles)
     assert isinstance(list_files_op.file_indexer, FooterFileIndexer)
-    assert list_files_op.file_partitioner is None
+    # The packer *is* the partitioner now: listing discovers row groups, the
+    # partitioner groups them into read units.
+    assert isinstance(list_files_op.file_partitioner, OnlineBinPacker)
     assert restore_ctx.read_op_min_num_blocks == original
+
+
+def _write_row_groups(path, *, num_files, rows_per_file, row_group_size):
+    """Write ``num_files`` parquet files, each split into several row groups."""
+    for i in range(num_files):
+        pq.write_table(
+            pa.table({"a": list(range(rows_per_file))}),
+            str(path / f"f{i}.parquet"),
+            row_group_size=row_group_size,
+        )
+
+
+def _optimized_count_plan(ds):
+    """The plan ``Dataset.count()`` executes, without executing it.
+
+    ``Dataset.count()`` builds this internally and never exposes it, so tests
+    reconstruct it to assert on the optimizer's output.
+    """
+    from ray.data._internal.logical.interfaces import LogicalPlan
+    from ray.data._internal.logical.operators.count_operator import Count
+    from ray.data._internal.logical.operators.map_operator import Project
+    from ray.data._internal.logical.optimizers import LogicalOptimizer
+
+    count_op = Count(
+        input_dependencies=[
+            Project(exprs=[], input_dependencies=[ds._logical_plan.dag])
+        ]
+    )
+    return LogicalOptimizer().optimize(LogicalPlan(count_op, ds.context))
+
+
+def _walk(op):
+    yield op
+    for child in op.input_dependencies:
+        yield from _walk(child)
+
+
+def test_count_pushdown_replaces_footer_indexer(tmp_path, restore_ctx, monkeypatch):
+    """``count()`` must not run the footer indexer.
+
+    ``FooterFileIndexer`` subclasses ``NonSamplingFileIndexer`` but overrides
+    ``list_files``, so it footer-sweeps every file during listing -- the exact
+    IO this rule exists to defer into the parallel count pass -- and emits one
+    manifest row per row-group run, which would count each file once per run.
+    """
+    from ray.data._internal.datasource_v2.chunkers.file_chunker import WholeFileChunker
+    from ray.data._internal.datasource_v2.listing.file_indexer import (
+        NonSamplingFileIndexer,
+    )
+    from ray.data._internal.logical.operators.map_operator import MapBatches
+
+    monkeypatch.setenv("RAY_DATA_PARQUET_ENABLE_FOOTER_INDEXER", "1")
+    _write(tmp_path / "data.parquet", pa.table({"a": [1, 2, 3]}))
+
+    restore_ctx.use_datasource_v2 = True
+    ds = ray.data.read_parquet(str(tmp_path))
+    list_files_before = ds._logical_plan.dag.input_dependencies[0]
+    assert isinstance(list_files_before, ListFiles)
+    assert isinstance(list_files_before.file_indexer, FooterFileIndexer)
+
+    dag = _optimized_count_plan(ds).dag
+
+    assert isinstance(dag, MapBatches)
+    assert not any(isinstance(op, ReadFiles) for op in _walk(dag))
+
+    (list_files_op,) = [op for op in _walk(dag) if isinstance(op, ListFiles)]
+    # Exact type: an ``isinstance`` check is precisely what let the footer
+    # indexer through before.
+    assert type(list_files_op.file_indexer) is NonSamplingFileIndexer
+    assert isinstance(list_files_op.file_indexer.file_chunker, WholeFileChunker)
+    assert list_files_op.file_partitioner is None
+
+
+@pytest.mark.parametrize(
+    "read_kwargs", [{}, {"include_paths": True}], ids=["plain", "include_paths"]
+)
+def test_count_pushdown_preserves_list_files_fields(
+    tmp_path, restore_ctx, read_kwargs, monkeypatch
+):
+    monkeypatch.setenv("RAY_DATA_PARQUET_ENABLE_FOOTER_INDEXER", "1")
+    _write(tmp_path / "data.parquet", pa.table({"a": [1, 2, 3]}))
+
+    restore_ctx.use_datasource_v2 = True
+    ds = ray.data.read_parquet(str(tmp_path), **read_kwargs)
+    original = ds._logical_plan.dag.input_dependencies[0]
+    assert isinstance(original, ListFiles)
+
+    (rebuilt,) = [
+        op for op in _walk(_optimized_count_plan(ds).dag) if isinstance(op, ListFiles)
+    ]
+
+    assert rebuilt.paths == original.paths
+    assert rebuilt.source_paths == original.source_paths
+    assert rebuilt.file_extensions == original.file_extensions
+    assert rebuilt.partition_filter is original.partition_filter
+
+
+@pytest.mark.parametrize("case", ["predicate", "limit"])
+def test_count_pushdown_declines_row_reducing_reads(
+    tmp_path, restore_ctx, case, monkeypatch
+):
+    """A row-reducing pushdown makes footer ``num_rows`` an overcount."""
+    from ray.data.expressions import col
+
+    monkeypatch.setenv("RAY_DATA_PARQUET_ENABLE_FOOTER_INDEXER", "1")
+    _write(tmp_path / "data.parquet", pa.table({"a": [1, 2, 3, 4]}))
+
+    restore_ctx.use_datasource_v2 = True
+    ds = ray.data.read_parquet(str(tmp_path))
+    ds = ds.filter(expr=col("a") > 2) if case == "predicate" else ds.limit(2)
+
+    assert any(isinstance(op, ReadFiles) for op in _walk(_optimized_count_plan(ds).dag))
+
+
+@pytest.mark.parametrize(
+    "num_files,rows_per_file,row_group_size",
+    [(1, 10, None), (3, 100, 10), (4, 1000, 250)],
+    ids=["single_file", "multi_file_many_row_groups", "multi_file_large"],
+)
+def test_count_matches_rows(
+    tmp_path, restore_ctx, num_files, rows_per_file, row_group_size, monkeypatch
+):
+    """End-to-end count correctness, including multi-row-group files.
+
+    Regression guard for over-counting: the footer indexer emits one manifest
+    row per row-group run, so a multi-row-group file would otherwise be counted
+    once per run.
+    """
+    monkeypatch.setenv("RAY_DATA_PARQUET_ENABLE_FOOTER_INDEXER", "1")
+    _write_row_groups(
+        tmp_path,
+        num_files=num_files,
+        rows_per_file=rows_per_file,
+        row_group_size=row_group_size,
+    )
+
+    restore_ctx.use_datasource_v2 = True
+
+    assert ray.data.read_parquet(str(tmp_path)).count() == num_files * rows_per_file
 
 
 if __name__ == "__main__":

--- a/python/ray/data/tests/datasource/test_read_parquet_v2.py
+++ b/python/ray/data/tests/datasource/test_read_parquet_v2.py
@@ -485,6 +485,37 @@ def test_count_matches_rows(
     assert ray.data.read_parquet(str(tmp_path)).count() == num_files * rows_per_file
 
 
+def test_count_pushdown_honors_skip_paths(tmp_path, restore_ctx, monkeypatch):
+    """The rebuilt indexer must keep ``skip_paths``, or the skipped file's rows
+    are counted even though reading the dataset excludes them."""
+    monkeypatch.setenv("RAY_DATA_PARQUET_ENABLE_FOOTER_INDEXER", "1")
+    a = tmp_path / "a.parquet"
+    b = tmp_path / "b.parquet"
+    _write(a, pa.table({"a": [1, 2]}))
+    _write(b, pa.table({"a": [3, 4, 5]}))
+
+    restore_ctx.use_datasource_v2 = True
+    ds = ray.data.read_parquet([str(a), str(b)], skip_paths=[str(b)])
+
+    assert ds.count() == 2
+
+
+def test_count_pushdown_skip_paths_tolerates_missing_path(
+    tmp_path, restore_ctx, monkeypatch
+):
+    """``skip_paths`` drops a named path before the existence check, so a
+    skipped-but-missing path must not fail a pushed-down ``count()``."""
+    monkeypatch.setenv("RAY_DATA_PARQUET_ENABLE_FOOTER_INDEXER", "1")
+    a = tmp_path / "a.parquet"
+    _write(a, pa.table({"a": [1, 2]}))
+    missing = str(tmp_path / "gone.parquet")
+
+    restore_ctx.use_datasource_v2 = True
+    ds = ray.data.read_parquet([str(a), missing], skip_paths=[missing])
+
+    assert ds.count() == 2
+
+
 if __name__ == "__main__":
     import sys
 

--- a/python/ray/data/tests/datasource/test_read_parquet_v2.py
+++ b/python/ray/data/tests/datasource/test_read_parquet_v2.py
@@ -314,6 +314,33 @@ def test_read_parquet_v1_empty_skip_paths_is_noop(tmp_path, restore_ctx):
     assert _rows(ds) == [1, 2]
 
 
+def test_read_parquet_v2_uses_footer_indexer_without_partitioner(
+    tmp_path, restore_ctx, monkeypatch
+):
+    """With the footer indexer on, ``ListFiles`` carries no partitioner.
+
+    The indexer bin-packs read units itself, so ``override_num_blocks`` no
+    longer drives a partitioner bucket count for Parquet. The global
+    ``DataContext`` must still not be mutated.
+    """
+    from ray.data._internal.datasource_v2.listing.footer_file_indexer import (
+        FooterFileIndexer,
+    )
+
+    _write(tmp_path / "data.parquet", pa.table({"a": [1, 2, 3]}))
+    monkeypatch.setenv("RAY_DATA_PARQUET_ENABLE_FOOTER_INDEXER", "1")
+
+    restore_ctx.use_datasource_v2 = True
+    original = restore_ctx.read_op_min_num_blocks
+    ds = ray.data.read_parquet(str(tmp_path), override_num_blocks=7)
+
+    list_files_op = ds._logical_plan.dag.input_dependencies[0]
+    assert isinstance(list_files_op, ListFiles)
+    assert isinstance(list_files_op.file_indexer, FooterFileIndexer)
+    assert list_files_op.file_partitioner is None
+    assert restore_ctx.read_op_min_num_blocks == original
+
+
 if __name__ == "__main__":
     import sys
 

--- a/python/ray/data/tests/unit/datasource_v2/test_file_indexer.py
+++ b/python/ray/data/tests/unit/datasource_v2/test_file_indexer.py
@@ -391,6 +391,67 @@ class TestFileChunkerIntegration:
         assert rows[-1][2]["chunk_byte_end_idx"] == 10_000
 
 
+class TestAsWholeFileIndexer:
+    """``as_whole_file_indexer`` must downgrade to a plain per-file lister.
+
+    ``PushdownCountFiles`` relies on this to count each file exactly once
+    without triggering a metadata-aware subclass's listing strategy.
+    """
+
+    def test_returns_base_type_from_metadata_aware_subclass(self):
+        from ray.data._internal.datasource_v2.listing.footer_file_indexer import (
+            FooterFileIndexer,
+        )
+
+        downgraded = FooterFileIndexer(
+            ignore_missing_paths=False
+        ).as_whole_file_indexer()
+
+        # Exact type, not isinstance: FooterFileIndexer subclasses
+        # NonSamplingFileIndexer but overrides list_files, so an isinstance
+        # check here would not catch a regression.
+        assert type(downgraded) is NonSamplingFileIndexer
+
+    @pytest.mark.parametrize(
+        "ignore_missing_paths,num_workers,max_paths_per_output",
+        [(False, 1, 10), (True, 4, 1000)],
+    )
+    def test_carries_over_traversal_config(
+        self, ignore_missing_paths, num_workers, max_paths_per_output
+    ):
+        source = NonSamplingFileIndexer(
+            ignore_missing_paths=ignore_missing_paths,
+            num_workers=num_workers,
+            max_paths_per_output=max_paths_per_output,
+        )
+
+        downgraded = source.as_whole_file_indexer()
+
+        assert downgraded._ignore_missing_paths == ignore_missing_paths
+        assert downgraded._num_workers == num_workers
+        assert downgraded._max_paths_per_output == max_paths_per_output
+        # Derived in __init__, so rebuilding must recompute it rather than
+        # copying a stale value.
+        assert downgraded._queue_size_per_thread == max_paths_per_output * 4
+
+    def test_always_uses_whole_file_chunker(self):
+        source = NonSamplingFileIndexer(
+            ignore_missing_paths=False, file_chunker=LineDelimitedFileChunker()
+        )
+
+        assert isinstance(source.as_whole_file_indexer().file_chunker, WholeFileChunker)
+
+    def test_source_indexer_is_not_mutated(self):
+        source = NonSamplingFileIndexer(
+            ignore_missing_paths=False, file_chunker=LineDelimitedFileChunker()
+        )
+
+        source.as_whole_file_indexer()
+
+        # Guards against regressing to in-place mutation of the caller's indexer.
+        assert isinstance(source.file_chunker, LineDelimitedFileChunker)
+
+
 if __name__ == "__main__":
     import sys
 

--- a/python/ray/data/tests/unit/datasource_v2/test_file_indexer.py
+++ b/python/ray/data/tests/unit/datasource_v2/test_file_indexer.py
@@ -11,8 +11,10 @@ from ray.data._internal.datasource_v2.chunkers.file_chunker import (
 )
 from ray.data._internal.datasource_v2.listing.file_indexer import (
     NonSamplingFileIndexer,
+    _shuffle_file_infos,
 )
 from ray.data._internal.datasource_v2.listing.file_pruners import FileExtensionPruner
+from ray.data.datasource.file_based_datasource import FileShuffleConfig
 
 
 def _list_all(indexer, paths, **kwargs):
@@ -33,6 +35,18 @@ def _list_all_file_infos(indexer, paths, **kwargs):
         pa.array(paths), filesystem=LocalFileSystem(), **kwargs
     )
     return sorted((fi.path, fi.size) for fi in file_infos)
+
+
+def _list_paths_in_order(indexer, paths, **kwargs):
+    """Run list_files and flatten paths in yield order (not sorted)."""
+    pa_paths = pa.array(paths)
+    fs = LocalFileSystem()
+    manifests = list(indexer.list_files(pa_paths, filesystem=fs, **kwargs))
+    results = []
+    for m in manifests:
+        for p in m.paths:
+            results.append(str(p))
+    return results
 
 
 @pytest.fixture(params=[1, 2], ids=["sequential", "threaded"])
@@ -480,6 +494,115 @@ class TestAsWholeFileIndexer:
         downgraded = source.as_whole_file_indexer()
 
         assert _list_all(downgraded, [str(kept), missing]) == [(str(kept), 10)]
+
+
+class TestFileShuffle:
+    """File shuffle runs after path discovery and before chunking/metadata."""
+
+    def _write_files(self, tmp_path, n=10):
+        paths = []
+        for i in range(n):
+            path = tmp_path / f"f{i:02d}.txt"
+            path.write_bytes(b"x" * (i + 1))
+            paths.append(str(path))
+        return paths
+
+    def test_seeded_shuffle_is_deterministic_and_permutes(self, tmp_path, indexer):
+        paths = self._write_files(tmp_path)
+        shuffle_config = FileShuffleConfig(seed=42, reseed_after_execution=False)
+        listed = list(
+            indexer.list_file_infos(
+                pa.array(paths),
+                filesystem=LocalFileSystem(),
+                preserve_order=True,
+            )
+        )
+        expected_paths = [fi.path for fi in _shuffle_file_infos(listed, seed=42)]
+
+        first = _list_paths_in_order(
+            indexer, paths, shuffle_config=shuffle_config, preserve_order=True
+        )
+        second = _list_paths_in_order(
+            indexer, paths, shuffle_config=shuffle_config, preserve_order=True
+        )
+        unshuffled = _list_paths_in_order(indexer, paths, preserve_order=True)
+
+        assert first == second == expected_paths
+        assert first != unshuffled
+        assert sorted(first) == sorted(unshuffled)
+
+    def test_list_file_infos_is_not_shuffled(self, tmp_path, indexer):
+        paths = self._write_files(tmp_path)
+        shuffle_config = FileShuffleConfig(seed=42, reseed_after_execution=False)
+        shuffled = _list_paths_in_order(
+            indexer, paths, shuffle_config=shuffle_config, preserve_order=True
+        )
+        infos = [
+            fi.path
+            for fi in indexer.list_file_infos(
+                pa.array(paths), filesystem=LocalFileSystem(), preserve_order=True
+            )
+        ]
+        unshuffled = _list_paths_in_order(indexer, paths, preserve_order=True)
+
+        assert infos == unshuffled
+        assert infos != shuffled
+
+    def test_unshuffled_listing_matches_file_info_order(self, tmp_path, indexer):
+        paths = self._write_files(tmp_path)
+        infos = [
+            fi.path
+            for fi in indexer.list_file_infos(
+                pa.array(paths), filesystem=LocalFileSystem(), preserve_order=True
+            )
+        ]
+        assert _list_paths_in_order(indexer, paths, preserve_order=True) == infos
+
+
+class TestFooterIndexerFileShuffle:
+    """Footer indexer shuffles files before footer-read batches."""
+
+    def test_shuffled_file_infos_drive_footer_batches(self, tmp_path):
+        from ray.data._internal.datasource_v2.listing.footer_file_indexer import (
+            FooterFileIndexer,
+        )
+
+        paths = []
+        for i in range(8):
+            path = tmp_path / f"f{i:02d}.parquet"
+            path.write_bytes(b"x")
+            paths.append(str(path))
+
+        indexer = FooterFileIndexer(
+            ignore_missing_paths=False,
+            num_workers=1,
+            footer_batch_size=3,
+        )
+        shuffle_config = FileShuffleConfig(seed=42, reseed_after_execution=False)
+        shuffled = list(
+            indexer._iter_file_infos_for_list(
+                pa.array(paths),
+                filesystem=LocalFileSystem(),
+                preserve_order=True,
+                shuffle_config=shuffle_config,
+            )
+        )
+        unshuffled = list(
+            indexer.list_file_infos(
+                pa.array(paths),
+                filesystem=LocalFileSystem(),
+                preserve_order=True,
+            )
+        )
+        assert [fi.path for fi in shuffled] != [fi.path for fi in unshuffled]
+        assert [fi.path for fi in shuffled] == [
+            fi.path for fi in _shuffle_file_infos(unshuffled, seed=42)
+        ]
+
+        batches = list(indexer._batches(iter(shuffled)))
+        flattened = [p for batch in batches for p, _ in batch]
+        assert flattened == [fi.path for fi in shuffled]
+        assert len(batches) > 1
 
 
 if __name__ == "__main__":

--- a/python/ray/data/tests/unit/datasource_v2/test_file_indexer.py
+++ b/python/ray/data/tests/unit/datasource_v2/test_file_indexer.py
@@ -451,6 +451,36 @@ class TestAsWholeFileIndexer:
         # Guards against regressing to in-place mutation of the caller's indexer.
         assert isinstance(source.file_chunker, LineDelimitedFileChunker)
 
+    def test_carries_over_skip_paths(self, tmp_path):
+        """A dropped ``skip_paths`` would let excluded files back into the
+        listing, inflating a pushed-down ``count()``."""
+        kept = tmp_path / "kept.csv"
+        skipped = tmp_path / "skipped.csv"
+        kept.write_bytes(b"x" * 10)
+        skipped.write_bytes(b"x" * 20)
+        source = NonSamplingFileIndexer(
+            ignore_missing_paths=False, skip_paths={str(skipped)}
+        )
+
+        downgraded = source.as_whole_file_indexer()
+
+        assert downgraded._skip_paths == frozenset({str(skipped)})
+        assert _list_all(downgraded, [str(tmp_path)]) == [(str(kept), 10)]
+
+    def test_carried_skip_paths_still_tolerate_missing_path(self, tmp_path):
+        """``skip_paths`` drops a named path whether or not it exists, so a
+        skip-only missing path must not raise once carried over."""
+        kept = tmp_path / "kept.csv"
+        kept.write_bytes(b"x" * 10)
+        missing = str(tmp_path / "gone.csv")
+        source = NonSamplingFileIndexer(
+            ignore_missing_paths=False, skip_paths={missing}
+        )
+
+        downgraded = source.as_whole_file_indexer()
+
+        assert _list_all(downgraded, [str(kept), missing]) == [(str(kept), 10)]
+
 
 if __name__ == "__main__":
     import sys

--- a/python/ray/data/tests/unit/datasource_v2/test_online_bin_packer.py
+++ b/python/ray/data/tests/unit/datasource_v2/test_online_bin_packer.py
@@ -10,6 +10,9 @@ from ray.data._internal.datasource_v2.chunkers.parquet_row_group_coalescing impo
     coalesce_row_groups,
 )
 from ray.data._internal.datasource_v2.listing.file_manifest import FileManifest
+from ray.data._internal.datasource_v2.listing.footer_file_indexer import (
+    _manifest_of_runs,
+)
 from ray.data._internal.datasource_v2.partitioners.online_bin_packer import (
     OnlineBinPacker,
 )
@@ -106,7 +109,7 @@ def _pack(
     packer = OnlineBinPacker(max_bin_bytes, **kwargs)
     bins = []
     for file_chunks in file_chunks_list:
-        packer.add_file_chunks(file_chunks)
+        packer.add_input(_manifest_of_runs(file_chunks))
         while packer.has_partition():
             bins.append(_manifest_map(packer.next_partition()))
     packer.finalize()
@@ -169,15 +172,17 @@ def test_full_heavy_bin_is_sealed_immediately() -> None:
     # The first two row groups are light and fill a shared bin, which seals
     # immediately. The third makes this colour heavy and exactly fills its
     # dedicated bin, which must also seal for early scheduling.
-    packer.add_file_chunks(
-        FileChunks(
-            path="a",
-            size=200,
-            row_groups=(
-                _rg(idx=0, size=60),
-                _rg(idx=1, size=40),
-                _rg(idx=2, size=100),
-            ),
+    packer.add_input(
+        _manifest_of_runs(
+            FileChunks(
+                path="a",
+                size=200,
+                row_groups=(
+                    _rg(idx=0, size=60),
+                    _rg(idx=1, size=40),
+                    _rg(idx=2, size=100),
+                ),
+            )
         )
     )
     assert _manifest_map(packer.next_partition()) == {"a": [0, 1]}

--- a/python/ray/data/tests/unit/datasource_v2/test_online_bin_packer.py
+++ b/python/ray/data/tests/unit/datasource_v2/test_online_bin_packer.py
@@ -11,7 +11,7 @@ from ray.data._internal.datasource_v2.chunkers.parquet_row_group_coalescing impo
 )
 from ray.data._internal.datasource_v2.listing.file_manifest import FileManifest
 from ray.data._internal.datasource_v2.listing.footer_file_indexer import (
-    _manifest_of_runs,
+    _file_chunks_to_manifest,
 )
 from ray.data._internal.datasource_v2.partitioners.online_bin_packer import (
     OnlineBinPacker,
@@ -109,7 +109,7 @@ def _pack(
     packer = OnlineBinPacker(max_bin_bytes, **kwargs)
     bins = []
     for file_chunks in file_chunks_list:
-        packer.add_input(_manifest_of_runs(file_chunks))
+        packer.add_input(_file_chunks_to_manifest(file_chunks))
         while packer.has_partition():
             bins.append(_manifest_map(packer.next_partition()))
     packer.finalize()
@@ -173,7 +173,7 @@ def test_full_heavy_bin_is_sealed_immediately() -> None:
     # immediately. The third makes this colour heavy and exactly fills its
     # dedicated bin, which must also seal for early scheduling.
     packer.add_input(
-        _manifest_of_runs(
+        _file_chunks_to_manifest(
             FileChunks(
                 path="a",
                 size=200,


### PR DESCRIPTION
## Why

Parquet V2 chunks files **blindly**. `ParquetFileChunker` splits each file by `ceil(file_size / 1 GiB)` *without reading the footer*, and `RoundRobinPartitioner` bin-packs those guesses with a fixed encoding-ratio estimate. Bin sizes are inaccurate because the compression ratio is unknown until the footer is read, there is no row-group skipping, and nothing from predicate / limit / projection push-down reaches listing.

This wires steps 1–5 into a working read path — the first PR in the split where the footer path is *reachable*.

**Default-off.** Gated on `RAY_DATA_PARQUET_ENABLE_FOOTER_INDEXER`; without it every Parquet V2 read behaves exactly as today. Flipping the default and deleting the blind chunker are separate later steps, which keeps this reviewable and leaves a one-line revert lever.

## What this changes

**1. `FooterFileIndexer` — listing that reads footers.** New indexer, returned from `_get_file_indexer()` only when the flag is set. It footer-reads files on a `FooterReader` actor pool (step 5) and emits **one listing row per row-group run**, each carrying that run's exact stats: `num_rows`, `uncompressed_size`, per-row-group `rg_sizes` / `rg_rows`, and `fully_matched`. Actor pool is killed in a `finally`, in-flight footer batches are bounded, and listing stops early once `limit` exact-survivor rows are delivered.

**2. Bin packing is a `FilePartitioner`, not an indexer detail.** Listing discovers work; the partitioner groups it. `OnlineBinPacker` (step 4) becomes a real `FilePartitioner` supplied via a new `DataSourceV2.get_file_partitioner()` hook, so it runs in the normal partitioner stage and can split runs at exact row-group boundaries. `FileIndexer.produces_partitioned_manifests` is deleted in favor of `FilePartitioner.requires_global_input`, which is what tells `plan_list_files_op` to keep listing on one task.

This is not just tidying — it fixes a parallelism bug. `produces_partitioned_manifests` made the planner skip the partitioner stage entirely, so with `shuffle="files"` the footer path read the **whole dataset in a single task**: `shuffle_files` concatenates every sealed bin into one manifest block, and with no partitioner downstream nothing was left to re-split it.

**3. `count()` push-down.** `PushdownCountFiles` tried to force whole-file listing by overwriting the indexer's `_file_chunker`, but `FooterFileIndexer` overrides `list_files` outright and ignores its chunker, so the swap was a silent no-op. It now swaps the indexer itself via `as_whole_file_indexer()`. This is what makes (2) safe: once listing emits a row per row-group run, `read_metadata` returns the whole file's row count for *each* row, so a 4-row-group file counts 4×. The hard `assert isinstance(...)` also becomes a debug log and bail-out, so a third-party indexer falls back to the regular read path instead of crashing the optimizer.

**4. `skip_paths` on the footer path.** `FooterFileIndexer` was constructed without it, so `read_parquet(..., skip_paths=...)` silently did nothing when the flag was on — excluded files were read, and a path named only in `skip_paths` could fail the listing instead of being ignored.

These land together because (3) guards a bug that (2) introduces, and both touch the same listing contract.

## Flow

```mermaid
flowchart TD
  LF[ListFiles] --> FI[FooterFileIndexer]
  FI --> LI["list_file_infos<br/>(step 1)"]
  LI --> BA[batch paths]
  BA --> AP["FooterReaderActor pool<br/>SPREAD (step 5)"]
  AP -->|one row per row-group run| SH[shuffle_files]
  SH --> BP["OnlineBinPacker<br/>(step 4), a FilePartitioner"]
  BP -->|sealed bins| MB[manifest blocks]
  MB --> RF[ReadFiles]
  RF --> PR["ParquetFileReader<br/>reads exactly the named row groups"]
  LF -.->|"predicate / limit / projected_columns<br/>(step 3)"| FI
```

`OnlineBinPacker.requires_global_input = True` keeps listing on a single task, since the packer holds one pool of open bins across all files.

## Files

| File | Change |
| --- | --- |
| `listing/footer_file_indexer.py` | **new** — `FooterFileIndexer`. All knobs re-read in `__init__` so `monkeypatch.setenv` and release-test overrides apply. |
| `listing/file_indexer.py` | drops `produces_partitioned_manifests`; adds `as_whole_file_indexer()` |
| `partitioners/online_bin_packer.py` | now a `FilePartitioner` (`add_input`, `requires_global_input`) |
| `partitioners/file_partitioner.py` | adds `requires_global_input` |
| `datasource_v2.py` / `read_api.py` | new `get_file_partitioner()` hook; default stays `RoundRobinPartitioner` |
| `parquet_datasource_v2.py` | flag-gated indexer + packer; wires `skip_paths` |
| `planner/plan_list_files_op.py` | partitioner stage always runs; single-task listing keys off `requires_global_input` |
| `rules/pushdown_count_files.py` | replaces the indexer instead of reconfiguring it |
| `chunkers/file_chunker.py` | `ParquetRowGroupChunkMetadata` gains `fully_matched`, `rg_sizes`, `rg_rows` |
| `chunkers/parquet_file_chunking_utils.py` | adds `_fragments_from_row_group_ids`, `_with_io_retry` |
| `readers/parquet_file_reader.py` | dispatches on metadata type so both chunkers coexist; sizes batches from footer stats already on the manifest |
| `readers/file_reader.py` | `_resolve_batch_size(dataset, manifest)` |

## Testing

```
pytest python/ray/data/tests/unit/datasource_v2/test_file_indexer.py \
       python/ray/data/tests/unit/datasource_v2/test_online_bin_packer.py \
       python/ray/data/_internal/datasource_v2/tests/test_parquet_datasource_v2.py \
       python/ray/data/_internal/datasource_v2/tests/test_footer_chunking.py \
       python/ray/data/tests/datasource/test_read_parquet_v2.py
# 145 passed
```

The two that carry the most weight:

- `test_count_matches_rows`, parametrized over `(4 files, 1000 rows, row_group_size=250)`. This is the guard for (3): without `as_whole_file_indexer()` it fails `assert 4800 == 1200`.
- `test_e2e_filter_then_limit_with_nulls`, 20 files at 10% non-null over five limits. If a null were ever counted as an exact survivor, listing would stop short and `Limit` would quietly return fewer rows than asked. (The classification behind that landed in #65273.)

**Known gap:** `skip_paths` has unit coverage in `test_parquet_datasource_v2.py` but no end-to-end test through `read_parquet` on the footer path.

## Stack

Step 6 of an 11-step split of #64985 (43 files, +3234 −719, not reviewable as one unit).

- #65167 `[1/11]` `FileIndexer.list_file_infos` ✅ · #65168 `[2/11]` limit into `ReadFiles` ✅
- #65214 `[3/11]` derive `ListFiles` pushdown state ✅ · #65210 `[4/11]` footer types + bin packer ✅
- #65273 `[5/11]` `FooterReader` actor pool ✅
- **this PR** — consumes all of the above; first step that makes the path reachable
- #65169 `[9/11]` pin the footer actor pool to 1 in tests (open, independent)

This PR **absorbs what was going to be step 7** (`count()` push-down), so the remaining steps renumber down by one. Step 7 can't be split out downstream of this: the packing change is what triggers the over-count, so the fix has to ship at or below it.

## AI assistance

AI assistance was used for this change. I have reviewed every changed line and run the tests above locally.

Not a duplicate: `gh pr list --repo ray-project/ray --state open --search "FooterFileIndexer"` and `--search "footer indexer parquet"` return only this PR, the stack members listed above, and #64985 — the mega-PR this stack is splitting up, which closes once the stack lands.
