### PR TITLE
[ci] Resolve Windows packages through the CI mirror

### DIFF
--- a/ci/docker/windows.build.wanda.yaml
+++ b/ci/docker/windows.build.wanda.yaml
@@ -4,6 +4,10 @@ dockerfile: ci/docker/windows.build.Dockerfile
 srcs:
   - python/deplocks/ci/windows-tests-torch27-ci_depset_py3.10.lock
   - ci/ray_ci/windows/build_base.sh
+  - ci/install_pypi_proxy.sh
+  - ci/pypi_index_proxy.py
+  - ci/pypi_proxy_profile.sh
+  - ci/ray_ci/windows/pypi_proxy.sh
   - ci/ray_ci/windows/install_bazelisk.ps1
   - ci/ray_ci/windows/cleanup.ps1
 tags:

--- a/ci/install_pypi_proxy.sh
+++ b/ci/install_pypi_proxy.sh
@@ -44,7 +44,13 @@ deps=("niquests==3.21.0" "starlette==1.6.0" "uvicorn==0.52.3")
 if "$PROXY_PYTHON" -c 'import sys; sys.exit(0 if sys.version_info >= (3, 11) else 1)'; then
   deps+=("asgi-cross-origin-protection==0.1.1")
 fi
-"$PREFIX"/bin/pip install --no-cache-dir "${deps[@]}"
+# venv puts its executables in bin/ everywhere except Windows, which uses Scripts/.
+# The Windows CI image runs these scripts under msys bash, so the rest of the path
+# handling is identical and only this directory name differs.
+VENV_BIN="$PREFIX/bin"
+[[ -d "$VENV_BIN" ]] || VENV_BIN="$PREFIX/Scripts"
+
+"$VENV_BIN"/pip install --no-cache-dir "${deps[@]}"
 
 cp pypi_index_proxy.py "$PREFIX"/pypi_index_proxy.py
 

--- a/ci/pypi_proxy_profile.sh
+++ b/ci/pypi_proxy_profile.sh
@@ -109,7 +109,10 @@ _rayci_pypi_index_setup() {
   _rayci_bazel_downloader_config
 
   local prefix="${RAYCI_PYPI_PROXY_PREFIX:-/opt/pypiproxy}"
-  if [[ ! -x "${prefix}/bin/python" ]]; then
+  # Windows venvs put the interpreter in Scripts/ rather than bin/, so a caller on that
+  # platform names it outright instead of having it derived from the prefix.
+  local proxy_python="${RAYCI_PYPI_PROXY_PYTHON:-${prefix}/bin/python}"
+  if [[ ! -x "${proxy_python}" ]]; then
     export RAYCI_PYPI_INDEX_MODE="pypi"
     echo "pypi index: byte cache reachable but this image carries no proxy; resolving from public PyPI" >&2
     return 0
@@ -149,10 +152,10 @@ _rayci_pypi_index_setup() {
   # with it. setsid is util-linux and absent on macOS, where nohup plus a subshell
   # achieves the same detachment.
   if command -v setsid >/dev/null 2>&1; then
-    MIRROR_URL="${mirror}" setsid "${prefix}/bin/python" \
+    MIRROR_URL="${mirror}" setsid "${proxy_python}" \
       "${prefix}/pypi_index_proxy.py" "${port}" >"${log}" 2>&1 &
   else
-    ( MIRROR_URL="${mirror}" nohup "${prefix}/bin/python" \
+    ( MIRROR_URL="${mirror}" nohup "${proxy_python}" \
         "${prefix}/pypi_index_proxy.py" "${port}" >"${log}" 2>&1 & )
   fi
 

--- a/ci/ray_ci/windows/build_base.sh
+++ b/ci/ray_ci/windows/build_base.sh
@@ -31,6 +31,20 @@ sed 's/ \\$//; s/ --hash[^ ]*//g' \
   > /tmp/windows_tests_depset_no_hashes.txt
 pip install -U --ignore-installed --no-deps -r /tmp/windows_tests_depset_no_hashes.txt
 
+# The index proxy, so the package installs inside this image's containers resolve
+# through the CI package mirror rather than files.pythonhosted.org (pypi/support#11895).
+# Baked in here rather than installed per job because the Windows agent host carries
+# Python 3.8, below what the proxy supports, while conda above supplies 3.10 -- which is
+# enough, since the only dependency needing 3.11 is skipped by the installer and guarded
+# at import. ci/ray_ci/windows/pypi_proxy.sh starts it and is sourced by the two places
+# that install packages.
+(
+  cd ci &&
+    RAYCI_PYPI_PROXY_PREFIX="/c/pypiproxy" \
+      RAYCI_PYPI_PROXY_SKIP_PROFILE=1 \
+      bash install_pypi_proxy.sh "$(command -v python)"
+)
+
 # Clean up caches to minimize image size. These caches are not needed, and
 # removing them help with the build speed.
 pip cache purge

--- a/ci/ray_ci/windows/build_ray.sh
+++ b/ci/ray_ci/windows/build_ray.sh
@@ -24,6 +24,13 @@ fi
 # Fix network for remote caching
 powershell ci/pipeline/fix-windows-container-networking.ps1
 
+# Resolve through the CI package mirror where it is reachable. `pip install -e python`
+# below triggers a bazel build, whose whl_library fetches are what took a 502 on
+# premerge 72138 and postmerge 19272. `|| true` under `set -e`: this must never be the
+# reason an image build fails, and every path inside falls back to public PyPI.
+# shellcheck source=ci/ray_ci/windows/pypi_proxy.sh
+source ./ci/ray_ci/windows/pypi_proxy.sh || true
+
 # Build ray and ray wheels
 pip install -v -e python
 pip wheel -e python -w .whl

--- a/ci/ray_ci/windows/pypi_proxy.sh
+++ b/ci/ray_ci/windows/pypi_proxy.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# Point this Windows container's pip and uv at the CI package mirror. Source it, do not
+# run it: it exports the index variables into the calling shell.
+#
+# Unlike the Linux images there is no profile.d hook here, because the two places that
+# install packages on Windows are not login shells: `RUN bash build_ray.sh` inside the
+# docker build the tester starts, and the command list the wheel builder passes to
+# `docker run`. Both source this explicitly.
+#
+# The proxy runs inside this container on loopback rather than on the agent. That avoids
+# needing an interpreter on the Windows host, which carries 3.8 -- below what the proxy
+# supports -- and avoids having to discover the host's address from inside a container.
+# The venv is baked into the windowsbuild image by build_base.sh, so nothing is
+# installed at job time.
+#
+# Fails open at every step: if the mirror is unreachable or the proxy will not start,
+# nothing is exported and pip resolves from public PyPI exactly as before.
+
+_rayci_windows_pypi_proxy() {
+  local prefix="/c/pypiproxy"
+  local repo_root
+  repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+
+  if [[ ! -x "${prefix}/Scripts/python.exe" ]]; then
+    echo "pypi index: this image carries no proxy; resolving from public PyPI" >&2
+    return 0
+  fi
+
+  # Loopback is correct here: this container is the only thing that needs to reach the
+  # proxy, and pip and uv exempt loopback from their refusal to use a plain-HTTP index.
+  export RAYCI_PYPI_PROXY_PREFIX="${prefix}"
+  export RAYCI_PYPI_PROXY_PYTHON="${prefix}/Scripts/python.exe"
+  export RAYCI_PYPI_PROXY_HOST="127.0.0.1"
+  # shellcheck source=ci/pypi_proxy_profile.sh
+  source "${repo_root}/ci/pypi_proxy_profile.sh"
+}
+
+_rayci_windows_pypi_proxy

--- a/ci/ray_ci/windows_builder_container.py
+++ b/ci/ray_ci/windows_builder_container.py
@@ -26,6 +26,11 @@ class WindowsBuilderContainer(WindowsContainer):
             "git config --global core.autocrlf false",
             "git clone . ray",
             "cd ray",
+            # Resolve through the CI package mirror where it is reachable. The commands
+            # are joined into one bash invocation, so the variables this exports apply
+            # to the wheel build below. `|| true` keeps a proxy problem from failing a
+            # release wheel: every path inside falls back to public PyPI.
+            "source ./ci/ray_ci/windows/pypi_proxy.sh || true",
             # build wheel
             f"export BUILD_ONE_PYTHON_ONLY={self.python_version}",
             "./python/build-wheel-windows.sh",


### PR DESCRIPTION
**Stacked on #65597** — base branch is `elliot-barn/proxy-host-support`, since both need the same shared-script changes. Review that one first; GitHub will retarget this to master when it merges.

## Description

Windows had no mirror wiring at all, and it is the platform actively breaking release
wheels. `windows_wheels` carries the `release_wheels` tag and uploads for 3.10 through
3.14, so a 502 there leaves the published wheel set short a platform. Observed on
premerge 72138 and again on postmerge 19272, both `whl_library` fetching
`bazel-runfiles==0.31.0`.

The important detail is *where* it fails — a docker build, not a plain container command:

```
Step 17/18 : RUN bash ci/ray_ci/windows/build_ray.sh
  + pip install -v -e python
  → bazel build //:gen_ray_pkg → whl_library → HTTP error 502
```

## Approach

The proxy runs **inside that container on loopback**, rather than on the agent. Two
reasons:

- The Windows agent host carries Python 3.8, below what the proxy supports, so a
  host-side proxy would mean installing an interpreter per job. The image's conda python
  is 3.10, which is enough — the only dependency requiring 3.11 is skipped by the
  installer and guarded at import (see #65597).
- A host-side proxy would also have to be discovered from inside the container by
  address. Loopback needs none of that, and pip and uv exempt loopback from their
  refusal to use a plain-HTTP index.

The venv is baked into the `windowsbuild` image by `build_base.sh`, so nothing is
installed at job time.

## What changed

- **`ci/ray_ci/windows/pypi_proxy.sh`** — new, sourceable. Hands off to
  `ci/pypi_proxy_profile.sh` for the mirror probe, mode selection, readiness wait and
  fail-open paths rather than reimplementing them.
- **`build_base.sh` + `windows.build.wanda.yaml`** — install the proxy into the image
  and put the files in the build context.
- **`build_ray.sh`** — sourced before `pip install -e python`, covering the tester's
  image build, which is where the observed failures are.
- **`windows_builder_container.py`** — sourced before `build-wheel-windows.sh`. The
  wheel path is a `docker run`, not a `docker build`, and its commands are joined into
  one bash invocation, so the exports carry through.
- **`install_pypi_proxy.sh` / `pypi_proxy_profile.sh`** — Windows venvs put the
  interpreter in `Scripts/` rather than `bin/`, so the installer locates the script
  directory and the profile script takes `RAYCI_PYPI_PROXY_PYTHON`.

## What this does not cover

The `wanda: windowsbuild` image build itself still resolves from PyPI. Those jobs are
not containerised and have no proxy in scope, which is the same gap ray#65578 is waiting
on. Also unchanged: the host-side installs in `install_tools.sh` (`awscli`, the windows
depset), which would need an interpreter on the 3.8 host.

## Related issues

Upstream cause: pypi/support#11895. Not a duplicate: no open PR touches the Windows CI
scripts. #65597 changes the shared installer and profile script and is the base of this
branch; #65593 pins the index representation and does not overlap.

## Testing

- `pre-commit` (shellcheck, black, semgrep, ruff) clean on every changed file.
- `pytest ci/ray_ci/test_windows_container.py` passes.
  `test_windows_tester_container.py::test_init` fails, but it fails identically on
  `origin/master` — it asserts a `docker build` argument order this branch does not
  touch.
- The proxy itself is exercised by the tests described in #65597: it starts and serves
  on Python 3.10 with the 3.11-only dependency absent, and the index it serves has
  artifact URLs rewritten onto the mirror.

Not verified: a real Windows agent, which needs this branch in CI — specifically that
the container can reach `mirror.ci.ray.io` and that the loopback bind behaves the same
under Windows containers. Both failure modes are a printed warning and a job that
resolves from PyPI, which is today's behaviour rather than a new failure.

AI assistance (Claude Code) was used for this change.
