### PR TITLE
[ci][DO NOT MERGE] PyPI mirror: the complete picture

### DIFF
--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -36,3 +36,11 @@ fi
 
 RAYCI_CHECKOUT_DIR="$(pwd)"
 export RAYCI_CHECKOUT_DIR
+
+# Point this agent's pip and uv at the CI package mirror, for the steps no image can
+# cover: the release pipeline's init step and every wanda image build run directly on the
+# agent, never entering a container, so the profile.d hook in forge and manylinux does not
+# reach them. Sourced, because it exports. `|| true` under `set -e`: a package mirror must
+# never be the reason a job fails, and every path inside falls back to public PyPI.
+# shellcheck source=ci/pypi_proxy_agent.sh
+source ./ci/pypi_proxy_agent.sh || true

--- a/ci/docker/base.cu128.wanda.yaml
+++ b/ci/docker/base.cu128.wanda.yaml
@@ -14,5 +14,6 @@ build_args:
   - PYTHON
   - BASE_IMAGE=nvidia/cuda:12.8.1-cudnn-devel-ubuntu22.04
   - CUDA_VERSION=12.8.1
+  - RAYCI_IMAGE_PIP_INDEX_URL
 tags:
   - cr.ray.io/rayproject/oss-ci-base_cu128-py$PYTHON

--- a/ci/docker/base.cu130.wanda.yaml
+++ b/ci/docker/base.cu130.wanda.yaml
@@ -14,5 +14,6 @@ build_args:
   - PYTHON
   - BASE_IMAGE=nvidia/cuda:13.0.0-cudnn-devel-ubuntu22.04
   - CUDA_VERSION=13.0.0
+  - RAYCI_IMAGE_PIP_INDEX_URL
 tags:
   - cr.ray.io/rayproject/oss-ci-base_cu130-py$PYTHON

--- a/ci/docker/base.gpu.Dockerfile
+++ b/ci/docker/base.gpu.Dockerfile
@@ -7,6 +7,17 @@ ARG PYTHON=3.10
 ARG CUDA_VERSION=12.8.1
 
 ENV DEBIAN_FRONTEND=noninteractive
+
+# Where pip and uv resolve from while building this image. Docker builds cannot see an
+# index configured in the CI step's environment -- BuildKit RUN steps inherit nothing
+# from it -- so it arrives as a build arg, which wanda resolves from
+# RAYCI_IMAGE_PIP_INDEX_URL in the job environment.
+#
+# Empty for anyone building these images outside CI, and then this is exactly the index
+# pip would have used anyway, so an external build behaves as it does today.
+ARG RAYCI_IMAGE_PIP_INDEX_URL=""
+ENV PIP_INDEX_URL=${RAYCI_IMAGE_PIP_INDEX_URL:-https://pypi.org/simple}
+ENV UV_INDEX_URL=${RAYCI_IMAGE_PIP_INDEX_URL:-https://pypi.org/simple}
 ENV TZ=America/Los_Angeles
 
 ENV RAY_BUILD_ENV=ubuntu22.04_clang14_cuda${CUDA_VERSION}_py$PYTHON

--- a/ci/docker/base.gpu.wanda.yaml
+++ b/ci/docker/base.gpu.wanda.yaml
@@ -13,5 +13,6 @@ build_args:
   - BUILDKITE_BAZEL_CACHE_URL
   - PYTHON
   - CUDA_VERSION
+  - RAYCI_IMAGE_PIP_INDEX_URL
 tags:
   - cr.ray.io/rayproject/oss-ci-base_gpu-py$PYTHON

--- a/ci/docker/base.test.Dockerfile
+++ b/ci/docker/base.test.Dockerfile
@@ -6,6 +6,17 @@ ARG BUILDKITE_BAZEL_CACHE_URL
 ARG PYTHON=3.10
 
 ENV DEBIAN_FRONTEND=noninteractive
+
+# Where pip and uv resolve from while building this image. Docker builds cannot see an
+# index configured in the CI step's environment -- BuildKit RUN steps inherit nothing
+# from it -- so it arrives as a build arg, which wanda resolves from
+# RAYCI_IMAGE_PIP_INDEX_URL in the job environment.
+#
+# Empty for anyone building these images outside CI, and then this is exactly the index
+# pip would have used anyway, so an external build behaves as it does today.
+ARG RAYCI_IMAGE_PIP_INDEX_URL=""
+ENV PIP_INDEX_URL=${RAYCI_IMAGE_PIP_INDEX_URL:-https://pypi.org/simple}
+ENV UV_INDEX_URL=${RAYCI_IMAGE_PIP_INDEX_URL:-https://pypi.org/simple}
 ENV TZ=America/Los_Angeles
 
 ENV RAY_BUILD_ENV=ubuntu22.04_clang14_py$PYTHON

--- a/ci/docker/base.test.aarch64.wanda.yaml
+++ b/ci/docker/base.test.aarch64.wanda.yaml
@@ -9,5 +9,6 @@ srcs:
 build_args:
   - BUILDKITE_BAZEL_CACHE_URL
   - PYTHON
+  - RAYCI_IMAGE_PIP_INDEX_URL
 tags:
   - cr.ray.io/rayproject/oss-ci-base_test-aarch64-py$PYTHON

--- a/ci/docker/base.test.wanda.yaml
+++ b/ci/docker/base.test.wanda.yaml
@@ -9,5 +9,6 @@ srcs:
 build_args:
   - BUILDKITE_BAZEL_CACHE_URL
   - PYTHON
+  - RAYCI_IMAGE_PIP_INDEX_URL
 tags:
   - cr.ray.io/rayproject/oss-ci-base_test-py$PYTHON

--- a/ci/docker/forge.Dockerfile
+++ b/ci/docker/forge.Dockerfile
@@ -5,6 +5,17 @@ FROM ubuntu:22.04
 ARG BUILDKITE_BAZEL_CACHE_URL
 
 ENV DEBIAN_FRONTEND=noninteractive
+
+# Where pip and uv resolve from while building this image. Docker builds cannot see an
+# index configured in the CI step's environment -- BuildKit RUN steps inherit nothing
+# from it -- so it arrives as a build arg, which wanda resolves from
+# RAYCI_IMAGE_PIP_INDEX_URL in the job environment.
+#
+# Empty for anyone building these images outside CI, and then this is exactly the index
+# pip would have used anyway, so an external build behaves as it does today.
+ARG RAYCI_IMAGE_PIP_INDEX_URL=""
+ENV PIP_INDEX_URL=${RAYCI_IMAGE_PIP_INDEX_URL:-https://pypi.org/simple}
+ENV UV_INDEX_URL=${RAYCI_IMAGE_PIP_INDEX_URL:-https://pypi.org/simple}
 ENV PATH="/home/forge/.local/bin:${PATH}"
 ENV BUILDKITE_BAZEL_CACHE_URL=${BUILDKITE_BAZEL_CACHE_URL}
 ENV RAY_BUILD_ENV=ubuntu22.04_forge

--- a/ci/docker/forge.aarch64.wanda.yaml
+++ b/ci/docker/forge.aarch64.wanda.yaml
@@ -3,6 +3,7 @@ froms:
   - ubuntu:22.04
 build_args:
   - BUILDKITE_BAZEL_CACHE_URL
+  - RAYCI_IMAGE_PIP_INDEX_URL
 dockerfile: ci/docker/forge.Dockerfile
 srcs:
   - ci/k8s/install-k8s-tools.sh

--- a/ci/docker/forge.wanda.yaml
+++ b/ci/docker/forge.wanda.yaml
@@ -3,6 +3,7 @@ froms:
   - ubuntu:22.04
 build_args:
   - BUILDKITE_BAZEL_CACHE_URL
+  - RAYCI_IMAGE_PIP_INDEX_URL
 dockerfile: ci/docker/forge.Dockerfile
 srcs:
   - ci/k8s/install-k8s-tools.sh

--- a/ci/docker/manylinux-cibase.wanda.yaml
+++ b/ci/docker/manylinux-cibase.wanda.yaml
@@ -7,4 +7,5 @@ build_args:
   - BUILDKITE_BAZEL_CACHE_URL
   - RAYCI_DISABLE_JAVA
   - HOSTTYPE
+  - RAYCI_IMAGE_PIP_INDEX_URL
 dockerfile: ci/docker/manylinux.Dockerfile

--- a/ci/docker/manylinux.Dockerfile
+++ b/ci/docker/manylinux.Dockerfile
@@ -10,6 +10,17 @@ ARG RAYCI_DISABLE_JAVA=false
 ARG FORGE_UID=2000
 
 ENV BUILD_JAR=1
+
+# Where pip and uv resolve from while building this image. Docker builds cannot see an
+# index configured in the CI step's environment -- BuildKit RUN steps inherit nothing
+# from it -- so it arrives as a build arg, which wanda resolves from
+# RAYCI_IMAGE_PIP_INDEX_URL in the job environment.
+#
+# Empty for anyone building these images outside CI, and then this is exactly the index
+# pip would have used anyway, so an external build behaves as it does today.
+ARG RAYCI_IMAGE_PIP_INDEX_URL=""
+ENV PIP_INDEX_URL=${RAYCI_IMAGE_PIP_INDEX_URL:-https://pypi.org/simple}
+ENV UV_INDEX_URL=${RAYCI_IMAGE_PIP_INDEX_URL:-https://pypi.org/simple}
 ENV RAYCI_DISABLE_JAVA=$RAYCI_DISABLE_JAVA
 ENV RAY_INSTALL_JAVA=1
 ENV BUILDKITE_BAZEL_CACHE_URL=$BUILDKITE_BAZEL_CACHE_URL

--- a/ci/docker/windows.build.wanda.yaml
+++ b/ci/docker/windows.build.wanda.yaml
@@ -4,6 +4,10 @@ dockerfile: ci/docker/windows.build.Dockerfile
 srcs:
   - python/deplocks/ci/windows-tests-torch27-ci_depset_py3.10.lock
   - ci/ray_ci/windows/build_base.sh
+  - ci/install_pypi_proxy.sh
+  - ci/pypi_index_proxy.py
+  - ci/pypi_proxy_profile.sh
+  - ci/ray_ci/windows/pypi_proxy.sh
   - ci/ray_ci/windows/install_bazelisk.ps1
   - ci/ray_ci/windows/cleanup.ps1
 tags:

--- a/ci/install_pypi_proxy.sh
+++ b/ci/install_pypi_proxy.sh
@@ -1,56 +1,29 @@
 #!/bin/bash
-# Install the job-local PyPI index proxy.
+# Install the job-local PyPI index proxy into an image.
 #
-# Shared by every image whose steps resolve Python packages, and by the agents that run
-# steps with no image at all, so the install lives in one place rather than being copied
-# per caller. Expects ci/pypi_index_proxy.py and ci/pypi_proxy_profile.sh to be present
-# in the working directory, which image callers arrange with --mount=type=bind.
+# Shared by every image whose steps resolve Python packages, so the install lives in
+# one place rather than being copied per Dockerfile. Expects ci/pypi_index_proxy.py
+# and ci/pypi_proxy_profile.sh to be present in the working directory, which the
+# callers arrange with --mount=type=bind.
 #
-# $1 is the interpreter to build the venv from. Python 3.10 is enough; 3.11+ additionally
-# gets the cross-origin middleware, which is the one dependency that requires it (see
-# pypi_index_proxy.py). Images whose default interpreter is older pass a second one here
-# rather than moving their default.
-#
-# RAYCI_PYPI_PROXY_PREFIX chooses where the venv lands, defaulting to /opt/pypiproxy.
-# Agents that run steps directly on the host -- macOS, Windows -- point it somewhere
-# writable without sudo, since there is no image build to run as root.
-#
-# RAYCI_PYPI_PROXY_SKIP_PROFILE=1 skips installing the profile.d hook, for the same
-# hosts: they have no /etc/profile.d worth writing to and start the proxy explicitly.
+# $1 is a python >= 3.11: asgi-cross-origin-protection requires it, and images whose
+# default interpreter is older pass a second one here rather than moving their
+# default. The venv is self-contained in /opt/pypiproxy, so nothing else in the image
+# resolves through it.
 
 set -euo pipefail
 
-PROXY_PYTHON="${1:?usage: install_pypi_proxy.sh <path-to-python3.10+>}"
-PREFIX="${RAYCI_PYPI_PROXY_PREFIX:-/opt/pypiproxy}"
+PROXY_PYTHON="${1:?usage: install_pypi_proxy.sh <path-to-python3.11+>}"
 
-# Refuse an interpreter the proxy cannot run on, rather than building a venv that fails
-# at import time in the middle of a job.
-"$PROXY_PYTHON" -c 'import sys; sys.exit(0 if sys.version_info >= (3, 10) else 1)' || {
-  echo "install_pypi_proxy: $PROXY_PYTHON is older than 3.10" >&2
-  "$PROXY_PYTHON" --version >&2 || true
-  exit 1
-}
+"$PROXY_PYTHON" -m venv /opt/pypiproxy
+/opt/pypiproxy/bin/pip install --no-cache-dir \
+  "asgi-cross-origin-protection==0.1.1" \
+  "niquests==3.21.0" \
+  "starlette==1.6.0" \
+  "uvicorn==0.52.3"
+cp pypi_index_proxy.py /opt/pypiproxy/pypi_index_proxy.py
 
-# --clear so a re-install repairs a broken venv rather than inheriting it. Without it,
-# an attempt that failed partway -- a bad interpreter, an interrupted job -- leaves
-# stale bin/ symlinks that a later attempt with a good interpreter keeps, and the
-# result is a venv whose python cannot start at all.
-"$PROXY_PYTHON" -m venv --clear "$PREFIX"
-
-# starlette and uvicorn need 3.10, niquests 3.7, but asgi-cross-origin-protection needs
-# 3.11 -- so on an older interpreter it is left out and the proxy guards its import. It
-# only ever matters for non-GET routes, and every route here is a GET.
-deps=("niquests==3.21.0" "starlette==1.6.0" "uvicorn==0.52.3")
-if "$PROXY_PYTHON" -c 'import sys; sys.exit(0 if sys.version_info >= (3, 11) else 1)'; then
-  deps+=("asgi-cross-origin-protection==0.1.1")
-fi
-"$PREFIX"/bin/pip install --no-cache-dir "${deps[@]}"
-
-cp pypi_index_proxy.py "$PREFIX"/pypi_index_proxy.py
-
-if [[ "${RAYCI_PYPI_PROXY_SKIP_PROFILE:-0}" != "1" ]]; then
-  # Sourced automatically: CI steps run under `bash -elic`, a login shell. The zz-
-  # prefix runs it after anything else in profile.d that might set HOME or PATH.
-  cp pypi_proxy_profile.sh /etc/profile.d/zz-rayci-pypi-proxy.sh
-  chmod 0644 /etc/profile.d/zz-rayci-pypi-proxy.sh
-fi
+# Sourced automatically: CI steps run under `bash -elic`, a login shell. The zz-
+# prefix runs it after anything else in profile.d that might set HOME or PATH.
+cp pypi_proxy_profile.sh /etc/profile.d/zz-rayci-pypi-proxy.sh
+chmod 0644 /etc/profile.d/zz-rayci-pypi-proxy.sh

--- a/ci/install_pypi_proxy.sh
+++ b/ci/install_pypi_proxy.sh
@@ -44,7 +44,13 @@ deps=("niquests==3.21.0" "starlette==1.6.0" "uvicorn==0.52.3")
 if "$PROXY_PYTHON" -c 'import sys; sys.exit(0 if sys.version_info >= (3, 11) else 1)'; then
   deps+=("asgi-cross-origin-protection==0.1.1")
 fi
-"$PREFIX"/bin/pip install --no-cache-dir "${deps[@]}"
+# venv puts its executables in bin/ everywhere except Windows, which uses Scripts/.
+# The Windows CI image runs these scripts under msys bash, so the rest of the path
+# handling is identical and only this directory name differs.
+VENV_BIN="$PREFIX/bin"
+[[ -d "$VENV_BIN" ]] || VENV_BIN="$PREFIX/Scripts"
+
+"$VENV_BIN"/pip install --no-cache-dir "${deps[@]}"
 
 cp pypi_index_proxy.py "$PREFIX"/pypi_index_proxy.py
 

--- a/ci/install_pypi_proxy.sh
+++ b/ci/install_pypi_proxy.sh
@@ -1,29 +1,56 @@
 #!/bin/bash
-# Install the job-local PyPI index proxy into an image.
+# Install the job-local PyPI index proxy.
 #
-# Shared by every image whose steps resolve Python packages, so the install lives in
-# one place rather than being copied per Dockerfile. Expects ci/pypi_index_proxy.py
-# and ci/pypi_proxy_profile.sh to be present in the working directory, which the
-# callers arrange with --mount=type=bind.
+# Shared by every image whose steps resolve Python packages, and by the agents that run
+# steps with no image at all, so the install lives in one place rather than being copied
+# per caller. Expects ci/pypi_index_proxy.py and ci/pypi_proxy_profile.sh to be present
+# in the working directory, which image callers arrange with --mount=type=bind.
 #
-# $1 is a python >= 3.11: asgi-cross-origin-protection requires it, and images whose
-# default interpreter is older pass a second one here rather than moving their
-# default. The venv is self-contained in /opt/pypiproxy, so nothing else in the image
-# resolves through it.
+# $1 is the interpreter to build the venv from. Python 3.10 is enough; 3.11+ additionally
+# gets the cross-origin middleware, which is the one dependency that requires it (see
+# pypi_index_proxy.py). Images whose default interpreter is older pass a second one here
+# rather than moving their default.
+#
+# RAYCI_PYPI_PROXY_PREFIX chooses where the venv lands, defaulting to /opt/pypiproxy.
+# Agents that run steps directly on the host -- macOS, Windows -- point it somewhere
+# writable without sudo, since there is no image build to run as root.
+#
+# RAYCI_PYPI_PROXY_SKIP_PROFILE=1 skips installing the profile.d hook, for the same
+# hosts: they have no /etc/profile.d worth writing to and start the proxy explicitly.
 
 set -euo pipefail
 
-PROXY_PYTHON="${1:?usage: install_pypi_proxy.sh <path-to-python3.11+>}"
+PROXY_PYTHON="${1:?usage: install_pypi_proxy.sh <path-to-python3.10+>}"
+PREFIX="${RAYCI_PYPI_PROXY_PREFIX:-/opt/pypiproxy}"
 
-"$PROXY_PYTHON" -m venv /opt/pypiproxy
-/opt/pypiproxy/bin/pip install --no-cache-dir \
-  "asgi-cross-origin-protection==0.1.1" \
-  "niquests==3.21.0" \
-  "starlette==1.6.0" \
-  "uvicorn==0.52.3"
-cp pypi_index_proxy.py /opt/pypiproxy/pypi_index_proxy.py
+# Refuse an interpreter the proxy cannot run on, rather than building a venv that fails
+# at import time in the middle of a job.
+"$PROXY_PYTHON" -c 'import sys; sys.exit(0 if sys.version_info >= (3, 10) else 1)' || {
+  echo "install_pypi_proxy: $PROXY_PYTHON is older than 3.10" >&2
+  "$PROXY_PYTHON" --version >&2 || true
+  exit 1
+}
 
-# Sourced automatically: CI steps run under `bash -elic`, a login shell. The zz-
-# prefix runs it after anything else in profile.d that might set HOME or PATH.
-cp pypi_proxy_profile.sh /etc/profile.d/zz-rayci-pypi-proxy.sh
-chmod 0644 /etc/profile.d/zz-rayci-pypi-proxy.sh
+# --clear so a re-install repairs a broken venv rather than inheriting it. Without it,
+# an attempt that failed partway -- a bad interpreter, an interrupted job -- leaves
+# stale bin/ symlinks that a later attempt with a good interpreter keeps, and the
+# result is a venv whose python cannot start at all.
+"$PROXY_PYTHON" -m venv --clear "$PREFIX"
+
+# starlette and uvicorn need 3.10, niquests 3.7, but asgi-cross-origin-protection needs
+# 3.11 -- so on an older interpreter it is left out and the proxy guards its import. It
+# only ever matters for non-GET routes, and every route here is a GET.
+deps=("niquests==3.21.0" "starlette==1.6.0" "uvicorn==0.52.3")
+if "$PROXY_PYTHON" -c 'import sys; sys.exit(0 if sys.version_info >= (3, 11) else 1)'; then
+  deps+=("asgi-cross-origin-protection==0.1.1")
+fi
+"$PREFIX"/bin/pip install --no-cache-dir "${deps[@]}"
+
+cp pypi_index_proxy.py "$PREFIX"/pypi_index_proxy.py
+
+if [[ "${RAYCI_PYPI_PROXY_SKIP_PROFILE:-0}" != "1" ]]; then
+  # Sourced automatically: CI steps run under `bash -elic`, a login shell. The zz-
+  # prefix runs it after anything else in profile.d that might set HOME or PATH.
+  cp pypi_proxy_profile.sh /etc/profile.d/zz-rayci-pypi-proxy.sh
+  chmod 0644 /etc/profile.d/zz-rayci-pypi-proxy.sh
+fi

--- a/ci/pypi_index_proxy.py
+++ b/ci/pypi_index_proxy.py
@@ -46,11 +46,25 @@ import sys
 
 import niquests
 import uvicorn
-from asgi_cross_origin_protection import CrossOriginProtection
 from starlette.applications import Starlette
 from starlette.requests import Request
 from starlette.responses import PlainTextResponse, Response
 from starlette.routing import Route
+
+# Optional because it is the one dependency here that requires Python >= 3.11, and the
+# surfaces that need this proxy most are the ones without a modern interpreter: the
+# macOS agents carry 3.9 and 3.10 only, and the Windows agent host 3.8. Everything else
+# it needs supports 3.10. The middleware rejects cross-site state-changing requests via
+# Fetch Metadata, and every route here is a GET, which it always allows -- so where it
+# is absent nothing it would have done is skipped. Images that do have 3.11+ still
+# install it, and then it behaves exactly as before.
+try:
+    from asgi_cross_origin_protection import CrossOriginProtection
+except ImportError:  # pragma: no cover - depends on the interpreter, not the code path
+
+    def CrossOriginProtection(app):
+        return app
+
 
 MIRROR_URL = os.environ.get("MIRROR_URL", "https://mirror.ci.ray.io")
 

--- a/ci/pypi_index_proxy.py
+++ b/ci/pypi_index_proxy.py
@@ -69,12 +69,21 @@ client = niquests.AsyncSession()
 
 async def simple(request: Request) -> Response:
     upstream = f"{MIRROR_URL}/pypi.org/simple/{request.path_params['path']}"
-    headers = {}
-    # Content negotiation happens on this header: pip/uv choose between the
-    # HTML and PEP 691 JSON index representations with it.
-    accept = request.headers.get("accept")
-    if accept:
-        headers["Accept"] = accept
+    # Always ask upstream for HTML, ignoring what the client negotiated. The mirror
+    # caches /simple/ keyed on the URL alone with no Vary, so whichever
+    # representation is fetched first is what every later client gets. Forwarding the
+    # client's Accept therefore poisons the entry: uv asks for PEP 691 JSON, the
+    # mirror stores JSON, and then whl_library's pip -- which supports only
+    # text/html -- skips the page and reports "from versions: none". Seen on
+    # postmerge 19272:
+    #
+    #   WARNING: Skipping page .../simple/exceptiongroup/ because the GET request got
+    #   Content-Type: application/vnd.pypi.simple.v1+json. The only supported
+    #   Content-Type is text/html
+    #
+    # HTML rather than JSON because it is the representation every client here
+    # understands: that pip cannot read JSON at all, while uv reads both.
+    headers = {"Accept": "text/html"}
     try:
         response = await client.get(upstream, headers=headers, timeout=60)
     except niquests.exceptions.RequestException as e:
@@ -82,11 +91,20 @@ async def simple(request: Request) -> Response:
     body = response.content
     if response.status_code == 200:
         body = body.replace(UPSTREAM_FILES_PREFIX, MIRROR_FILES_PREFIX)
-    return Response(
-        body,
-        status_code=response.status_code,
-        media_type=response.headers.get("content-type", "text/html"),
-    )
+    content_type = response.headers.get("content-type", "text/html")
+    # Asking for HTML and getting something else means the mirror is holding a
+    # representation cached before this pinning landed. Pinning stops new entries going
+    # in but cannot evict old ones, since the Accept header is not part of the mirror's
+    # cache key -- those have to be deleted from the cache prefix. Say so, because the
+    # symptom at the client is the misleading "from versions: none".
+    if response.status_code == 200 and "html" not in content_type:
+        print(
+            f"pypi proxy: {upstream} returned {content_type} for an HTML request; "
+            "this is a stale mirror cache entry and clients that only read HTML will "
+            "skip it. Delete the cache/pypi.org/simple/ prefix to clear it.",
+            flush=True,
+        )
+    return Response(body, status_code=response.status_code, media_type=content_type)
 
 
 async def healthz(_request: Request) -> Response:

--- a/ci/pypi_index_proxy.py
+++ b/ci/pypi_index_proxy.py
@@ -46,11 +46,25 @@ import sys
 
 import niquests
 import uvicorn
-from asgi_cross_origin_protection import CrossOriginProtection
 from starlette.applications import Starlette
 from starlette.requests import Request
 from starlette.responses import PlainTextResponse, Response
 from starlette.routing import Route
+
+# Optional because it is the one dependency here that requires Python >= 3.11, and the
+# surfaces that need this proxy most are the ones without a modern interpreter: the
+# macOS agents carry 3.9 and 3.10 only, and the Windows agent host 3.8. Everything else
+# it needs supports 3.10. The middleware rejects cross-site state-changing requests via
+# Fetch Metadata, and every route here is a GET, which it always allows -- so where it
+# is absent nothing it would have done is skipped. Images that do have 3.11+ still
+# install it, and then it behaves exactly as before.
+try:
+    from asgi_cross_origin_protection import CrossOriginProtection
+except ImportError:  # pragma: no cover - depends on the interpreter, not the code path
+
+    def CrossOriginProtection(app):
+        return app
+
 
 MIRROR_URL = os.environ.get("MIRROR_URL", "https://mirror.ci.ray.io")
 
@@ -69,12 +83,21 @@ client = niquests.AsyncSession()
 
 async def simple(request: Request) -> Response:
     upstream = f"{MIRROR_URL}/pypi.org/simple/{request.path_params['path']}"
-    headers = {}
-    # Content negotiation happens on this header: pip/uv choose between the
-    # HTML and PEP 691 JSON index representations with it.
-    accept = request.headers.get("accept")
-    if accept:
-        headers["Accept"] = accept
+    # Always ask upstream for HTML, ignoring what the client negotiated. The mirror
+    # caches /simple/ keyed on the URL alone with no Vary, so whichever
+    # representation is fetched first is what every later client gets. Forwarding the
+    # client's Accept therefore poisons the entry: uv asks for PEP 691 JSON, the
+    # mirror stores JSON, and then whl_library's pip -- which supports only
+    # text/html -- skips the page and reports "from versions: none". Seen on
+    # postmerge 19272:
+    #
+    #   WARNING: Skipping page .../simple/exceptiongroup/ because the GET request got
+    #   Content-Type: application/vnd.pypi.simple.v1+json. The only supported
+    #   Content-Type is text/html
+    #
+    # HTML rather than JSON because it is the representation every client here
+    # understands: that pip cannot read JSON at all, while uv reads both.
+    headers = {"Accept": "text/html"}
     try:
         response = await client.get(upstream, headers=headers, timeout=60)
     except niquests.exceptions.RequestException as e:
@@ -82,11 +105,20 @@ async def simple(request: Request) -> Response:
     body = response.content
     if response.status_code == 200:
         body = body.replace(UPSTREAM_FILES_PREFIX, MIRROR_FILES_PREFIX)
-    return Response(
-        body,
-        status_code=response.status_code,
-        media_type=response.headers.get("content-type", "text/html"),
-    )
+    content_type = response.headers.get("content-type", "text/html")
+    # Asking for HTML and getting something else means the mirror is holding a
+    # representation cached before this pinning landed. Pinning stops new entries going
+    # in but cannot evict old ones, since the Accept header is not part of the mirror's
+    # cache key -- those have to be deleted from the cache prefix. Say so, because the
+    # symptom at the client is the misleading "from versions: none".
+    if response.status_code == 200 and "html" not in content_type:
+        print(
+            f"pypi proxy: {upstream} returned {content_type} for an HTML request; "
+            "this is a stale mirror cache entry and clients that only read HTML will "
+            "skip it. Delete the cache/pypi.org/simple/ prefix to clear it.",
+            flush=True,
+        )
+    return Response(body, status_code=response.status_code, media_type=content_type)
 
 
 async def healthz(_request: Request) -> Response:

--- a/ci/pypi_index_proxy.py
+++ b/ci/pypi_index_proxy.py
@@ -91,13 +91,17 @@ async def simple(request: Request) -> Response:
     body = response.content
     if response.status_code == 200:
         body = body.replace(UPSTREAM_FILES_PREFIX, MIRROR_FILES_PREFIX)
-    content_type = response.headers.get("content-type", "text/html")
+    # `or` rather than a default: covers a header that is present but empty, which a
+    # default does not.
+    content_type = response.headers.get("content-type") or "text/html"
     # Asking for HTML and getting something else means the mirror is holding a
     # representation cached before this pinning landed. Pinning stops new entries going
     # in but cannot evict old ones, since the Accept header is not part of the mirror's
     # cache key -- those have to be deleted from the cache prefix. Say so, because the
     # symptom at the client is the misleading "from versions: none".
-    if response.status_code == 200 and "html" not in content_type:
+    # Lowercased because header values are case-insensitive, and a false positive here
+    # tells the reader to delete cache entries that are in fact fine.
+    if response.status_code == 200 and "html" not in content_type.lower():
         print(
             f"pypi proxy: {upstream} returned {content_type} for an HTML request; "
             "this is a stale mirror cache entry and clients that only read HTML will "

--- a/ci/pypi_index_proxy.py
+++ b/ci/pypi_index_proxy.py
@@ -46,25 +46,11 @@ import sys
 
 import niquests
 import uvicorn
+from asgi_cross_origin_protection import CrossOriginProtection
 from starlette.applications import Starlette
 from starlette.requests import Request
 from starlette.responses import PlainTextResponse, Response
 from starlette.routing import Route
-
-# Optional because it is the one dependency here that requires Python >= 3.11, and the
-# surfaces that need this proxy most are the ones without a modern interpreter: the
-# macOS agents carry 3.9 and 3.10 only, and the Windows agent host 3.8. Everything else
-# it needs supports 3.10. The middleware rejects cross-site state-changing requests via
-# Fetch Metadata, and every route here is a GET, which it always allows -- so where it
-# is absent nothing it would have done is skipped. Images that do have 3.11+ still
-# install it, and then it behaves exactly as before.
-try:
-    from asgi_cross_origin_protection import CrossOriginProtection
-except ImportError:  # pragma: no cover - depends on the interpreter, not the code path
-
-    def CrossOriginProtection(app):
-        return app
-
 
 MIRROR_URL = os.environ.get("MIRROR_URL", "https://mirror.ci.ray.io")
 
@@ -83,21 +69,12 @@ client = niquests.AsyncSession()
 
 async def simple(request: Request) -> Response:
     upstream = f"{MIRROR_URL}/pypi.org/simple/{request.path_params['path']}"
-    # Always ask upstream for HTML, ignoring what the client negotiated. The mirror
-    # caches /simple/ keyed on the URL alone with no Vary, so whichever
-    # representation is fetched first is what every later client gets. Forwarding the
-    # client's Accept therefore poisons the entry: uv asks for PEP 691 JSON, the
-    # mirror stores JSON, and then whl_library's pip -- which supports only
-    # text/html -- skips the page and reports "from versions: none". Seen on
-    # postmerge 19272:
-    #
-    #   WARNING: Skipping page .../simple/exceptiongroup/ because the GET request got
-    #   Content-Type: application/vnd.pypi.simple.v1+json. The only supported
-    #   Content-Type is text/html
-    #
-    # HTML rather than JSON because it is the representation every client here
-    # understands: that pip cannot read JSON at all, while uv reads both.
-    headers = {"Accept": "text/html"}
+    headers = {}
+    # Content negotiation happens on this header: pip/uv choose between the
+    # HTML and PEP 691 JSON index representations with it.
+    accept = request.headers.get("accept")
+    if accept:
+        headers["Accept"] = accept
     try:
         response = await client.get(upstream, headers=headers, timeout=60)
     except niquests.exceptions.RequestException as e:
@@ -105,20 +82,11 @@ async def simple(request: Request) -> Response:
     body = response.content
     if response.status_code == 200:
         body = body.replace(UPSTREAM_FILES_PREFIX, MIRROR_FILES_PREFIX)
-    content_type = response.headers.get("content-type", "text/html")
-    # Asking for HTML and getting something else means the mirror is holding a
-    # representation cached before this pinning landed. Pinning stops new entries going
-    # in but cannot evict old ones, since the Accept header is not part of the mirror's
-    # cache key -- those have to be deleted from the cache prefix. Say so, because the
-    # symptom at the client is the misleading "from versions: none".
-    if response.status_code == 200 and "html" not in content_type:
-        print(
-            f"pypi proxy: {upstream} returned {content_type} for an HTML request; "
-            "this is a stale mirror cache entry and clients that only read HTML will "
-            "skip it. Delete the cache/pypi.org/simple/ prefix to clear it.",
-            flush=True,
-        )
-    return Response(body, status_code=response.status_code, media_type=content_type)
+    return Response(
+        body,
+        status_code=response.status_code,
+        media_type=response.headers.get("content-type", "text/html"),
+    )
 
 
 async def healthz(_request: Request) -> Response:

--- a/ci/pypi_proxy_agent.sh
+++ b/ci/pypi_proxy_agent.sh
@@ -1,0 +1,129 @@
+#!/bin/bash
+# Start the PyPI index proxy on the Buildkite agent, for the steps that no image can
+# reach. Sourced from .buildkite/hooks/pre-command; it exports and must not be run.
+#
+# The images cover steps that run inside them: forge and manylinux each carry the proxy
+# and start it from /etc/profile.d. What they cannot cover is anything that never enters
+# a container -- the release pipeline's init step, and every wanda image build, which run
+# directly on the agent. Those are the surfaces still resolving from files.pythonhosted.org
+# (pypi/support#11895), and init failing means zero release tests run at all.
+#
+# Two addresses come out of this, because they serve different consumers:
+#
+#   PIP_INDEX_URL              127.0.0.1 -- for pip and uv running on the agent itself.
+#                              Loopback, so pip and uv accept it over plain HTTP with no
+#                              trusted-host handling.
+#   RAYCI_IMAGE_PIP_INDEX_URL  the docker bridge gateway -- for docker builds, which have
+#                              their own loopback and reach the agent here. wanda resolves
+#                              build args from its own process environment, so exporting
+#                              this is what lets an image build use the mirror.
+#
+# Everything is guarded: the hook runs under `set -e`, and a package mirror must never be
+# the reason a job fails. Every path here leaves the environment untouched, and a step
+# that gets nothing exported resolves from public PyPI exactly as it does today.
+
+_rayci_agent_pypi_proxy() {
+  [[ -n "${BUILDKITE:-}" ]] || return 0
+  # profile.d in the images sets this; if a previous hook run already did the work, or a
+  # step re-sources us, do not start a second copy.
+  [[ -z "${RAYCI_PYPI_INDEX_MODE:-}" ]] || return 0
+
+  local mirror="${RAYCI_PYPI_MIRROR_URL:-https://mirror.ci.ray.io}"
+  local port="${RAYCI_PYPI_PROXY_PORT:-35999}"
+  local prefix="${RAYCI_PYPI_PROXY_PREFIX:-/var/tmp/rayci-pypiproxy}"
+  local log="/tmp/rayci_pypi_proxy_agent.log"
+  : >"${log}" 2>/dev/null || true
+  local repo_root
+  repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+  # Reachability first: on a fleet with no mirror deployed this is the only check that
+  # runs, and it costs one request.
+  if ! curl -sf -m 15 -o /dev/null "${mirror}/pypi.org/simple/pip/" 2>/dev/null; then
+    echo "pypi index: mirror unreachable from this agent; resolving from public PyPI" >&2
+    return 0
+  fi
+
+  # Validate rather than test for a directory: a half-finished install from an interrupted
+  # job would otherwise look complete and fail later, inside pip.
+  if ! "${prefix}/bin/python" -c 'import niquests, starlette, uvicorn' 2>/dev/null; then
+    # RAYCI_PYPI_PROXY_PYTHON names the interpreter outright, for agents where the search
+    # would not find a suitable one -- the Windows host carries 3.8, so it needs one
+    # provisioned (uv python install) and named here.
+    local candidate found="${RAYCI_PYPI_PROXY_PYTHON:-}"
+    for candidate in python3.13 python3.12 python3.11 python3.10 python3; do
+      [[ -z "${found}" ]] || break
+      local path
+      path="$(command -v "${candidate}" 2>/dev/null)" || continue
+      if [[ -n "${path}" ]] && "${path}" -c 'import sys; sys.exit(0 if sys.version_info >= (3, 10) else 1)' 2>/dev/null; then
+        found="${path}"
+        break
+      fi
+    done
+    if [[ -z "${found}" ]]; then
+      echo "pypi index: no python >= 3.10 on this agent; resolving from public PyPI" >&2
+      return 0
+    fi
+
+    echo "pypi index: installing the index proxy into ${prefix} with ${found}"
+    # This install is itself a PyPI fetch, so it can hit the very fault being worked
+    # around. It fails open, which makes it no worse than not trying.
+    if ! (
+      cd "${repo_root}/ci" &&
+        RAYCI_PYPI_PROXY_PREFIX="${prefix}" \
+          RAYCI_PYPI_PROXY_SKIP_PROFILE=1 \
+          bash install_pypi_proxy.sh "${found}"
+    ) >>"${log}" 2>&1; then
+      echo "pypi index: proxy install failed; resolving from public PyPI" >&2
+      tail -n 20 "${log}" >&2 || true
+      return 0
+    fi
+  fi
+
+  # Bound on all interfaces so both consumers can reach it: the agent over loopback, and
+  # docker builds over the bridge gateway.
+  if ! curl -sf -m 5 -o /dev/null "http://127.0.0.1:${port}/healthz" 2>/dev/null; then
+    if command -v setsid >/dev/null 2>&1; then
+      MIRROR_URL="${mirror}" setsid "${prefix}/bin/python" \
+        "${prefix}/pypi_index_proxy.py" "${port}" >>"${log}" 2>&1 &
+    else
+      ( MIRROR_URL="${mirror}" nohup "${prefix}/bin/python" \
+          "${prefix}/pypi_index_proxy.py" "${port}" >>"${log}" 2>&1 & )
+    fi
+    local _
+    for _ in $(seq 1 60); do
+      curl -sf -m 5 -o /dev/null "http://127.0.0.1:${port}/healthz" 2>/dev/null && break
+      sleep 0.5
+    done
+  fi
+
+  # Probed through the proxy rather than at /healthz, which does not touch the mirror: a
+  # process that is up but cannot reach its upstream must not be advertised.
+  if ! curl -sf -m 20 -o /dev/null "http://127.0.0.1:${port}/simple/pip/" 2>/dev/null; then
+    echo "pypi index: proxy did not serve an index; resolving from public PyPI" >&2
+    tail -n 20 "${log}" >&2 || true
+    return 0
+  fi
+
+  export RAYCI_PYPI_INDEX_MODE="agent-proxy"
+  export PIP_INDEX_URL="http://127.0.0.1:${port}/simple"
+  export UV_INDEX_URL="http://127.0.0.1:${port}/simple"
+  # rules_python passes --isolated to whl_library's pip, which makes it ignore every PIP_*
+  # variable. It reads this before deciding to pass the flag.
+  export RULES_PYTHON_PIP_ISOLATED=0
+  echo "pypi index: agent proxy over the mirror -> ${PIP_INDEX_URL}"
+
+  # The address a docker build reaches the agent on. Best effort: without it, image builds
+  # simply keep resolving from PyPI, which is today's behaviour.
+  local gateway=""
+  if command -v docker >/dev/null 2>&1; then
+    gateway="$(docker network inspect bridge -f '{{range .IPAM.Config}}{{.Gateway}}{{end}}' 2>/dev/null || true)"
+  fi
+  if [[ -n "${gateway}" ]]; then
+    export RAYCI_IMAGE_PIP_INDEX_URL="http://${gateway}:${port}/simple"
+    echo "pypi index: image builds -> ${RAYCI_IMAGE_PIP_INDEX_URL}"
+  else
+    echo "pypi index: no docker bridge gateway found; image builds stay on PyPI" >&2
+  fi
+}
+
+_rayci_agent_pypi_proxy

--- a/ci/pypi_proxy_profile.sh
+++ b/ci/pypi_proxy_profile.sh
@@ -67,7 +67,10 @@ _rayci_pypi_index_setup() {
     return 0
   fi
   local prefix="${RAYCI_PYPI_PROXY_PREFIX:-/opt/pypiproxy}"
-  if [[ ! -x "${prefix}/bin/python" ]]; then
+  # Windows venvs put python in Scripts/ rather than bin/, so callers on that platform
+  # name the interpreter instead of having it derived.
+  local proxy_python="${RAYCI_PYPI_PROXY_PYTHON:-${prefix}/bin/python}"
+  if [[ ! -x "${proxy_python}" ]]; then
     export RAYCI_PYPI_INDEX_MODE="pypi"
     echo "pypi index: byte cache reachable but this image carries no proxy; resolving from public PyPI" >&2
     return 0
@@ -107,10 +110,10 @@ _rayci_pypi_index_setup() {
   # with it. setsid is util-linux and absent on macOS, where nohup plus a subshell
   # achieves the same detachment.
   if command -v setsid >/dev/null 2>&1; then
-    MIRROR_URL="${mirror}" setsid "${prefix}/bin/python" \
+    MIRROR_URL="${mirror}" setsid "${proxy_python}" \
       "${prefix}/pypi_index_proxy.py" "${port}" >"${log}" 2>&1 &
   else
-    ( MIRROR_URL="${mirror}" nohup "${prefix}/bin/python" \
+    ( MIRROR_URL="${mirror}" nohup "${proxy_python}" \
         "${prefix}/pypi_index_proxy.py" "${port}" >"${log}" 2>&1 & )
   fi
 

--- a/ci/pypi_proxy_profile.sh
+++ b/ci/pypi_proxy_profile.sh
@@ -66,7 +66,8 @@ _rayci_pypi_index_setup() {
     echo "pypi index: mirror unreachable from this agent; resolving from public PyPI" >&2
     return 0
   fi
-  if [[ ! -x /opt/pypiproxy/bin/python ]]; then
+  local prefix="${RAYCI_PYPI_PROXY_PREFIX:-/opt/pypiproxy}"
+  if [[ ! -x "${prefix}/bin/python" ]]; then
     export RAYCI_PYPI_INDEX_MODE="pypi"
     echo "pypi index: byte cache reachable but this image carries no proxy; resolving from public PyPI" >&2
     return 0
@@ -85,8 +86,15 @@ _rayci_pypi_index_setup() {
   # start. Sharing a namespace would also share ports with the tests, which is its
   # own hazard. This address works unchanged from here and from any container on the
   # same bridge.
-  local host
-  host="$(hostname -i 2>/dev/null | awk '{print $1}')"
+  # RAYCI_PYPI_PROXY_HOST lets a caller name the address instead. Steps that run
+  # directly on an agent rather than in a container -- macOS, and the Windows host --
+  # set it, because `hostname -i` is a Linux-only spelling and because there is no
+  # nested container that needs to reach this: loopback is both correct and, for pip
+  # and uv, exempt from the plain-HTTP refusal below.
+  local host="${RAYCI_PYPI_PROXY_HOST:-}"
+  if [[ -z "${host}" ]]; then
+    host="$(hostname -i 2>/dev/null | awk '{print $1}')"
+  fi
   if [[ -z "${host}" ]]; then
     export RAYCI_PYPI_INDEX_MODE="pypi"
     echo "pypi index: could not determine this container's address; resolving from public PyPI" >&2
@@ -94,11 +102,17 @@ _rayci_pypi_index_setup() {
   fi
   local url="http://${host}:${port}"
 
-  # setsid gives the proxy its own session: `bash -i` enables job control, so a
-  # plain background job shares the step shell's process group and would be
-  # signalled along with it.
-  MIRROR_URL="${mirror}" setsid /opt/pypiproxy/bin/python \
-    /opt/pypiproxy/pypi_index_proxy.py "${port}" >"${log}" 2>&1 &
+  # The proxy needs its own session: `bash -i` enables job control, so a plain
+  # background job shares the step shell's process group and would be signalled along
+  # with it. setsid is util-linux and absent on macOS, where nohup plus a subshell
+  # achieves the same detachment.
+  if command -v setsid >/dev/null 2>&1; then
+    MIRROR_URL="${mirror}" setsid "${prefix}/bin/python" \
+      "${prefix}/pypi_index_proxy.py" "${port}" >"${log}" 2>&1 &
+  else
+    ( MIRROR_URL="${mirror}" nohup "${prefix}/bin/python" \
+        "${prefix}/pypi_index_proxy.py" "${port}" >"${log}" 2>&1 & )
+  fi
 
   local _
   for _ in $(seq 1 60); do

--- a/ci/pypi_proxy_profile.sh
+++ b/ci/pypi_proxy_profile.sh
@@ -43,24 +43,12 @@ _rayci_pypi_index_setup() {
   resolved="$(getent hosts "${mirror#https://}" 2>/dev/null | awk '{print $1}' | paste -sd, -)"
   echo "pypi index: mirror=${mirror} resolves_to=${resolved:-<unresolved>}"
 
-  local body
-  # 1. Rewriting simple index. Accepted only if the page points at the mirror for
-  #    artifacts; a page that still names files.pythonhosted.org would leave the
-  #    downloads on the origin.
-  if body="$(curl -sf -m 15 -H 'Accept: text/html' "${mirror}/simple/${probe_pkg}/" 2>/dev/null)" \
-    && [[ -n "${body}" ]]; then
-    if grep -qF "${mirror}/files.pythonhosted.org/" <<<"${body}"; then
-      export RAYCI_PYPI_INDEX_MODE="mirror-simple"
-      export PIP_INDEX_URL="${mirror}/simple"
-      export UV_INDEX_URL="${mirror}/simple"
-      export RULES_PYTHON_PIP_ISOLATED=0
-      echo "pypi index: using the mirror's rewriting simple index -> ${PIP_INDEX_URL}"
-      return 0
-    fi
-    echo "pypi index: ${mirror}/simple answers but does not rewrite artifact URLs; trying the byte cache" >&2
-  fi
-
-  # 2. Path-prefixed byte cache, which needs the local rewriting proxy in front.
+  # The mirror is a byte cache, not an index. It parses only /<host>/<path>, so
+  # <mirror>/simple/ reads as a host named "simple"; and it serves cache hits as 303
+  # redirects to presigned S3 URLs, so it never holds a body it could rewrite. There is
+  # therefore no mode where pip points straight at it -- an index has to be put in front.
+  # This probe establishes reachability for everything below, including the bazel
+  # downloader rewrite, which needs only the mirror and not the proxy.
   if ! curl -sf -m 15 -o /dev/null "${mirror}/pypi.org/simple/${probe_pkg}/" 2>/dev/null; then
     export RAYCI_PYPI_INDEX_MODE="pypi"
     echo "pypi index: mirror unreachable from this agent; resolving from public PyPI" >&2
@@ -82,7 +70,7 @@ _rayci_pypi_index_setup() {
   # VPC-internal: a checkout outside CI would rewrite its downloads to a name that does
   # not resolve, turning a working build into a broken one.
   _rayci_bazel_downloader_config() {
-    local cfg="${TMPDIR:-/tmp}/rayci_bazel_downloader.cfg"
+    local cfg="${HOME}/.rayci_bazel_downloader.cfg"
     local rc="${HOME}/.bazelrc"
     local host="${mirror#*://}"
 
@@ -97,12 +85,24 @@ _rayci_pypi_index_setup() {
 
     # The replacement keeps the upstream host as a path segment, which is how the mirror
     # addresses upstreams, and bazel preserves the original https scheme.
-    echo "rewrite files\\.pythonhosted\\.org/(.*) ${host}/files.pythonhosted.org/\$1" >"${cfg}" || return 0
+    # Two rules, and the second is load-bearing. A matching rewrite *replaces* the URL
+    # set rather than adding to it, so the first rule alone would discard the origin --
+    # turning a mirror outage into a hard failure where bazel would otherwise have fallen
+    # back. Verified against bazel 7.5.0: with an unreachable mirror, one rule fails the
+    # build and two rules warn and succeed. Credit to anyscale/rayturbo#4205, which found
+    # this and notes it also discards the fallbacks auto_http_archive builds for the C++
+    # dependencies if the pattern is ever broadened beyond pythonhosted.
+    {
+      echo "rewrite files\\.pythonhosted\\.org/(.*) ${host}/files.pythonhosted.org/\$1"
+      echo "rewrite files\\.pythonhosted\\.org/(.*) files.pythonhosted.org/\$1"
+    } >"${cfg}" || return 0
 
     # Appended once: this file may already carry the bazel cache settings the image
     # wrote, and profile.d can be sourced more than once per job.
     if ! grep -qsF -- "--experimental_downloader_config=${cfg}" "${rc}"; then
-      echo "common --experimental_downloader_config=${cfg}" >>"${rc}" || return 0
+      # Leading newline: the image writes this file, and appending to one that does not
+      # end in a newline would splice this onto the last option rather than adding it.
+      printf '\n%s\n' "common --experimental_downloader_config=${cfg}" >>"${rc}" || return 0
     fi
     echo "pypi index: bazel downloads of files.pythonhosted.org rewritten to ${host}"
   }

--- a/ci/pypi_proxy_profile.sh
+++ b/ci/pypi_proxy_profile.sh
@@ -66,6 +66,48 @@ _rayci_pypi_index_setup() {
     echo "pypi index: mirror unreachable from this agent; resolving from public PyPI" >&2
     return 0
   fi
+  # Bazel's own downloader is a separate problem from pip's index, and needs a separate
+  # answer. rules_python declares its bootstrap wheels as http_archive with literal
+  # files.pythonhosted.org URLs, and http_archive never consults PIP_INDEX_URL -- so no
+  # index setting reaches them. That is what failed microcheck 52470 and the docs-example
+  # jobs on postmerge 19272: bazel's Java downloader taking a 502 on click-8.0.1, during
+  # repository mapping, which takes the whole analysis phase with it.
+  #
+  # --experimental_downloader_config rewrites download URLs before they are fetched, so
+  # those archives come from the mirror instead. It needs only the mirror, not the local
+  # proxy, which is why it is set up here rather than after the proxy starts: an image
+  # with no proxy still gets its bazel downloads mirrored.
+  #
+  # Written per job rather than committed to .bazelrc because the hostname is
+  # VPC-internal: a checkout outside CI would rewrite its downloads to a name that does
+  # not resolve, turning a working build into a broken one.
+  _rayci_bazel_downloader_config() {
+    local cfg="${TMPDIR:-/tmp}/rayci_bazel_downloader.cfg"
+    local rc="${HOME}/.bazelrc"
+    local host="${mirror#*://}"
+
+    # Bazel preserves the original scheme when it rewrites, and every URL rewritten here
+    # is https. A mirror reachable only over http would therefore be addressed as https
+    # and fail in a way that looks like a broken mirror rather than a misconfiguration,
+    # so leave bazel alone in that case.
+    if [[ "${mirror}" != https://* ]]; then
+      echo "pypi index: mirror is not https, leaving bazel downloads on the origin" >&2
+      return 0
+    fi
+
+    # The replacement keeps the upstream host as a path segment, which is how the mirror
+    # addresses upstreams, and bazel preserves the original https scheme.
+    echo "rewrite files\\.pythonhosted\\.org/(.*) ${host}/files.pythonhosted.org/\$1" >"${cfg}" || return 0
+
+    # Appended once: this file may already carry the bazel cache settings the image
+    # wrote, and profile.d can be sourced more than once per job.
+    if ! grep -qsF -- "--experimental_downloader_config=${cfg}" "${rc}"; then
+      echo "common --experimental_downloader_config=${cfg}" >>"${rc}" || return 0
+    fi
+    echo "pypi index: bazel downloads of files.pythonhosted.org rewritten to ${host}"
+  }
+  _rayci_bazel_downloader_config
+
   if [[ ! -x /opt/pypiproxy/bin/python ]]; then
     export RAYCI_PYPI_INDEX_MODE="pypi"
     echo "pypi index: byte cache reachable but this image carries no proxy; resolving from public PyPI" >&2

--- a/ci/ray_ci/linux_container.py
+++ b/ci/ray_ci/linux_container.py
@@ -47,6 +47,9 @@ class LinuxContainer(Container):
         self, build_type: Optional[str] = None, mask: Optional[str] = None
     ) -> List[str]:
         cache_readonly = os.environ.get("BUILDKITE_CACHE_READONLY", "")
+        # Empty unless CI names an index that a docker build can reach; the
+        # Dockerfile falls back to PyPI on an empty value.
+        image_index_url = os.environ.get("RAYCI_IMAGE_PIP_INDEX_URL", "")
 
         env = os.environ.copy()
         env["DOCKER_BUILDKIT"] = "1"
@@ -63,6 +66,8 @@ class LinuxContainer(Container):
             f"BUILD_TYPE={build_type or ''}",
             "--build-arg",
             f"BUILDKITE_CACHE_READONLY={cache_readonly}",
+            "--build-arg",
+            f"RAYCI_IMAGE_PIP_INDEX_URL={image_index_url}",
         ]
 
         if not build_type or build_type in (

--- a/ci/ray_ci/linux_container.py
+++ b/ci/ray_ci/linux_container.py
@@ -47,9 +47,15 @@ class LinuxContainer(Container):
         self, build_type: Optional[str] = None, mask: Optional[str] = None
     ) -> List[str]:
         cache_readonly = os.environ.get("BUILDKITE_CACHE_READONLY", "")
-        # Empty unless CI names an index that a docker build can reach; the
-        # Dockerfile falls back to PyPI on an empty value.
-        image_index_url = os.environ.get("RAYCI_IMAGE_PIP_INDEX_URL", "")
+        # The step's own index, because a docker build can reach it: measured on
+        # premerge 72149, a RUN step reached the job-local proxy on both the BuildKit
+        # and legacy builders with default networking, no --network=host needed.
+        # RAYCI_IMAGE_PIP_INDEX_URL remains an explicit override for a fleet that
+        # needs a different value, or "" to opt out. Unset outside CI, and then the
+        # Dockerfile falls back to PyPI.
+        image_index_url = os.environ.get(
+            "RAYCI_IMAGE_PIP_INDEX_URL", os.environ.get("PIP_INDEX_URL", "")
+        )
 
         env = os.environ.copy()
         env["DOCKER_BUILDKIT"] = "1"

--- a/ci/ray_ci/macos/macos_ci.sh
+++ b/ci/ray_ci/macos/macos_ci.sh
@@ -122,6 +122,13 @@ _prelude() {
     (which bazel && bazel clean) || true;
   fi
   export SKIP_PIP_INSTALL=1
+  # Resolve pip and uv through the CI package mirror where it is reachable, so the
+  # installs below do not depend on files.pythonhosted.org being healthy
+  # (pypi/support#11895). Sourced, because it exports the index variables. The `|| true`
+  # matters under `set -e`: this must never be the reason a wheel build fails, and every
+  # path inside it already falls back to public PyPI.
+  # shellcheck source=ci/ray_ci/macos/pypi_proxy.sh
+  source ./ci/ray_ci/macos/pypi_proxy.sh || true
   . ./ci/ci.sh init && source ~/.zshenv
   source ~/.zshrc
 

--- a/ci/ray_ci/macos/macos_ci_build.sh
+++ b/ci/ray_ci/macos/macos_ci_build.sh
@@ -37,6 +37,13 @@ build() {
   export MAC_JARS=1
   export RAY_INSTALL_JAVA=1
   export RAY_ENABLE_WINDOWS_OR_OSX_CLUSTER=1
+  # Resolve pip and uv through the CI package mirror where it is reachable, so the
+  # installs below do not depend on files.pythonhosted.org being healthy
+  # (pypi/support#11895). Sourced, because it exports the index variables. The `|| true`
+  # matters under `set -e`: this must never be the reason a wheel build fails, and every
+  # path inside it already falls back to public PyPI.
+  # shellcheck source=ci/ray_ci/macos/pypi_proxy.sh
+  source ./ci/ray_ci/macos/pypi_proxy.sh || true
   . ./ci/ci.sh init && source ~/.zshenv
   source ~/.zshrc
   ./ci/ci.sh build_macos_wheels_and_jars

--- a/ci/ray_ci/macos/pypi_proxy.sh
+++ b/ci/ray_ci/macos/pypi_proxy.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+# Point this macOS job's pip and uv at the CI package mirror. Source it, do not run it:
+# it exports the index variables into the calling shell.
+#
+# Why macOS needs its own entry point rather than the profile.d hook the Linux images
+# use: these steps run directly on the agent, not in a container, so there is no image
+# to install the proxy into and no /etc/profile.d being sourced. What is here instead is
+# the same two pieces -- install, then start -- called explicitly.
+#
+# Two properties of these agents make this cheap. They are long-lived (a launchd
+# service, no disconnect-after-job) with a persistent HOME, so the venv below is built
+# once per machine rather than once per job. And nothing else needs to reach the proxy,
+# since no containers are involved, so it binds loopback -- which pip and uv accept over
+# plain HTTP without any trusted-host handling.
+#
+# Every failure path leaves the environment untouched, so a job resolves from PyPI
+# exactly as it did before. That includes the first install on a cold machine, which
+# necessarily fetches from PyPI itself and can hit the very 502s this works around.
+
+_rayci_macos_pypi_proxy() {
+  local prefix="${HOME}/.pypiproxy"
+  local repo_root
+  repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+
+  # Validate rather than test for the directory: a half-finished install from an
+  # interrupted job would otherwise look complete and fail later, inside pip.
+  if ! "${prefix}/bin/python" -c 'import niquests, starlette, uvicorn' 2>/dev/null; then
+    # Newest first: the proxy only needs 3.10, and from 3.11 it also gets the
+    # cross-origin middleware. python.org builds land in /Library/Frameworks -- the
+    # reef userdata installs 3.9 and 3.10 there -- and miniforge supplies another 3.10.
+    local candidate found=""
+    for candidate in \
+      /Library/Frameworks/Python.framework/Versions/3.12/bin/python3.12 \
+      /Library/Frameworks/Python.framework/Versions/3.11/bin/python3.11 \
+      /Library/Frameworks/Python.framework/Versions/3.10/bin/python3.10 \
+      /opt/homebrew/opt/miniforge/bin/python3 \
+      "$(command -v python3.12 2>/dev/null)" \
+      "$(command -v python3.11 2>/dev/null)" \
+      "$(command -v python3.10 2>/dev/null)"; do
+      if [[ -n "${candidate}" && -x "${candidate}" ]]; then
+        found="${candidate}"
+        break
+      fi
+    done
+    if [[ -z "${found}" ]]; then
+      echo "pypi index: no python >= 3.10 on this agent; resolving from public PyPI" >&2
+      return 0
+    fi
+
+    echo "pypi index: installing the index proxy into ${prefix} with ${found}"
+    # venv creation is idempotent, so a failed attempt is simply retried next job
+    # rather than needing the directory cleared.
+    if ! (
+      cd "${repo_root}/ci" &&
+        RAYCI_PYPI_PROXY_PREFIX="${prefix}" \
+          RAYCI_PYPI_PROXY_SKIP_PROFILE=1 \
+          bash install_pypi_proxy.sh "${found}"
+    ); then
+      echo "pypi index: proxy install failed; resolving from public PyPI" >&2
+      return 0
+    fi
+  fi
+
+  # The mirror probe, the mode selection, the readiness wait and the fail-open paths are
+  # all shared with the Linux images rather than reimplemented here.
+  export RAYCI_PYPI_PROXY_PREFIX="${prefix}"
+  export RAYCI_PYPI_PROXY_HOST="127.0.0.1"
+  # shellcheck source=ci/pypi_proxy_profile.sh
+  source "${repo_root}/ci/pypi_proxy_profile.sh"
+}
+
+_rayci_macos_pypi_proxy

--- a/ci/ray_ci/test_linux_tester_container.py
+++ b/ci/ray_ci/test_linux_tester_container.py
@@ -164,7 +164,15 @@ def test_ray_installation() -> None:
     def _mock_subprocess(inputs: List[str], env, stdout, stderr) -> None:
         install_ray_cmds.append(inputs)
 
-    with mock.patch("subprocess.check_call", side_effect=_mock_subprocess):
+    # PIP_INDEX_URL is set in every forge step, and install_ray now falls back to
+    # it, so the expected command below depends on the environment unless both
+    # variables are pinned here.
+    with mock.patch(
+        "subprocess.check_call", side_effect=_mock_subprocess
+    ), mock.patch.dict(
+        os.environ,
+        {"RAYCI_IMAGE_PIP_INDEX_URL": "", "PIP_INDEX_URL": ""},
+    ):
         LinuxTesterContainer("team", build_type="debug")
         docker_image = f"{_DOCKER_ECR_REPO}:team"
         assert install_ray_cmds[-1] == [

--- a/ci/ray_ci/test_linux_tester_container.py
+++ b/ci/ray_ci/test_linux_tester_container.py
@@ -180,6 +180,8 @@ def test_ray_installation() -> None:
             "BUILD_TYPE=debug",
             "--build-arg",
             "BUILDKITE_CACHE_READONLY=",
+            "--build-arg",
+            "RAYCI_IMAGE_PIP_INDEX_URL=",
             "-f",
             "ci/ray_ci/tests.env.Dockerfile",
             "/ray",

--- a/ci/ray_ci/tests.env.Dockerfile
+++ b/ci/ray_ci/tests.env.Dockerfile
@@ -19,6 +19,17 @@ ARG RAY_INSTALL_MASK=
 # To use C++ API/worker, set BUILD_TYPE to "multi-lang".
 ENV RAY_DISABLE_EXTRA_CPP=1
 
+# Where pip and uv resolve from while building this image. Docker builds cannot see an
+# index configured in the CI step's environment -- BuildKit RUN steps inherit nothing
+# from it -- so it arrives as a build arg, which wanda resolves from
+# RAYCI_IMAGE_PIP_INDEX_URL in the job environment.
+#
+# Empty for anyone building these images outside CI, and then this is exactly the index
+# pip would have used anyway, so an external build behaves as it does today.
+ARG RAYCI_IMAGE_PIP_INDEX_URL=""
+ENV PIP_INDEX_URL=${RAYCI_IMAGE_PIP_INDEX_URL:-https://pypi.org/simple}
+ENV UV_INDEX_URL=${RAYCI_IMAGE_PIP_INDEX_URL:-https://pypi.org/simple}
+
 RUN <<EOF
 #!/bin/bash
 

--- a/ci/ray_ci/windows/build_base.sh
+++ b/ci/ray_ci/windows/build_base.sh
@@ -31,6 +31,20 @@ sed 's/ \\$//; s/ --hash[^ ]*//g' \
   > /tmp/windows_tests_depset_no_hashes.txt
 pip install -U --ignore-installed --no-deps -r /tmp/windows_tests_depset_no_hashes.txt
 
+# The index proxy, so the package installs inside this image's containers resolve
+# through the CI package mirror rather than files.pythonhosted.org (pypi/support#11895).
+# Baked in here rather than installed per job because the Windows agent host carries
+# Python 3.8, below what the proxy supports, while conda above supplies 3.10 -- which is
+# enough, since the only dependency needing 3.11 is skipped by the installer and guarded
+# at import. ci/ray_ci/windows/pypi_proxy.sh starts it and is sourced by the two places
+# that install packages.
+(
+  cd ci &&
+    RAYCI_PYPI_PROXY_PREFIX="/c/pypiproxy" \
+      RAYCI_PYPI_PROXY_SKIP_PROFILE=1 \
+      bash install_pypi_proxy.sh "$(command -v python)"
+)
+
 # Clean up caches to minimize image size. These caches are not needed, and
 # removing them help with the build speed.
 pip cache purge

--- a/ci/ray_ci/windows/build_ray.sh
+++ b/ci/ray_ci/windows/build_ray.sh
@@ -24,6 +24,13 @@ fi
 # Fix network for remote caching
 powershell ci/pipeline/fix-windows-container-networking.ps1
 
+# Resolve through the CI package mirror where it is reachable. `pip install -e python`
+# below triggers a bazel build, whose whl_library fetches are what took a 502 on
+# premerge 72138 and postmerge 19272. `|| true` under `set -e`: this must never be the
+# reason an image build fails, and every path inside falls back to public PyPI.
+# shellcheck source=ci/ray_ci/windows/pypi_proxy.sh
+source ./ci/ray_ci/windows/pypi_proxy.sh || true
+
 # Build ray and ray wheels
 pip install -v -e python
 pip wheel -e python -w .whl

--- a/ci/ray_ci/windows/pypi_proxy.sh
+++ b/ci/ray_ci/windows/pypi_proxy.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# Point this Windows container's pip and uv at the CI package mirror. Source it, do not
+# run it: it exports the index variables into the calling shell.
+#
+# Unlike the Linux images there is no profile.d hook here, because the two places that
+# install packages on Windows are not login shells: `RUN bash build_ray.sh` inside the
+# docker build the tester starts, and the command list the wheel builder passes to
+# `docker run`. Both source this explicitly.
+#
+# The proxy runs inside this container on loopback rather than on the agent. That avoids
+# needing an interpreter on the Windows host, which carries 3.8 -- below what the proxy
+# supports -- and avoids having to discover the host's address from inside a container.
+# The venv is baked into the windowsbuild image by build_base.sh, so nothing is
+# installed at job time.
+#
+# Fails open at every step: if the mirror is unreachable or the proxy will not start,
+# nothing is exported and pip resolves from public PyPI exactly as before.
+
+_rayci_windows_pypi_proxy() {
+  local prefix="/c/pypiproxy"
+  local repo_root
+  repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+
+  if [[ ! -x "${prefix}/Scripts/python.exe" ]]; then
+    echo "pypi index: this image carries no proxy; resolving from public PyPI" >&2
+    return 0
+  fi
+
+  # Loopback is correct here: this container is the only thing that needs to reach the
+  # proxy, and pip and uv exempt loopback from their refusal to use a plain-HTTP index.
+  export RAYCI_PYPI_PROXY_PREFIX="${prefix}"
+  export RAYCI_PYPI_PROXY_PYTHON="${prefix}/Scripts/python.exe"
+  export RAYCI_PYPI_PROXY_HOST="127.0.0.1"
+  # shellcheck source=ci/pypi_proxy_profile.sh
+  source "${repo_root}/ci/pypi_proxy_profile.sh"
+}
+
+_rayci_windows_pypi_proxy

--- a/ci/ray_ci/windows_builder_container.py
+++ b/ci/ray_ci/windows_builder_container.py
@@ -26,6 +26,11 @@ class WindowsBuilderContainer(WindowsContainer):
             "git config --global core.autocrlf false",
             "git clone . ray",
             "cd ray",
+            # Resolve through the CI package mirror where it is reachable. The commands
+            # are joined into one bash invocation, so the variables this exports apply
+            # to the wheel build below. `|| true` keeps a proxy problem from failing a
+            # release wheel: every path inside falls back to public PyPI.
+            "source ./ci/ray_ci/windows/pypi_proxy.sh || true",
             # build wheel
             f"export BUILD_ONE_PYTHON_ONLY={self.python_version}",
             "./python/build-wheel-windows.sh",

--- a/docker/base-extra-testdeps/cpu.wanda.yaml
+++ b/docker/base-extra-testdeps/cpu.wanda.yaml
@@ -7,5 +7,6 @@ build_args:
   - BASE_IMAGE=cr.ray.io/rayproject/$IMAGE_TYPE-py$PYTHON_VERSION-cpu-base-extra
   - PYTHON_VERSION
   - IMAGE_TYPE
+  - RAYCI_IMAGE_PIP_INDEX_URL
 tags:
   - cr.ray.io/rayproject/$IMAGE_TYPE-py$PYTHON_VERSION-cpu-base-extra-testdeps

--- a/docker/base-extra-testdeps/cuda.wanda.yaml
+++ b/docker/base-extra-testdeps/cuda.wanda.yaml
@@ -7,5 +7,6 @@ build_args:
   - BASE_IMAGE=cr.ray.io/rayproject/$IMAGE_TYPE-py$PYTHON_VERSION-cu$CUDA_VERSION-base-extra
   - PYTHON_VERSION
   - IMAGE_TYPE
+  - RAYCI_IMAGE_PIP_INDEX_URL
 tags:
   - cr.ray.io/rayproject/$IMAGE_TYPE-py$PYTHON_VERSION-cu$CUDA_VERSION-base-extra-testdeps

--- a/release/ray_release/byod/build.py
+++ b/release/ray_release/byod/build.py
@@ -43,6 +43,18 @@ def build_anyscale_custom_byod_image(
         docker_build_cmd = "docker build --progress=plain .".split()
         docker_build_cmd += ["--build-arg", f"BASE_IMAGE={base_image}"]
         docker_build_cmd += ["-t", image]
+        # This build runs inside a forge step on the release stack, so the step's
+        # index is a live rewriting proxy and a RUN step can reach it (premerge
+        # 72149). Without this the ARG in byod.Dockerfile has no value to take.
+        # Appended after -t so the argument prefix stays stable for callers and
+        # tests that match on it.
+        docker_build_cmd += [
+            "--build-arg",
+            "RAYCI_IMAGE_PIP_INDEX_URL="
+            + os.environ.get(
+                "RAYCI_IMAGE_PIP_INDEX_URL", os.environ.get("PIP_INDEX_URL", "")
+            ),
+        ]
 
         env = os.environ.copy()
         env["DOCKER_BUILDKIT"] = "1"

--- a/release/ray_release/byod/byod.Dockerfile
+++ b/release/ray_release/byod/byod.Dockerfile
@@ -8,6 +8,18 @@ ARG PYTHON_VERSION=3.10
 ARG IMAGE_TYPE="ray"
 ARG PIP_REQUIREMENTS="python/deplocks/base_extra_testdeps/${IMAGE_TYPE}-base_extra_testdeps_py${PYTHON_VERSION}.lock"
 
+# Where pip and uv resolve from while building this image. Docker builds cannot see an
+# index configured in the CI step's environment -- BuildKit RUN steps inherit nothing
+# from it -- so it arrives as a build arg, which wanda resolves from
+# RAYCI_IMAGE_PIP_INDEX_URL in the job environment.
+#
+# Empty for anyone building this image outside CI, and then this is exactly the index
+# pip would have used anyway. This one carries the release tests' extra dependencies,
+# so a failed fetch here costs a nightly rather than one job.
+ARG RAYCI_IMAGE_PIP_INDEX_URL=""
+ENV PIP_INDEX_URL=${RAYCI_IMAGE_PIP_INDEX_URL:-https://pypi.org/simple}
+ENV UV_INDEX_URL=${RAYCI_IMAGE_PIP_INDEX_URL:-https://pypi.org/simple}
+
 COPY "$PIP_REQUIREMENTS" extra-test-requirements.txt
 
 RUN <<EOF


### PR DESCRIPTION
**DO NOT MERGE — integration preview.** This branch merges the five PRs below so the end state is legible as one diff. Review and merge the individual PRs; this exists to answer "what does it look like when it is all in".

## The problem

`files.pythonhosted.org` returns intermittent 502s (pypi/support#11895) in ~45 second bursts at a 10–17% error rate. A CI job cold-fetches dozens of wheels concurrently, so it samples that fault repeatedly. Retries do not clear it: pip with `--retries=50` exhausted on a single wheel while 47 of 62 *job-level* retries passed in the same build, because urllib3 reuses the pooled connection and stays pinned to the same bad Fastly edge.

The fix already deployed is a caching mirror per Buildkite stack (`mirror.ci.ray.io`, reef#273). These PRs are what point CI at it.

## The one structural fact everything follows from

The mirror is a **byte cache, not an index**. PyPI's `/simple/` pages carry absolute artifact URLs — all 4426 links on cython's page point at `files.pythonhosted.org` — so pointing pip at the mirror's copy fetches the *listing* through the cache and the *wheels* from the origin, which is the half that fails. And the mirror cannot rewrite them: it parses only `/<host>/<path>`, and serves cache hits as 303 redirects to presigned S3 URLs, so it never holds a body to edit.

Hence a small rewriting proxy in front of it. Everything below is a consequence of that.

## The five PRs

| PR | What it does | Why separate |
|---|---|---|
| **#65593** | Pins the index representation to `text/html` | Fixes a live red; smallest, most urgent |
| **#65599** | Points bazel's own downloader at the mirror | Different mechanism entirely — `http_archive`, not pip |
| **#65597** | macOS resolves through the mirror | Platform-specific; also carries the off-image install support |
| **#65598** | Windows resolves through the mirror | Stacked on #65597 |
| **#65578** | Image builds get an index | Was parked; the agent hook gives it a value |
| *(this branch)* | plus the agent hook | Highest blast radius — runs on every agent, every job |

## What each surface gets

| Surface | Before | After |
|---|---|---|
| forge, manylinux steps | covered | covered |
| bazel `whl_library` | covered | covered |
| bazel `http_archive` | **origin** | mirror, with the origin kept as fallback (#65599) |
| release pipeline `init` | **origin** | agent proxy |
| wanda image builds | **origin** | agent proxy + build arg (#65578) |
| macOS | **origin** | agent hook / #65597 |
| Windows | **origin** | in-container proxy (#65598) |
| cluster-side installs at test runtime | origin | **still origin** — Anyscale accounts cannot reach an internal ALB |

## Things worth knowing while reading

**The representation bug is why #65593 exists.** The mirror caches `/simple/` keyed on URL with no `Vary`, and the proxy forwarded each client's `Accept`. uv asks for PEP 691 JSON, so JSON got cached; `whl_library`'s pip is 22.0.4, two releases before PEP 691 support landed in pip 22.2, so it skipped the page and reported `from versions: none` — which reads exactly like a bad version pin. It gets worse with use, since every uv-driven job poisons more entries and `cache/` holds them for 180 days. Pinning stops new poisoning; the already-cached entries need the `cache/pypi.org/simple/` prefix deleted.

**A bazel rewrite replaces the URL set rather than adding to it.** So the naive single rule discards the origin and turns a mirror outage into a hard build failure. #65599 emits an identity rewrite alongside, verified against bazel 7.5.0: with an unreachable mirror, one rule fails the build and two rules warn and succeed. Found by reading anyscale/rayturbo#4205, which also notes it would discard the fallbacks `auto_http_archive` builds for the C++ dependencies if the pattern is broadened past pythonhosted.

**Two addresses, not one.** The agent hook exports `PIP_INDEX_URL` on loopback for pip running on the agent, and `RAYCI_IMAGE_PIP_INDEX_URL` on the docker bridge gateway for docker builds, which have their own loopback. wanda resolves build args from its own process environment, which is what lets an image build use the mirror at all.

**Reachability from a docker build was measured, not assumed** — premerge 72149, both the BuildKit and legacy builders, default networking, no `--network=host`.

**Everything fails open.** Every path leaves the environment untouched when the mirror is unreachable, the proxy will not start, or no suitable interpreter exists, and the job then resolves from public PyPI exactly as it does today. That includes the agent install, which necessarily fetches from PyPI and so can hit the very fault being worked around.

## Testing

Each PR carries its own testing notes. Across this branch: `pre-commit` (shellcheck, ruff, black, semgrep) clean on all 32 files; the proxy verified on Python 3.10 and 3.11, with and without the optional middleware; the bazel rewrite verified against 7.5.0 for scheme preservation, config acceptance, identity fallback, and `common` scoping; the agent hook and the macOS path exercised end to end against a stub mirror, including their fail-open paths.

Not verified anywhere: real macOS and Windows agents, and a real wanda image build against the live mirror. Those are what the first CI run on each PR shows.

AI assistance (Claude Code) was used for this change.
