### PR TITLE
[ci] Resolve macOS and agent-side packages through the CI mirror

### DIFF
--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -36,3 +36,11 @@ fi
 
 RAYCI_CHECKOUT_DIR="$(pwd)"
 export RAYCI_CHECKOUT_DIR
+
+# Point this agent's pip and uv at the CI package mirror, for the steps no image can
+# cover: the release pipeline's init step and every wanda image build run directly on the
+# agent, never entering a container, so the profile.d hook in forge and manylinux does not
+# reach them. Sourced, because it exports. `|| true` under `set -e`: a package mirror must
+# never be the reason a job fails, and every path inside falls back to public PyPI.
+# shellcheck source=ci/pypi_proxy_agent.sh
+source ./ci/pypi_proxy_agent.sh || true

--- a/ci/install_pypi_proxy.sh
+++ b/ci/install_pypi_proxy.sh
@@ -1,29 +1,56 @@
 #!/bin/bash
-# Install the job-local PyPI index proxy into an image.
+# Install the job-local PyPI index proxy.
 #
-# Shared by every image whose steps resolve Python packages, so the install lives in
-# one place rather than being copied per Dockerfile. Expects ci/pypi_index_proxy.py
-# and ci/pypi_proxy_profile.sh to be present in the working directory, which the
-# callers arrange with --mount=type=bind.
+# Shared by every image whose steps resolve Python packages, and by the agents that run
+# steps with no image at all, so the install lives in one place rather than being copied
+# per caller. Expects ci/pypi_index_proxy.py and ci/pypi_proxy_profile.sh to be present
+# in the working directory, which image callers arrange with --mount=type=bind.
 #
-# $1 is a python >= 3.11: asgi-cross-origin-protection requires it, and images whose
-# default interpreter is older pass a second one here rather than moving their
-# default. The venv is self-contained in /opt/pypiproxy, so nothing else in the image
-# resolves through it.
+# $1 is the interpreter to build the venv from. Python 3.10 is enough; 3.11+ additionally
+# gets the cross-origin middleware, which is the one dependency that requires it (see
+# pypi_index_proxy.py). Images whose default interpreter is older pass a second one here
+# rather than moving their default.
+#
+# RAYCI_PYPI_PROXY_PREFIX chooses where the venv lands, defaulting to /opt/pypiproxy.
+# Agents that run steps directly on the host -- macOS, Windows -- point it somewhere
+# writable without sudo, since there is no image build to run as root.
+#
+# RAYCI_PYPI_PROXY_SKIP_PROFILE=1 skips installing the profile.d hook, for the same
+# hosts: they have no /etc/profile.d worth writing to and start the proxy explicitly.
 
 set -euo pipefail
 
-PROXY_PYTHON="${1:?usage: install_pypi_proxy.sh <path-to-python3.11+>}"
+PROXY_PYTHON="${1:?usage: install_pypi_proxy.sh <path-to-python3.10+>}"
+PREFIX="${RAYCI_PYPI_PROXY_PREFIX:-/opt/pypiproxy}"
 
-"$PROXY_PYTHON" -m venv /opt/pypiproxy
-/opt/pypiproxy/bin/pip install --no-cache-dir \
-  "asgi-cross-origin-protection==0.1.1" \
-  "niquests==3.21.0" \
-  "starlette==1.6.0" \
-  "uvicorn==0.52.3"
-cp pypi_index_proxy.py /opt/pypiproxy/pypi_index_proxy.py
+# Refuse an interpreter the proxy cannot run on, rather than building a venv that fails
+# at import time in the middle of a job.
+"$PROXY_PYTHON" -c 'import sys; sys.exit(0 if sys.version_info >= (3, 10) else 1)' || {
+  echo "install_pypi_proxy: $PROXY_PYTHON is older than 3.10" >&2
+  "$PROXY_PYTHON" --version >&2 || true
+  exit 1
+}
 
-# Sourced automatically: CI steps run under `bash -elic`, a login shell. The zz-
-# prefix runs it after anything else in profile.d that might set HOME or PATH.
-cp pypi_proxy_profile.sh /etc/profile.d/zz-rayci-pypi-proxy.sh
-chmod 0644 /etc/profile.d/zz-rayci-pypi-proxy.sh
+# --clear so a re-install repairs a broken venv rather than inheriting it. Without it,
+# an attempt that failed partway -- a bad interpreter, an interrupted job -- leaves
+# stale bin/ symlinks that a later attempt with a good interpreter keeps, and the
+# result is a venv whose python cannot start at all.
+"$PROXY_PYTHON" -m venv --clear "$PREFIX"
+
+# starlette and uvicorn need 3.10, niquests 3.7, but asgi-cross-origin-protection needs
+# 3.11 -- so on an older interpreter it is left out and the proxy guards its import. It
+# only ever matters for non-GET routes, and every route here is a GET.
+deps=("niquests==3.21.0" "starlette==1.6.0" "uvicorn==0.52.3")
+if "$PROXY_PYTHON" -c 'import sys; sys.exit(0 if sys.version_info >= (3, 11) else 1)'; then
+  deps+=("asgi-cross-origin-protection==0.1.1")
+fi
+"$PREFIX"/bin/pip install --no-cache-dir "${deps[@]}"
+
+cp pypi_index_proxy.py "$PREFIX"/pypi_index_proxy.py
+
+if [[ "${RAYCI_PYPI_PROXY_SKIP_PROFILE:-0}" != "1" ]]; then
+  # Sourced automatically: CI steps run under `bash -elic`, a login shell. The zz-
+  # prefix runs it after anything else in profile.d that might set HOME or PATH.
+  cp pypi_proxy_profile.sh /etc/profile.d/zz-rayci-pypi-proxy.sh
+  chmod 0644 /etc/profile.d/zz-rayci-pypi-proxy.sh
+fi

--- a/ci/pypi_index_proxy.py
+++ b/ci/pypi_index_proxy.py
@@ -46,11 +46,25 @@ import sys
 
 import niquests
 import uvicorn
-from asgi_cross_origin_protection import CrossOriginProtection
 from starlette.applications import Starlette
 from starlette.requests import Request
 from starlette.responses import PlainTextResponse, Response
 from starlette.routing import Route
+
+# Optional because it is the one dependency here that requires Python >= 3.11, and the
+# surfaces that need this proxy most are the ones without a modern interpreter: the
+# macOS agents carry 3.9 and 3.10 only, and the Windows agent host 3.8. Everything else
+# it needs supports 3.10. The middleware rejects cross-site state-changing requests via
+# Fetch Metadata, and every route here is a GET, which it always allows -- so where it
+# is absent nothing it would have done is skipped. Images that do have 3.11+ still
+# install it, and then it behaves exactly as before.
+try:
+    from asgi_cross_origin_protection import CrossOriginProtection
+except ImportError:  # pragma: no cover - depends on the interpreter, not the code path
+
+    def CrossOriginProtection(app):
+        return app
+
 
 MIRROR_URL = os.environ.get("MIRROR_URL", "https://mirror.ci.ray.io")
 

--- a/ci/pypi_proxy_agent.sh
+++ b/ci/pypi_proxy_agent.sh
@@ -1,0 +1,129 @@
+#!/bin/bash
+# Start the PyPI index proxy on the Buildkite agent, for the steps that no image can
+# reach. Sourced from .buildkite/hooks/pre-command; it exports and must not be run.
+#
+# The images cover steps that run inside them: forge and manylinux each carry the proxy
+# and start it from /etc/profile.d. What they cannot cover is anything that never enters
+# a container -- the release pipeline's init step, and every wanda image build, which run
+# directly on the agent. Those are the surfaces still resolving from files.pythonhosted.org
+# (pypi/support#11895), and init failing means zero release tests run at all.
+#
+# Two addresses come out of this, because they serve different consumers:
+#
+#   PIP_INDEX_URL              127.0.0.1 -- for pip and uv running on the agent itself.
+#                              Loopback, so pip and uv accept it over plain HTTP with no
+#                              trusted-host handling.
+#   RAYCI_IMAGE_PIP_INDEX_URL  the docker bridge gateway -- for docker builds, which have
+#                              their own loopback and reach the agent here. wanda resolves
+#                              build args from its own process environment, so exporting
+#                              this is what lets an image build use the mirror.
+#
+# Everything is guarded: the hook runs under `set -e`, and a package mirror must never be
+# the reason a job fails. Every path here leaves the environment untouched, and a step
+# that gets nothing exported resolves from public PyPI exactly as it does today.
+
+_rayci_agent_pypi_proxy() {
+  [[ -n "${BUILDKITE:-}" ]] || return 0
+  # profile.d in the images sets this; if a previous hook run already did the work, or a
+  # step re-sources us, do not start a second copy.
+  [[ -z "${RAYCI_PYPI_INDEX_MODE:-}" ]] || return 0
+
+  local mirror="${RAYCI_PYPI_MIRROR_URL:-https://mirror.ci.ray.io}"
+  local port="${RAYCI_PYPI_PROXY_PORT:-35999}"
+  local prefix="${RAYCI_PYPI_PROXY_PREFIX:-/var/tmp/rayci-pypiproxy}"
+  local log="/tmp/rayci_pypi_proxy_agent.log"
+  : >"${log}" 2>/dev/null || true
+  local repo_root
+  repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+  # Reachability first: on a fleet with no mirror deployed this is the only check that
+  # runs, and it costs one request.
+  if ! curl -sf -m 15 -o /dev/null "${mirror}/pypi.org/simple/pip/" 2>/dev/null; then
+    echo "pypi index: mirror unreachable from this agent; resolving from public PyPI" >&2
+    return 0
+  fi
+
+  # Validate rather than test for a directory: a half-finished install from an interrupted
+  # job would otherwise look complete and fail later, inside pip.
+  if ! "${prefix}/bin/python" -c 'import niquests, starlette, uvicorn' 2>/dev/null; then
+    # RAYCI_PYPI_PROXY_PYTHON names the interpreter outright, for agents where the search
+    # would not find a suitable one -- the Windows host carries 3.8, so it needs one
+    # provisioned (uv python install) and named here.
+    local candidate found="${RAYCI_PYPI_PROXY_PYTHON:-}"
+    for candidate in python3.13 python3.12 python3.11 python3.10 python3; do
+      [[ -z "${found}" ]] || break
+      local path
+      path="$(command -v "${candidate}" 2>/dev/null)" || continue
+      if [[ -n "${path}" ]] && "${path}" -c 'import sys; sys.exit(0 if sys.version_info >= (3, 10) else 1)' 2>/dev/null; then
+        found="${path}"
+        break
+      fi
+    done
+    if [[ -z "${found}" ]]; then
+      echo "pypi index: no python >= 3.10 on this agent; resolving from public PyPI" >&2
+      return 0
+    fi
+
+    echo "pypi index: installing the index proxy into ${prefix} with ${found}"
+    # This install is itself a PyPI fetch, so it can hit the very fault being worked
+    # around. It fails open, which makes it no worse than not trying.
+    if ! (
+      cd "${repo_root}/ci" &&
+        RAYCI_PYPI_PROXY_PREFIX="${prefix}" \
+          RAYCI_PYPI_PROXY_SKIP_PROFILE=1 \
+          bash install_pypi_proxy.sh "${found}"
+    ) >>"${log}" 2>&1; then
+      echo "pypi index: proxy install failed; resolving from public PyPI" >&2
+      tail -n 20 "${log}" >&2 || true
+      return 0
+    fi
+  fi
+
+  # Bound on all interfaces so both consumers can reach it: the agent over loopback, and
+  # docker builds over the bridge gateway.
+  if ! curl -sf -m 5 -o /dev/null "http://127.0.0.1:${port}/healthz" 2>/dev/null; then
+    if command -v setsid >/dev/null 2>&1; then
+      MIRROR_URL="${mirror}" setsid "${prefix}/bin/python" \
+        "${prefix}/pypi_index_proxy.py" "${port}" >>"${log}" 2>&1 &
+    else
+      ( MIRROR_URL="${mirror}" nohup "${prefix}/bin/python" \
+          "${prefix}/pypi_index_proxy.py" "${port}" >>"${log}" 2>&1 & )
+    fi
+    local _
+    for _ in $(seq 1 60); do
+      curl -sf -m 5 -o /dev/null "http://127.0.0.1:${port}/healthz" 2>/dev/null && break
+      sleep 0.5
+    done
+  fi
+
+  # Probed through the proxy rather than at /healthz, which does not touch the mirror: a
+  # process that is up but cannot reach its upstream must not be advertised.
+  if ! curl -sf -m 20 -o /dev/null "http://127.0.0.1:${port}/simple/pip/" 2>/dev/null; then
+    echo "pypi index: proxy did not serve an index; resolving from public PyPI" >&2
+    tail -n 20 "${log}" >&2 || true
+    return 0
+  fi
+
+  export RAYCI_PYPI_INDEX_MODE="agent-proxy"
+  export PIP_INDEX_URL="http://127.0.0.1:${port}/simple"
+  export UV_INDEX_URL="http://127.0.0.1:${port}/simple"
+  # rules_python passes --isolated to whl_library's pip, which makes it ignore every PIP_*
+  # variable. It reads this before deciding to pass the flag.
+  export RULES_PYTHON_PIP_ISOLATED=0
+  echo "pypi index: agent proxy over the mirror -> ${PIP_INDEX_URL}"
+
+  # The address a docker build reaches the agent on. Best effort: without it, image builds
+  # simply keep resolving from PyPI, which is today's behaviour.
+  local gateway=""
+  if command -v docker >/dev/null 2>&1; then
+    gateway="$(docker network inspect bridge -f '{{range .IPAM.Config}}{{.Gateway}}{{end}}' 2>/dev/null || true)"
+  fi
+  if [[ -n "${gateway}" ]]; then
+    export RAYCI_IMAGE_PIP_INDEX_URL="http://${gateway}:${port}/simple"
+    echo "pypi index: image builds -> ${RAYCI_IMAGE_PIP_INDEX_URL}"
+  else
+    echo "pypi index: no docker bridge gateway found; image builds stay on PyPI" >&2
+  fi
+}
+
+_rayci_agent_pypi_proxy

--- a/ci/pypi_proxy_profile.sh
+++ b/ci/pypi_proxy_profile.sh
@@ -66,7 +66,8 @@ _rayci_pypi_index_setup() {
     echo "pypi index: mirror unreachable from this agent; resolving from public PyPI" >&2
     return 0
   fi
-  if [[ ! -x /opt/pypiproxy/bin/python ]]; then
+  local prefix="${RAYCI_PYPI_PROXY_PREFIX:-/opt/pypiproxy}"
+  if [[ ! -x "${prefix}/bin/python" ]]; then
     export RAYCI_PYPI_INDEX_MODE="pypi"
     echo "pypi index: byte cache reachable but this image carries no proxy; resolving from public PyPI" >&2
     return 0
@@ -85,8 +86,15 @@ _rayci_pypi_index_setup() {
   # start. Sharing a namespace would also share ports with the tests, which is its
   # own hazard. This address works unchanged from here and from any container on the
   # same bridge.
-  local host
-  host="$(hostname -i 2>/dev/null | awk '{print $1}')"
+  # RAYCI_PYPI_PROXY_HOST lets a caller name the address instead. Steps that run
+  # directly on an agent rather than in a container -- macOS, and the Windows host --
+  # set it, because `hostname -i` is a Linux-only spelling and because there is no
+  # nested container that needs to reach this: loopback is both correct and, for pip
+  # and uv, exempt from the plain-HTTP refusal below.
+  local host="${RAYCI_PYPI_PROXY_HOST:-}"
+  if [[ -z "${host}" ]]; then
+    host="$(hostname -i 2>/dev/null | awk '{print $1}')"
+  fi
   if [[ -z "${host}" ]]; then
     export RAYCI_PYPI_INDEX_MODE="pypi"
     echo "pypi index: could not determine this container's address; resolving from public PyPI" >&2
@@ -94,11 +102,17 @@ _rayci_pypi_index_setup() {
   fi
   local url="http://${host}:${port}"
 
-  # setsid gives the proxy its own session: `bash -i` enables job control, so a
-  # plain background job shares the step shell's process group and would be
-  # signalled along with it.
-  MIRROR_URL="${mirror}" setsid /opt/pypiproxy/bin/python \
-    /opt/pypiproxy/pypi_index_proxy.py "${port}" >"${log}" 2>&1 &
+  # The proxy needs its own session: `bash -i` enables job control, so a plain
+  # background job shares the step shell's process group and would be signalled along
+  # with it. setsid is util-linux and absent on macOS, where nohup plus a subshell
+  # achieves the same detachment.
+  if command -v setsid >/dev/null 2>&1; then
+    MIRROR_URL="${mirror}" setsid "${prefix}/bin/python" \
+      "${prefix}/pypi_index_proxy.py" "${port}" >"${log}" 2>&1 &
+  else
+    ( MIRROR_URL="${mirror}" nohup "${prefix}/bin/python" \
+        "${prefix}/pypi_index_proxy.py" "${port}" >"${log}" 2>&1 & )
+  fi
 
   local _
   for _ in $(seq 1 60); do

--- a/ci/ray_ci/macos/macos_ci.sh
+++ b/ci/ray_ci/macos/macos_ci.sh
@@ -122,6 +122,13 @@ _prelude() {
     (which bazel && bazel clean) || true;
   fi
   export SKIP_PIP_INSTALL=1
+  # Resolve pip and uv through the CI package mirror where it is reachable, so the
+  # installs below do not depend on files.pythonhosted.org being healthy
+  # (pypi/support#11895). Sourced, because it exports the index variables. The `|| true`
+  # matters under `set -e`: this must never be the reason a wheel build fails, and every
+  # path inside it already falls back to public PyPI.
+  # shellcheck source=ci/ray_ci/macos/pypi_proxy.sh
+  source ./ci/ray_ci/macos/pypi_proxy.sh || true
   . ./ci/ci.sh init && source ~/.zshenv
   source ~/.zshrc
 

--- a/ci/ray_ci/macos/macos_ci_build.sh
+++ b/ci/ray_ci/macos/macos_ci_build.sh
@@ -37,6 +37,13 @@ build() {
   export MAC_JARS=1
   export RAY_INSTALL_JAVA=1
   export RAY_ENABLE_WINDOWS_OR_OSX_CLUSTER=1
+  # Resolve pip and uv through the CI package mirror where it is reachable, so the
+  # installs below do not depend on files.pythonhosted.org being healthy
+  # (pypi/support#11895). Sourced, because it exports the index variables. The `|| true`
+  # matters under `set -e`: this must never be the reason a wheel build fails, and every
+  # path inside it already falls back to public PyPI.
+  # shellcheck source=ci/ray_ci/macos/pypi_proxy.sh
+  source ./ci/ray_ci/macos/pypi_proxy.sh || true
   . ./ci/ci.sh init && source ~/.zshenv
   source ~/.zshrc
   ./ci/ci.sh build_macos_wheels_and_jars

--- a/ci/ray_ci/macos/pypi_proxy.sh
+++ b/ci/ray_ci/macos/pypi_proxy.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+# Point this macOS job's pip and uv at the CI package mirror. Source it, do not run it:
+# it exports the index variables into the calling shell.
+#
+# Why macOS needs its own entry point rather than the profile.d hook the Linux images
+# use: these steps run directly on the agent, not in a container, so there is no image
+# to install the proxy into and no /etc/profile.d being sourced. What is here instead is
+# the same two pieces -- install, then start -- called explicitly.
+#
+# Two properties of these agents make this cheap. They are long-lived (a launchd
+# service, no disconnect-after-job) with a persistent HOME, so the venv below is built
+# once per machine rather than once per job. And nothing else needs to reach the proxy,
+# since no containers are involved, so it binds loopback -- which pip and uv accept over
+# plain HTTP without any trusted-host handling.
+#
+# Every failure path leaves the environment untouched, so a job resolves from PyPI
+# exactly as it did before. That includes the first install on a cold machine, which
+# necessarily fetches from PyPI itself and can hit the very 502s this works around.
+
+_rayci_macos_pypi_proxy() {
+  local prefix="${HOME}/.pypiproxy"
+  local repo_root
+  repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+
+  # Validate rather than test for the directory: a half-finished install from an
+  # interrupted job would otherwise look complete and fail later, inside pip.
+  if ! "${prefix}/bin/python" -c 'import niquests, starlette, uvicorn' 2>/dev/null; then
+    # Newest first: the proxy only needs 3.10, and from 3.11 it also gets the
+    # cross-origin middleware. python.org builds land in /Library/Frameworks -- the
+    # reef userdata installs 3.9 and 3.10 there -- and miniforge supplies another 3.10.
+    local candidate found=""
+    for candidate in \
+      /Library/Frameworks/Python.framework/Versions/3.12/bin/python3.12 \
+      /Library/Frameworks/Python.framework/Versions/3.11/bin/python3.11 \
+      /Library/Frameworks/Python.framework/Versions/3.10/bin/python3.10 \
+      /opt/homebrew/opt/miniforge/bin/python3 \
+      "$(command -v python3.12 2>/dev/null)" \
+      "$(command -v python3.11 2>/dev/null)" \
+      "$(command -v python3.10 2>/dev/null)"; do
+      if [[ -n "${candidate}" && -x "${candidate}" ]]; then
+        found="${candidate}"
+        break
+      fi
+    done
+    if [[ -z "${found}" ]]; then
+      echo "pypi index: no python >= 3.10 on this agent; resolving from public PyPI" >&2
+      return 0
+    fi
+
+    echo "pypi index: installing the index proxy into ${prefix} with ${found}"
+    # venv creation is idempotent, so a failed attempt is simply retried next job
+    # rather than needing the directory cleared.
+    if ! (
+      cd "${repo_root}/ci" &&
+        RAYCI_PYPI_PROXY_PREFIX="${prefix}" \
+          RAYCI_PYPI_PROXY_SKIP_PROFILE=1 \
+          bash install_pypi_proxy.sh "${found}"
+    ); then
+      echo "pypi index: proxy install failed; resolving from public PyPI" >&2
+      return 0
+    fi
+  fi
+
+  # The mirror probe, the mode selection, the readiness wait and the fail-open paths are
+  # all shared with the Linux images rather than reimplemented here.
+  export RAYCI_PYPI_PROXY_PREFIX="${prefix}"
+  export RAYCI_PYPI_PROXY_HOST="127.0.0.1"
+  # shellcheck source=ci/pypi_proxy_profile.sh
+  source "${repo_root}/ci/pypi_proxy_profile.sh"
+}
+
+_rayci_macos_pypi_proxy


### PR DESCRIPTION
Replaces #65597 and #65601, which accumulated a tangled history (a squash-merge between them, a master merge, and two DCO repairs). Same content, byte-identical to #65597's head, as two clean commits.

## Description

Two surfaces still resolve from `files.pythonhosted.org` (pypi/support#11895), and neither can be reached by the images:

- **macOS** — steps run directly on the agent, so there is no image to install the proxy into and no `/etc/profile.d` being sourced. `macos_wheels_arm64` carries the `release_wheels` tag and publishes to the wheels destination on master, so a 502 there leaves the published wheel set short a platform.
- **The release pipeline's `init` step, and every wanda image build** — both run directly on the agent too. `init` is the one that hurts: when it fails, **zero release tests run**. It failed on the mirror-merge commit itself (release 104738), and 104422 only got through after three retries.

The mirror was already reachable from all of them — the macOS builders take `vpc_id` from `module.prod_environment`, the same VPC as that stack's `mirror-cache` and its private zone. What was missing was a way to use it.

## What changed

**`ci/ray_ci/macos/pypi_proxy.sh`** — sourced from `macos_ci.sh` and `macos_ci_build.sh` before their first installs.

**`.buildkite/hooks/pre-command`** + **`ci/pypi_proxy_agent.sh`** — the hook runs on the agent before every step, *including wanda steps*, so it is the one place that reaches them. It exports two addresses because they serve different consumers:

```
PIP_INDEX_URL              127.0.0.1        for pip and uv on the agent itself
RAYCI_IMAGE_PIP_INDEX_URL  bridge gateway   for docker builds, which have their own loopback
```

The second is what unparks **#65578**: wanda resolves build args from its own process environment, and nothing set that variable before, so the `ARG` defaulted to empty and every image build silently fell back to PyPI.

**Shared-script changes** that any off-image install needs: an install prefix and a skip-profile switch (so a host installs without sudo); an address override, because `hostname -i` is Linux-only and returns nothing on macOS, plus `nohup` where `setsid` is absent; a guarded `asgi_cross_origin_protection` import, the only dependency requiring 3.11 when these agents have none; and `venv --clear`, without which a half-finished install leaves stale `bin/` symlinks that a retry inherits, producing a venv whose python cannot start.

## Reachability was measured

On premerge 72149, a `docker build` RUN step reached a proxy outside its network namespace on **both the BuildKit and legacy builders, default networking, no `--network=host`**.

## Known cost, worth reviewing carefully

Linux agents terminate per job, so the hook's install runs on **every job**, including ones that never touch Python. macOS and Windows agents are long-lived and install once per machine. Two ways to remove that, neither done here: scope the hook to the steps that actually need it (containerised steps already get a proxy from `profile.d`), or run the proxy *from* the forge image, which already carries it at `/opt/pypiproxy`, instead of installing.

## Fail-open everywhere

The hook runs under `set -e` and a package mirror must never be the reason a job fails. An unreachable mirror, no suitable interpreter, a failed install, or a proxy that starts but cannot serve all leave the environment untouched, and the step resolves from public PyPI exactly as today.

## Testing

Exercised end to end against a stub mirror: installs to a user-writable prefix with no sudo, starts the proxy, exports both addresses with the bridge gateway detected automatically, and serves an index whose artifact URLs are rewritten onto the mirror. Fail-open verified twice, with a broken interpreter and with an unreachable mirror. The proxy runs on 3.10 with the optional middleware absent and on 3.11 with it present. `pre-commit` (shellcheck, ruff, black, semgrep) clean.

Not verified: real macOS agents, and the interaction with a real wanda image build. The failure mode if the interpreter search, the loopback bind, or the gateway detection is wrong on a real agent is a printed warning and a job that resolves from PyPI — the status quo, not a new failure.

AI assistance (Claude Code) was used for this change.
