### PR TITLE
[docs] Drop the unreachable pytorch_lightning intersphinx target

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -852,7 +852,9 @@ intersphinx_mapping = {
     "pymongoarrow": ("https://mongo-arrow.readthedocs.io/en/latest/", None),
     "pyspark": ("https://spark.apache.org/docs/latest/api/python/", None),
     "python": ("https://docs.python.org/3", None),
-    "pytorch_lightning": ("https://lightning.ai/docs/pytorch/stable/", None),
+    # pytorch_lightning is intentionally absent. As of 2026-08-19 lightning.ai
+    # serves its single-page app shell for every docs path, so objects.inv
+    # returns HTML and intersphinx fails the -W build. No mirror is reachable.
     "scipy": (
         "https://docs.scipy.org/doc/scipy/",
         "https://github.com/ray-project/scipy/releases/download/object-mirror-0.1.0/objects.inv",


### PR DESCRIPTION
## Why this change

Ray's docs build on `master` has been failing since roughly 17:41 UTC on 2026-08-19. Sphinx fails to load the PyTorch Lightning intersphinx inventory, and because the build runs with `-W`, the single warning is fatal:

```
WARNING: failed to reach any of the inventories with the following issues:
unknown or unsupported inventory version: ValueError('invalid inventory header: <!doctype html>')
build finished with problems, 1 warning (with warnings treated as errors).
```

`https://lightning.ai/docs/pytorch/stable/objects.inv` now returns HTTP 200 with `text/html` — the lightning.ai single-page app shell — instead of a Sphinx inventory. This is upstream hosting, not anything in this repo.

Three consecutive `master` builds failed with the identical warning (RtD builds 4337531, 4337840, 4337999); the last green one was 4337028 at 17:58 UTC. The `last-modified` header on the lightning.ai docs shell is `Wed, 19 Aug 2026 17:41:25 GMT`, which lines up with the start of the failures.

The warning text does not name the failing project, because intersphinx loads inventories concurrently and the adjacent `loading intersphinx inventory ...` line belongs to a different project in each build. I identified it by fetching all 26 inventory URLs in `conf.py` directly. Exactly one is broken; the other 25 return valid inventories.

There is no working URL to repoint at. All of the following return the same app shell:

- `/docs/pytorch/{stable,latest}/objects.inv`
- `/docs/pytorch/{2.5.5,2.4.0,1.9.5}/objects.inv`
- `/docs/pytorch/stable/{_static,api,_downloads}/objects.inv`
- `/docs/{fabric,torchmetrics,litserve}/stable/objects.inv`
- `pytorch-lightning.readthedocs.io/en/{stable,latest,1.9.5,2.6.5}/objects.inv` (302 into lightning.ai)

`docs.pytorchlightning.ai` is still a live Read the Docs custom domain, but it serves a 566-byte meta-refresh stub pointing at lightning.ai; `objects.inv`, `searchindex.js`, and `_static/documentation_options.js` all 404 there. Content pages under lightning.ai are client-rendered too, so this looks site-wide rather than one missing asset.

## What this removes

The `pytorch_lightning` entry in `intersphinx_mapping`, leaving 25 targets. Nothing else changes.

No prose cross-reference depends on it. Grepping `doc/source` for Sphinx role xrefs (`:class:`, `:meth:`, `:func:`, `:obj:`, and the MyST `{class}` equivalents) targeting `pytorch_lightning` / `lightning.pytorch` returns zero matches. Every mention in the Lightning docs pages and notebooks is prose, a code sample, or a hardcoded `https://lightning.ai/...html` link, none of which use intersphinx.

The references that do resolve through this inventory are autodoc-generated, from Ray classes that subclass or annotate Lightning types:

| Ray API | Lightning target |
|---|---|
| `ray.train.lightning.RayDDPStrategy` | `lightning.pytorch.strategies.DDPStrategy` (base) |
| `ray.train.lightning.RayFSDPStrategy` | `lightning.pytorch.strategies.FSDPStrategy` (base) |
| `ray.train.lightning.RayDeepSpeedStrategy` | `lightning.pytorch.strategies.DeepSpeedStrategy` (base) |
| `ray.train.lightning.RayLightningEnvironment` | `lightning.pytorch.plugins.environments.LightningEnvironment` (base) |
| `ray.train.lightning.RayTrainReportCallback` | `lightning.pytorch.callbacks.Callback` (base) |
| `ray.train.lightning.prepare_trainer` | `pl.Trainer` (parameter and return annotation) |
| `ray.tune.integration.pytorch_lightning.TuneReportCheckpointCallback` | `lightning.pytorch.callbacks.Callback`, via its `TuneCallback` base |
| `ray.tune.integration.pytorch_lightning.TuneReportCallback` | same, inherited |

On those eight API pages, the `Bases:` line and the `prepare_trainer` annotations render as plain text instead of links to Lightning's docs. That is the entire user-visible cost, and those links are dead right now anyway, since lightning.ai serves no docs content.

Removing the entry does not introduce nitpick warnings. Every reference above resolves as a `py:class` ref, and `conf.py` carries `("py:class", ".*")` in `nitpick_ignore_regex`, which suppresses that class repo-wide.

## Relationship to #64977

#64977 (`[docs] Pre-bake intersphinx inventory snapshots`, approved 2026-08-14) is the better fix and **should** make this change unnecessary. It commits `doc/source/_intersphinx/pytorch_lightning.inv` — a valid PyTorch Lightning 2.6.1 inventory with 7,134 entries, captured before lightning.ai broke — and rewrites `intersphinx_mapping` to read the local snapshot first with the upstream URL only as a fallback. That both unblocks the build and keeps every cross-reference in the table above working, which this PR does not.

I'm raising this only as a faster stopgap for a currently red `master`. If #64977 lands first, close this one unmerged. If this lands first, #64977 should restore the `pytorch_lightning` entry alongside its snapshot, and the comment this PR leaves in `conf.py` should go with it.

## Testing

I did not run a full local Sphinx build. The Read the Docs `-W` build on this PR is the real gate, since it reproduces the exact failing configuration.

What I ran:

- `python3 -c "import ast; ast.parse(...)"` on `doc/source/conf.py` — parses clean; `intersphinx_mapping` has 25 targets and no `pytorch_lightning` key.
- Grepped `doc/source` for Sphinx and MyST role xrefs to `pytorch_lightning` / `lightning.pytorch` / `lightning.fabric` — 0 matches, confirming no prose reference breaks.
- Confirmed `("py:class", ".*")` is present in `nitpick_ignore_regex` (`doc/source/conf.py:293`).
- Fetched all 26 inventory URLs from `conf.py` plus the alternate hosts listed above, checking each response for the `# Sphinx inventory version` magic bytes.

## Duplicate check

`gh pr list --state open --search "intersphinx"` returns #64977 and two unrelated Dependabot PRs. #64977 is the overlap and is described above; this change is deliberately different in approach and intended lifetime, and I'd rather see #64977 merge than this.

## AI assistance

AI assistance was used to diagnose the failure and draft this change and description.
