### PR TITLE
[ci] Mirror bazel's downloads on the agent, and keep the config

### DIFF
--- a/ci/bazel_mirror_downloader.sh
+++ b/ci/bazel_mirror_downloader.sh
@@ -1,0 +1,92 @@
+# shellcheck shell=bash
+# Point bazel's own downloader at the CI package mirror. Source this, then call
+# rayci_bazel_downloader_config where the mirror has just been found reachable, or
+# rayci_bazel_downloader_restore where ~/.bazelrc has just been rewritten.
+#
+# This is a separate mechanism from the pip index, and needs a separate answer:
+# rules_python declares its bootstrap wheels as http_archive with literal
+# files.pythonhosted.org URLs, and http_archive never consults PIP_INDEX_URL. A 502 there
+# takes the whole analysis phase rather than one target, during repository mapping --
+# microcheck 52470 and the docs-example jobs on postmerge 19272, both on click-8.0.1.
+#
+# Sourced from three places, because bazel runs in all three and each can be the last
+# writer of ~/.bazelrc:
+#
+#   ci/pypi_proxy_profile.sh  the images, once per step, after its mirror probe
+#   ci/pypi_proxy_agent.sh    the agent, for the steps that never enter a container --
+#                             the release pipeline's init step and wanda image builds
+#   ci/env/install-bazel.sh   restore only, because it clears ~/.bazelrc in CI and would
+#                             otherwise drop whichever hook ran first
+#
+# Everything fails open. A package mirror must never be the reason a build fails, and the
+# two rewrite rules below leave the origin in place besides.
+
+_rayci_bazel_downloader_cfg_path() {
+  echo "${HOME}/.rayci_bazel_downloader.cfg"
+}
+
+# Add the option to ~/.bazelrc unless it is already there. profile.d can be sourced more
+# than once per job, and the file may already carry the bazel cache settings the image
+# wrote, so this appends rather than replaces.
+_rayci_bazel_downloader_add_rc() {
+  local cfg="$1"
+  local rc="${HOME}/.bazelrc"
+
+  if ! grep -qsF -- "--experimental_downloader_config=${cfg}" "${rc}"; then
+    # Leading newline: appending to a file that does not end in one would splice this
+    # onto the last option rather than adding it.
+    printf '\n%s\n' "common --experimental_downloader_config=${cfg}" >>"${rc}" || return 0
+  fi
+}
+
+# Write the rewrite config and reference it from ~/.bazelrc. Call this only where the
+# mirror has been probed and answered: the config file's existence is what
+# rayci_bazel_downloader_restore later reads as "this job has a reachable mirror".
+rayci_bazel_downloader_config() {
+  local mirror="${1:-${RAYCI_PYPI_MIRROR_URL:-https://mirror.ci.ray.io}}"
+  local cfg
+  cfg="$(_rayci_bazel_downloader_cfg_path)"
+  local host="${mirror#*://}"
+
+  # Off CI the mirror is unreachable by design, so leave developer machines alone.
+  [[ -n "${BUILDKITE:-}" ]] || return 0
+
+  # Bazel preserves the original scheme when it rewrites, and every URL rewritten here is
+  # https. A mirror reachable only over http would therefore be addressed as https and
+  # fail in a way that looks like a broken mirror rather than a misconfiguration.
+  if [[ "${mirror}" != https://* ]]; then
+    echo "pypi index: mirror is not https, leaving bazel downloads on the origin" >&2
+    return 0
+  fi
+
+  # The replacement keeps the upstream host as a path segment, which is how the mirror
+  # addresses upstreams.
+  # Two rules, and the second is load-bearing. A matching rewrite *replaces* the URL set
+  # rather than adding to it, so the first rule alone would discard the origin -- turning
+  # a mirror outage into a hard failure where bazel would otherwise have fallen back.
+  # Verified against bazel 7.5.0: with an unreachable mirror, one rule fails the build and
+  # two rules warn and succeed. Credit to anyscale/rayturbo#4205, which found this and
+  # notes it also discards the fallbacks auto_http_archive builds for the C++
+  # dependencies if the pattern is ever broadened beyond pythonhosted.
+  {
+    echo "rewrite files\\.pythonhosted\\.org/(.*) ${host}/files.pythonhosted.org/\$1"
+    echo "rewrite files\\.pythonhosted\\.org/(.*) files.pythonhosted.org/\$1"
+  } >"${cfg}" || return 0
+
+  _rayci_bazel_downloader_add_rc "${cfg}"
+  echo "pypi index: bazel downloads of files.pythonhosted.org rewritten to ${host}"
+}
+
+# Re-add the option after something has rewritten ~/.bazelrc. Deliberately does not probe
+# or write the config: it restores what was clobbered and nothing more, so a job whose
+# mirror was unreachable stays on the origin rather than acquiring a rewrite here.
+rayci_bazel_downloader_restore() {
+  local cfg
+  cfg="$(_rayci_bazel_downloader_cfg_path)"
+
+  [[ -n "${BUILDKITE:-}" ]] || return 0
+  [[ -f "${cfg}" ]] || return 0
+
+  _rayci_bazel_downloader_add_rc "${cfg}"
+  echo "pypi index: restored the bazel downloader rewrite to ~/.bazelrc"
+}

--- a/ci/docker/forge.Dockerfile
+++ b/ci/docker/forge.Dockerfile
@@ -14,6 +14,7 @@ RUN \
   --mount=type=bind,source=ci/pypi_index_proxy.py,target=pypi_index_proxy.py \
   --mount=type=bind,source=ci/pypi_proxy_profile.sh,target=pypi_proxy_profile.sh \
   --mount=type=bind,source=ci/install_pypi_proxy.sh,target=install_pypi_proxy.sh \
+  --mount=type=bind,source=ci/bazel_mirror_downloader.sh,target=bazel_mirror_downloader.sh \
 <<EOF
 #!/bin/bash
 

--- a/ci/docker/forge.wanda.yaml
+++ b/ci/docker/forge.wanda.yaml
@@ -9,3 +9,4 @@ srcs:
   - ci/pypi_index_proxy.py
   - ci/pypi_proxy_profile.sh
   - ci/install_pypi_proxy.sh
+  - ci/bazel_mirror_downloader.sh

--- a/ci/docker/manylinux-retag.Dockerfile
+++ b/ci/docker/manylinux-retag.Dockerfile
@@ -26,6 +26,7 @@ RUN \
   --mount=type=bind,source=ci/pypi_index_proxy.py,target=pypi_index_proxy.py \
   --mount=type=bind,source=ci/pypi_proxy_profile.sh,target=pypi_proxy_profile.sh \
   --mount=type=bind,source=ci/install_pypi_proxy.sh,target=install_pypi_proxy.sh \
+  --mount=type=bind,source=ci/bazel_mirror_downloader.sh,target=bazel_mirror_downloader.sh \
 <<EOF
 #!/bin/bash
 

--- a/ci/docker/manylinux.wanda.yaml
+++ b/ci/docker/manylinux.wanda.yaml
@@ -10,3 +10,4 @@ srcs:
   - ci/pypi_index_proxy.py
   - ci/pypi_proxy_profile.sh
   - ci/install_pypi_proxy.sh
+  - ci/bazel_mirror_downloader.sh

--- a/ci/env/install-bazel.sh
+++ b/ci/env/install-bazel.sh
@@ -120,4 +120,14 @@ if [[ "${CI-}" == "true" && "${BUILDKITE-}" != "" ]]; then
       echo "build --remote_upload_local_results=false" >> ~/.bazelrc
     fi
   fi
+
+  # The clear above drops the mirror rewrite whichever pypi proxy hook wrote it, and this
+  # script runs after them: `ci/ci.sh init` reaches here through install-dependencies.sh,
+  # and on macOS that is the line straight after the proxy is sourced
+  # (ci/ray_ci/macos/macos_ci.sh). Restoring is a no-op unless a hook already found the
+  # mirror reachable, so an unreachable mirror still means no rewrite.
+  # shellcheck source=ci/bazel_mirror_downloader.sh
+  if source "$(dirname "${BASH_SOURCE[0]}")/../bazel_mirror_downloader.sh" 2>/dev/null; then
+    rayci_bazel_downloader_restore
+  fi
 fi

--- a/ci/install_pypi_proxy.sh
+++ b/ci/install_pypi_proxy.sh
@@ -50,7 +50,17 @@ cp pypi_index_proxy.py "$PREFIX"/pypi_index_proxy.py
 # The bazel downloader helper travels with the proxy, because the profile.d hook that
 # calls it is installed into the image and cannot reach a checkout that does not exist
 # yet at shell start.
-cp bazel_mirror_downloader.sh "$PREFIX"/bazel_mirror_downloader.sh
+#
+# Conditional, because the callers do not all hand this script the same files. An image
+# build sees only what its wanda spec lists in srcs, and a spec that predates this file
+# would otherwise fail the whole build on a missing cp. The hook that reads it already
+# reports when it finds nothing and leaves bazel on the origin.
+if [[ -f bazel_mirror_downloader.sh ]]; then
+  cp bazel_mirror_downloader.sh "$PREFIX"/bazel_mirror_downloader.sh
+else
+  echo "install_pypi_proxy: no bazel_mirror_downloader.sh in this context;" \
+    "bazel downloads will stay on the origin in images built from it" >&2
+fi
 
 if [[ "${RAYCI_PYPI_PROXY_SKIP_PROFILE:-0}" != "1" ]]; then
   # Sourced automatically: CI steps run under `bash -elic`, a login shell. The zz-

--- a/ci/install_pypi_proxy.sh
+++ b/ci/install_pypi_proxy.sh
@@ -47,6 +47,10 @@ fi
 "$PREFIX"/bin/pip install --no-cache-dir "${deps[@]}"
 
 cp pypi_index_proxy.py "$PREFIX"/pypi_index_proxy.py
+# The bazel downloader helper travels with the proxy, because the profile.d hook that
+# calls it is installed into the image and cannot reach a checkout that does not exist
+# yet at shell start.
+cp bazel_mirror_downloader.sh "$PREFIX"/bazel_mirror_downloader.sh
 
 if [[ "${RAYCI_PYPI_PROXY_SKIP_PROFILE:-0}" != "1" ]]; then
   # Sourced automatically: CI steps run under `bash -elic`, a login shell. The zz-

--- a/ci/pypi_proxy_agent.sh
+++ b/ci/pypi_proxy_agent.sh
@@ -43,6 +43,19 @@ _rayci_agent_pypi_proxy() {
     return 0
   fi
 
+  # Bazel runs on the agent too, and its downloader is a separate mechanism from pip's
+  # index: rules_python declares its bootstrap wheels as http_archive with literal
+  # files.pythonhosted.org URLs, which no index setting reaches. The images have had this
+  # since #65599 and the agent had nothing, so release 104848's init step still fetched
+  # tomli-2.0.1 from the origin. Done here, before the proxy, because it needs only the
+  # mirror -- and the probe above has just established that.
+  # shellcheck source=ci/bazel_mirror_downloader.sh
+  if source "${repo_root}/ci/bazel_mirror_downloader.sh" 2>/dev/null; then
+    rayci_bazel_downloader_config "${mirror}"
+  else
+    echo "pypi index: no bazel downloader helper in this checkout; bazel stays on the origin" >&2
+  fi
+
   # Validate rather than test for a directory: a half-finished install from an interrupted
   # job would otherwise look complete and fail later, inside pip.
   if ! "${prefix}/bin/python" -c 'import niquests, starlette, uvicorn' 2>/dev/null; then

--- a/ci/pypi_proxy_profile.sh
+++ b/ci/pypi_proxy_profile.sh
@@ -7,18 +7,16 @@
 # wiring. The variables it exports are the ones .bazelrc forwards to repository
 # rules and ci/ray_ci/container.py forwards into nested containers.
 #
-# Which index to use is decided by probing, not by assuming, because the mirror
-# serves two different shapes and only one of them is usable directly:
+# Which index to use is decided by probing, not by assuming. The mirror is a byte
+# cache and not an index -- it parses only /<host>/<path>, and serves cache hits as
+# 303 redirects to presigned S3 URLs, so it never holds a body it could rewrite --
+# so there is no mode where pip points straight at it, and two outcomes:
 #
-#   1. A rewriting simple index at /simple. Its pages already point at the mirror
-#      for the artifacts, so pip can use it as-is. Nothing local runs and nested
-#      containers reach it by hostname.
-#   2. A path-prefixed byte cache at /pypi.org/simple. Those pages are PyPI's own,
-#      so their bodies still point at files.pythonhosted.org and using them as an
-#      index leaves every wheel download on the origin that returns the 502s. In
-#      that case start ci/pypi_index_proxy.py, which fetches those pages and
-#      rewrites the file URLs in them.
-#   3. Neither reachable: export nothing and let the retry settings carry the job.
+#   1. Mirror reachable and this image carries the proxy: start
+#      ci/pypi_index_proxy.py, which reads PyPI's index pages through the mirror and
+#      rewrites the file URLs in them, and point pip and uv at that.
+#   2. Mirror unreachable, or reachable but no proxy in this image: export nothing
+#      and let the retry settings carry the job.
 #
 # Fail-open is load-bearing, and it is why the probe hits the mirror rather than
 # only the local process: a healthy proxy in front of an unreachable mirror answers
@@ -54,59 +52,33 @@ _rayci_pypi_index_setup() {
     echo "pypi index: mirror unreachable from this agent; resolving from public PyPI" >&2
     return 0
   fi
-  # Bazel's own downloader is a separate problem from pip's index, and needs a separate
-  # answer. rules_python declares its bootstrap wheels as http_archive with literal
-  # files.pythonhosted.org URLs, and http_archive never consults PIP_INDEX_URL -- so no
-  # index setting reaches them. That is what failed microcheck 52470 and the docs-example
-  # jobs on postmerge 19272: bazel's Java downloader taking a 502 on click-8.0.1, during
-  # repository mapping, which takes the whole analysis phase with it.
+  # Bazel's own downloader is a separate problem from pip's index and gets its own
+  # answer, in ci/bazel_mirror_downloader.sh. Called here rather than after the proxy
+  # starts because it needs only the mirror: an image carrying no proxy still gets its
+  # bazel downloads mirrored.
   #
-  # --experimental_downloader_config rewrites download URLs before they are fetched, so
-  # those archives come from the mirror instead. It needs only the mirror, not the local
-  # proxy, which is why it is set up here rather than after the proxy starts: an image
-  # with no proxy still gets its bazel downloads mirrored.
-  #
-  # Written per job rather than committed to .bazelrc because the hostname is
-  # VPC-internal: a checkout outside CI would rewrite its downloads to a name that does
-  # not resolve, turning a working build into a broken one.
-  _rayci_bazel_downloader_config() {
-    local cfg="${HOME}/.rayci_bazel_downloader.cfg"
-    local rc="${HOME}/.bazelrc"
-    local host="${mirror#*://}"
-
-    # Bazel preserves the original scheme when it rewrites, and every URL rewritten here
-    # is https. A mirror reachable only over http would therefore be addressed as https
-    # and fail in a way that looks like a broken mirror rather than a misconfiguration,
-    # so leave bazel alone in that case.
-    if [[ "${mirror}" != https://* ]]; then
-      echo "pypi index: mirror is not https, leaving bazel downloads on the origin" >&2
-      return 0
-    fi
-
-    # The replacement keeps the upstream host as a path segment, which is how the mirror
-    # addresses upstreams, and bazel preserves the original https scheme.
-    # Two rules, and the second is load-bearing. A matching rewrite *replaces* the URL
-    # set rather than adding to it, so the first rule alone would discard the origin --
-    # turning a mirror outage into a hard failure where bazel would otherwise have fallen
-    # back. Verified against bazel 7.5.0: with an unreachable mirror, one rule fails the
-    # build and two rules warn and succeed. Credit to anyscale/rayturbo#4205, which found
-    # this and notes it also discards the fallbacks auto_http_archive builds for the C++
-    # dependencies if the pattern is ever broadened beyond pythonhosted.
-    {
-      echo "rewrite files\\.pythonhosted\\.org/(.*) ${host}/files.pythonhosted.org/\$1"
-      echo "rewrite files\\.pythonhosted\\.org/(.*) files.pythonhosted.org/\$1"
-    } >"${cfg}" || return 0
-
-    # Appended once: this file may already carry the bazel cache settings the image
-    # wrote, and profile.d can be sourced more than once per job.
-    if ! grep -qsF -- "--experimental_downloader_config=${cfg}" "${rc}"; then
-      # Leading newline: the image writes this file, and appending to one that does not
-      # end in a newline would splice this onto the last option rather than adding it.
-      printf '\n%s\n' "common --experimental_downloader_config=${cfg}" >>"${rc}" || return 0
-    fi
-    echo "pypi index: bazel downloads of files.pythonhosted.org rewritten to ${host}"
+  # Found rather than assumed, because this file is installed into the image as
+  # /etc/profile.d/zz-rayci-pypi-proxy.sh and runs at shell start, when the only copy it
+  # can count on is the one install_pypi_proxy.sh put beside the proxy. The checkout
+  # paths cover images that carry no proxy.
+  _rayci_source_bazel_downloader() {
+    local candidate
+    for candidate in \
+      "${RAYCI_BAZEL_DOWNLOADER_LIB:-}" \
+      "${RAYCI_PYPI_PROXY_PREFIX:-/opt/pypiproxy}/bazel_mirror_downloader.sh" \
+      "${RAYCI_CHECKOUT_DIR:+${RAYCI_CHECKOUT_DIR}/ci/bazel_mirror_downloader.sh}" \
+      "./ci/bazel_mirror_downloader.sh"; do
+      [[ -n "${candidate}" && -f "${candidate}" ]] || continue
+      # shellcheck source=ci/bazel_mirror_downloader.sh
+      source "${candidate}" && return 0
+    done
+    return 1
   }
-  _rayci_bazel_downloader_config
+  if _rayci_source_bazel_downloader; then
+    rayci_bazel_downloader_config "${mirror}"
+  else
+    echo "pypi index: no bazel downloader helper found; bazel downloads stay on the origin" >&2
+  fi
 
   local prefix="${RAYCI_PYPI_PROXY_PREFIX:-/opt/pypiproxy}"
   if [[ ! -x "${prefix}/bin/python" ]]; then


### PR DESCRIPTION
## What

Follows up #65599, which pointed bazel's downloader at the CI mirror inside the images. Three gaps in that same mechanism, so one change:

1. **The agent had no rewrite at all.** `ci/pypi_proxy_agent.sh` now sets it up for the steps that never enter a container — the release pipeline's `init` step and every wanda image build.
2. **`ci/env/install-bazel.sh` clears `~/.bazelrc`** and runs *after* the hooks that write into it, so the rewrite is restored after the clear.
3. **The rewrite rules move into one file**, `ci/bazel_mirror_downloader.sh`, instead of being copied per caller.

It also corrects the header comment of `ci/pypi_proxy_profile.sh`, which still described a usable "rewriting simple index at `/simple`" that the code below it had already ruled out.

Addresses both review comments from @sai-miduthuri on #65599.

## Why

**The agent gap is measurable.** I audited all 41 finished jobs of release build 104848 and counted mirror versus origin fetches: 58 fetches through `mirror.ci.ray.io`, 0 untrusted-host warnings, and exactly one direct `https://files.pythonhosted.org` fetch — in `init`:

```
Fetching https://files.pythonhosted.org/.../tomli-2.0.1-py3-none-any.whl; Checking in SHA-256 cache
```

That is a bazel repository fetch, not pip. The rewrite is written by `ci/pypi_proxy_profile.sh`, which only runs inside the images; `init` runs on the bare agent. That one was served from the SHA-256 cache, but a cache miss goes to the origin — and `init` failing means zero release tests run.

**The clobber is real and ordered against us.** `install-bazel.sh` does `echo > ~/.bazelrc` when `CI=true` and `BUILDKITE` is set, and `ci/ci.sh init` reaches it through `install-dependencies.sh`. On macOS it is the line immediately after the proxy is sourced:

```bash
source ./ci/ray_ci/macos/pypi_proxy.sh || true    # writes the rewrite into ~/.bazelrc
. ./ci/ci.sh init && source ~/.zshenv             # truncates ~/.bazelrc
```

Restore is deliberately not a second `config`: it re-adds the option only when the config file already exists, and that file's existence is the record that a hook probed the mirror and got an answer. A job whose mirror is unreachable therefore stays on the origin rather than acquiring a rewrite from here.

Image builds are unaffected either way — they never set `CI=true`, so that block does not run at image build time.

## Testing

Sourced the helper directly and checked each behaviour:

| case | expected | result |
|---|---|---|
| `config` on a reachable mirror | writes cfg + one rc line | ✅ |
| second `config` call | adds nothing | ✅ |
| rc cleared, then `restore` | line back, cache settings intact | ✅ |
| `restore` with no cfg | no-op | ✅ |
| non-https mirror | nothing written, message on stderr | ✅ |
| `BUILDKITE` unset | nothing touched | ✅ |

`bash -n` clean on all four scripts; pre-commit (including shellcheck) clean.

AI assistance was used for this change. Not a duplicate: #65599 is merged, and this is the follow-up its own review asked for.