### PR TITLE
[ci] Give the custom BYOD build a name for the agent

### DIFF
--- a/release/ray_release/byod/build.py
+++ b/release/ray_release/byod/build.py
@@ -43,6 +43,17 @@ def build_anyscale_custom_byod_image(
         docker_build_cmd = "docker build --progress=plain .".split()
         docker_build_cmd += ["--build-arg", f"BASE_IMAGE={base_image}"]
         docker_build_cmd += ["-t", image]
+        # Give the build the same name for the agent that wanda gives every image build
+        # it starts (ray-project/rayci#501). This is a plain docker build rather than a
+        # wanda one, so it inherits none of that, and the index below is a name the
+        # build has no way to resolve on its own: release 104848 failed
+        # hello_world_custom_byod.{aws,gce} with "failed to lookup address information:
+        # No address associated with hostname". uv resolves these depsets and errors out
+        # where pip would have fallen back, so the whole image build fails.
+        #
+        # Unconditional, matching wanda: docker resolves host-gateway itself, and one
+        # extra hosts entry is inert for a build that never uses the name.
+        docker_build_cmd += ["--add-host", "rayci.localhost:host-gateway"]
         # This build runs inside a forge step on the release stack, so the step's
         # index is a live rewriting proxy and a RUN step can reach it (premerge
         # 72149). Without this the ARG in byod.Dockerfile has no value to take.


### PR DESCRIPTION
## What

Passes `--add-host rayci.localhost:host-gateway` to the `docker build` that builds custom BYOD images, which is what wanda already passes to every image build it starts (ray-project/rayci#501).

## Why

Release build 104848, on the commit that became #65578, failed `hello_world_custom_byod.aws` and `hello_world_custom_byod.gce`:

```
#11 6.043 error: Request failed after 3 retries in 5.7s
#11 6.043   Caused by: failed to lookup address information: No address associated with hostname
#11 ERROR: process "/bin/bash -c bash /tmp/install_python_deps.sh python_depset.lock" did not complete successfully: exit code: 2
```

Custom BYOD images are built here by a plain `docker build`, not by wanda, so they inherit none of wanda's networking flags. `RAYCI_IMAGE_PIP_INDEX_URL` reaches the build as `http://rayci.localhost:35999/simple` — a name the build has no way to resolve — and `install_python_deps.sh` resolves the depsets with **uv**, which fails hard where pip would have fallen back to PyPI. So the image build dies rather than degrading.

Everything else on that build was green (78 passed at the time, including `wanda: forge`, all five wheel builds, the `base-extra-testdeps` images, and the `hello_world*` release tests on AWS, GCE and released images) — this is the one path that reaches the agent proxy without going through wanda.

Unconditional, matching wanda: docker resolves `host-gateway` itself, and one extra hosts entry is inert for a build that never uses the name.

## Testing

`python -m pytest release/ray_release/tests/test_byod_build.py` — 4 passed. The flag goes in after `-t <image>`, so the argument prefix those tests match on is unchanged.

AI assistance was used for this change.