### PR TITLE
[cherry-pick][2.58.0][Data] Update docs for hash shuffle v2 (#65372) in release 2.58

### DIFF
--- a/doc/source/data/aggregating-data.rst
+++ b/doc/source/data/aggregating-data.rst
@@ -159,10 +159,10 @@ Here's an example of creating a custom aggregator that calculates the Mean of va
 
 
 .. note::
-    Internally, aggregations support both the :ref:`hash-shuffle backend <hash-shuffle>` and the :ref:`range based backend <range-partitioning-shuffle>`.
+    Internally, aggregations support both the :ref:`hash-shuffle backend <hash-shuffle>` and the :ref:`range based backend <range-partitioning-shuffle>`. Hash-shuffle (``ShuffleStrategy.HASH_SHUFFLE``) is the default.
 
     Hash-shuffling can provide better performance for aggregations in certain cases. For more information see `comparison between hash based shuffling and Range Based shuffling approach <https://www.anyscale.com/blog/ray-data-joins-hash-shuffle#performance-benchmarks/>`_ .
 
-    To use the hash-shuffle algorithm for aggregations, you need to set the shuffle strategy explicitly:    
-    ``ray.data.DataContext.get_current().shuffle_strategy = ShuffleStrategy.HASH_SHUFFLE`` before creating a ``Dataset``
+    A new shuffle strategy, :ref:`Shuffle v2 <shuffle-v2>` (``ShuffleStrategy.SHUFFLE_V2``), is currently in Alpha. To use it for aggregations, set the strategy before creating a ``Dataset``:
+    ``ray.data.DataContext.get_current().shuffle_strategy = ShuffleStrategy.SHUFFLE_V2``. See :ref:`Tuning shuffle v2 <tuning-shuffle-v2>` for the available knobs.
     

--- a/doc/source/data/aggregating-data.rst
+++ b/doc/source/data/aggregating-data.rst
@@ -163,6 +163,6 @@ Here's an example of creating a custom aggregator that calculates the Mean of va
 
     Hash-shuffling can provide better performance for aggregations in certain cases. For more information see `comparison between hash based shuffling and Range Based shuffling approach <https://www.anyscale.com/blog/ray-data-joins-hash-shuffle#performance-benchmarks/>`_ .
 
-    A new shuffle strategy, :ref:`Shuffle v2 <shuffle-v2>` (``ShuffleStrategy.SHUFFLE_V2``), is currently in Alpha. To use it for aggregations, set the strategy before creating a ``Dataset``:
-    ``ray.data.DataContext.get_current().shuffle_strategy = ShuffleStrategy.SHUFFLE_V2``. See :ref:`Tuning shuffle v2 <tuning-shuffle-v2>` for the available knobs.
+    A new shuffle strategy, :ref:`Shuffle v2 <shuffle-v2>` (``ShuffleStrategy.HASH_SHUFFLE_V2``), is currently in Alpha. To use it for aggregations, set the strategy before creating a ``Dataset``:
+    ``ray.data.DataContext.get_current().shuffle_strategy = ShuffleStrategy.HASH_SHUFFLE_V2``. See :ref:`Tuning shuffle v2 <tuning-shuffle-v2>` for the available knobs.
     

--- a/doc/source/data/data-internals.rst
+++ b/doc/source/data/data-internals.rst
@@ -111,7 +111,7 @@ in Alpha), is the intended replacement for the classical :ref:`hash-shuffling <h
 Shuffle v2
 ~~~~~~~~~~
 
-.. note:: Shuffle v2 (``ShuffleStrategy.SHUFFLE_V2``) is currently in **Alpha**.
+.. note:: Shuffle v2 (``ShuffleStrategy.HASH_SHUFFLE_V2``) is currently in **Alpha**.
 
 Shuffle v2 is a new shuffle backend intended to replace the other shuffle backends. Today it
 provides an updated hash-shuffle implementation. Unlike the aggregator-actor model used by the previous
@@ -142,7 +142,7 @@ application:
 
 .. code-block:: bash
 
-    RAY_DATA_DEFAULT_SHUFFLE_STRATEGY="shuffle_v2"
+    RAY_DATA_DEFAULT_SHUFFLE_STRATEGY="hash_shuffle_v2"
 
 To enable it at runtime, set the shuffle strategy before creating a ``Dataset``:
 
@@ -150,7 +150,7 @@ To enable it at runtime, set the shuffle strategy before creating a ``Dataset``:
 
     from ray.data.context import DataContext, ShuffleStrategy
 
-    DataContext.get_current().shuffle_strategy = ShuffleStrategy.SHUFFLE_V2
+    DataContext.get_current().shuffle_strategy = ShuffleStrategy.HASH_SHUFFLE_V2
 
 .. _tuning-shuffle-v2:
 
@@ -161,7 +161,7 @@ Shuffle v2 provides the following knobs:
 
 **Input batch size** (``DataContext.shuffle_input_batch_bytes``, environment variable
 ``RAY_DATA_SHUFFLE_INPUT_BATCH_BYTES``, default 1 GiB). This setting only applies to the
-``SHUFFLE_V2`` strategy.
+``HASH_SHUFFLE_V2`` strategy.
 
 Shuffle v2 buffers input blocks from the same node until their combined size reaches this
 threshold, then partitions that batch as a unit. This controls the trade-off between shuffle

--- a/doc/source/data/data-internals.rst
+++ b/doc/source/data/data-internals.rst
@@ -102,7 +102,91 @@ Shuffle Algorithms
 In data processing, shuffling refers to the process of redistributing individual dataset's partitions (that in Ray Data are
 called :ref:`blocks <data_key_concepts>`).
 
-Ray Data implements two main shuffle algorithms:
+Ray Data provides several shuffle backends. The newest, :ref:`Shuffle v2 <shuffle-v2>` (currently
+in Alpha), is the intended replacement for the classical :ref:`hash-shuffling <hash-shuffle>` and
+:ref:`range-partitioning <range-partitioning-shuffle>` backends.
+
+.. _shuffle-v2:
+
+Shuffle v2
+~~~~~~~~~~
+
+.. note:: Shuffle v2 (``ShuffleStrategy.SHUFFLE_V2``) is currently in **Alpha**.
+
+Shuffle v2 is a new shuffle backend intended to replace the other shuffle backends. Today it
+provides an updated hash-shuffle implementation. Unlike the aggregator-actor model used by the previous
+:ref:`hash-shuffling <hash-shuffle>` implementation, shuffle v2 is *driver-driven* and doesn't store intermediate
+shuffle data in long-lived aggregator actors. Instead, that data lives in the object store, which
+means:
+
+- Ray can spill intermediate data to disk under memory pressure, avoiding the out-of-memory risk of
+  holding whole partitions in aggregator memory.
+- Reduce-side memory adapts to observed partition sizes, improving memory accounting on skewed
+  datasets.
+
+Shuffle v2 also coalesces shuffle inputs into larger batches before partitioning.
+
+Shuffle v2 supports the following operations:
+
+- Aggregations (:meth:`Dataset.aggregate <ray.data.Dataset.aggregate>`)
+- Group-bys (:meth:`Dataset.groupby <ray.data.Dataset.groupby>`)
+- Key-based repartitioning (:meth:`Dataset.repartition <ray.data.Dataset.repartition>` with ``keys``)
+- Joins (:meth:`Dataset.join <ray.data.Dataset.join>`)
+
+Shuffle v2 doesn't yet support :meth:`Dataset.sort <ray.data.Dataset.sort>` or
+:meth:`Dataset.random_shuffle <ray.data.Dataset.random_shuffle>`, which use the
+:ref:`range-partitioning shuffle <range-partitioning-shuffle>`.
+
+To enable shuffle v2 for the whole cluster, set the environment variable before starting your
+application:
+
+.. code-block:: bash
+
+    RAY_DATA_DEFAULT_SHUFFLE_STRATEGY="shuffle_v2"
+
+To enable it at runtime, set the shuffle strategy before creating a ``Dataset``:
+
+.. code-block:: python
+
+    from ray.data.context import DataContext, ShuffleStrategy
+
+    DataContext.get_current().shuffle_strategy = ShuffleStrategy.SHUFFLE_V2
+
+.. _tuning-shuffle-v2:
+
+Tuning shuffle v2
+^^^^^^^^^^^^^^^^^
+
+Shuffle v2 provides the following knobs:
+
+**Input batch size** (``DataContext.shuffle_input_batch_bytes``, environment variable
+``RAY_DATA_SHUFFLE_INPUT_BATCH_BYTES``, default 1 GiB). This setting only applies to the
+``SHUFFLE_V2`` strategy.
+
+Shuffle v2 buffers input blocks from the same node until their combined size reaches this
+threshold, then partitions that batch as a unit. This controls the trade-off between shuffle
+parallelism and the number of intermediate shard objects:
+
+- A **higher** threshold produces fewer, larger intermediate shard objects and less object-store
+  overhead, but reduces shuffle parallelism.
+- A **lower** threshold increases shuffle parallelism at the cost of more, smaller intermediate
+  objects. Lower the threshold if CPU utilization is low because the units of work are too
+  coarse-grained.
+- Set the threshold to ``0`` to disable batching and partition each input bundle individually.
+
+**Inline object threshold** (``max_direct_call_object_size``, environment variable
+``RAY_max_direct_call_object_size``, default 100 KB). This is a Ray Core setting rather than a Ray
+Data one.
+
+When shuffle v2 partitions a block across many partitions, an individual partition's shard can be
+smaller than this threshold. Ray transfers objects below the threshold *inline*, storing them in
+the memory of the process that submitted the work (typically the driver on the head node) rather
+than in the object store. For a shuffle that produces many small shards, these inline objects
+accumulate on the head node and can cause an out-of-memory failure there.
+
+Lower this threshold (for example, ``RAY_max_direct_call_object_size=8192`` for 8 KB) so that only
+small metadata stays inline and shard data travels through the object store, which is spillable and
+distributed across the cluster. This reduces the risk of head-node out-of-memory failures.
 
 .. _hash-shuffle:
 
@@ -120,8 +204,11 @@ Hash-shuffling is a classical hash-partitioning based shuffling where:
 Hash-shuffling is particularly useful for operations that require deterministic partitioning based on keys, such as joins, group-by operations, and key-based repartitioning, by
 ensuring that rows with the same key-values are being placed into the same partition.
 
-.. note:: To use hash-shuffling in your aggregations and repartitioning operations, you need to currently specify
-    ``ray.data.DataContext.get_current().shuffle_strategy = ShuffleStrategy.HASH_SHUFFLE`` before creating a ``Dataset``.
+.. note:: Hash-shuffle (``ShuffleStrategy.HASH_SHUFFLE``) is the default shuffle strategy for
+    key-based operations: aggregations, group-bys, key-based repartitioning, and joins. To set it
+    explicitly, specify
+    ``ray.data.DataContext.get_current().shuffle_strategy = ShuffleStrategy.HASH_SHUFFLE`` before
+    creating a ``Dataset``.
 
 .. _range-partitioning-shuffle:
 
@@ -136,8 +223,6 @@ the real ranges of the totally ordered (sorted) dataset.
 2. **Partition phase:** every block is sorted and split into partitions based on the *range boundaries* derived in the previous step.
 3. **Reduce phase:** individual partitions within the same range are then recombined to produce the resulting block.
 
-.. note:: Range-partitioning shuffle is a default shuffling strategy. To set it explicitly specify
-    ``ray.data.DataContext.get_current().shuffle_strategy = ShuffleStrategy.SORT_SHUFFLE_PULL_BASED`` before creating a ``Dataset``.
 
 
 Operators, plans, and planning

--- a/doc/source/data/joining-data.rst
+++ b/doc/source/data/joining-data.rst
@@ -41,10 +41,10 @@ only returning columns from the requested side)
 columns from the requested side)
 
 Internally joins are currently powered by the :ref:`hash-shuffle backend <hash-shuffle>`.
-:ref:`Shuffle v2 <shuffle-v2>` (``ShuffleStrategy.SHUFFLE_V2``), currently in Alpha, provides an
+:ref:`Shuffle v2 <shuffle-v2>` (``ShuffleStrategy.HASH_SHUFFLE_V2``), currently in Alpha, provides an
 updated hash-shuffle implementation for joins. To use it, set the shuffle strategy before creating a
 ``Dataset``:
-``ray.data.DataContext.get_current().shuffle_strategy = ShuffleStrategy.SHUFFLE_V2``. See
+``ray.data.DataContext.get_current().shuffle_strategy = ShuffleStrategy.HASH_SHUFFLE_V2``. See
 :ref:`Tuning shuffle v2 <tuning-shuffle-v2>` for memory-related knobs.
 
 Configuring Joins

--- a/doc/source/data/joining-data.rst
+++ b/doc/source/data/joining-data.rst
@@ -41,6 +41,11 @@ only returning columns from the requested side)
 columns from the requested side)
 
 Internally joins are currently powered by the :ref:`hash-shuffle backend <hash-shuffle>`.
+:ref:`Shuffle v2 <shuffle-v2>` (``ShuffleStrategy.SHUFFLE_V2``), currently in Alpha, provides an
+updated hash-shuffle implementation for joins. To use it, set the shuffle strategy before creating a
+``Dataset``:
+``ray.data.DataContext.get_current().shuffle_strategy = ShuffleStrategy.SHUFFLE_V2``. See
+:ref:`Tuning shuffle v2 <tuning-shuffle-v2>` for memory-related knobs.
 
 Configuring Joins
 ----------------------------------
@@ -50,7 +55,7 @@ Joins are generally memory-intensive operations that require accurate memory acc
 Ray Data provides the following levers to allow tuning the performance of joins for your workload:
 
 -   `num_partitions`: (required) specifies number of partitions both incoming datasets will be hash-partitioned into. Check out :ref:`configuring number of partitions <joins_configuring_num_partitions>` section for guidance on how to tune this up.
--   `partition_size_hint`: (optional) Hint to joining operator about the estimated avg expected size of the individual partition (in bytes). If not specified, defaults to DataContext.target_max_block_size (128Mb by default).
+-   `partition_size_hint`: (optional) Hint to joining operator about the estimated avg expected size of the individual partition (in bytes). If not specified, defaults to DataContext.target_max_block_size (128Mb by default). Expect this parameter to be deprecated in 2.58.
     -   Note that, `num_partitions * partition_size_hint` should ideally be approximating actual dataset size, ie `partition_size_hint` could be estimated as dataset size divided by `num_partitions` (assuming relatively evenly sized partitions)
     -   However, in cases when dataset partitioning is expected to be heavily skewed `partition_size_hint` should approximate largest partition to prevent Out-of-Memory (OOM) errors
 

--- a/doc/source/data/joining-data.rst
+++ b/doc/source/data/joining-data.rst
@@ -55,9 +55,7 @@ Joins are generally memory-intensive operations that require accurate memory acc
 Ray Data provides the following levers to allow tuning the performance of joins for your workload:
 
 -   `num_partitions`: (required) specifies number of partitions both incoming datasets will be hash-partitioned into. Check out :ref:`configuring number of partitions <joins_configuring_num_partitions>` section for guidance on how to tune this up.
--   `partition_size_hint`: (optional) Hint to joining operator about the estimated avg expected size of the individual partition (in bytes). If not specified, defaults to DataContext.target_max_block_size (128Mb by default). Expect this parameter to be deprecated in 2.58.
-    -   Note that, `num_partitions * partition_size_hint` should ideally be approximating actual dataset size, ie `partition_size_hint` could be estimated as dataset size divided by `num_partitions` (assuming relatively evenly sized partitions)
-    -   However, in cases when dataset partitioning is expected to be heavily skewed `partition_size_hint` should approximate largest partition to prevent Out-of-Memory (OOM) errors
+-   `partition_size_hint`: (**deprecated**) Hint to joining operator about the estimated avg expected size of the individual partition (in bytes). Ray Data ignores this parameter and a future release removes it. Passing a value emits a `DeprecationWarning`. The join path sizes reduce-task memory from observed partition sizes instead of from a hint.
 
 .. _joins_configuring_num_partitions:
 
@@ -78,7 +76,7 @@ Configuring number of Aggregators
 
 Following are important considerations for successfully configuring number of aggregators in your pool:
 
-- Defaults to 64 or `num_partitions` (in cases when there are less than 64 partitions)
+- Defaults to the smallest of `num_partitions`, the number of CPUs in the cluster, and `DataContext.max_hash_shuffle_aggregators` (128 by default)
 - Individual Aggregators might be assigned to handle more than one partition (partitions are evenly split in round-robin fashion among the aggregators)
 - Aggregators are stateful components that hold the state (partitions) during shuffling **in memory**
 

--- a/doc/source/data/saving-data.rst
+++ b/doc/source/data/saving-data.rst
@@ -193,7 +193,8 @@ number of files & their sizes (since every block could potentially carry the row
     )
 
     ds = ray.data.from_pandas(df)
-    DataContext.shuffle_strategy=ShuffleStrategy.HASH_SHUFFLE
+    # Key-based repartitioning requires a hash-shuffle strategy such as Shuffle v2.
+    DataContext.shuffle_strategy=ShuffleStrategy.SHUFFLE_V2
 
     # ── Partitioned write ──────────────────────────────────────────────────────
     # 1. Repartition so all rows with the same (city, year) land in the same

--- a/doc/source/data/saving-data.rst
+++ b/doc/source/data/saving-data.rst
@@ -194,7 +194,7 @@ number of files & their sizes (since every block could potentially carry the row
 
     ds = ray.data.from_pandas(df)
     # Key-based repartitioning requires a hash-shuffle strategy such as Shuffle v2.
-    DataContext.shuffle_strategy=ShuffleStrategy.SHUFFLE_V2
+    DataContext.get_current().shuffle_strategy = ShuffleStrategy.SHUFFLE_V2
 
     # ── Partitioned write ──────────────────────────────────────────────────────
     # 1. Repartition so all rows with the same (city, year) land in the same

--- a/doc/source/data/saving-data.rst
+++ b/doc/source/data/saving-data.rst
@@ -194,7 +194,7 @@ number of files & their sizes (since every block could potentially carry the row
 
     ds = ray.data.from_pandas(df)
     # Key-based repartitioning requires a hash-shuffle strategy such as Shuffle v2.
-    DataContext.get_current().shuffle_strategy = ShuffleStrategy.SHUFFLE_V2
+    DataContext.get_current().shuffle_strategy = ShuffleStrategy.HASH_SHUFFLE_V2
 
     # ── Partitioned write ──────────────────────────────────────────────────────
     # 1. Repartition so all rows with the same (city, year) land in the same

--- a/doc/source/data/shuffling-data.rst
+++ b/doc/source/data/shuffling-data.rst
@@ -229,6 +229,19 @@ Example of hash shuffling based on column `id`:
     # Hash-shuffle
     hash_shuffled_ds = ds.repartition(keys="id", num_blocks=200)
 
+.. tip::
+
+    :ref:`Shuffle v2 <shuffle-v2>` (``ShuffleStrategy.SHUFFLE_V2``) is a new shuffle backend,
+    currently in Alpha, that provides an updated hash-shuffle implementation:
+
+    .. code-block:: python
+
+        from ray.data.context import DataContext, ShuffleStrategy
+
+        DataContext.get_current().shuffle_strategy = ShuffleStrategy.SHUFFLE_V2
+
+    See :ref:`Tuning shuffle v2 <tuning-shuffle-v2>` for the available knobs.
+
 .. _optimizing_shuffles:
 
 Advanced: Optimizing shuffles
@@ -260,6 +273,10 @@ shuffle quality higher until you reach this threshold.
 
 Enabling push-based shuffle
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. note:: ``DataContext.use_push_based_shuffle`` and the ``RAY_DATA_PUSH_BASED_SHUFFLE`` environment
+    variable are deprecated. Configure the shuffle strategy through ``DataContext.shuffle_strategy``
+    (for example, ``ShuffleStrategy.SORT_SHUFFLE_PUSH_BASED``) instead.
 
 Some Dataset operations require a *shuffle* operation, meaning that the system shuffles data from all of the input partitions to all of the output partitions.
 These operations include :meth:`Dataset.random_shuffle <ray.data.Dataset.random_shuffle>`,

--- a/doc/source/data/shuffling-data.rst
+++ b/doc/source/data/shuffling-data.rst
@@ -231,14 +231,14 @@ Example of hash shuffling based on column `id`:
 
 .. tip::
 
-    :ref:`Shuffle v2 <shuffle-v2>` (``ShuffleStrategy.SHUFFLE_V2``) is a new shuffle backend,
+    :ref:`Shuffle v2 <shuffle-v2>` (``ShuffleStrategy.HASH_SHUFFLE_V2``) is a new shuffle backend,
     currently in Alpha, that provides an updated hash-shuffle implementation:
 
     .. code-block:: python
 
         from ray.data.context import DataContext, ShuffleStrategy
 
-        DataContext.get_current().shuffle_strategy = ShuffleStrategy.SHUFFLE_V2
+        DataContext.get_current().shuffle_strategy = ShuffleStrategy.HASH_SHUFFLE_V2
 
     See :ref:`Tuning shuffle v2 <tuning-shuffle-v2>` for the available knobs.
 


### PR DESCRIPTION
## Description
Backfill the doc of shuffle v2 into release 2.58 and use the name of `hash_shuffle_v2` because the name`shuffle_v2` only exist on 2.58

This is a doc only changes so it's not blocking the PyPI release

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
(cherry picked from commit fd223b6)