### PR TITLE
[serve] Deflake test_proxy on loaded CI shards

### DIFF
--- a/python/ray/serve/tests/BUILD.bazel
+++ b/python/ray/serve/tests/BUILD.bazel
@@ -128,7 +128,6 @@ py_test_module_list(
         "test_list_outbound_deployments.py",
         "test_max_replicas_per_node.py",
         "test_multiplex.py",
-        "test_proxy.py",
         "test_proxy_actor_wrapper.py",
         "test_proxy_response_generator.py",
         "test_queue_monitor.py",
@@ -156,13 +155,14 @@ py_test_module_list(
     ],
 )
 
-# Multi-node cluster test. On the shared Windows shard it runs at ~79% of the
-# default medium timeout, so a loaded runner tips it over; give it headroom.
+# Multi-node cluster tests. On the shared Windows shard these run at 65-79% of the
+# default medium timeout, so a loaded runner tips them over; give them headroom.
 py_test_module_list(
     size = "medium",
     timeout = "long",
     files = [
         "test_cluster.py",
+        "test_proxy.py",
     ],
     tags = [
         "exclusive",

--- a/python/ray/serve/tests/test_proxy.py
+++ b/python/ray/serve/tests/test_proxy.py
@@ -26,6 +26,13 @@ from ray.serve.schema import ProxyStatus, ServeInstanceDetails
 from ray.tests.conftest import call_ray_stop_only  # noqa: F401
 from ray.util.state import list_actors
 
+# Windows CI runs these on a shared, heavily loaded shard where multi-node
+# convergence routinely overruns wait_for_condition's 10s default.
+WAIT_TIMEOUT_S = 60
+# Per-request budget, kept well under WAIT_TIMEOUT_S: request_with_retries already
+# retries internally, and these run in loops of 10.
+REQUEST_TIMEOUT_S = 30
+
 
 @pytest.fixture
 def shutdown_ray():
@@ -129,17 +136,25 @@ def test_grpc_proxy_on_draining_nodes(ray_cluster):
             len(
                 {
                     a.node_id
-                    for a in list_actors(address=cluster.address)
+                    for a in list_actors(
+                        address=cluster.address, filters=[("STATE", "=", "ALIVE")]
+                    )
                     if a.class_name.startswith("ServeReplica")
                 }
             )
             == 1
         )
 
-    wait_for_condition(check_replicas_on_worker_nodes)
+    wait_for_condition(check_replicas_on_worker_nodes, timeout=WAIT_TIMEOUT_S)
 
     # Ensure total actors of 2 proxies, 1 controller, and 2 replicas, and 2 nodes exist.
-    wait_for_condition(lambda: len(list_actors(address=cluster.address)) == 5)
+    wait_for_condition(
+        lambda: len(
+            list_actors(address=cluster.address, filters=[("STATE", "=", "ALIVE")])
+        )
+        == 5,
+        timeout=WAIT_TIMEOUT_S,
+    )
     assert len(ray.nodes()) == 2
 
     # Set up gRPC channels.
@@ -152,7 +167,10 @@ def test_grpc_proxy_on_draining_nodes(ray_cluster):
 
     # Ensures ListApplications method on the head node is succeeding.
     wait_for_condition(
-        ping_grpc_list_applications, channel=head_node_channel, app_names=[app_name]
+        ping_grpc_list_applications,
+        channel=head_node_channel,
+        app_names=[app_name],
+        timeout=WAIT_TIMEOUT_S,
     )
 
     # Ensures Healthz method on the head node is succeeding.
@@ -163,7 +181,7 @@ def test_grpc_proxy_on_draining_nodes(ray_cluster):
         ping_grpc_list_applications,
         channel=worker_node_channel,
         app_names=[app_name],
-        timeout=30,
+        timeout=WAIT_TIMEOUT_S,
     )
 
     # Ensures Healthz method on the worker node is succeeding.
@@ -178,11 +196,15 @@ def test_grpc_proxy_on_draining_nodes(ray_cluster):
             list_actors(address=cluster.address, filters=[("STATE", "=", "ALIVE")])
         )
         == 3,
+        timeout=WAIT_TIMEOUT_S,
     )
 
     # Ensures ListApplications method on the head node is succeeding.
     wait_for_condition(
-        ping_grpc_list_applications, channel=head_node_channel, app_names=[]
+        ping_grpc_list_applications,
+        channel=head_node_channel,
+        app_names=[],
+        timeout=WAIT_TIMEOUT_S,
     )
 
     # Ensures Healthz method on the head node is succeeding.
@@ -194,6 +216,7 @@ def test_grpc_proxy_on_draining_nodes(ray_cluster):
         channel=worker_node_channel,
         app_names=[],
         test_draining=True,
+        timeout=WAIT_TIMEOUT_S,
     )
 
     # Ensures Healthz method on the worker node is draining.
@@ -228,7 +251,10 @@ def test_drain_and_undrain_http_proxy_actors(
     serve.run(HelloModel.options(num_replicas=2).bind())
 
     # 3 proxies, 1 controller, 2 replicas.
-    wait_for_condition(lambda: len(list_actors()) == 6)
+    wait_for_condition(
+        lambda: len(list_actors(filters=[("STATE", "=", "ALIVE")])) == 6,
+        timeout=WAIT_TIMEOUT_S,
+    )
     assert len(ray.nodes()) == 3
 
     client = _get_global_client()
@@ -255,6 +281,7 @@ def test_drain_and_undrain_http_proxy_actors(
     wait_for_condition(
         condition_predictor=check_proxy_status,
         proxy_status_to_count={ProxyStatus.HEALTHY: 2, ProxyStatus.DRAINING: 1},
+        timeout=WAIT_TIMEOUT_S,
     )
 
     serve.run(HelloModel.options(num_replicas=2).bind())
@@ -262,6 +289,7 @@ def test_drain_and_undrain_http_proxy_actors(
     wait_for_condition(
         condition_predictor=check_proxy_status,
         proxy_status_to_count={ProxyStatus.HEALTHY: 3},
+        timeout=WAIT_TIMEOUT_S,
     )
     serve_details = ServeInstanceDetails(
         **ray.get(client._controller.get_serve_instance_details.remote())
@@ -275,7 +303,7 @@ def test_drain_and_undrain_http_proxy_actors(
     # 1 proxy should be draining and eventually be drained.
     wait_for_condition(
         condition_predictor=check_proxy_status,
-        timeout=40,
+        timeout=WAIT_TIMEOUT_S,
         proxy_status_to_count={ProxyStatus.HEALTHY: 2},
     )
 
@@ -298,10 +326,10 @@ def test_http_proxy_failure(serve_instance):
 
     serve.run(function.bind())
 
-    assert request_with_retries(timeout=1.0).text == "hello1"
+    assert request_with_retries(timeout=REQUEST_TIMEOUT_S).text == "hello1"
 
     for _ in range(10):
-        response = request_with_retries(timeout=30)
+        response = request_with_retries(timeout=REQUEST_TIMEOUT_S)
         assert response.text == "hello1"
 
     _kill_http_proxies()
@@ -313,12 +341,12 @@ def test_http_proxy_failure(serve_instance):
 
     def check_new():
         for _ in range(10):
-            response = request_with_retries(timeout=30)
+            response = request_with_retries(timeout=REQUEST_TIMEOUT_S)
             if response.text != "hello2":
                 return False
         return True
 
-    wait_for_condition(check_new)
+    wait_for_condition(check_new, timeout=WAIT_TIMEOUT_S)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
test_proxy flakes 14% of postmerge runs on the Windows serve shard (3 flaky, 0 hard failures in 22 runs). It is load-sensitive in three ways:

- The bazel target was `size = "medium"` with no explicit timeout, so a 300s limit against a 194s max observed runtime -- 65% of budget, the tightest of any serve target on that shard bar test_cluster. Every comparable target there already carries an explicit `long`/`eternal` or is `enormous`. Give it `timeout = "long"`.
- 9 of 11 wait_for_condition calls ran on the bare 10s default while waiting on three-node cluster convergence and proxy HEALTHY/DRAINING/DRAINED transitions. Route them through a named WAIT_TIMEOUT_S.
- One request_with_retries used timeout=1.0, which is both the httpx timeout and the outer retry budget, so it got a single attempt on a busy box.

Also filter three list_actors() calls to STATE = ALIVE. They back exact-count waits, and counting DEAD actors means the count never recovers once anything restarts. A fourth site in the same test already filtered, so the file was internally inconsistent.

No assertions change.
