### PR TITLE
[serve] Deflake test_grpc - drop the redundant ray_shutdown fixture

### DIFF
--- a/python/ray/serve/tests/test_grpc.py
+++ b/python/ray/serve/tests/test_grpc.py
@@ -267,7 +267,7 @@ def test_grpc_request_with_request_id(ray_cluster):
 
 
 @pytest.mark.parametrize("streaming", [False, True])
-def test_grpc_request_timeouts(ray_instance, ray_shutdown, streaming: bool):
+def test_grpc_request_timeouts(ray_instance, streaming: bool):
     """Test gRPC request timed out.
 
     When the request timed out, gRPC proxy should return timeout response for both
@@ -330,7 +330,7 @@ def test_grpc_request_timeouts(ray_instance, ray_shutdown, streaming: bool):
 
 
 @pytest.mark.parametrize("streaming", [False, True])
-def test_grpc_request_internal_error(ray_instance, ray_shutdown, streaming: bool):
+def test_grpc_request_internal_error(ray_instance, streaming: bool):
     """Test gRPC request error out.
 
     When the request error out, gRPC proxy should return INTERNAL status and the error
@@ -379,7 +379,7 @@ def test_grpc_request_internal_error(ray_instance, ray_shutdown, streaming: bool
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("streaming", [False, True])
-async def test_grpc_request_cancellation(ray_instance, ray_shutdown, streaming: bool):
+async def test_grpc_request_cancellation(ray_instance, streaming: bool):
     """Test gRPC request client cancelled.
 
     When the request is canceled, gRPC proxy should cancel the underlying task.
@@ -440,7 +440,7 @@ async def test_grpc_request_cancellation(ray_instance, ray_shutdown, streaming: 
 
 
 @pytest.mark.parametrize("streaming", [False, True])
-def test_using_grpc_context(ray_instance, ray_shutdown, streaming: bool):
+def test_using_grpc_context(ray_instance, streaming: bool):
     """Test using gRPC context.
 
     When the deployment sets code, details, and trailing metadata in the gRPC context,
@@ -507,7 +507,7 @@ def test_using_grpc_context(ray_instance, ray_shutdown, streaming: bool):
 
 
 @pytest.mark.parametrize("streaming", [False, True])
-def test_using_grpc_context_exception(ray_instance, ray_shutdown, streaming: bool):
+def test_using_grpc_context_exception(ray_instance, streaming: bool):
     """Test setting code on gRPC context then raised exception.
 
     When the deployment sets a status code on the gRPC context and then raises an
@@ -567,9 +567,7 @@ def test_using_grpc_context_exception(ray_instance, ray_shutdown, streaming: boo
 
 
 @pytest.mark.parametrize("streaming", [False, True])
-def test_exception_without_grpc_context_code(
-    ray_instance, ray_shutdown, streaming: bool
-):
+def test_exception_without_grpc_context_code(ray_instance, streaming: bool):
     """Test raising exception without setting gRPC status code.
 
     When the deployment raises an exception without setting a status code on the
@@ -630,7 +628,7 @@ def test_exception_without_grpc_context_code(
 @pytest.mark.parametrize("streaming", [False, True])
 @pytest.mark.parametrize("issue", ["incorrect_spelling", "more_args"])
 def test_using_grpc_context_bad_function_signature(
-    ray_instance, ray_shutdown, streaming: bool, issue: str
+    ray_instance, streaming: bool, issue: str
 ):
     """Test using gRPC context with bad function signature.
 
@@ -730,7 +728,7 @@ def test_using_grpc_context_bad_function_signature(
         assert "extra_required_arg" in rpc_error.details()
 
 
-def test_grpc_client_sending_large_payload(ray_instance, ray_shutdown):
+def test_grpc_client_sending_large_payload(ray_instance):
     """Test gRPC client sending large payload.
 
     Serve's gRPC proxy should be configured to allow the client to send large payloads
@@ -768,7 +766,7 @@ def test_grpc_client_sending_large_payload(ray_instance, ray_shutdown):
     )
 
 
-def test_grpc_client_streaming(ray_instance, ray_shutdown):
+def test_grpc_client_streaming(ray_instance):
     """Test gRPC client streaming (stream-unary) requests.
 
     When a client sends a stream of requests, the deployment should receive
@@ -817,7 +815,7 @@ def test_grpc_client_streaming(ray_instance, ray_shutdown):
     assert response.num_x2 == 30  # (1+2+3+4+5) * 2 = 30
 
 
-def test_grpc_unary_not_found(ray_instance, ray_shutdown):
+def test_grpc_unary_not_found(ray_instance):
     """Test gRPC unary returns clean NOT_FOUND when app doesn't exist.
 
     When proxy_request yields only ResponseStatus (no body), returning None would
@@ -856,7 +854,7 @@ def test_grpc_unary_not_found(ray_instance, ray_shutdown):
     assert exc_info.value.code() == grpc.StatusCode.NOT_FOUND
 
 
-def test_grpc_client_streaming_not_found(ray_instance, ray_shutdown):
+def test_grpc_client_streaming_not_found(ray_instance):
     """Test gRPC client streaming returns clean NOT_FOUND when app doesn't exist.
 
     When proxy_request yields only ResponseStatus (no body), returning None would
@@ -904,7 +902,7 @@ def test_grpc_client_streaming_not_found(ray_instance, ray_shutdown):
     assert exc_info.value.code() == grpc.StatusCode.NOT_FOUND
 
 
-def test_grpc_bidirectional_streaming(ray_instance, ray_shutdown):
+def test_grpc_bidirectional_streaming(ray_instance):
     """Test gRPC bidirectional streaming (stream-stream) requests.
 
     When a client sends a stream of requests, the deployment should
@@ -954,7 +952,7 @@ def test_grpc_bidirectional_streaming(ray_instance, ray_shutdown):
     assert responses[2].num_x2 == 40
 
 
-def test_grpc_client_streaming_with_grpc_context(ray_instance, ray_shutdown):
+def test_grpc_client_streaming_with_grpc_context(ray_instance):
     """Test gRPC client streaming with gRPC context.
 
     The deployment should be able to access and modify the gRPC context
@@ -1014,7 +1012,7 @@ def test_grpc_client_streaming_with_grpc_context(ray_instance, ray_shutdown):
     assert ("custom-key", "custom-value") in rpc_error.trailing_metadata()
 
 
-def test_grpc_bidirectional_streaming_with_grpc_context(ray_instance, ray_shutdown):
+def test_grpc_bidirectional_streaming_with_grpc_context(ray_instance):
     """Test gRPC bidirectional streaming with gRPC context.
 
     The deployment should be able to access and modify the gRPC context
@@ -1073,7 +1071,7 @@ def test_grpc_bidirectional_streaming_with_grpc_context(ray_instance, ray_shutdo
 
 
 @pytest.mark.parametrize("streaming_type", ["client", "bidi"])
-def test_grpc_streaming_internal_error(ray_instance, ray_shutdown, streaming_type: str):
+def test_grpc_streaming_internal_error(ray_instance, streaming_type: str):
     """Test gRPC streaming request with internal error.
 
     When the handler raises an exception, it should return INTERNAL status.
@@ -1126,7 +1124,7 @@ def test_grpc_streaming_internal_error(ray_instance, ray_shutdown, streaming_typ
 
 
 @pytest.mark.parametrize("streaming_type", ["client", "bidi"])
-def test_grpc_streaming_timeout(ray_instance, ray_shutdown, streaming_type: str):
+def test_grpc_streaming_timeout(ray_instance, streaming_type: str):
     """Test gRPC streaming request timeout.
 
     When the request takes longer than the timeout, it should return
@@ -1189,7 +1187,7 @@ def test_grpc_streaming_timeout(ray_instance, ray_shutdown, streaming_type: str)
     ray.get(signal_actor.send.remote(clear=True))
 
 
-def test_grpc_client_streaming_empty_stream(ray_instance, ray_shutdown):
+def test_grpc_client_streaming_empty_stream(ray_instance):
     """Test gRPC client streaming with empty stream.
 
     When the client sends no messages, the handler should still work.
@@ -1233,7 +1231,7 @@ def test_grpc_client_streaming_empty_stream(ray_instance, ray_shutdown):
     assert response.num_x2 == 0
 
 
-def test_grpc_bidi_streaming_empty_stream(ray_instance, ray_shutdown):
+def test_grpc_bidi_streaming_empty_stream(ray_instance):
     """Test gRPC bidirectional streaming with empty stream.
 
     When the client sends no messages, the handler should yield no responses.
@@ -1276,9 +1274,7 @@ def test_grpc_bidi_streaming_empty_stream(ray_instance, ray_shutdown):
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("streaming_type", ["client", "bidi"])
-async def test_grpc_streaming_cancellation(
-    ray_instance, ray_shutdown, streaming_type: str
-):
+async def test_grpc_streaming_cancellation(ray_instance, streaming_type: str):
     """Test gRPC streaming request client cancellation.
 
     When the client cancels the request, it should propagate to the handler.
@@ -1346,9 +1342,7 @@ async def test_grpc_streaming_cancellation(
 
 
 @pytest.mark.parametrize("streaming_type", ["client", "bidi"])
-def test_grpc_streaming_context_with_exception(
-    ray_instance, ray_shutdown, streaming_type: str
-):
+def test_grpc_streaming_context_with_exception(ray_instance, streaming_type: str):
     """Test setting gRPC context then raising exception in streaming.
 
     When the handler sets a custom gRPC status code on the context then raises
@@ -1413,7 +1407,7 @@ def test_grpc_streaming_context_with_exception(
 
 
 @pytest.mark.parametrize("streaming_type", ["client", "bidi"])
-def test_grpc_streaming_backpressure(ray_instance, ray_shutdown, streaming_type: str):
+def test_grpc_streaming_backpressure(ray_instance, streaming_type: str):
     """Test gRPC streaming with slow consumer (backpressure).
 
     When the server processes messages slower than the client sends them,
@@ -1483,9 +1477,7 @@ def test_grpc_streaming_backpressure(ray_instance, ray_shutdown, streaming_type:
 
 
 @pytest.mark.parametrize("streaming_type", ["client", "bidi"])
-def test_grpc_streaming_client_error_mid_stream(
-    ray_instance, ray_shutdown, streaming_type: str
-):
+def test_grpc_streaming_client_error_mid_stream(ray_instance, streaming_type: str):
     """Test gRPC streaming when client raises error mid-stream.
 
     When the client generator raises an exception while streaming,
@@ -1550,7 +1542,7 @@ def test_grpc_streaming_client_error_mid_stream(
             list(stub.BidiStreaming(error_request_generator()))
 
 
-def test_grpc_streaming_client_closes_channel_mid_stream(ray_instance, ray_shutdown):
+def test_grpc_streaming_client_closes_channel_mid_stream(ray_instance):
     """Test gRPC streaming when client closes channel mid-stream.
 
     When the client closes the gRPC channel while streaming, the server

--- a/python/ray/serve/tests/test_haproxy.py
+++ b/python/ray/serve/tests/test_haproxy.py
@@ -269,7 +269,7 @@ class TestTimeoutKeepAliveConfig:
         ],
         indirect=True,
     )
-    def test_set_keep_alive_timeout_in_env(self, ray_instance, ray_shutdown):
+    def test_set_keep_alive_timeout_in_env(self, ray_instance):
         """Test when keep_alive_timeout_s is in env.
 
         When the keep_alive_timeout_s is set in env, the uvicorn keep alive
@@ -288,9 +288,7 @@ class TestTimeoutKeepAliveConfig:
         ],
         indirect=True,
     )
-    def test_set_timeout_keep_alive_in_both_config_and_env(
-        self, ray_instance, ray_shutdown
-    ):
+    def test_set_timeout_keep_alive_in_both_config_and_env(self, ray_instance):
         """Test when keep_alive_timeout_s is in both http configs and env.
 
         When the keep_alive_timeout_s is set in env, the uvicorn keep alive


### PR DESCRIPTION
All 23 fixture-using tests in test_grpc.py take both ray_instance and ray_shutdown, and the two undo each other. ray_shutdown's setup body runs serve.shutdown() + ray.shutdown(), tearing down the cluster ray_instance just created; that serve.shutdown() runs with Ray down so it reaches _connect(), which re-inits Ray just to look for a controller. The test body then starts with Ray uninitialized and serve.start() implicitly creates a third, default cluster - without the _metrics_export_port / _system_config that ray_instance exists to supply.

So each of these tests starts three Ray clusters instead of one and silently discards its fixture configuration. Each extra startup is another chance to lose a cluster-startup race, which fits this target being the flakiest Serve target on Windows (~17% of runs vs ~2.6% on Linux, always green on retry).

ray_instance already does serve.shutdown() + ray.shutdown() in its own teardown, so ray_shutdown is pure overhead wherever ray_instance is present. Tests that use ray_shutdown on its own are correct and are left alone.

Measured on an empty test, counting Ray session dirs: 3 clusters / 32s with both fixtures vs 1 cluster / 12s with ray_instance alone. On four real tests from this file, both arms green: 12 clusters / 145.9s before, 4 / 68.7s after.