### PR TITLE
[cherry-pick][2.58.0][Fix][Core] Give `canceled_tasks_` its own mutex to break a lock-order cycle (#65393)

### DIFF
--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -885,6 +885,7 @@ void CoreWorker::HandleOwnerDied(const WorkerID &dead_owner) {
         to_erase.push_back(generator_id);
         // Mark the gen task canceled so the executor loop bails before the
         // next gen.send instead of running another iteration of user code.
+        absl::MutexLock canceled_lock(&canceled_tasks_mutex_);
         canceled_tasks_.insert(generator_id.TaskId());
       }
     }
@@ -2658,7 +2659,7 @@ Status CoreWorker::CancelTask(const ObjectID &object_id,
 bool CoreWorker::IsTaskCanceled(const TaskID &task_id) const {
   // Check if the task is canceled on executor side. Check the canceled_tasks_ which is
   // populated when CancelTask RPC is received.
-  absl::MutexLock lock(&mutex_);
+  absl::MutexLock lock(&canceled_tasks_mutex_);
   return canceled_tasks_.find(task_id) != canceled_tasks_.end();
 }
 
@@ -3186,7 +3187,10 @@ Status CoreWorker::ExecuteTask(
     size_t erased = running_tasks_.erase(task_spec.TaskId());
     RAY_CHECK(erased == 1);
     // Clean up cancellation state for this task
-    canceled_tasks_.erase(task_spec.TaskId());
+    {
+      absl::MutexLock canceled_lock(&canceled_tasks_mutex_);
+      canceled_tasks_.erase(task_spec.TaskId());
+    }
     if (task_spec.IsNormalTask()) {
       resource_ids_.clear();
     }
@@ -4365,6 +4369,7 @@ void CoreWorker::CancelTaskOnExecutor(TaskID task_id,
     requested_task_running = main_thread_task_id_ == task_id;
 
     if (requested_task_running) {
+      absl::MutexLock canceled_lock(&canceled_tasks_mutex_);
       canceled_tasks_.insert(task_id);
     }
   }
@@ -4421,6 +4426,7 @@ void CoreWorker::CancelActorTaskOnExecutor(WorkerID caller_worker_id,
         is_running = running_tasks_.find(task_id) != running_tasks_.end();
 
         if (is_running) {
+          absl::MutexLock canceled_lock(&canceled_tasks_mutex_);
           canceled_tasks_.insert(task_id);
         }
       }

--- a/src/ray/core_worker/core_worker.h
+++ b/src/ray/core_worker/core_worker.h
@@ -2054,7 +2054,12 @@ class CoreWorker : public std::enable_shared_from_this<CoreWorker> {
   /// We have to track this separately because cancellation requests come from submitter
   /// thread than the thread executing the task, so we cannot get the cancellation status
   /// from the thread-local WorkerThreadContext.
-  absl::flat_hash_set<TaskID> canceled_tasks_ ABSL_GUARDED_BY(mutex_);
+  ///
+  /// This has its own mutex because IsTaskCanceled() is called from check_signals
+  /// while the process-level core_worker_ lock is held, and taking mutex_ there
+  /// closes a lock-order cycle.
+  mutable absl::Mutex canceled_tasks_mutex_ ABSL_ACQUIRED_AFTER(mutex_);
+  absl::flat_hash_set<TaskID> canceled_tasks_ ABSL_GUARDED_BY(canceled_tasks_mutex_);
 
   /// Actor repr name if overrides by the user, empty string if not.
   std::string actor_repr_name_ ABSL_GUARDED_BY(mutex_);


### PR DESCRIPTION
## Description

Cherry-pick of #65393 (`e3ff26cec3`) into `releases/2.58.0`.

The release branch has the cherry-pick of #65184 (`90489021a8`, via #65400), which introduced a mutex lock-order cycle, but is missing the follow-up fix #65393 that breaks the cycle by giving `canceled_tasks_` its own mutex. In debug builds, absl's deadlock detector observes the cycle (`CoreWorker::HandleGetCoreWorkerStats()` → `ReferenceCounter::NumObjectIDsInScope()`) and SIGABRTs the worker.

This is deterministically failing the `core: debug tests` job on the release branch postmerge: https://buildkite.com/ray-project/postmerge/builds/19264 — `test_object_spilling{,_2,_3}_debug_mode` and `test_scheduling{,_2}_debug_mode` all abort with `RAW: Potential Mutex deadlock ... a cycle in the historical lock ordering graph has been observed`. The same job passes on master, which has both commits.

## Verification

- Clean cherry-pick (`git cherry-pick -x -s e3ff26cec3`), no conflicts; 2 files changed matching the original commit.
- Root cause confirmed from the postmerge build 19264 logs: the abort stack matches the exact cycle described in #65393's description, and `releases/2.58.0` still had `canceled_tasks_ ABSL_GUARDED_BY(mutex_)` (pre-fix) while master has the dedicated `canceled_tasks_mutex_`.
- The failing `core: debug tests` postmerge job on this branch will validate the fix in CI; the original change passed full CI on master.

Not a duplicate: no existing open/closed cherry-pick PR for #65393 targets `releases/2.58.0` (checked via `gh pr list`).

AI assistance (Claude Code) was used to triage the postmerge failure and prepare this cherry-pick.

🤖 Generated with [Claude Code](https://claude.com/claude-code)