### PR TITLE
[cherry-pick][2.58.0][core][sandbox] Make Ray Sandbox run Docker-built images out of the box (#65570)

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -763,7 +763,14 @@ intersphinx_mapping = {
     "pymongoarrow": ("https://mongo-arrow.readthedocs.io/en/latest/", None),
     "pyspark": ("https://spark.apache.org/docs/latest/api/python/", None),
     "python": ("https://docs.python.org/3", None),
-    "pytorch_lightning": ("https://lightning.ai/docs/pytorch/stable/", None),
+    "pytorch_lightning": (
+        "https://lightning.ai/docs/pytorch/stable/",
+        # lightning.ai serves its docs as an SPA and returns HTML for
+        # objects.inv (recent readthedocs versions redirect there and do the
+        # same, breaking -W builds with "invalid inventory header"); 2.0.9 is
+        # the newest readthedocs version still serving a real inventory.
+        "https://pytorch-lightning.readthedocs.io/en/2.0.9/objects.inv",
+    ),
     "scipy": (
         "https://docs.scipy.org/doc/scipy/",
         "https://github.com/ray-project/scipy/releases/download/object-mirror-0.1.0/objects.inv",

--- a/doc/source/ray-core/sandboxes.md
+++ b/doc/source/ray-core/sandboxes.md
@@ -193,8 +193,7 @@ For advanced workloads, you might need to configure low-level runtime options su
 The `_oci_spec_transform_fn` callable receives the fully generated OCI specification dictionary. It can mutate the dictionary in place or return a modified one. Common use cases include the following:
 
 * **Host mounts**: Mount host directories, read-only datasets, or model weights into the sandbox container.
-* **Networking and DNS**: Set up DNS resolution by mounting host configuration files such as `/etc/resolv.conf` and `/etc/hosts`, or modify network namespace parameters when using `network="sandbox"`.
-* **Linux capabilities**: Add or restrict Linux process capabilities such as `CAP_NET_RAW` or `CAP_SYS_PTRACE` under `spec["process"]["capabilities"]`.
+* **Namespace or mount details** that the first-class options don't cover. Internet access, DNS, and Linux capabilities no longer need this hook — use `network=`, `dns=`, and `capabilities=` (including `capabilities=[]` to run with none at all; see [Networking and DNS](#networking-and-dns)). The hook remains for advanced network or capability configurations beyond those options.
 
 ```python
 import ray
@@ -214,23 +213,6 @@ def configure_oci_spec(spec: dict) -> dict:
         }
     )
 
-    # Configure networking and DNS resolution
-    spec["mounts"].append(
-        {
-            "destination": "/etc/resolv.conf",
-            "source": "/etc/resolv.conf",
-            "type": "bind",
-            "options": ["rbind", "ro"],
-        }
-    )
-
-    # Grant additional Linux process capabilities
-    caps = spec.setdefault("process", {}).setdefault("capabilities", {})
-    for cap_set in ["bounding", "effective", "permitted"]:
-        caps.setdefault(cap_set, [])
-        if "CAP_NET_RAW" not in caps[cap_set]:
-            caps[cap_set].append("CAP_NET_RAW")
-
     return spec
 
 
@@ -238,7 +220,6 @@ def configure_oci_spec(spec: dict) -> dict:
 sb = sandbox.create(
     image="python:3.10-slim",
     workdir="/workspace",
-    network="sandbox",  # Enable network isolation namespace in gVisor
     _oci_spec_transform_fn=configure_oci_spec,
 )
 
@@ -253,6 +234,42 @@ print(result.stdout)
 # Clean up resources
 ray.get(sb.delete.remote())
 ```
+
+## Networking and DNS
+
+Sandboxes support four network modes. `none` is the default, following the
+safe-defaults principle; `public` is the recommended mode when a sandbox
+needs internet access.
+
+| Mode | Network access | `/etc/resolv.conf` | Security property |
+| --- | --- | --- | --- |
+| `none` *(default)* | None | untouched | No egress. |
+| `public` — **recommended for internet access** | Host egress | Generated from `dns` (default `8.8.8.8`, `1.1.1.1`), mounted read-only | Egress works, but the sandbox inherits *nothing* from the host's resolver configuration — no internal search domains, resolver addresses, or `ndots` options leak in, and the sandbox config stays portable across clusters. |
+| `host` | Full host network identity | Host's own file, mounted read-only (`dns=` overrides it) | Strictly more permissive than `public`: the sandbox can reach anything the node can reach, including internal networks and node-local services. Prefer `public` for untrusted code. |
+| `sandbox` | gVisor netstack | untouched | Requires `rootless=False`; runsc doesn't support the sandbox netstack in rootless mode. |
+
+The recommended way to give a sandbox internet access — together with
+Docker-parity capabilities so standard images behave the way they do under
+Docker (`apt-get`, `tar` ownership restore, and similar all need them):
+
+```python
+from ray.experimental import sandbox
+from ray.experimental.sandbox import DOCKER_DEFAULT_CAPABILITIES
+
+sb = sandbox.create(
+    image="python:3.10-slim",
+    network="public",
+    capabilities=DOCKER_DEFAULT_CAPABILITIES,
+    readonly=False,
+)
+```
+
+**DNS in locked-down networks.** Some VPCs block outbound port 53 to public
+resolvers, where the `public` defaults can't resolve. Pass your internal
+resolver instead — `network="public", dns=["10.0.0.2"]` — or fall back to
+`network="host"` (which uses the host's resolv.conf) at the cost of full host
+network identity. Anything beyond that can be configured through the OCI spec
+(see [Pass custom OCI configurations to gVisor](#pass-custom-oci-configurations-to-gvisor)).
 
 ## Architecture
 
@@ -308,7 +325,7 @@ Ray Sandboxes implement multi-layered defense-in-depth isolation:
 * **System call interception**: gVisor's Sentry application kernel intercepts system calls in user space, isolating untrusted code from the host Linux kernel.
 * **Read-only root filesystem**: Ray mounts base container filesystems read-only (`readonly=True`) with an isolated copy-on-write overlay directory per sandbox.
 * **Restricted working directory**: Only the explicit `workdir`, such as `/workspace`, is mounted read-write for application artifacts.
-* **Network containment**: By default, `network="none"` disables all outbound network interfaces, which prevents untrusted code from making external API calls or scanning the internal cluster network.
+* **Network containment**: By default, `network="none"` disables all outbound network interfaces, which prevents untrusted code from making external API calls or scanning the internal cluster network. When internet access is needed, `network="public"` grants egress without handing over the host's resolver configuration or network identity; see [Networking and DNS](#networking-and-dns).
 * **Resource quotas**: cgroups enforce CPU quotas and memory limits, which prevents CPU starvation and out-of-memory (OOM) conditions from affecting other Ray actors.
 
 ## API reference

--- a/python/ray/experimental/sandbox/__init__.py
+++ b/python/ray/experimental/sandbox/__init__.py
@@ -1,4 +1,4 @@
-from typing import Dict, Optional, Union
+from typing import Dict, List, Optional, Union
 
 from ray.actor import ActorHandle
 from ray.experimental.sandbox.backend.base import (
@@ -8,7 +8,11 @@ from ray.experimental.sandbox.backend.base import (
     SandboxStatus,
 )
 from ray.experimental.sandbox.backend.gvisor import GVisorSandboxBackend
-from ray.experimental.sandbox.config import parse_memory_bytes
+from ray.experimental.sandbox.config import (
+    DEFAULT_PUBLIC_DNS,
+    DOCKER_DEFAULT_CAPABILITIES,
+    parse_memory_bytes,
+)
 from ray.experimental.sandbox.exceptions import (
     SandboxCreationError,
     SandboxError,
@@ -33,10 +37,12 @@ def create(
     memory: Optional[Union[str, int, float]] = None,
     env: Optional[Dict[str, str]] = None,
     workdir: Optional[str] = None,
-    ttl_seconds: Optional[int] = 3600,
+    ttl_seconds: Optional[int] = None,
     timeout_seconds: float = 30.0,
     rootless: bool = True,
     network: str = "none",
+    dns: Optional[List[str]] = None,
+    capabilities: Optional[List[str]] = None,
     resources: Optional[Dict[str, float]] = None,
     readonly: bool = True,
     **kwargs,
@@ -53,13 +59,22 @@ def create(
         cpu: Number of CPU cores allocated to the sandbox.
         memory: Amount of memory allocated to the sandbox (e.g. "1Gi", "512Mi").
         env: Environment variables to inject into the sandbox.
-        workdir: Default working directory inside the sandbox. By default, the
-            working directory is the only writable path in the sandbox (unless
-            ``readonly=False`` is set). If not provided, the container's WORKDIR is used.
-        ttl_seconds: Optional automatic cleanup time-to-live in seconds.
+        workdir: Working directory for commands; None uses the image's
+            WORKDIR. On a readonly rootfs an explicit workdir is also the
+            sandbox's only writable path; see
+            :class:`~ray.experimental.sandbox.config.SandboxConfig`.
+        ttl_seconds: Optional time-to-live in seconds, wall-clock from
+            creation (not idle time). None (default) or <= 0 disables it.
         timeout_seconds: Timeout in seconds for sandbox creation.
         rootless: If True, run gVisor in rootless mode.
-        network: Network mode for runsc.
+        network: Network mode ("none", "public", "host", "sandbox"); see
+            :class:`~ray.experimental.sandbox.config.SandboxConfig`. "public"
+            is the recommended internet-access mode.
+        dns: Optional nameserver IPs for the generated /etc/resolv.conf
+            (public resolvers by default for "public").
+        capabilities: Linux capabilities, written exactly (None keeps the
+            runtime default; ``[]`` means none). Use
+            ``DOCKER_DEFAULT_CAPABILITIES`` for Docker parity.
         resources: Custom logical resource requirements.
         readonly: If True (default), mount container image rootfs in read-only mode
             such that only ``workdir`` is writable. If False, the entire root filesystem
@@ -92,6 +107,8 @@ def create(
         timeout_seconds=timeout_seconds,
         rootless=rootless,
         network=network,
+        dns=dns,
+        capabilities=capabilities,
         readonly=readonly,
         **kwargs,
     )
@@ -99,6 +116,8 @@ def create(
 
 __all__ = [
     "create",
+    "DEFAULT_PUBLIC_DNS",
+    "DOCKER_DEFAULT_CAPABILITIES",
     "Sandbox",
     "SandboxRuntime",
     "BaseImageManager",

--- a/python/ray/experimental/sandbox/backend/base.py
+++ b/python/ray/experimental/sandbox/backend/base.py
@@ -87,6 +87,7 @@ class BaseSandboxBackend(ABC):
         timeout: Optional[float] = None,
         cwd: Optional[str] = None,
         env: Optional[Dict[str, str]] = None,
+        shell: Optional[str] = None,
     ) -> ExecResult:
         """Execute a command synchronously inside the sandbox.
 
@@ -96,6 +97,8 @@ class BaseSandboxBackend(ABC):
             timeout: Optional maximum execution time in seconds.
             cwd: Optional working directory override.
             env: Optional additional environment variables.
+            shell: Optional shell for string commands, overriding the
+                sandbox's configured shell (default /bin/bash).
 
         Returns:
             An ExecResult instance containing stdout, stderr, and exit code.

--- a/python/ray/experimental/sandbox/backend/gvisor.py
+++ b/python/ray/experimental/sandbox/backend/gvisor.py
@@ -57,22 +57,29 @@ class GVisorSandboxBackend(BaseSandboxBackend):
             self._image_manager.pull_image(
                 config.image, timeout_seconds=config.timeout_seconds
             )
-            if not config.workdir:
-                config.workdir = self._image_manager.get_workdir(config.image)
-                if not config.workdir:
-                    config.workdir = "/"
-
-            workdir_path = os.path.abspath(
-                os.path.join(root_dir, config.workdir.lstrip("/"))
+            # The process cwd: an explicit workdir, else the image's WORKDIR.
+            container_cwd = (
+                config.workdir or self._image_manager.get_workdir(config.image) or "/"
             )
-            if not (
-                workdir_path == os.path.abspath(root_dir)
-                or workdir_path.startswith(os.path.abspath(root_dir) + os.sep)
-            ):
-                raise SandboxCreationError(
-                    f"Invalid workdir '{config.workdir}': Path traversal detected."
+
+            # A host-backed scratch directory exists only for an *explicitly*
+            # requested workdir on a readonly rootfs — the sandbox's single
+            # writable path there. A writable rootfs needs none (the overlay
+            # covers writes), and an inherited image WORKDIR is never
+            # silently made writable.
+            workdir_path = None
+            if config.workdir and config.readonly:
+                workdir_path = os.path.abspath(
+                    os.path.join(root_dir, config.workdir.lstrip("/"))
                 )
-            os.makedirs(workdir_path, mode=0o777, exist_ok=True)
+                if not (
+                    workdir_path == os.path.abspath(root_dir)
+                    or workdir_path.startswith(os.path.abspath(root_dir) + os.sep)
+                ):
+                    raise SandboxCreationError(
+                        f"Invalid workdir '{config.workdir}': Path traversal detected."
+                    )
+                os.makedirs(workdir_path, mode=0o777, exist_ok=True)
         except Exception as err:
             raise SandboxCreationError(
                 f"Failed to initialize local sandbox directory '{root_dir}': {err}"
@@ -82,17 +89,23 @@ class GVisorSandboxBackend(BaseSandboxBackend):
         self._image_manager.prepare_oci_bundle(
             root_dir=root_dir,
             workdir_path=workdir_path,
-            container_cwd=config.workdir,
+            container_cwd=container_cwd,
             image=config.image,
             env_dict=config.env,
             cpu=config.cpu,
             memory=config.memory,
             readonly=config.readonly,
+            capabilities=config.capabilities,
+            network=config.network,
+            dns=config.dns,
             _oci_spec_transform_fn=config._oci_spec_transform_fn,
         )
         run_args = self._runsc_base_args(config)
         if config.network:
-            run_args.extend(["--network", config.network])
+            # "public" = host egress + generated resolv.conf (handled in the
+            # OCI bundle); runsc itself just sees host networking.
+            runsc_network = "host" if config.network == "public" else config.network
+            run_args.extend(["--network", runsc_network])
         overlay_dir = os.path.join(root_dir, "overlay")
         os.makedirs(overlay_dir, mode=0o777, exist_ok=True)
         run_args.append(f"--overlay2=root:dir={overlay_dir}")
@@ -159,6 +172,7 @@ class GVisorSandboxBackend(BaseSandboxBackend):
         self._sandbox_metadata[sandbox_id] = {
             "root_dir": root_dir,
             "workdir": workdir_path,
+            "cwd": container_cwd,
             "config": config,
             "proc": proc,
             "stderr_file": stderr_file,
@@ -208,6 +222,7 @@ class GVisorSandboxBackend(BaseSandboxBackend):
         timeout: Optional[float] = None,
         cwd: Optional[str] = None,
         env: Optional[Dict[str, str]] = None,
+        shell: Optional[str] = None,
     ) -> ExecResult:
         """Execute a process inside the running gVisor sandbox instance via runsc exec."""
         meta = self._get_metadata_or_raise(sandbox_id)
@@ -217,7 +232,7 @@ class GVisorSandboxBackend(BaseSandboxBackend):
         if env:
             exec_env.update(env)
 
-        exec_cwd = cwd or config.workdir
+        exec_cwd = cwd or meta["cwd"]
 
         # Production execution against running container via `runsc exec`
         runsc_args = self._runsc_base_args(config)
@@ -228,7 +243,8 @@ class GVisorSandboxBackend(BaseSandboxBackend):
         if isinstance(command, list):
             runsc_args.extend([sandbox_id] + command)
         else:
-            runsc_args.extend([sandbox_id, "/bin/sh", "-c", command])
+            exec_shell = shell or config.shell
+            runsc_args.extend([sandbox_id, exec_shell, "-c", command])
 
         start_time = time.time()
 
@@ -269,7 +285,7 @@ class GVisorSandboxBackend(BaseSandboxBackend):
         config: SandboxConfig = meta["config"]
 
         runsc_args = self._runsc_base_args(config)
-        exec_cwd = config.workdir
+        exec_cwd = meta["cwd"]
         runsc_args.extend(
             [
                 "exec",
@@ -304,7 +320,7 @@ class GVisorSandboxBackend(BaseSandboxBackend):
         config: SandboxConfig = meta["config"]
 
         runsc_args = self._runsc_base_args(config)
-        exec_cwd = config.workdir
+        exec_cwd = meta["cwd"]
         runsc_args.extend(["exec", "-cwd", exec_cwd, sandbox_id, "cat", "--", path])
 
         proc = subprocess.Popen(
@@ -364,6 +380,9 @@ class GVisorSandboxBackend(BaseSandboxBackend):
         cpu: Optional[float] = None,
         memory: Optional[Union[str, int, float]] = None,
         readonly: bool = True,
+        capabilities: Optional[List[str]] = None,
+        network: str = "none",
+        dns: Optional[List[str]] = None,
         _oci_spec_transform_fn: Optional[Callable[[Dict], Optional[Dict]]] = None,
     ) -> str:
         return self._image_manager.prepare_oci_bundle(
@@ -375,5 +394,8 @@ class GVisorSandboxBackend(BaseSandboxBackend):
             cpu=cpu,
             memory=memory,
             readonly=readonly,
+            capabilities=capabilities,
+            network=network,
+            dns=dns,
             _oci_spec_transform_fn=_oci_spec_transform_fn,
         )

--- a/python/ray/experimental/sandbox/config.py
+++ b/python/ray/experimental/sandbox/config.py
@@ -1,6 +1,36 @@
 import re
 from dataclasses import dataclass, field
-from typing import Callable, Dict, Optional, Union
+from typing import Callable, Dict, List, Optional, Union
+
+# Sandbox network modes. All but "public" map directly to runsc --network;
+# "public" is host egress plus a generated, host-independent resolv.conf.
+VALID_NETWORK_MODES = ("none", "public", "host", "sandbox")
+
+# Default resolvers for network="public" (Google and Cloudflare public DNS).
+DEFAULT_PUBLIC_DNS = ("8.8.8.8", "1.1.1.1")
+
+# Docker's default capability set (see
+# https://docs.docker.com/engine/containers/run/#runtime-privilege-and-linux-capabilities,
+# canonical list: https://github.com/moby/moby/blob/master/oci/caps/defaults.go).
+# The runtime default (what ``runsc spec`` emits) is far narrower and breaks
+# common images: apt-get needs CAP_SETUID/CAP_SETGID, tar-as-root needs
+# CAP_CHOWN. Pass this list to run images the way Docker does.
+DOCKER_DEFAULT_CAPABILITIES = [
+    "CAP_AUDIT_WRITE",
+    "CAP_CHOWN",
+    "CAP_DAC_OVERRIDE",
+    "CAP_FOWNER",
+    "CAP_FSETID",
+    "CAP_KILL",
+    "CAP_MKNOD",
+    "CAP_NET_BIND_SERVICE",
+    "CAP_NET_RAW",
+    "CAP_SETFCAP",
+    "CAP_SETGID",
+    "CAP_SETPCAP",
+    "CAP_SETUID",
+    "CAP_SYS_CHROOT",
+]
 
 
 def parse_memory_bytes(memory: Optional[Union[str, int, float]]) -> Optional[int]:
@@ -53,18 +83,41 @@ class SandboxConfig:
         cpu: Number of CPU cores allocated to the sandbox.
         memory: Amount of memory allocated to the sandbox (e.g. "1Gi", "512Mi").
         env: Environment variables to inject into the sandbox.
-        workdir: Default working directory inside the sandbox. By default, the
-            working directory is the only writable path in the sandbox (unless
-            ``readonly=False`` is set). If not provided, the container's WORKDIR is used.
-        ttl_seconds: Optional automatic cleanup time-to-live in seconds.
+        workdir: Working directory for commands (the process cwd). None
+            (default) uses the image's WORKDIR, or "/" if the image sets
+            none. On a readonly rootfs, an *explicitly* passed workdir is
+            also bind-mounted as the sandbox's only writable path
+            (host-backed scratch); an inherited image WORKDIR is never
+            silently made writable.
+        ttl_seconds: Optional time-to-live in seconds, measured wall-clock
+            from creation (not idle time). None (default) or <= 0 disables it.
         timeout_seconds: Timeout in seconds for sandbox creation.
         rootless: If True, run gVisor in rootless mode (default: True).
-        network: Network mode for runsc ("none", "host", "sandbox") (default: "none").
-        readonly: If True (default), mount container image rootfs in read-only mode
-            such that only ``workdir`` is writable. If False, the entire root filesystem
-            is writable. Writes are isolated within a per-sandbox copy-on-write overlay
-            filesystem, ensuring multiple sandboxes running the same container image do
-            not interfere with each other or modify the base image.
+        network: Network mode (default: "none" — no network access).
+            "public" (recommended for internet access) gives host egress with
+            a generated /etc/resolv.conf from ``dns``, inheriting nothing
+            from the host resolver. "host" gives full host network identity,
+            including the host's resolv.conf and internal networks.
+            "sandbox" uses gVisor's netstack and requires ``rootless=False``.
+        dns: Nameserver IPs for a generated /etc/resolv.conf, mounted
+            read-only (like ``docker --dns``); useful when public DNS is
+            blocked. Defaults to ``DEFAULT_PUBLIC_DNS`` for "public";
+            overrides the host file for "host". Only valid with those modes.
+        capabilities: Linux capabilities for the container process. None
+            (default) keeps the runtime default (what ``runsc spec`` emits);
+            otherwise the bounding/effective/permitted sets are written
+            exactly, so ``[]`` means no capabilities. Inheritable and ambient
+            stay untouched, matching modern Docker (CVE-2022-24769).
+        shell: Shell for *string* commands (list commands bypass it).
+            Defaults to "/bin/bash", which string commands overwhelmingly
+            assume; set to "/bin/sh" for images without bash.
+        readonly: If True (default), the rootfs is read-only and only an
+            explicitly passed ``workdir`` is writable — with no workdir,
+            nothing on the rootfs is (safe by default; standard tmpfs mounts
+            such as /tmp remain writable). If False, the entire rootfs is
+            writable through the per-sandbox copy-on-write overlay: image
+            content stays visible, sandboxes don't interfere with each
+            other, and the base image is never modified.
     """
 
     image: str
@@ -72,10 +125,13 @@ class SandboxConfig:
     memory: Union[str, int, float] = 0
     env: Dict[str, str] = field(default_factory=dict)
     workdir: Optional[str] = None
-    ttl_seconds: Optional[int] = 3600
+    ttl_seconds: Optional[int] = None
     timeout_seconds: float = 30.0
     rootless: bool = True
     network: str = "none"
+    dns: Optional[List[str]] = None
+    capabilities: Optional[List[str]] = None
+    shell: str = "/bin/bash"
     readonly: bool = True
     _oci_spec_transform_fn: Optional[Callable[[Dict], Optional[Dict]]] = field(
         default=None, repr=False, compare=False
@@ -85,6 +141,24 @@ class SandboxConfig:
     def __post_init__(self):
         if not self.image or not isinstance(self.image, str) or not self.image.strip():
             raise ValueError("A valid container image name must be specified.")
+        if self.network not in VALID_NETWORK_MODES:
+            raise ValueError(
+                f"Invalid network mode '{self.network}'. "
+                f"Expected one of {VALID_NETWORK_MODES}."
+            )
+        if self.network == "sandbox" and self.rootless:
+            # runsc only rejects this at container start, after the pull.
+            raise ValueError(
+                "network='sandbox' requires rootless=False; runsc does not "
+                "support the sandbox netstack in rootless mode. Use "
+                "network='public' or network='host' for a rootless sandbox "
+                "with network access."
+            )
+        if self.dns is not None and self.network not in ("public", "host"):
+            raise ValueError(
+                "dns is only valid with network='public' or network='host'; "
+                f"network={self.network!r} does not mount a resolv.conf."
+            )
 
 
 GVisorSandboxConfig = SandboxConfig

--- a/python/ray/experimental/sandbox/image_manager.py
+++ b/python/ray/experimental/sandbox/image_manager.py
@@ -12,9 +12,18 @@ from ray.experimental.sandbox._internal.image_utils import (
     pull_and_extract_container_image,
     sanitize_image_name,
 )
-from ray.experimental.sandbox.config import parse_memory_bytes
+from ray.experimental.sandbox.config import DEFAULT_PUBLIC_DNS, parse_memory_bytes
 
 logger = logging.getLogger(__name__)
+
+# The OCI capability sets written when `capabilities` is given (schema:
+# https://github.com/opencontainers/runtime-spec/blob/main/config.md#linux-process).
+# Modern Docker populates exactly these: "inheritable" was dropped by Docker
+# for CVE-2022-24769, and "ambient" would survive into non-root execve'd
+# children.
+_OCI_CAPABILITY_SETS = ("bounding", "effective", "permitted")
+
+_RESOLV_CONF = "/etc/resolv.conf"
 
 
 def get_default_oci_spec() -> Dict[str, Any]:
@@ -126,6 +135,9 @@ class BaseImageManager(ABC):
         cpu: Optional[float] = None,
         memory: Optional[Union[str, int, float]] = None,
         readonly: bool = True,
+        capabilities: Optional[List[str]] = None,
+        network: str = "none",
+        resolv_conf_source: Optional[str] = None,
         base_spec: Optional[Dict[str, Any]] = None,
         _oci_spec_transform_fn: Optional[Callable[[Dict], Optional[Dict]]] = None,
     ) -> Dict[str, Any]:
@@ -134,11 +146,19 @@ class BaseImageManager(ABC):
         Args:
             image: Container image name or tar path.
             container_cwd: Working directory inside the container.
-            workdir_path: Host path to bind mount into container_cwd.
+            workdir_path: Optional host directory to bind-mount read-write
+                at container_cwd — the single writable path on a readonly
+                rootfs. None mounts nothing.
             env_dict: Optional environment variables dictionary overriding image envs.
             cpu: CPU core allocation.
             memory: Memory allocation specifier.
             readonly: Whether rootfs is mounted read-only.
+            capabilities: None keeps the runtime default; otherwise the
+                bounding/effective/permitted sets are written exactly.
+            network: Sandbox network mode; "host" and "public" drop the
+                spec's empty network namespace.
+            resolv_conf_source: Optional file to bind-mount read-only at
+                /etc/resolv.conf.
             base_spec: Optional base OCI spec dict to modify instead of generating a default.
             _oci_spec_transform_fn: Optional callback to transform the final spec.
 
@@ -158,19 +178,27 @@ class BaseImageManager(ABC):
         cpu: Optional[float] = None,
         memory: Optional[Union[str, int, float]] = None,
         readonly: bool = True,
+        capabilities: Optional[List[str]] = None,
+        network: str = "none",
+        dns: Optional[List[str]] = None,
         _oci_spec_transform_fn: Optional[Callable[[Dict], Optional[Dict]]] = None,
     ) -> str:
         """Prepare an OCI bundle directory containing config.json for a container instance.
 
         Args:
             root_dir: Host directory for the container bundle.
-            workdir_path: Host directory for the sandbox working directory.
+            workdir_path: Optional host directory bind-mounted read-write at
+                container_cwd (see create_oci_spec). None mounts nothing.
             container_cwd: Working directory inside container.
             image: Container image name or tar path.
             env_dict: Environment variables dictionary.
             cpu: CPU core allocation.
             memory: Memory allocation specifier.
             readonly: Read-only rootfs flag.
+            capabilities: Optional additional Linux capabilities (see create_oci_spec).
+            network: Sandbox network mode; picks the resolv.conf to mount
+                ("public"/dns: generated, "host": the host's own).
+            dns: Optional nameserver IPs for the generated resolv.conf.
             _oci_spec_transform_fn: Optional OCI spec transform function.
 
         Returns:
@@ -298,6 +326,9 @@ class ImageManager(BaseImageManager):
         cpu: Optional[float] = None,
         memory: Optional[Union[str, int, float]] = None,
         readonly: bool = True,
+        capabilities: Optional[List[str]] = None,
+        network: str = "none",
+        resolv_conf_source: Optional[str] = None,
         base_spec: Optional[Dict[str, Any]] = None,
         _oci_spec_transform_fn: Optional[Callable[[Dict], Optional[Dict]]] = None,
     ) -> Dict[str, Any]:
@@ -306,11 +337,19 @@ class ImageManager(BaseImageManager):
         Args:
             image: Container image name or tar path.
             container_cwd: Working directory inside the container.
-            workdir_path: Host path to bind mount into container_cwd.
+            workdir_path: Optional host directory to bind-mount read-write
+                at container_cwd — the single writable path on a readonly
+                rootfs. None mounts nothing.
             env_dict: Optional environment variables dictionary overriding image envs.
             cpu: CPU core allocation.
             memory: Memory allocation specifier.
             readonly: Whether rootfs is mounted read-only.
+            capabilities: None keeps the runtime default; otherwise the
+                bounding/effective/permitted sets are written exactly.
+            network: Sandbox network mode; "host" and "public" drop the
+                spec's empty network namespace.
+            resolv_conf_source: Optional file to bind-mount read-only at
+                /etc/resolv.conf.
             base_spec: Optional base OCI spec dict to modify instead of generating a default.
             _oci_spec_transform_fn: Optional callback to transform the final spec.
 
@@ -349,6 +388,16 @@ class ImageManager(BaseImageManager):
                 envs.append(f"{k}={v}")
         spec["process"]["env"] = envs
 
+        if capabilities is not None:
+            # The key may exist with a null value in a caller-supplied base_spec.
+            caps = spec["process"].get("capabilities")
+            if not isinstance(caps, dict):
+                caps = {}
+                spec["process"]["capabilities"] = caps
+            for cap_set in _OCI_CAPABILITY_SETS:
+                # Written exactly (not unioned): [] runs with no capabilities.
+                caps[cap_set] = list(dict.fromkeys(capabilities))
+
         # Set up default mounts
         mounts = spec.get("mounts", [])
         existing_dests = {m.get("destination") for m in mounts}
@@ -370,6 +419,41 @@ class ImageManager(BaseImageManager):
                             ],
                         }
                     )
+                    existing_dests.add(dest)
+        if network in ("host", "public"):
+            # The default spec carries an empty "network" namespace, which
+            # would leave the sandbox loopback-only despite --network=host.
+            # Drop it so the container inherits runsc's netns; a *pathed*
+            # entry is somebody's explicit choice and is kept.
+            linux_spec = spec.get("linux")
+            if not isinstance(linux_spec, dict):
+                linux_spec = {}
+                spec["linux"] = linux_spec
+            namespaces = linux_spec.get("namespaces")
+            if isinstance(namespaces, list):
+                linux_spec["namespaces"] = [
+                    ns
+                    for ns in namespaces
+                    if not (
+                        isinstance(ns, dict)
+                        and ns.get("type") == "network"
+                        and not ns.get("path")
+                    )
+                ]
+
+        # Images usually ship an empty /etc/resolv.conf (container engines
+        # inject one at run time); prepare_oci_bundle picks the file to mount.
+        if resolv_conf_source and _RESOLV_CONF not in existing_dests:
+            mounts.append(
+                {
+                    "destination": _RESOLV_CONF,
+                    "type": "bind",
+                    "source": resolv_conf_source,
+                    "options": ["rbind", "ro"],
+                }
+            )
+            existing_dests.add(_RESOLV_CONF)
+
         spec["mounts"] = mounts
 
         # Configure OCI cgroup resource limits for CPU and memory
@@ -405,19 +489,27 @@ class ImageManager(BaseImageManager):
         cpu: Optional[float] = None,
         memory: Optional[Union[str, int, float]] = None,
         readonly: bool = True,
+        capabilities: Optional[List[str]] = None,
+        network: str = "none",
+        dns: Optional[List[str]] = None,
         _oci_spec_transform_fn: Optional[Callable[[Dict], Optional[Dict]]] = None,
     ) -> str:
         """Prepare an OCI bundle directory containing config.json for a container instance.
 
         Args:
             root_dir: Host directory for the container bundle.
-            workdir_path: Host directory for the sandbox working directory.
+            workdir_path: Optional host directory bind-mounted read-write at
+                container_cwd (see create_oci_spec). None mounts nothing.
             container_cwd: Working directory inside container.
             image: Container image name or tar path.
             env_dict: Environment variables dictionary.
             cpu: CPU core allocation.
             memory: Memory allocation specifier.
             readonly: Read-only rootfs flag.
+            capabilities: Optional additional Linux capabilities (see create_oci_spec).
+            network: Sandbox network mode; picks the resolv.conf to mount
+                ("public"/dns: generated, "host": the host's own).
+            dns: Optional nameserver IPs for the generated resolv.conf.
             _oci_spec_transform_fn: Optional OCI spec transform function.
 
         Returns:
@@ -427,6 +519,20 @@ class ImageManager(BaseImageManager):
         rootfs_dir = os.path.join(root_dir, "rootfs")
         os.makedirs(rootfs_dir, exist_ok=True)
 
+        resolv_conf_source: Optional[str] = None
+        if network in ("public", "host"):
+            nameservers = list(dns) if dns else None
+            if network == "public" and nameservers is None:
+                nameservers = list(DEFAULT_PUBLIC_DNS)
+            if nameservers is not None:
+                # Generated and host-independent: no search domains, resolver
+                # VIPs, or ndots options leak in from the host.
+                resolv_conf_source = os.path.join(root_dir, "resolv.conf")
+                with open(resolv_conf_source, "w", encoding="utf-8") as f:
+                    f.write("".join(f"nameserver {ip}\n" for ip in nameservers))
+            elif os.path.exists(_RESOLV_CONF):
+                resolv_conf_source = _RESOLV_CONF
+
         spec = self.create_oci_spec(
             image=image,
             container_cwd=container_cwd,
@@ -435,6 +541,9 @@ class ImageManager(BaseImageManager):
             cpu=cpu,
             memory=memory,
             readonly=readonly,
+            capabilities=capabilities,
+            network=network,
+            resolv_conf_source=resolv_conf_source,
             _oci_spec_transform_fn=_oci_spec_transform_fn,
         )
 

--- a/python/ray/experimental/sandbox/runtime.py
+++ b/python/ray/experimental/sandbox/runtime.py
@@ -1,5 +1,6 @@
 import asyncio
 import os
+import threading
 from typing import Callable, Dict, List, Optional, Union
 
 from ray.experimental.sandbox.backend.base import (
@@ -19,6 +20,7 @@ class SandboxRuntime:
     def __init__(self):
         self._image_manager = ImageManager()
         self._backend = GVisorSandboxBackend(image_manager=self._image_manager)
+        self._ttl_timers: Dict[str, threading.Timer] = {}
 
     @property
     def image_manager(self) -> ImageManager:
@@ -49,10 +51,12 @@ class SandboxRuntime:
         memory: Union[str, int, float] = 0,
         env: Optional[Dict[str, str]] = None,
         workdir: Optional[str] = None,
-        ttl_seconds: Optional[int] = 3600,
+        ttl_seconds: Optional[int] = None,
         timeout_seconds: float = 30.0,
         rootless: bool = True,
         network: str = "none",
+        dns: Optional[List[str]] = None,
+        capabilities: Optional[List[str]] = None,
         readonly: bool = True,
         _oci_spec_transform_fn: Optional[Callable[[Dict], Optional[Dict]]] = None,
         _ignore_cgroups: bool = False,
@@ -65,13 +69,23 @@ class SandboxRuntime:
             cpu: Number of CPU cores allocated to the sandbox.
             memory: Amount of memory allocated to the sandbox (e.g. "1Gi", "512Mi").
             env: Environment variables to inject into the sandbox.
-            workdir: Default working directory inside the sandbox. By default, the
-                working directory is the only writable path in the sandbox (unless
-                ``readonly=False`` is set). If not provided, the container's WORKDIR is used.
-            ttl_seconds: Optional automatic cleanup time-to-live in seconds.
+            workdir: Working directory for commands; None uses the image's
+                WORKDIR. On a readonly rootfs an explicit workdir is also the
+                sandbox's only writable path; see
+                :class:`~ray.experimental.sandbox.config.SandboxConfig`.
+            ttl_seconds: Optional time-to-live in seconds, wall-clock from
+                creation (not idle time), enforced by this runtime with a
+                daemon timer. None (default) or <= 0 disables it.
             timeout_seconds: Timeout in seconds for sandbox creation.
             rootless: If True, run gVisor in rootless mode.
-            network: Network mode for runsc.
+            network: Network mode ("none", "public", "host", "sandbox");
+                see :class:`~ray.experimental.sandbox.config.SandboxConfig`.
+                "public" is the recommended internet-access mode.
+            dns: Optional nameserver IPs for the generated /etc/resolv.conf
+                (public resolvers by default for "public").
+            capabilities: Linux capabilities, written exactly (None keeps
+                the runtime default; ``[]`` means none). Use
+                ``DOCKER_DEFAULT_CAPABILITIES`` for Docker parity.
             readonly: If True (default), mount container image rootfs in read-only mode
                 such that only ``workdir`` is writable. If False, the entire root filesystem
                 is writable. Writes are isolated within a per-sandbox copy-on-write overlay
@@ -96,13 +110,28 @@ class SandboxRuntime:
             timeout_seconds=timeout_seconds,
             rootless=rootless,
             network=network,
+            dns=dns,
+            capabilities=capabilities,
             readonly=readonly,
             _oci_spec_transform_fn=_oci_spec_transform_fn,
             _ignore_cgroups=_ignore_cgroups,
             **kwargs,
         )
         self._image_manager.pull_image(cfg.image, timeout_seconds=cfg.timeout_seconds)
-        return self._backend.create_sandbox(cfg)
+        instance_id = self._backend.create_sandbox(cfg)
+        if cfg.ttl_seconds is not None and cfg.ttl_seconds > 0:
+            timer = threading.Timer(cfg.ttl_seconds, self._expire, args=(instance_id,))
+            timer.daemon = True
+            self._ttl_timers[instance_id] = timer
+            timer.start()
+        return instance_id
+
+    def _expire(self, instance_id: str) -> None:
+        """TTL callback: best-effort delete (the sandbox may already be gone)."""
+        try:
+            self.delete(instance_id)
+        except Exception:
+            pass
 
     def exec(
         self,
@@ -111,6 +140,7 @@ class SandboxRuntime:
         timeout: Optional[float] = None,
         cwd: Optional[str] = None,
         env: Optional[Dict[str, str]] = None,
+        shell: Optional[str] = None,
     ) -> ExecResult:
         """Execute a command inside the specified sandbox.
 
@@ -120,6 +150,8 @@ class SandboxRuntime:
             timeout: Maximum execution time in seconds.
             cwd: Working directory inside the sandbox for command execution.
             env: Environment variables to set for the command.
+            shell: Optional shell for string commands, overriding the
+                sandbox's configured shell (default /bin/bash).
 
         Returns:
             ExecResult containing exit code, stdout, and stderr.
@@ -130,6 +162,7 @@ class SandboxRuntime:
             timeout=timeout,
             cwd=cwd,
             env=env,
+            shell=shell,
         )
 
     async def exec_async(
@@ -139,6 +172,7 @@ class SandboxRuntime:
         timeout: Optional[float] = None,
         cwd: Optional[str] = None,
         env: Optional[Dict[str, str]] = None,
+        shell: Optional[str] = None,
     ) -> ExecResult:
         """Execute a command inside the specified sandbox asynchronously.
 
@@ -148,6 +182,8 @@ class SandboxRuntime:
             timeout: Maximum execution time in seconds.
             cwd: Working directory inside the sandbox for command execution.
             env: Environment variables to set for the command.
+            shell: Optional shell for string commands, overriding the
+                sandbox's configured shell (default /bin/bash).
 
         Returns:
             ExecResult containing exit code, stdout, and stderr.
@@ -159,6 +195,7 @@ class SandboxRuntime:
             timeout=timeout,
             cwd=cwd,
             env=env,
+            shell=shell,
         )
 
     def upload_file(self, instance_id: str, local_path: str, remote_path: str) -> None:
@@ -231,6 +268,9 @@ class SandboxRuntime:
         Args:
             instance_id: Unique identifier of the sandbox instance.
         """
+        timer = self._ttl_timers.pop(instance_id, None)
+        if timer is not None:
+            timer.cancel()
         self._backend.delete_sandbox(instance_id)
 
     def terminate(self, instance_id: str) -> None:

--- a/python/ray/experimental/sandbox/sandbox.py
+++ b/python/ray/experimental/sandbox/sandbox.py
@@ -19,13 +19,22 @@ class Sandbox:
         cpu: Number of CPU cores allocated to the sandbox.
         memory: Amount of memory allocated to the sandbox (e.g. "1Gi", "512Mi").
         env: Environment variables to inject into the sandbox.
-        workdir: Default working directory inside the sandbox. By default, the
-            working directory is the only writable path in the sandbox (unless
-            ``readonly=False`` is set). If not provided, the container's WORKDIR is used.
-        ttl_seconds: Optional automatic cleanup time-to-live in seconds.
+        workdir: Working directory for commands; None uses the image's
+            WORKDIR. On a readonly rootfs an explicit workdir is also the
+            sandbox's only writable path; see
+            :class:`~ray.experimental.sandbox.config.SandboxConfig`.
+        ttl_seconds: Optional time-to-live in seconds, wall-clock from
+            creation (not idle time). None (default) or <= 0 disables it.
         timeout_seconds: Timeout in seconds for sandbox creation.
         rootless: If True, run gVisor in rootless mode.
-        network: Network mode for runsc.
+        network: Network mode ("none", "public", "host", "sandbox"); see
+            :class:`~ray.experimental.sandbox.config.SandboxConfig`. "public"
+            is the recommended internet-access mode.
+        dns: Optional nameserver IPs for the generated /etc/resolv.conf
+            (public resolvers by default for "public").
+        capabilities: Linux capabilities, written exactly (None keeps the
+            runtime default; ``[]`` means none); see
+            ``DOCKER_DEFAULT_CAPABILITIES``.
         readonly: If True (default), mount container image rootfs in read-only mode
             such that only ``workdir`` is writable. If False, the entire root filesystem
             is writable. Writes are isolated within a per-sandbox copy-on-write overlay
@@ -41,10 +50,12 @@ class Sandbox:
         memory: Optional[Union[str, int, float]] = None,
         env: Optional[Dict[str, str]] = None,
         workdir: Optional[str] = None,
-        ttl_seconds: Optional[int] = 3600,
+        ttl_seconds: Optional[int] = None,
         timeout_seconds: float = 30.0,
         rootless: bool = True,
         network: str = "none",
+        dns: Optional[List[str]] = None,
+        capabilities: Optional[List[str]] = None,
         readonly: bool = True,
         **kwargs,
     ):
@@ -72,17 +83,11 @@ class Sandbox:
             timeout_seconds=timeout_seconds,
             rootless=rootless,
             network=network,
+            dns=dns,
+            capabilities=capabilities,
             readonly=readonly,
             **kwargs,
         )
-
-        self._ttl_timer = None
-        if ttl_seconds is not None and ttl_seconds > 0:
-            import threading
-
-            self._ttl_timer = threading.Timer(ttl_seconds, self.delete)
-            self._ttl_timer.daemon = True
-            self._ttl_timer.start()
 
     def __del__(self):
         try:
@@ -117,6 +122,7 @@ class Sandbox:
         timeout: Optional[float] = None,
         cwd: Optional[str] = None,
         env: Optional[Dict[str, str]] = None,
+        shell: Optional[str] = None,
     ) -> ExecResult:
         """Execute a command inside the sandbox.
 
@@ -125,12 +131,14 @@ class Sandbox:
             timeout: Maximum execution time in seconds.
             cwd: Working directory inside the sandbox for command execution.
             env: Environment variables to set for the command.
+            shell: Optional shell for string commands, overriding the
+                sandbox's configured shell (default /bin/bash).
 
         Returns:
             ExecResult containing exit code, stdout, and stderr.
         """
         return self.runtime.exec(
-            self.instance_id, command, timeout=timeout, cwd=cwd, env=env
+            self.instance_id, command, timeout=timeout, cwd=cwd, env=env, shell=shell
         )
 
     def upload_file(self, local_path: str, remote_path: str) -> None:
@@ -181,9 +189,6 @@ class Sandbox:
 
     def delete(self) -> None:
         """Clean up and terminate the sandbox instance."""
-        if self._ttl_timer:
-            self._ttl_timer.cancel()
-            self._ttl_timer = None
         self.runtime.delete(self.instance_id)
 
     def terminate(self) -> None:

--- a/python/ray/experimental/sandbox/tests/test_gvisor_backend.py
+++ b/python/ray/experimental/sandbox/tests/test_gvisor_backend.py
@@ -13,12 +13,14 @@ from ray.experimental.sandbox.exceptions import (
     SandboxCreationError,
     SandboxNotFoundError,
 )
+from ray.experimental.sandbox.runtime import SandboxRuntime
 
 
 def test_gvisor_backend_local_lifecycle_and_file_ops():
     backend = GVisorSandboxBackend()
     config = GVisorSandboxConfig(
         image="busybox:latest",
+        shell="/bin/sh",
         workdir="/workspace",
         cpu=1.0,
         memory="512Mi",
@@ -54,7 +56,7 @@ def test_gvisor_backend_not_found():
 def test_create_sandbox_helper():
     if not ray.is_initialized():
         ray.init(ignore_reinit_error=True)
-    sb = create("busybox:latest", workdir="/workspace")
+    sb = create("busybox:latest", workdir="/workspace", shell="/bin/sh")
     assert isinstance(sb, ActorHandle)
     res = ray.get(sb.exec.remote("echo 'Process isolation'"))
     assert res.exit_code == 0
@@ -67,6 +69,7 @@ def test_gvisor_backend_container_image_support():
     backend = GVisorSandboxBackend()
     config = GVisorSandboxConfig(
         image="busybox:latest",
+        shell="/bin/sh",
         workdir="/workspace",
     )
     sandbox_id = backend.create_sandbox(config)
@@ -115,11 +118,13 @@ def test_gvisor_backend_container_image_overlay_isolation():
     backend = GVisorSandboxBackend()
     cfg1 = GVisorSandboxConfig(
         image="busybox:latest",
+        shell="/bin/sh",
         workdir="/workspace",
         readonly=False,
     )
     cfg2 = GVisorSandboxConfig(
         image="busybox:latest",
+        shell="/bin/sh",
         workdir="/workspace",
         readonly=False,
     )
@@ -159,6 +164,7 @@ def test_gvisor_backend_container_image_overlay_isolation():
     # A newly created SB3 should not see /overlay_test.txt
     cfg3 = GVisorSandboxConfig(
         image="busybox:latest",
+        shell="/bin/sh",
         workdir="/workspace",
         readonly=False,
     )
@@ -175,6 +181,7 @@ def test_gvisor_backend_readonly_rootfs():
     # Default is readonly=True
     cfg = GVisorSandboxConfig(
         image="busybox:latest",
+        shell="/bin/sh",
         workdir="/workspace",
     )
     assert cfg.readonly is True
@@ -200,18 +207,102 @@ def test_gvisor_backend_readonly_rootfs():
 
 def test_gvisor_backend_ignore_cgroups_flag():
     backend = GVisorSandboxBackend()
-    cfg_default = GVisorSandboxConfig(image="busybox:latest")
+    cfg_default = GVisorSandboxConfig(image="busybox:latest", shell="/bin/sh")
     orig_env = os.environ.pop("RAY_SANDBOX_IGNORE_CGROUPS", None)
     try:
         args_default = backend._runsc_base_args(cfg_default)
         assert "--ignore-cgroups" not in args_default
 
-        cfg_ignored = GVisorSandboxConfig(image="busybox:latest", _ignore_cgroups=True)
+        cfg_ignored = GVisorSandboxConfig(
+            image="busybox:latest", shell="/bin/sh", _ignore_cgroups=True
+        )
         args_ignored = backend._runsc_base_args(cfg_ignored)
         assert "--ignore-cgroups" in args_ignored
     finally:
         if orig_env is not None:
             os.environ["RAY_SANDBOX_IGNORE_CGROUPS"] = orig_env
+
+
+def test_string_exec_shell_configuration():
+    """String commands run under config.shell (default /bin/bash) with a
+    per-exec override; there is no auto-detection."""
+    # busybox has /bin/sh but no /bin/bash: with the deterministic bash
+    # default a string exec fails loudly instead of degrading to sh, so this
+    # image configures the shell explicitly.
+    runtime = SandboxRuntime()
+    instance_id = runtime.create(
+        image="busybox:latest", readonly=False, shell="/bin/sh"
+    )
+    try:
+        result = runtime.exec(instance_id, "echo hello-$0")
+        assert result.exit_code == 0
+        assert "hello-" in result.stdout
+        # Per-exec override beats the configured shell.
+        result = runtime.exec(instance_id, "echo again", shell="/bin/sh")
+        assert result.exit_code == 0
+    finally:
+        runtime.delete(instance_id)
+
+
+def test_workdir_writability_matrix():
+    """readonly=True + workdir=None -> nothing writable; explicit workdir is
+    the only writable path; readonly=False -> everything writable."""
+    runtime = SandboxRuntime()
+
+    # Default (readonly=True, workdir=None): the rootfs is not writable.
+    # (Standard tmpfs mounts like /tmp are, as in any container runtime.)
+    instance_id = runtime.create(image="busybox:latest", shell="/bin/sh")
+    try:
+        assert runtime.exec(instance_id, "touch /probe").exit_code != 0
+        assert runtime.exec(instance_id, "touch /etc/probe").exit_code != 0
+    finally:
+        runtime.delete(instance_id)
+
+    # readonly=True, explicit workdir: it is the only writable path.
+    instance_id = runtime.create(
+        image="busybox:latest", workdir="/data", shell="/bin/sh"
+    )
+    try:
+        assert runtime.exec(instance_id, "touch /data/probe").exit_code == 0
+        assert runtime.exec(instance_id, "touch /etc/probe").exit_code != 0
+        assert runtime.exec(instance_id, "pwd").stdout.strip() == "/data"
+    finally:
+        runtime.delete(instance_id)
+
+    # readonly=False: everything is writable, with or without a workdir.
+    instance_id = runtime.create(
+        image="busybox:latest", readonly=False, shell="/bin/sh"
+    )
+    try:
+        assert runtime.exec(instance_id, "touch /etc/probe").exit_code == 0
+    finally:
+        runtime.delete(instance_id)
+
+
+def test_image_workdir_sets_cwd_without_becoming_writable():
+    """The image's own WORKDIR is inherited as the process cwd only — its
+    content stays visible and it is never silently made writable."""
+    runtime = SandboxRuntime()
+    # golang:alpine sets WORKDIR /go and ships /go/bin and /go/src.
+    instance_id = runtime.create(image="golang:1.22-alpine", shell="/bin/sh")
+    try:
+        assert runtime.exec(instance_id, "pwd").stdout.strip() == "/go"
+        listing = runtime.exec(instance_id, "ls /go").stdout
+        assert "bin" in listing and "src" in listing
+        # Inherited WORKDIR is not a scratch mount: still readonly.
+        assert runtime.exec(instance_id, "touch /go/probe").exit_code != 0
+    finally:
+        runtime.delete(instance_id)
+
+    # With a writable rootfs the same path is writable and unshadowed.
+    instance_id = runtime.create(
+        image="golang:1.22-alpine", readonly=False, shell="/bin/sh"
+    )
+    try:
+        assert "bin" in runtime.exec(instance_id, "ls /go").stdout
+        assert runtime.exec(instance_id, "touch /go/probe").exit_code == 0
+    finally:
+        runtime.delete(instance_id)
 
 
 if __name__ == "__main__":

--- a/python/ray/experimental/sandbox/tests/test_image_manager.py
+++ b/python/ray/experimental/sandbox/tests/test_image_manager.py
@@ -280,5 +280,235 @@ def test_custom_image_manager_subclass(tmp_path):
     assert ("another-image", 120.0) in custom_mgr.pull_calls
 
 
+class _StubImageManager(ImageManager):
+    """ImageManager that skips pulling so spec construction is testable offline."""
+
+    def __init__(self, tmp_path):
+        super().__init__(images_dir=str(tmp_path))
+        self._fake_image_dir = str(tmp_path)
+
+    def pull_image(self, image, timeout_seconds=120.0):
+        return self._fake_image_dir
+
+    def get_image_config(self, image):
+        return {}
+
+
+def _sample_base_spec():
+    return {
+        "process": {"capabilities": {"bounding": ["CAP_KILL"]}},
+        "root": {},
+        "mounts": [],
+        "linux": {
+            "namespaces": [
+                {"type": "pid"},
+                {"type": "network"},
+                {"type": "mount"},
+            ]
+        },
+    }
+
+
+def test_create_oci_spec_sets_capabilities_exactly(tmp_path):
+    mgr = _StubImageManager(tmp_path)
+    spec = mgr.create_oci_spec(
+        image="fake:latest",
+        base_spec=_sample_base_spec(),
+        capabilities=["CAP_CHOWN", "CAP_SETUID"],
+    )
+    for cap_set in ("bounding", "effective", "permitted"):
+        assert spec["process"]["capabilities"][cap_set] == [
+            "CAP_CHOWN",
+            "CAP_SETUID",
+        ]
+    # Inheritable and ambient are left alone (modern Docker behavior).
+    assert "inheritable" not in spec["process"]["capabilities"]
+    assert "ambient" not in spec["process"]["capabilities"]
+
+
+def test_create_oci_spec_empty_capabilities_remove_all(tmp_path):
+    mgr = _StubImageManager(tmp_path)
+    spec = mgr.create_oci_spec(
+        image="fake:latest", base_spec=_sample_base_spec(), capabilities=[]
+    )
+    for cap_set in ("bounding", "effective", "permitted"):
+        assert spec["process"]["capabilities"][cap_set] == []
+
+
+def test_create_oci_spec_default_capabilities_untouched(tmp_path):
+    mgr = _StubImageManager(tmp_path)
+    spec = mgr.create_oci_spec(image="fake:latest", base_spec=_sample_base_spec())
+    assert spec["process"]["capabilities"] == {"bounding": ["CAP_KILL"]}
+
+
+def test_create_oci_spec_host_side_networking_drops_empty_netns(tmp_path):
+    mgr = _StubImageManager(tmp_path)
+    for mode in ("host", "public"):
+        spec = mgr.create_oci_spec(
+            image="fake:latest", base_spec=_sample_base_spec(), network=mode
+        )
+        assert {"type": "network"} not in spec["linux"]["namespaces"]
+        assert {"type": "pid"} in spec["linux"]["namespaces"]
+
+
+def test_create_oci_spec_mounts_resolv_conf_source(tmp_path):
+    mgr = _StubImageManager(tmp_path)
+    source = tmp_path / "resolv.conf"
+    source.write_text("nameserver 8.8.8.8\n")
+    spec = mgr.create_oci_spec(
+        image="fake:latest",
+        base_spec=_sample_base_spec(),
+        network="public",
+        resolv_conf_source=str(source),
+    )
+    (mount,) = [m for m in spec["mounts"] if m["destination"] == "/etc/resolv.conf"]
+    assert mount["source"] == str(source)
+    assert "ro" in mount["options"]
+
+    # No source, no mount.
+    spec = mgr.create_oci_spec(
+        image="fake:latest", base_spec=_sample_base_spec(), network="public"
+    )
+    assert not any(m["destination"] == "/etc/resolv.conf" for m in spec["mounts"])
+
+
+def test_create_oci_spec_host_network_keeps_pathed_netns(tmp_path):
+    mgr = _StubImageManager(tmp_path)
+    base = _sample_base_spec()
+    base["linux"]["namespaces"] = [{"type": "network", "path": "/proc/1/ns/net"}]
+    spec = mgr.create_oci_spec(image="fake:latest", base_spec=base, network="host")
+    # A *pathed* network namespace is somebody's explicit choice; keep it.
+    assert spec["linux"]["namespaces"] == [
+        {"type": "network", "path": "/proc/1/ns/net"}
+    ]
+
+
+def test_create_oci_spec_tolerates_null_capability_set(tmp_path):
+    """A base_spec capability *set* (not just the dict) may be null."""
+    mgr = _StubImageManager(tmp_path)
+    base = _sample_base_spec()
+    base["process"]["capabilities"] = {"effective": None, "bounding": ["CAP_KILL"]}
+    spec = mgr.create_oci_spec(
+        image="fake:latest", base_spec=base, capabilities=["CAP_CHOWN"]
+    )
+    assert spec["process"]["capabilities"]["effective"] == ["CAP_CHOWN"]
+    assert spec["process"]["capabilities"]["bounding"] == ["CAP_CHOWN"]
+
+
+def test_create_oci_spec_tolerates_non_dict_namespace_entries(tmp_path):
+    """Malformed namespace entries are kept for runsc to reject, not dropped."""
+    mgr = _StubImageManager(tmp_path)
+    base = _sample_base_spec()
+    base["linux"]["namespaces"] = [{"type": "network"}, "pid", None]
+    spec = mgr.create_oci_spec(image="fake:latest", base_spec=base, network="host")
+    assert spec["linux"]["namespaces"] == ["pid", None]
+
+
+def test_create_oci_spec_workdir_path_drives_the_scratch_mount(tmp_path):
+    """The scratch bind exists iff a workdir_path is given; the process cwd
+    is independent of it."""
+    mgr = _StubImageManager(tmp_path)
+    workdir_path = str(tmp_path / "scratch")
+    os.makedirs(workdir_path, exist_ok=True)
+
+    mounted = mgr.create_oci_spec(
+        image="fake:latest",
+        base_spec=_sample_base_spec(),
+        container_cwd="/app",
+        workdir_path=workdir_path,
+    )
+    assert any(m["destination"] == "/app" for m in mounted["mounts"])
+
+    unmounted = mgr.create_oci_spec(
+        image="fake:latest",
+        base_spec=_sample_base_spec(),
+        container_cwd="/app",
+        workdir_path=None,
+    )
+    assert not any(m["destination"] == "/app" for m in unmounted["mounts"])
+    assert unmounted["process"]["cwd"] == "/app"
+
+
+def test_create_oci_spec_tolerates_null_sections_in_base_spec(tmp_path):
+    """A caller-supplied base_spec may carry null capabilities/linux keys."""
+    mgr = _StubImageManager(tmp_path)
+    base = _sample_base_spec()
+    base["process"]["capabilities"] = None
+    base["linux"] = None
+    spec = mgr.create_oci_spec(
+        image="fake:latest",
+        base_spec=base,
+        capabilities=["CAP_CHOWN"],
+        network="host",
+    )
+    assert "CAP_CHOWN" in spec["process"]["capabilities"]["bounding"]
+    assert isinstance(spec["linux"], dict)
+
+
+def test_create_oci_spec_non_host_network_untouched(tmp_path):
+    mgr = _StubImageManager(tmp_path)
+    for mode in ("none", "sandbox"):
+        spec = mgr.create_oci_spec(
+            image="fake:latest", base_spec=_sample_base_spec(), network=mode
+        )
+        assert {"type": "network"} in spec["linux"]["namespaces"]
+        assert all(m["destination"] != "/etc/resolv.conf" for m in spec["mounts"])
+
+
+class _SpecCapturingManager(_StubImageManager):
+    """Captures create_oci_spec kwargs so prepare_oci_bundle's resolv policy
+    is testable without runsc."""
+
+    def __init__(self, tmp_path):
+        super().__init__(tmp_path)
+        self.spec_kwargs = None
+
+    def create_oci_spec(self, image, **kwargs):
+        self.spec_kwargs = kwargs
+        return {}
+
+
+def _prepare(mgr, root_dir, **kwargs):
+    mgr.prepare_oci_bundle(
+        root_dir=str(root_dir),
+        workdir_path=str(root_dir),
+        container_cwd="/",
+        image="fake:latest",
+        **kwargs,
+    )
+    return mgr.spec_kwargs["resolv_conf_source"]
+
+
+def test_prepare_oci_bundle_public_generates_default_resolv(tmp_path):
+    mgr = _SpecCapturingManager(tmp_path)
+    source = _prepare(mgr, tmp_path, network="public")
+    assert source == os.path.join(str(tmp_path), "resolv.conf")
+    content = open(source, encoding="utf-8").read()
+    assert content == "nameserver 8.8.8.8\nnameserver 1.1.1.1\n"
+
+
+def test_prepare_oci_bundle_dns_overrides_for_public_and_host(tmp_path):
+    for network in ("public", "host"):
+        mgr = _SpecCapturingManager(tmp_path)
+        source = _prepare(mgr, tmp_path, network=network, dns=["10.0.0.2"])
+        content = open(source, encoding="utf-8").read()
+        assert content == "nameserver 10.0.0.2\n"
+
+
+def test_prepare_oci_bundle_host_uses_host_resolv(tmp_path):
+    mgr = _SpecCapturingManager(tmp_path)
+    source = _prepare(mgr, tmp_path, network="host")
+    if os.path.exists("/etc/resolv.conf"):
+        assert source == "/etc/resolv.conf"
+    else:
+        assert source is None
+
+
+def test_prepare_oci_bundle_no_resolv_without_host_side_networking(tmp_path):
+    for network in ("none", "sandbox"):
+        mgr = _SpecCapturingManager(tmp_path)
+        assert _prepare(mgr, tmp_path, network=network) is None
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main(["-v", __file__]))

--- a/python/ray/experimental/sandbox/tests/test_sandbox.py
+++ b/python/ray/experimental/sandbox/tests/test_sandbox.py
@@ -9,7 +9,9 @@ from ray.experimental.sandbox.runtime import SandboxRuntime
 
 def test_sandbox_runtime_interface(tmp_path):
     rt = SandboxRuntime()
-    instance_id = rt.create(image="busybox:latest", workdir="/workspace")
+    instance_id = rt.create(
+        image="busybox:latest", shell="/bin/sh", workdir="/workspace"
+    )
     assert instance_id.startswith("ray-sandbox-")
 
     res = rt.exec(instance_id, "echo 'Hello world'")
@@ -34,7 +36,9 @@ def test_sandbox_actor_wrapper():
     if not ray.is_initialized():
         ray.init(ignore_reinit_error=True)
 
-    actor = Sandbox.remote(image="busybox:latest", workdir="/workspace")
+    actor = Sandbox.remote(
+        image="busybox:latest", shell="/bin/sh", workdir="/workspace"
+    )
     instance_id = ray.get(actor.get_instance_id.remote())
     assert instance_id.startswith("ray-sandbox-")
 
@@ -59,7 +63,7 @@ def test_custom_sandbox_actor_with_sandbox_runtime():
         def __init__(self):
             self.runtime = SandboxRuntime()
             self.instance_id = self.runtime.create(
-                image="busybox:latest", workdir="/workspace"
+                image="busybox:latest", shell="/bin/sh", workdir="/workspace"
             )
 
         def exec(self, command, timeout=None, env=None):
@@ -87,7 +91,9 @@ def test_ray_remote_sandbox_runtime():
     rt_actor = remote_rt_cls.remote()
 
     instance_id = ray.get(
-        rt_actor.create.remote(image="busybox:latest", workdir="/workspace")
+        rt_actor.create.remote(
+            image="busybox:latest", shell="/bin/sh", workdir="/workspace"
+        )
     )
     assert instance_id.startswith("ray-sandbox-")
 
@@ -104,7 +110,7 @@ def test_sandbox_actor_resource_translation():
         ray.init(ignore_reinit_error=True)
 
     actor = Sandbox.options(num_cpus=2.0).remote(
-        image="busybox:latest", cpu=2.0, workdir="/workspace"
+        image="busybox:latest", shell="/bin/sh", cpu=2.0, workdir="/workspace"
     )
 
     ret_config = ray.get(actor.get_config.remote())
@@ -123,7 +129,7 @@ def test_sandbox_runtime_create_variants():
     rt.delete(id1)
 
     # Pass image as keyword arg
-    id2 = rt.create(image="busybox:latest", workdir="/workspace")
+    id2 = rt.create(image="busybox:latest", shell="/bin/sh", workdir="/workspace")
     assert id2.startswith("ray-sandbox-")
     rt.delete(id2)
 

--- a/python/ray/experimental/sandbox/tests/test_sandbox_config.py
+++ b/python/ray/experimental/sandbox/tests/test_sandbox_config.py
@@ -15,10 +15,11 @@ def test_default_sandbox_config():
     assert config.cpu == 0.0
     assert config.memory == 0
     assert config.workdir is None
-    assert config.ttl_seconds == 3600
+    assert config.ttl_seconds is None
     assert config.rootless is True
     assert config.network == "none"
     assert config.readonly is True
+    assert config.shell == "/bin/bash"
     assert config._ignore_cgroups is False
 
     # SandboxConfig requires image
@@ -47,6 +48,52 @@ def test_gvisor_sandbox_config():
     assert config.env == {"TEST_VAR": "value"}
     assert config.readonly is False
     assert config._ignore_cgroups is True
+
+
+def test_capabilities_config():
+    config = SandboxConfig(image="python:3.10-slim")
+    assert config.capabilities is None
+
+    config = SandboxConfig(
+        image="python:3.10-slim", capabilities=["CAP_CHOWN", "CAP_SETUID"]
+    )
+    assert config.capabilities == ["CAP_CHOWN", "CAP_SETUID"]
+
+
+def test_invalid_network_mode_rejected():
+    with pytest.raises(ValueError, match="network mode"):
+        SandboxConfig(image="python:3.10-slim", network="bridge")
+
+    for mode in ("none", "public", "host"):
+        assert SandboxConfig(image="python:3.10-slim", network=mode).network == mode
+    # "sandbox" additionally requires rootless=False (see the test below).
+    config = SandboxConfig(image="python:3.10-slim", network="sandbox", rootless=False)
+    assert config.network == "sandbox"
+
+
+def test_dns_only_valid_with_host_side_networking():
+    for mode in ("public", "host"):
+        config = SandboxConfig(image="python:3.10-slim", network=mode, dns=["10.0.0.2"])
+        assert config.dns == ["10.0.0.2"]
+
+    with pytest.raises(ValueError, match="dns"):
+        SandboxConfig(image="python:3.10-slim", dns=["8.8.8.8"])
+
+    with pytest.raises(ValueError, match="dns"):
+        SandboxConfig(
+            image="python:3.10-slim",
+            network="sandbox",
+            rootless=False,
+            dns=["8.8.8.8"],
+        )
+
+
+def test_sandbox_network_requires_rootful():
+    with pytest.raises(ValueError, match="rootless"):
+        SandboxConfig(image="python:3.10-slim", network="sandbox")
+
+    config = SandboxConfig(image="python:3.10-slim", network="sandbox", rootless=False)
+    assert config.network == "sandbox"
 
 
 def test_parse_memory_bytes():

--- a/python/ray/experimental/sandbox/tests/test_sandbox_runtime.py
+++ b/python/ray/experimental/sandbox/tests/test_sandbox_runtime.py
@@ -1,0 +1,116 @@
+"""SandboxRuntime-layer tests with fake manager/backend (no runsc needed).
+
+These pin that ``create()`` arguments actually reach the backend's
+``SandboxConfig`` — the layer where a declared-but-unforwarded field once
+shipped behind a green suite.
+"""
+
+import sys
+import time
+
+import pytest
+
+from ray.experimental.sandbox.backend.base import ExecResult, SandboxStatus
+from ray.experimental.sandbox.runtime import SandboxRuntime
+
+
+class _FakeImageManager:
+    def pull_image(self, image, timeout_seconds=120.0):
+        return f"/tmp/fake-images/{image}"
+
+
+class _FakeBackend:
+    def __init__(self):
+        self.configs = []
+        self.deleted = []
+
+    def create_sandbox(self, config):
+        self.configs.append(config)
+        return "ray-sandbox-fake0001"
+
+    def delete_sandbox(self, sandbox_id):
+        self.deleted.append(sandbox_id)
+
+    def exec_command(self, sandbox_id, command, timeout=None, cwd=None, env=None):
+        return ExecResult(exit_code=0, stdout="", stderr="", duration_seconds=0.0)
+
+    def write_file(self, sandbox_id, path, content):
+        pass
+
+    def read_file(self, sandbox_id, path):
+        return b""
+
+    def get_status(self, sandbox_id):
+        return SandboxStatus.RUNNING
+
+
+def _fake_runtime():
+    runtime = SandboxRuntime()
+    runtime._image_manager = _FakeImageManager()
+    runtime._backend = _FakeBackend()
+    return runtime
+
+
+def test_create_forwards_config_fields_to_backend():
+    runtime = _fake_runtime()
+    runtime.create(
+        image="fake:latest",
+        cpu=2.0,
+        memory="1Gi",
+        env={"A": "1"},
+        workdir="/app",
+        network="host",
+        dns=["10.0.0.2"],
+        capabilities=["CAP_CHOWN"],
+        rootless=True,
+        readonly=False,
+        shell="/bin/bash",
+    )
+    (config,) = runtime._backend.configs
+    assert config.image == "fake:latest"
+    assert config.cpu == 2.0
+    assert config.env == {"A": "1"}
+    assert config.workdir == "/app"
+    assert config.network == "host"
+    assert config.dns == ["10.0.0.2"]
+    assert config.capabilities == ["CAP_CHOWN"]
+    assert config.rootless is True
+    assert config.readonly is False
+    assert config.shell == "/bin/bash"
+
+
+def test_ttl_is_enforced_by_the_runtime():
+    runtime = _fake_runtime()
+    instance_id = runtime.create(image="fake:latest", ttl_seconds=1)
+    assert runtime._backend.deleted == []
+    deadline = time.monotonic() + 5
+    while not runtime._backend.deleted and time.monotonic() < deadline:
+        time.sleep(0.05)
+    assert runtime._backend.deleted == [instance_id]
+    # The timer is gone after firing (delete popped it).
+    assert instance_id not in runtime._ttl_timers
+
+
+def test_delete_cancels_the_ttl_timer():
+    runtime = _fake_runtime()
+    instance_id = runtime.create(image="fake:latest", ttl_seconds=3600)
+    timer = runtime._ttl_timers[instance_id]
+    runtime.delete(instance_id)
+    assert instance_id not in runtime._ttl_timers
+    # cancel() sets the finished event; the thread itself may take a beat to
+    # exit, so assert the deterministic signal rather than thread liveness.
+    assert timer.finished.is_set()
+    assert runtime._backend.deleted == [instance_id]
+
+
+def test_no_ttl_by_default():
+    runtime = _fake_runtime()
+    instance_id = runtime.create(image="fake:latest")
+    assert instance_id not in runtime._ttl_timers
+    (config,) = runtime._backend.configs
+    assert config.ttl_seconds is None
+    assert config.shell == "/bin/bash"
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-v", __file__]))


### PR DESCRIPTION
## Description

Cherry-pick of #65570 (`7408258f64`) into `releases/2.58.0`.

Brings the Ray Sandbox Docker-image support onto the release branch, complementing the sandbox documentation already cherry-picked in #65573 (#65503). All changes are confined to `python/ray/experimental/sandbox/` plus its doc page and `doc/source/conf.py`.

## Verification

- Clean cherry-pick (`git cherry-pick -x -s 7408258f64`), no conflicts; 14 files changed matching the original commit.
- The original change passed full CI on master (merged 2026-08-20); release-branch CI on this PR will validate on 2.58.0.

Not a duplicate: no existing cherry-pick PR for #65570 targets `releases/2.58.0`.

AI assistance (Claude Code) was used to prepare this cherry-pick.

🤖 Generated with [Claude Code](https://claude.com/claude-code)