### PR TITLE
[serve] Deflake test_cluster on loaded CI shards

### DIFF
--- a/python/ray/serve/tests/BUILD.bazel
+++ b/python/ray/serve/tests/BUILD.bazel
@@ -106,7 +106,6 @@ py_test_module_list(
         "test_batching.py",
         "test_broadcast.py",
         "test_callback.py",
-        "test_cluster.py",
         "test_controller.py",
         "test_controller_benchmark.py",
         "test_controller_recovery.py",
@@ -145,6 +144,25 @@ py_test_module_list(
         "test_task_consumer_autoscaling.py",
         "test_task_processor.py",
         "test_util.py",
+    ],
+    tags = [
+        "exclusive",
+        "team:serve",
+    ],
+    deps = [
+        ":common",
+        ":conftest",
+        "//python/ray/serve:serve_lib",
+    ],
+)
+
+# Multi-node cluster test. On the shared Windows shard it runs at ~79% of the
+# default medium timeout, so a loaded runner tips it over; give it headroom.
+py_test_module_list(
+    size = "medium",
+    timeout = "long",
+    files = [
+        "test_cluster.py",
     ],
     tags = [
         "exclusive",

--- a/python/ray/serve/tests/test_cluster.py
+++ b/python/ray/serve/tests/test_cluster.py
@@ -30,8 +30,12 @@ from ray.serve.handle import DeploymentHandle
 from ray.serve.schema import ServeDeploySchema
 from ray.util.state import list_actors
 
+# Windows CI runs these on a shared, heavily loaded shard where multi-node
+# cluster convergence routinely overruns wait_for_condition's 10s default.
+WAIT_TIMEOUT_S = 60
 
-def get_pids(expected, deployment_name="D", app_name="default", timeout=30):
+
+def get_pids(expected, deployment_name="D", app_name="default", timeout=WAIT_TIMEOUT_S):
     handle = serve.get_deployment_handle(deployment_name, app_name)
     pids = set()
     start = time.time()
@@ -181,7 +185,9 @@ def test_replica_startup_status_transitions(ray_cluster):
         return replicas.get([replica_state])
 
     # wait for serve to start the replica
-    wait_for_condition(lambda: len(get_replicas(ReplicaState.STARTING)) > 0)
+    wait_for_condition(
+        lambda: len(get_replicas(ReplicaState.STARTING)) > 0, timeout=WAIT_TIMEOUT_S
+    )
 
     # currently there are no resources to allocate the replica
     def get_starting_replica():
@@ -194,12 +200,16 @@ def test_replica_startup_status_transitions(ray_cluster):
             return False
         return replica.check_started()[0] == ReplicaStartupStatus.PENDING_ALLOCATION
 
-    wait_for_condition(is_pending_allocation)
+    wait_for_condition(is_pending_allocation, timeout=WAIT_TIMEOUT_S)
 
     # add the necessary resources to allocate the replica
     cluster.add_node(num_cpus=4)
-    wait_for_condition(lambda: (ray.cluster_resources().get("CPU", 0) >= 4))
-    wait_for_condition(lambda: (ray.available_resources().get("CPU", 0) >= 2))
+    wait_for_condition(
+        lambda: (ray.cluster_resources().get("CPU", 0) >= 4), timeout=WAIT_TIMEOUT_S
+    )
+    wait_for_condition(
+        lambda: (ray.available_resources().get("CPU", 0) >= 2), timeout=WAIT_TIMEOUT_S
+    )
 
     def is_replica_pending_initialization():
         replica = get_starting_replica()
@@ -208,7 +218,7 @@ def test_replica_startup_status_transitions(ray_cluster):
         status, _ = replica.check_started()
         return status == ReplicaStartupStatus.PENDING_INITIALIZATION
 
-    wait_for_condition(is_replica_pending_initialization, timeout=25)
+    wait_for_condition(is_replica_pending_initialization, timeout=WAIT_TIMEOUT_S)
 
     # send signal to complete replica initialization
     ray.get(signal.send.remote())
@@ -229,7 +239,7 @@ def test_replica_startup_status_transitions(ray_cluster):
 
         return False
 
-    wait_for_condition(check_succeeded)
+    wait_for_condition(check_succeeded, timeout=WAIT_TIMEOUT_S)
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="Flaky on Windows.")
@@ -264,7 +274,9 @@ def test_gang_replica_startup_status_transitions(ray_cluster):
         return replicas.get([replica_state])
 
     # Wait for replicas to be created in STARTING state.
-    wait_for_condition(lambda: len(get_replicas(ReplicaState.STARTING)) > 0)
+    wait_for_condition(
+        lambda: len(get_replicas(ReplicaState.STARTING)) > 0, timeout=WAIT_TIMEOUT_S
+    )
 
     # With only 1 CPU available and each replica needing 0.75, replicas should
     # be stuck in PENDING_ALLOCATION.
@@ -277,11 +289,13 @@ def test_gang_replica_startup_status_transitions(ray_cluster):
             for r in replicas
         )
 
-    wait_for_condition(is_pending_allocation)
+    wait_for_condition(is_pending_allocation, timeout=WAIT_TIMEOUT_S)
 
     # Add enough resources for the gang
     cluster.add_node(num_cpus=1)
-    wait_for_condition(lambda: ray.cluster_resources().get("CPU", 0) == 2)
+    wait_for_condition(
+        lambda: ray.cluster_resources().get("CPU", 0) == 2, timeout=WAIT_TIMEOUT_S
+    )
 
     # Replicas should transition to PENDING_INITIALIZATION
     def is_pending_initialization():
@@ -293,7 +307,7 @@ def test_gang_replica_startup_status_transitions(ray_cluster):
             for r in replicas
         )
 
-    wait_for_condition(is_pending_initialization, timeout=30)
+    wait_for_condition(is_pending_initialization, timeout=WAIT_TIMEOUT_S)
 
     # Complete initialization
     ray.get(signal.send.remote())
@@ -303,7 +317,7 @@ def test_gang_replica_startup_status_transitions(ray_cluster):
         running_replicas = get_replicas(ReplicaState.RUNNING)
         return len(running_replicas) == 2
 
-    wait_for_condition(check_running, timeout=30)
+    wait_for_condition(check_running, timeout=WAIT_TIMEOUT_S)
 
 
 @serve.deployment
@@ -347,12 +361,16 @@ def test_intelligent_scale_down(ray_cluster):
         "deployments": [{"name": "f", "num_replicas": 3}],
     }
     client.deploy_apps(ServeDeploySchema(**{"applications": [app_config]}))
-    wait_for_condition(check_app_running_with_replicas, num_replicas=3)
+    wait_for_condition(
+        check_app_running_with_replicas, num_replicas=3, timeout=WAIT_TIMEOUT_S
+    )
     assert get_actor_distributions() == {2, 1}
 
     app_config["deployments"][0]["num_replicas"] = 2
     client.deploy_apps(ServeDeploySchema(**{"applications": [app_config]}))
-    wait_for_condition(check_app_running_with_replicas, num_replicas=2)
+    wait_for_condition(
+        check_app_running_with_replicas, num_replicas=2, timeout=WAIT_TIMEOUT_S
+    )
     assert get_actor_distributions() == {2}
 
 
@@ -392,7 +410,7 @@ def test_replica_spread(ray_cluster):
         return len(nodes)
 
     # Check that the two replicas are spread across the two nodes.
-    wait_for_condition(lambda: get_num_nodes() == 2)
+    wait_for_condition(lambda: get_num_nodes() == 2, timeout=WAIT_TIMEOUT_S)
 
     # Kill the worker node. The second replica should get rescheduled on
     # the head node.
@@ -400,7 +418,7 @@ def test_replica_spread(ray_cluster):
     cluster.remove_node(worker_node)
 
     # Check that the replica on the dead node can be rescheduled.
-    wait_for_condition(lambda: get_num_nodes() == 1)
+    wait_for_condition(lambda: get_num_nodes() == 1, timeout=WAIT_TIMEOUT_S)
 
 
 def test_autoscale_upscaling_stuck_then_healthy(ray_cluster):
@@ -445,6 +463,7 @@ def test_autoscale_upscaling_stuck_then_healthy(ray_cluster):
         check_deployment_status,
         name="blocking_replica",
         expected_status=DeploymentStatus.HEALTHY,
+        timeout=WAIT_TIMEOUT_S,
     )
 
     # Send 2 requests - first occupies the replica, second queues. With
@@ -457,7 +476,7 @@ def test_autoscale_upscaling_stuck_then_healthy(ray_cluster):
         check_deployment_status,
         name="blocking_replica",
         expected_status=DeploymentStatus.UPSCALING,
-        timeout=15,
+        timeout=WAIT_TIMEOUT_S,
     )
 
     # Release the signal so running requests complete and go to zero.
@@ -471,7 +490,7 @@ def test_autoscale_upscaling_stuck_then_healthy(ray_cluster):
         check_deployment_status,
         name="blocking_replica",
         expected_status=DeploymentStatus.HEALTHY,
-        timeout=30,
+        timeout=WAIT_TIMEOUT_S,
     )
 
 
@@ -629,14 +648,17 @@ class TestHealthzAndRoutes:
                 len(
                     {
                         a.node_id
-                        for a in list_actors(address=cluster.address)
+                        for a in list_actors(
+                            address=cluster.address,
+                            filters=[("STATE", "=", "ALIVE")],
+                        )
                         if a.class_name.startswith("ServeReplica")
                     }
                 )
                 == 1
             )
 
-        wait_for_condition(check_replicas_on_worker_nodes)
+        wait_for_condition(check_replicas_on_worker_nodes, timeout=WAIT_TIMEOUT_S)
 
         # Total alive actors: EveryNode proxies on both nodes + 1 controller +
         # 2 replicas. Under HAProxy each proxy node runs an HAProxyManager and
@@ -645,7 +667,11 @@ class TestHealthzAndRoutes:
             sum(expected_proxy_actors(num_proxy_nodes=2).values()) + 1 + 2
         )
         wait_for_condition(
-            lambda: len(list_actors(address=cluster.address)) == expected_num_actors
+            lambda: len(
+                list_actors(address=cluster.address, filters=[("STATE", "=", "ALIVE")])
+            )
+            == expected_num_actors,
+            timeout=WAIT_TIMEOUT_S,
         )
         assert len(ray.nodes()) == 2
 
@@ -662,6 +688,7 @@ class TestHealthzAndRoutes:
             url="http://127.0.0.1:8000/-/healthz",
             expected_code=200,
             expected_text="success",
+            timeout=WAIT_TIMEOUT_S,
         )
         assert httpx.get("http://127.0.0.1:8000/-/routes").status_code == 200
         assert httpx.get("http://127.0.0.1:8000/-/routes").text == '{"/":"default"}'
@@ -670,6 +697,7 @@ class TestHealthzAndRoutes:
             url="http://127.0.0.1:8001/-/healthz",
             expected_code=200,
             expected_text="success",
+            timeout=WAIT_TIMEOUT_S,
         )
         assert httpx.get("http://127.0.0.1:8001/-/routes").status_code == 200
         assert httpx.get("http://127.0.0.1:8001/-/routes").text == '{"/":"default"}'
@@ -687,6 +715,7 @@ class TestHealthzAndRoutes:
                 list_actors(address=cluster.address, filters=[("STATE", "=", "ALIVE")])
             )
             == expected_num_actors_after_delete,
+            timeout=WAIT_TIMEOUT_S,
         )
 
         # Ensure head node `/-/healthz` and `/-/routes` continue to
@@ -698,24 +727,28 @@ class TestHealthzAndRoutes:
             url="http://127.0.0.1:8000/-/healthz",
             expected_code=200,
             expected_text="success",
+            timeout=WAIT_TIMEOUT_S,
         )
         wait_for_condition(
             condition_predictor=check_request,
             url="http://127.0.0.1:8000/-/routes",
             expected_code=200,
             expected_text="{}",
+            timeout=WAIT_TIMEOUT_S,
         )
         wait_for_condition(
             condition_predictor=check_request,
             url="http://127.0.0.1:8001/-/healthz",
             expected_code=503,
             expected_text="This node is being drained.",
+            timeout=WAIT_TIMEOUT_S,
         )
         wait_for_condition(
             condition_predictor=check_request,
             url="http://127.0.0.1:8001/-/routes",
             expected_code=503,
             expected_text="This node is being drained.",
+            timeout=WAIT_TIMEOUT_S,
         )
 
 

--- a/python/ray/serve/tests/test_cluster.py
+++ b/python/ray/serve/tests/test_cluster.py
@@ -87,7 +87,7 @@ def test_scale_up(ray_cluster):
     client = serve.context._connect()
     client.deploy_apps(ServeDeploySchema(**{"applications": [app_config]}))
 
-    client._wait_for_application_running("default")
+    client._wait_for_application_running("default", timeout_s=WAIT_TIMEOUT_S)
     pids1 = get_pids(1, deployment_name="pid", app_name="default")
 
     app_config["deployments"][0]["num_replicas"] = 3
@@ -110,7 +110,7 @@ def test_scale_up(ray_cluster):
     # Add a node with another CPU, the final replica should get placed
     # and the deploy goal should be done.
     cluster.add_node(num_cpus=1)
-    client._wait_for_application_running("default")
+    client._wait_for_application_running("default", timeout_s=WAIT_TIMEOUT_S)
     pids3 = get_pids(3, deployment_name="pid", app_name="default")
     assert pids2.issubset(pids3)
 


### PR DESCRIPTION
## Why

`test_cluster` is the tightest-budgeted serve target on the shared Windows shard:
2 FLAKY / 0 FAILED in 23 runs, max observed runtime **238s against the 300s limit**
implied by `size = "medium"` — 79% of budget. The `linux` target from the same block
is slightly worse at **241.5s (80.5%)**. The shard has zero hard failures across its
19 tracked tests, which points at timeout and slow convergence rather than assertion
bugs. `test_cluster` also co-flaked with `test_proxy` on postmerge build 19184.

For comparison on the same shard: `test_grpc` is `enormous` (45% used),
`test_standalone` `enormous` (21%), `test_per_request_headers` `large` +
`timeout="eternal"` (28%), `test_metrics` `medium` + `timeout="long"` (60%).

## What

**1. Bazel headroom.** `test_cluster.py` moves into its own `py_test_module_list` with
`timeout = "long"` (300s → 900s). The block carries no `no_windows` tag, so this covers
both the `windows` and `linux` targets. Only the shared-medium entry moves; the
`no_windows` pack-scheduling variant is left alone.

**2. Load-sensitivity fixes in the test itself.**
- 22 `wait_for_condition` calls were on the bare 10s default. All now take one
  `WAIT_TIMEOUT_S = 60` module constant, which is also reused as the `get_pids`
  collection budget (previously a separate hardcoded 30). Five hand-picked sub-budgets
  (`timeout=15/25/30`) collapse into the same constant.
- Two `list_actors` calls omitted `filters=[("STATE", "=", "ALIVE")]`, so they counted
  DEAD actors and an exact-count wait could never recover once an actor restarted. The
  comment above one of them already read "Total alive actors", so this restores the
  documented intent.
- Two `client._wait_for_application_running("default")` calls relied on the default
  `timeout_s=-1`. The loop guard is `while ... < timeout_s or timeout_s < 0`, so that
  branch is permanently true and the `else: raise TimeoutError` is unreachable — the
  call cannot time out. Under contention the test hung until pytest-timeout killed it
  at 600s, burning the whole budget with no useful diagnostic. Both are now bounded.
  The two `timeout_s=1` calls are deliberately untouched: they sit inside
  `pytest.raises(TimeoutError)` and assert a replica has *not* started yet.

## Validation

Interleaved A/B on a 4-CPU box under synthetic CPU load, 3 reps × (baseline, patched),
arms alternating so external drift hits both equally:
