### PR TITLE
[docs] Style pass on the Ray Sandboxes networking section

### DIFF
--- a/doc/source/ray-core/sandboxes.md
+++ b/doc/source/ray-core/sandboxes.md
@@ -193,7 +193,9 @@ For advanced workloads, you might need to configure low-level runtime options su
 The `_oci_spec_transform_fn` callable receives the fully generated OCI specification dictionary. It can mutate the dictionary in place or return a modified one. Common use cases include the following:
 
 * **Host mounts**: Mount host directories, read-only datasets, or model weights into the sandbox container.
-* **Namespace or mount details** that the first-class options don't cover. Internet access, DNS, and Linux capabilities no longer need this hook — use `network=`, `dns=`, and `capabilities=` (including `capabilities=[]` to run with none at all; see [Networking and DNS](#networking-and-dns)). The hook remains for advanced network or capability configurations beyond those options.
+* **Namespace and mount details**: Configure namespace or mount behavior that the first-class options don't cover.
+
+Internet access, DNS, and Linux capabilities each have a first-class option: `network=`, `dns=`, and `capabilities=`. Pass `capabilities=[]` to run with no capabilities at all. Reserve the hook for network or capability configurations those options don't reach. See [Networking and DNS](#networking-and-dns).
 
 ```python
 import ray
@@ -237,20 +239,16 @@ ray.get(sb.delete.remote())
 
 ## Networking and DNS
 
-Sandboxes support four network modes. `none` is the default, following the
-safe-defaults principle; `public` is the recommended mode when a sandbox
-needs internet access.
+Sandboxes support four network modes. The default is `none`, which follows the safe-defaults principle. Use `public` when a sandbox needs internet access.
 
 | Mode | Network access | `/etc/resolv.conf` | Security property |
 | --- | --- | --- | --- |
 | `none` *(default)* | None | untouched | No egress. |
-| `public` — **recommended for internet access** | Host egress | Generated from `dns` (default `8.8.8.8`, `1.1.1.1`), mounted read-only | Egress works, but the sandbox inherits *nothing* from the host's resolver configuration — no internal search domains, resolver addresses, or `ndots` options leak in, and the sandbox config stays portable across clusters. |
-| `host` | Full host network identity | Host's own file, mounted read-only (`dns=` overrides it) | Strictly more permissive than `public`: the sandbox can reach anything the node can reach, including internal networks and node-local services. Prefer `public` for untrusted code. |
-| `sandbox` | gVisor netstack | untouched | Requires `rootless=False`; runsc doesn't support the sandbox netstack in rootless mode. |
+| `public` | Host egress | Generated from `dns` (default `8.8.8.8`, `1.1.1.1`), mounted read-only | Egress works, but the sandbox inherits nothing from the host's resolver configuration. No internal search domains, resolver addresses, or `ndots` options leak in, and the sandbox config stays portable across clusters. |
+| `host` | Full host network identity | Host's own file, mounted read-only (`dns=` overrides it) | Strictly more permissive than `public`. The sandbox can reach anything the node can reach, including internal networks and node-local services. Use `public` for untrusted code. |
+| `sandbox` | gVisor netstack | untouched | Requires `rootless=False`. runsc doesn't support the sandbox netstack in rootless mode. |
 
-The recommended way to give a sandbox internet access — together with
-Docker-parity capabilities so standard images behave the way they do under
-Docker (`apt-get`, `tar` ownership restore, and similar all need them):
+To give a sandbox internet access, use `network="public"`. Pair it with `DOCKER_DEFAULT_CAPABILITIES` so standard images behave the way they do under Docker, because `apt-get`, `tar` ownership restore, and similar operations all need those capabilities:
 
 ```python
 from ray.experimental import sandbox
@@ -264,12 +262,9 @@ sb = sandbox.create(
 )
 ```
 
-**DNS in locked-down networks.** Some VPCs block outbound port 53 to public
-resolvers, where the `public` defaults can't resolve. Pass your internal
-resolver instead — `network="public", dns=["10.0.0.2"]` — or fall back to
-`network="host"` (which uses the host's resolv.conf) at the cost of full host
-network identity. Anything beyond that can be configured through the OCI spec
-(see [Pass custom OCI configurations to gVisor](#pass-custom-oci-configurations-to-gvisor)).
+### DNS in locked-down networks
+
+Some VPCs block outbound port 53 to public resolvers, where the `public` defaults can't resolve. Pass your internal resolver instead with `network="public", dns=["10.0.0.2"]`. If that isn't an option, fall back to `network="host"`, which uses the host's `/etc/resolv.conf`, at the cost of full host network identity. Configure anything beyond that through the OCI spec. See [Pass custom OCI configurations to gVisor](#pass-custom-oci-configurations-to-gvisor).
 
 ## Architecture
 


### PR DESCRIPTION
## Description

Style-only follow-up on the "Networking and DNS" section added in #65570. No technical claim changes, and the section's structure and content are the author's; this is polish against the [Ray documentation style guide](https://docs.ray.io/en/master/ray-contribute/writing-style.html).

I was asked for a docs review on #65570 but it merged before I finished, so the feedback is landing here instead of as suggestions on a merged PR.

### What changed

The one pattern worth naming, because it repeats: the new prose was hard-wrapped at roughly 72 columns while the rest of the page uses one source line per paragraph. The guide asks for [soft-wrapped prose](https://docs.ray.io/en/master/ray-contribute/writing-style.html#soft-wrap-prose) so diffs stay legible.

Beyond that:

* **Sentence splits** where an em dash, a semicolon, or a mid-sentence colon was joining clauses. The guide asks us to [restructure rather than punctuate](https://docs.ray.io/en/master/ray-contribute/writing-style.html#sentence-structure). After this the whole page is free of Unicode dashes.
* **`### DNS in locked-down networks`** instead of a bold paragraph lead-in. The guide reserves [bold](https://docs.ray.io/en/master/ray-contribute/writing-style.html#bold-and-italics) for UI elements, admonition lead-ins, and definition lists. As a real heading it also picks up a TOC entry and a linkable anchor. A `note` admonition would work too if you'd rather it read as an aside.
* **Dropped `— **recommended for internet access**`** from the `public` row's first cell. That's bold for emphasis, and the prose above the table already makes the recommendation.
* **Parallel structure in the `_oci_spec_transform_fn` list.** The second bullet had lost the `**Term**: explanation` shape of the first and grown to four sentences, so the migration guidance moves into prose after the list. This also drops "no longer need this hook," which orients a reader who knew the previous behavior rather than one arriving fresh.
* **A complete lead-in** above the `network="public"` example, which was a noun phrase with a colon on the end.
* **Direct advice and active voice**: "Prefer `public` for untrusted code" to "Use `public`", and "Anything beyond that can be configured" to "Configure anything beyond that."

### One question I couldn't answer myself

The `sandbox` row's "Network access" cell reads "gVisor netstack," which says how the mode is implemented but not what the reader gets. Does `network="sandbox"` provide egress, or is it isolated like `none`? That's what someone scanning the table to pick a mode is asking, and it's the one cell that doesn't answer it. I left the cell alone rather than guess. Happy to add a few words here if you tell me which it is.

## Related issues

Follows #65570. Related to #64964.

## Additional information

`DOCKER_DEFAULT_CAPABILITIES` is in the sandbox package's `__all__`, so naming it in the prose above the example is safe. `myst_heading_anchors = 4`, so the new H3 and the existing `#pass-custom-oci-configurations-to-gvisor` link both resolve.

Note that no pre-commit hook covers Markdown under `doc/source/`, and Vale is scoped to the Ray Data docs and the example gallery, so nothing lints this file automatically. Verified by hand: heading depth tops out at H3, no stacked headings, and both in-page anchors match real headings.
