### PR TITLE
[docs] Replace Unicode punctuation inside copyable code blocks with ASCII

### DIFF
--- a/doc/source/data/saving-data.rst
+++ b/doc/source/data/saving-data.rst
@@ -194,7 +194,7 @@ number of files and their sizes, because every block can carry rows for any part
             for f in files:
                 print(f'{subindent}{f}')
 
-    # Sample dataset that we’ll partition by ``city`` and ``year``.
+    # Sample dataset to partition by ``city`` and ``year``.
     df = pd.DataFrame(
         {
             "city": ["SF", "SF", "NYC", "NYC", "SF", "NYC", "SF", "NYC"],
@@ -207,7 +207,7 @@ number of files and their sizes, because every block can carry rows for any part
     # Key-based repartitioning requires a hash-shuffle strategy such as Shuffle v2.
     DataContext.get_current().shuffle_strategy = ShuffleStrategy.SHUFFLE_V2
 
-    # ── Partitioned write ──────────────────────────────────────────────────────
+    # Partitioned write:
     # 1. Repartition so all rows with the same (city, year) land in the same
     #    block. This minimizes shuffling during the write.
     # 2. Pass the same columns to ``partition_cols`` so Ray creates a

--- a/doc/source/ray-contribute/dependency-management.md
+++ b/doc/source/ray-contribute/dependency-management.md
@@ -161,7 +161,7 @@ pip's backtracking resolver has a hardcoded round limit. When two requirements c
 Re-run the same resolution with uv, which has no such limit and prints the actual conflict. Below is an example of how uv can uncover dependency problems.
 
 ```bash
-# Resolve only, install nothing — surfaces the true error
+# Resolve only, install nothing. Surfaces the true error.
 uv pip install --dry-run "ax-platform==1.2.1" "jaxtyping<0.3.8"
 ```
 

--- a/doc/source/rllib/rllib-advanced-api.rst
+++ b/doc/source/rllib/rllib-advanced-api.rst
@@ -182,7 +182,7 @@ to setup different exploration behaviors from ``rllib/algorithms/algorithm.py``:
     "explore": True,
     "exploration_config": {
        # Exploration sub-class by name or full path to module+class
-       # (e.g., “ray.rllib.utils.exploration.epsilon_greedy.EpsilonGreedy”)
+       # (e.g., "ray.rllib.utils.exploration.epsilon_greedy.EpsilonGreedy")
        "type": "EpsilonGreedy",
        # Parameters for the Exploration class' constructor:
        "initial_epsilon": 1.0,

--- a/doc/source/train/user-guides/asynchronous-validation.rst
+++ b/doc/source/train/user-guides/asynchronous-validation.rst
@@ -224,7 +224,7 @@ redundant:
         with ray.data.DataContext.current(ctx):
             train_dataset = ray.data.read_parquet(...)
 
-        # (2) Pin per-worker ingest — Train replaces ds.context options
+        # (2) Pin per-worker ingest. Train replaces ds.context options
         # wholesale, so the selector must be restated here.
         trainer = ray.train.torch.TorchTrainer(
             ...,

--- a/doc/source/train/user-guides/data-loading-preprocessing.rst
+++ b/doc/source/train/user-guides/data-loading-preprocessing.rst
@@ -696,7 +696,7 @@ where data tasks can actually run. It requires adding labels to your worker node
     with ray.data.DataContext.current(ctx):
         train_dataset = ray.data.read_parquet(...)
 
-    # (2) Pin per-worker ingest — Train replaces ds.context options
+    # (2) Pin per-worker ingest. Train replaces ds.context options
     # wholesale, so the selector must be restated here.
     trainer = TorchTrainer(
         ...,


### PR DESCRIPTION
## Summary

Replaces Unicode punctuation inside copyable code blocks with plain ASCII, across five doc pages.

Readers copy code blocks into a shell or an editor. A smart quote that looks like a string delimiter, or an en dash that looks like a hyphen, is a syntax error waiting to happen and a confusing one to debug, because the character renders almost identically to the ASCII form it isn't.

`rllib-advanced-api.rst` is the clearest case. A class path wrapped in curly double quotes sits two lines above the real `"type": "EpsilonGreedy"` entry it describes:

```python
   # Exploration sub-class by name or full path to module+class
   # (e.g., "ray.rllib.utils.exploration.epsilon_greedy.EpsilonGreedy")
   "type": "EpsilonGreedy",
```

Anyone copying the commented form as a starting point gets an invalid literal.

## What changed

| File | Fix |
|---|---|
| `rllib/rllib-advanced-api.rst` | Curly double quotes to straight, around a class path in a Python comment |
| `data/saving-data.rst` | Curly apostrophe to none (reworded); box-drawing comment banner to a plain comment |
| `train/user-guides/asynchronous-validation.rst` | Em dash to a sentence break, in a Python comment |
| `train/user-guides/data-loading-preprocessing.rst` | Same, in the parallel snippet |
| `ray-contribute/dependency-management.md` | Em dash to a sentence break, in a Bash comment |

## What deliberately stayed

Scope is punctuation inside code blocks that has a plain ASCII equivalent. Prose is untouched, since em dashes read fine there and Ray's style guide doesn't ban them.

Captured program output stayed as-is even inside code blocks, because it's a reproduction rather than something to copy and run:

- Box-drawing table borders in `testoutput` blocks in `data/saving-data.rst`, `data/quickstart.rst`, and `ray-contribute/writing-code-snippets.md`. These are compared against real output, so changing them breaks the doctest.
- Progress-bar labels using a single-character ellipsis in `serve/tutorials/aws-neuron-core-inference.md`.
- Directory-tree diagrams in `serve/tutorials/triton-server-integration.md`, which use non-breaking spaces for alignment.
- The verbatim GSM8K prompt in `cluster/kubernetes/examples/verl-post-training.md`. Normalizing its apostrophe would misquote the dataset.

## Verification

The affected `testcode` blocks parse identically as Python before and after the change, so nothing that ran before stops running. Vale passes on the changed files.
