### PR TITLE
[train][jax] Relax test_jax_trainer test size to large

### DIFF
--- a/python/ray/train/v2/BUILD.bazel
+++ b/python/ray/train/v2/BUILD.bazel
@@ -382,7 +382,7 @@ py_test(
 
 py_test(
     name = "test_jax_trainer",
-    size = "medium",
+    size = "large",
     srcs = ["tests/test_jax_trainer.py"],
     env = {"RAY_TRAIN_V2_ENABLED": "1"},
     tags = [


### PR DESCRIPTION
## Description

`//python/ray/train/v2:test_jax_trainer` is declared `size = "medium"` (300s bazel timeout) but the suite now needs roughly 340s, so it TIMEOUTs intermittently depending on host load. This bumps it to `size = "large"` (900s).