### PR TITLE
[ci][doc] Log builder CPU and memory around the RtD Sphinx build

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -103,6 +103,14 @@ build:
     # every doc build and might buy nothing, since the right cap depends on
     # how many CPUs the builder has in the first place.
     #
+    # The worker count matters as much as the memory ceiling. Sphinx resolves
+    # -j auto through multiprocessing.cpu_count, which reports the logical
+    # CPUs on the host and is neither affinity- nor cgroup-aware, while nproc
+    # reports the affinity mask. If those two disagree, Sphinx forks more
+    # write workers than the container has CPUs to run them on, and each one
+    # carries its own copy of the environment. Print all three so the numbers
+    # can be compared rather than assumed.
+    #
     # The diagnostics run around the build rather than in a post_build job
     # because post_build is skipped when the build fails, and the failing
     # build is the one worth measuring. rc carries the make exit status
@@ -115,6 +123,7 @@ build:
         - |
           echo "=== builder capacity ==="
           nproc || true
+          python -c "import os, multiprocessing; print('os.cpu_count', os.cpu_count()); print('sched_getaffinity', len(os.sched_getaffinity(0))); print('multiprocessing.cpu_count', multiprocessing.cpu_count())" || true
           grep -E "MemTotal|MemAvailable" /proc/meminfo || true
           cat /sys/fs/cgroup/memory.max 2>/dev/null || echo "no cgroup v2 memory.max"
           cat /sys/fs/cgroup/memory.high 2>/dev/null || echo "no cgroup v2 memory.high"

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -105,11 +105,14 @@ build:
     #
     # The worker count matters as much as the memory ceiling. Sphinx resolves
     # -j auto through multiprocessing.cpu_count, which reports the logical
-    # CPUs on the host and is neither affinity- nor cgroup-aware, while nproc
-    # reports the affinity mask. If those two disagree, Sphinx forks more
-    # write workers than the container has CPUs to run them on, and each one
-    # carries its own copy of the environment. Print all three so the numbers
-    # can be compared rather than assumed.
+    # CPUs installed on the host and is neither affinity- nor cgroup-aware.
+    # nproc reports the affinity mask instead, and nproc --all reports what
+    # multiprocessing sees. If those two disagree, Sphinx forks more write
+    # workers than the container has CPUs to run them on, and each one
+    # carries its own copy of the environment, so print both rather than
+    # assuming they agree. Reported via nproc rather than a python -c one
+    # liner because the job runner strips single quotes from arguments,
+    # which silently turns quoted labels into bare names.
     #
     # The diagnostics run around the build rather than in a post_build job
     # because post_build is skipped when the build fails, and the failing
@@ -122,8 +125,9 @@ build:
       html:
         - |
           echo "=== builder capacity ==="
+          echo "cpus in affinity mask, then cpus installed on the host:"
           nproc || true
-          python -c "import os, multiprocessing; print('os.cpu_count', os.cpu_count()); print('sched_getaffinity', len(os.sched_getaffinity(0))); print('multiprocessing.cpu_count', multiprocessing.cpu_count())" || true
+          nproc --all || true
           grep -E "MemTotal|MemAvailable" /proc/meminfo || true
           cat /sys/fs/cgroup/memory.max 2>/dev/null || echo "no cgroup v2 memory.max"
           cat /sys/fs/cgroup/memory.high 2>/dev/null || echo "no cgroup v2 memory.high"

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -119,6 +119,22 @@ build:
     # build is the one worth measuring. rc carries the make exit status
     # through so a real Sphinx failure still fails the build.
     #
+    # Temporary, for this PR only: the html job runs the full build twice,
+    # once at the default -j auto and once at SPHINX_JOBS=2, to measure what
+    # the lower job count costs in wall clock. Both arms are full clean
+    # builds, since SPHINXOPTS carries -a -E, so neither reuses the other
+    # environment.
+    #
+    # Both arms run inside one job on purpose. html job times for the same
+    # build at -j auto range from 368 to 562 seconds across recent master
+    # builds, so between-build comparison cannot resolve the effect. Running
+    # both arms on one builder cancels that variance. The remaining confound
+    # is order, since the second arm starts with a warm page cache, so the
+    # arms get reversed on a following run.
+    #
+    # memory.peak is reset between arms where the kernel allows it, to get a
+    # per-arm peak rather than a high-water mark across both.
+    #
     # Remove this wrapper once the numbers are captured and the follow-up
     # fix lands.
     build:
@@ -131,13 +147,26 @@ build:
           grep -E "MemTotal|MemAvailable" /proc/meminfo || true
           cat /sys/fs/cgroup/memory.max 2>/dev/null || echo "no cgroup v2 memory.max"
           cat /sys/fs/cgroup/memory.high 2>/dev/null || echo "no cgroup v2 memory.high"
-          rc=0
-          make -C doc html HTMLDIR="$READTHEDOCS_OUTPUT/html" || rc=$?
-          echo "=== builder peak, sphinx exit $rc ==="
+          echo "=== ARM A jobs=auto start epoch ==="
+          date +%s
+          echo 0 > /sys/fs/cgroup/memory.peak 2>/dev/null || echo "peak not resettable"
+          rca=0
+          make -C doc html HTMLDIR="$READTHEDOCS_OUTPUT/html" || rca=$?
+          echo "=== ARM A jobs=auto end epoch, exit $rca ==="
+          date +%s
+          cat /sys/fs/cgroup/memory.peak 2>/dev/null || echo "no cgroup v2 memory.peak"
+          cat /sys/fs/cgroup/memory.events 2>/dev/null || echo "no cgroup v2 memory.events"
+          echo "=== ARM B jobs=2 start epoch ==="
+          date +%s
+          echo 0 > /sys/fs/cgroup/memory.peak 2>/dev/null || echo "peak not resettable"
+          rcb=0
+          make -C doc html HTMLDIR="$READTHEDOCS_OUTPUT/html" SPHINX_JOBS=2 || rcb=$?
+          echo "=== ARM B jobs=2 end epoch, exit $rcb ==="
+          date +%s
           cat /sys/fs/cgroup/memory.peak 2>/dev/null || echo "no cgroup v2 memory.peak"
           cat /sys/fs/cgroup/memory.events 2>/dev/null || echo "no cgroup v2 memory.events"
           grep -E "MemAvailable" /proc/meminfo || true
-          exit $rc
+          exit $rca
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -119,21 +119,20 @@ build:
     # build is the one worth measuring. rc carries the make exit status
     # through so a real Sphinx failure still fails the build.
     #
-    # Temporary, for this PR only: the html job runs the full build twice,
-    # once at the default -j auto and once at SPHINX_JOBS=2, to measure what
-    # the lower job count costs in wall clock. Both arms are full clean
-    # builds, since SPHINXOPTS carries -a -E, so neither reuses the other
-    # environment.
+    # Temporary, for this PR only. The paired run measured the wall clock
+    # cost: 349 seconds at -j auto against 620 seconds at SPHINX_JOBS=2 on
+    # one builder, so the lower job count costs about 78 percent more, and
+    # that is a lower bound because the second arm ran with a warm cache.
     #
-    # Both arms run inside one job on purpose. html job times for the same
-    # build at -j auto range from 368 to 562 seconds across recent master
-    # builds, so between-build comparison cannot resolve the effect. Running
-    # both arms on one builder cancels that variance. The remaining confound
-    # is order, since the second arm starts with a warm page cache, so the
-    # arms get reversed on a following run.
+    # What it could not measure is the memory saving, which is the whole
+    # point of lowering the count. memory.peak turned out not to be
+    # resettable on this kernel, so the reading after both arms was a single
+    # high-water mark across them rather than one figure per arm.
     #
-    # memory.peak is reset between arms where the kernel allows it, to get a
-    # per-arm peak rather than a high-water mark across both.
+    # So this run drops to a single arm at SPHINX_JOBS=2. Peak memory is
+    # far more stable across builders than duration is, three runs at
+    # -j auto landing within 180 MB of each other, so one clean sample is
+    # worth more here than a paired comparison.
     #
     # Remove this wrapper once the numbers are captured and the follow-up
     # fix lands.
@@ -147,26 +146,16 @@ build:
           grep -E "MemTotal|MemAvailable" /proc/meminfo || true
           cat /sys/fs/cgroup/memory.max 2>/dev/null || echo "no cgroup v2 memory.max"
           cat /sys/fs/cgroup/memory.high 2>/dev/null || echo "no cgroup v2 memory.high"
-          echo "=== ARM A jobs=auto start epoch ==="
+          echo "=== single arm jobs=2 start epoch ==="
           date +%s
-          echo 0 > /sys/fs/cgroup/memory.peak 2>/dev/null || echo "peak not resettable"
-          rca=0
-          make -C doc html HTMLDIR="$READTHEDOCS_OUTPUT/html" || rca=$?
-          echo "=== ARM A jobs=auto end epoch, exit $rca ==="
-          date +%s
-          cat /sys/fs/cgroup/memory.peak 2>/dev/null || echo "no cgroup v2 memory.peak"
-          cat /sys/fs/cgroup/memory.events 2>/dev/null || echo "no cgroup v2 memory.events"
-          echo "=== ARM B jobs=2 start epoch ==="
-          date +%s
-          echo 0 > /sys/fs/cgroup/memory.peak 2>/dev/null || echo "peak not resettable"
-          rcb=0
-          make -C doc html HTMLDIR="$READTHEDOCS_OUTPUT/html" SPHINX_JOBS=2 || rcb=$?
-          echo "=== ARM B jobs=2 end epoch, exit $rcb ==="
+          rc=0
+          make -C doc html HTMLDIR="$READTHEDOCS_OUTPUT/html" SPHINX_JOBS=2 || rc=$?
+          echo "=== single arm jobs=2 end epoch, exit $rc ==="
           date +%s
           cat /sys/fs/cgroup/memory.peak 2>/dev/null || echo "no cgroup v2 memory.peak"
           cat /sys/fs/cgroup/memory.events 2>/dev/null || echo "no cgroup v2 memory.events"
           grep -E "MemAvailable" /proc/meminfo || true
-          exit $rca
+          exit $rc
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -87,10 +87,44 @@ build:
         echo "[global]" > ~/.config/pip/pip.conf
         echo "retries = 10" >> ~/.config/pip/pip.conf
         cat ~/.config/pip/pip.conf
+    # Wrap the Sphinx build in builder resource diagnostics.
+    #
+    # Sphinx builds the docs with -j auto, so it forks one write worker per
+    # CPU. When a worker dies the parent only reports EOFError from
+    # multiprocessing/connection.py, with no indication of which document or
+    # why, and the reported document varies from build to build. Five builds
+    # in the last two days failed that way, including one on master, so the
+    # cause is the builder rather than any one PR.
+    #
+    # The likely mechanism is the kernel OOM-killing a write worker, but
+    # confirming that needs the builder's CPU count, its cgroup memory
+    # ceiling, the peak the build actually reached, and the cgroup OOM
+    # counters. Capping -j without those numbers would cost wall-clock on
+    # every doc build and might buy nothing, since the right cap depends on
+    # how many CPUs the builder has in the first place.
+    #
+    # The diagnostics run around the build rather than in a post_build job
+    # because post_build is skipped when the build fails, and the failing
+    # build is the one worth measuring. rc carries the make exit status
+    # through so a real Sphinx failure still fails the build.
+    #
+    # Remove this wrapper once the numbers are captured and the follow-up
+    # fix lands.
     build:
       html:
         - |
-          make -C doc html HTMLDIR="$READTHEDOCS_OUTPUT/html"
+          echo "=== builder capacity ==="
+          nproc || true
+          grep -E "MemTotal|MemAvailable" /proc/meminfo || true
+          cat /sys/fs/cgroup/memory.max 2>/dev/null || echo "no cgroup v2 memory.max"
+          cat /sys/fs/cgroup/memory.high 2>/dev/null || echo "no cgroup v2 memory.high"
+          rc=0
+          make -C doc html HTMLDIR="$READTHEDOCS_OUTPUT/html" || rc=$?
+          echo "=== builder peak, sphinx exit $rc ==="
+          cat /sys/fs/cgroup/memory.peak 2>/dev/null || echo "no cgroup v2 memory.peak"
+          cat /sys/fs/cgroup/memory.events 2>/dev/null || echo "no cgroup v2 memory.events"
+          grep -E "MemAvailable" /proc/meminfo || true
+          exit $rc
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -4,9 +4,15 @@
 # You can set these variables from the command line.
 # Allow linkcheck to run without treating warnings as errors; -W will
 # fast-fail if enabled; it's better to gather the whole list of bad links at once.
-SPHINXOPTS    = -a -E -W -j auto
-LOCALSPHINXOPTS = -W -j auto
-LINKCHECKOPTS = -a -E -j auto
+# Number of parallel Sphinx workers. "auto" is one per CPU, which is what
+# Sphinx does by default. Overridable so a memory-constrained builder can
+# ask for fewer without changing what everyone else builds with: each
+# worker carries its own copy of the environment, so the write phase costs
+# memory in proportion to this number.
+SPHINX_JOBS ?= auto
+SPHINXOPTS    = -a -E -W -j $(SPHINX_JOBS)
+LOCALSPHINXOPTS = -W -j $(SPHINX_JOBS)
+LINKCHECKOPTS = -a -E -j $(SPHINX_JOBS)
 # RtD-faithful build: our full-build options plus the two flags Read the Docs
 # adds to its synthesized html command (-T full tracebacks, -D language=en).
 RTDSPHINXOPTS = $(SPHINXOPTS) -T -D language=en


### PR DESCRIPTION
## Summary

Read the Docs builds intermittently fail with a bare `EOFError` raised from `multiprocessing/connection.py`, with no document named and no cause given:

```
Traceback
=========

      File ".../multiprocessing/connection.py", line 399, in _recv
        raise EOFError
    EOFError

make: *** [Makefile:91: html] Error 2
```

`doc/Makefile` builds with `-j auto`, so Sphinx forks one write worker per CPU. When a worker dies, the parent reports only that `EOFError`. This PR wraps the existing `make` invocation in the `.readthedocs.yaml` html job so the builder's CPU count, cgroup memory ceiling, peak memory, and cgroup OOM counters print around every build.

It's a measurement step, not a fix. Nothing about the build changes.

## Why this isn't a content problem

- The point in the write phase where it surfaces moves between builds: 58%, 78%, and 92% across three recent failures. A bad document would fail at the same place every time.
- Five builds in the last two days failed with this signature, one of them on `master`. Every other RtD failure in that window is an ordinary `fail_on_warning` trip.
- One PR hit it after passing an hour earlier on the same base commit, and other PRs built successfully in the same window.

| Build | When (UTC) | Version | Died at |
|---|---|---|---|
| 4343286 | Aug 20 21:52 | PR preview | 58% |
| 4343129 | Aug 20 21:11 | PR preview | 92% |
| 4343048 | Aug 20 20:59 | PR preview | — |
| 4342961 | Aug 20 20:35 | PR preview | — |
| 4339216 | Aug 20 03:41 | `master` | 78% |

## Why measure before capping `-j`

The likely mechanism is the kernel OOM-killing a write worker. Lowering `-j` is the obvious response, but choosing a value blind would cost wall-clock on every doc build and might buy nothing, since the useful cap depends on how many CPUs the builder actually has. If the builder has two CPUs, `-j auto` is already 2 and a cap isn't the answer at all. The cgroup `memory.events` OOM counters settle whether an OOM kill is even what's happening.

## Implementation notes

- The diagnostics run around the build rather than in a `post_build` job because `post_build` is skipped when the build fails, and the failing build is the one worth measuring.
- `rc` carries `make`'s exit status through to the job's exit, so a real Sphinx failure still fails the build. Verified under `sh -e` that the diagnostics run and the non-zero status propagates.
- Every probe is guarded with `|| true` or `|| echo`, so a missing file or a non-matching `grep` can't abort the job under `set -e`.
- The script avoids the constructs the RtD job runner is known to mishandle, per the existing comments in this file: no `printf` with escape sequences, no backslash escapes, and no shell comments inside the block.
- Validated with `sh -n` and by parsing the YAML.

## Follow-up

Once a few builds have reported their numbers, this wrapper comes back out along with whatever the real fix turns out to be.
