### PR TITLE
[ci] Give whl_library a pip that can read a JSON index

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -62,6 +62,70 @@ python_register_toolchains(
 load("@python3_10//:defs.bzl", python310 = "interpreter")
 load("@rules_python//python/pip_install:repositories.bzl", "pip_install_dependencies")
 
+# The pip that whl_library shells out to, overridden ahead of the one rules_python
+# brings.
+#
+# rules_python arrives here transitively at 0.9.0, from rules_foreign_cc 0.9.0. It wins
+# over protobuf's newer 0.14.0 pin because ray_deps_build_all() runs
+# rules_foreign_cc_dependencies() before grpc_extra_deps() reaches protobuf_deps(), and
+# protobuf declares rules_python through maybe(). 0.9.0 pins pip 22.0.4, which predates
+# PEP 691 support (pip 22.2): it asks for text/html and skips a JSON index page rather
+# than parsing it, so the resolve fails as though the package did not exist:
+#
+#   Skipping page http://.../simple/click/ because the GET request got Content-Type:
+#   application/vnd.pypi.simple.v1+json. The only supported Content-Type is text/html
+#   ERROR: Could not find a version that satisfies the requirement click==8.1.7
+#   (from versions: none)
+#
+# Which is what any index whose pages are not HTML produces here. The CI mirror caches
+# an index page keyed on URL while PyPI answers `Vary: Accept`, so whichever client
+# warms an entry picks the representation every later reader gets -- and a pip this old
+# can only read one of the two. A pip that understands JSON understands HTML as well, so
+# moving it forward makes the representation stop mattering in either direction, rather
+# than depending on every producer asking for the same one.
+#
+# Declared before pip_install_dependencies() deliberately: that function declares its
+# deps through maybe(), which skips any repository that already exists, so this wins.
+# The build file has to keep the `lib` target name, because rules_python resolves these
+# as @pypi__pip//:lib.
+#
+# 24.3.1 is the ceiling, not a preference. rules_python 0.9.0 parses the lock file with
+# pip's internal API -- parse_requirements_to_bzl reads ParsedLine.is_requirement -- and
+# pip 25.0 removed that attribute, so pip_repository dies with an AttributeError before
+# whl_library ever runs. 24.3.1 is the last release that still has it. The floor is 23.2:
+# PEP 691 support landed in 22.2, but 22.3 through 23.1 hard-fail on dist-info-metadata,
+# the bug PEP 714 was written for, fixed in 23.2. That leaves 23.2 through 24.3.1, and
+# this takes the top of that range.
+#
+# Note this does not match the pip ci/env/install-dependencies.sh installs (25.2). The
+# two cannot be aligned while rules_python is 0.9.0; aligning them means moving
+# rules_python first.
+http_archive(
+    name = "pypi__pip",
+    build_file_content = """\
+package(default_visibility = ["//visibility:public"])
+
+load("@rules_python//python:defs.bzl", "py_library")
+
+py_library(
+    name = "lib",
+    srcs = glob(["**/*.py"]),
+    data = glob(["**/*"], exclude = [
+        "**/*.py",
+        "**/*.pyc",
+        "**/* *",
+        "**/*.dist-info/RECORD",
+        "BUILD",
+        "WORKSPACE",
+    ]),
+    imports = ["."],
+)
+""",
+    sha256 = "3790624780082365f47549d032f3770eeb2b1e8bd1f7b2e02dace1afa361b4ed",
+    type = "zip",
+    url = "https://files.pythonhosted.org/packages/ef/7d/500c9ad20238fcfcb4cb9243eede163594d7020ce87bd9610c9e02771876/pip-24.3.1-py3-none-any.whl",
+)
+
 pip_install_dependencies()
 
 load("@rules_python//python:pip.bzl", "pip_parse")


### PR DESCRIPTION
## What

Declares `pypi__pip` at **pip 24.3.1** in `WORKSPACE`, ahead of the one `rules_python` brings, so the pip `whl_library` shells out to can read a PEP 691 JSON simple index.

## Why

An index page served as JSON is skipped rather than parsed, and the resolve then fails as though the package did not exist:

```
Skipping page .../simple/click/ because the GET request got
Content-Type: application/vnd.pypi.simple.v1+json. The only supported Content-Type is text/html
ERROR: Could not find a version that satisfies the requirement click==8.1.7 (from versions: none)
```

`rules_python` arrives transitively at **0.9.0**, from **rules_foreign_cc 0.9.0**. It wins over protobuf's newer 0.14.0 pin because `ray_deps_build_all()` runs `rules_foreign_cc_dependencies()` before `grpc_extra_deps()` reaches `protobuf_deps()`, and protobuf declares `rules_python` through `maybe()`. 0.9.0 pins **pip 22.0.4**, which predates PEP 691 support in **pip 22.2**.

Two things corroborate the version, since the resolved `rules_python` is not the one the WORKSPACE names:

- the error wording above is what pip emits only while it lacks PEP 691 — from 22.2 on it says "the supported Content-Types are";
- the failing stack trace runs `parse_requirements_to_bzl/extract_single_wheel/__init__.py`, a path that exists at 0.9.0 and was renamed after it.

Confirmed directly against the resolved repo:

```
$ grep -o "pip-[0-9.]*-py3-none-any.whl" $(bazel info output_base)/external/rules_python/python/pip_install/repositories.bzl
pip-22.0.4-py3-none-any.whl
```

This matters for the CI mirror. It caches an index page keyed on URL while PyPI answers `Vary: Accept`, so whichever client warms an entry fixes the representation for every later reader — uv asks for JSON, this pip can only read HTML. **A pip that reads JSON reads HTML too**, so moving this one forward makes the representation stop mattering in either direction, which is a property rather than a convention that every producer has to keep.

## Why override one wheel instead of bumping rules_python

`pip_install_dependencies()` declares its deps through `maybe()`, which skips any repository that already exists — so declaring `pypi__pip` earlier wins, and the blast radius is the single pip bazel shells out to for python dependency extraction.

A `rules_python` bump would be a migration, not a bump: this WORKSPACE uses `pip_install_dependencies`, the `interpreter` symbol from `@python3_10`, and `pip_parse` attributes that all changed in later releases, and newer `rules_python` drops the WORKSPACE mode this build runs in (bazel 7.5.0, `--noenable_bzlmod`).

## Why 24.3.1

24.3.1 is a ceiling, not a preference. The usable window is narrow at both ends:

| bound | version | reason |
|---|---|---|
| floor | 22.2 | PEP 691 JSON simple API support lands |
| floor | 23.2 | 22.3-23.1 hard-fail on `dist-info-metadata` in JSON ([PEP 714](https://peps.python.org/pep-0714/)); fixed in 23.2 |
| **ceiling** | **24.3.1** | pip 25.0 removes `ParsedLine.is_requirement`, which rules_python 0.9.0 reads |

The ceiling is the binding one. rules_python 0.9.0 parses the lock file through pip's *internal* API in `parse_requirements_to_bzl`:

```python
from pip._internal.req.req_file import RequirementsFileParser, get_line_parser, preprocess
...
if parsed_line.is_requirement:
```

pip 25.0 removed that attribute, so `pip_repository` dies before `whl_library` ever runs:

```
AttributeError: 'ParsedLine' object has no attribute 'is_requirement'. Did you mean: 'requirement'?
ERROR: Error computing the main repository mapping: no such package '@@py_deps_py310//'
```

This is why the pin does **not** match the pip `ci/env/install-dependencies.sh` installs (25.2). The two cannot be aligned while rules_python is 0.9.0 — aligning them means moving rules_python first, which is the migration this PR deliberately avoids.

## Testing

**The version boundary, against the real lock file.** rules_python 0.9.0's `parse_install_requirements` run directly over `release/requirements_py310.txt`, once per candidate pip:

```
pip 23.3.2: OK -- parsed 219 requirements, 0 extra args
pip 24.0:   OK -- parsed 219 requirements, 0 extra args
pip 24.2:   OK -- parsed 219 requirements, 0 extra args
pip 24.3.1: OK -- parsed 219 requirements, 0 extra args
pip 25.0:   AttributeError: 'ParsedLine' object has no attribute 'is_requirement'
pip 25.2:   AttributeError: 'ParsedLine' object has no attribute 'is_requirement'
```

**Cold-cache bazel, with a negative control.** An incremental `bazel fetch` does *not* exercise this — `py_deps_py310` is already materialised and the parse step never re-runs. Both runs below use a fresh `--output_base`:

```
# 24.3.1
$ bazel --output_base=<fresh> fetch @py_deps_py310//:requirements.bzl
INFO: All external dependencies for the requested targets fetched successfully.
$ ls <fresh>/external/pypi__pip | grep dist-info
pip-24.3.1.dist-info

# 25.2, same harness -- reproduces microcheck 52753 exactly
$ bazel --output_base=<fresh2> fetch @py_deps_py310//:requirements.bzl
AttributeError: 'ParsedLine' object has no attribute 'is_requirement'
ERROR: Error computing the main repository mapping: no such package '@@py_deps_py310//'
```

**The JSON index this PR is for.** Old pip reproduces the CI failure and 24.3.1 does not, against a local index that answers `application/vnd.pypi.simple.v1+json` and nothing else (PyPI cannot reproduce it — it answers HTML to a client that asks for HTML):

```
pip 22.0.4 → WARNING: Skipping page .../simple/click/ because the GET request got Content-Type:
             application/vnd.pypi.simple.v1+json.The only supported Content-Type is text/html
             ERROR: Could not find a version that satisfies the requirement click==8.1.7
             exit 1
pip 24.3.1 → Using cached click-8.1.7-py3-none-any.whl.metadata (3.0 kB)
             Saved ./out/click-8.1.7-py3-none-any.whl
             exit 0
```

**End to end**, the target whose fetch failed in premerge 72396, on the cold base:

```
$ bazel --output_base=<fresh> fetch //ci/ray_ci:test_in_docker
INFO: Analyzed target //ci/ray_ci:test_in_docker (137 packages loaded, 5708 targets configured).
INFO: All external dependencies for the requested targets fetched successfully.
```

Lint:

```
$ buildifier --lint=warn --mode=check WORKSPACE
$ pre-commit run --files WORKSPACE     # passed
```

## Not a duplicate

No other open PR touches `pypi__pip` or the `rules_python` pin. #65687 switches CI to the mirror-hosted PyPI index and is the change that surfaces this failure, but it does not touch the bazel-side pip; the two are complementary and this one stands alone on master.

## AI assistance

AI assistance was used for this change: the root-cause analysis (identifying the resolved `rules_python` as 0.9.0 rather than the named 0.14.0), the PEP 691 / PEP 714 version research, the discovery of the 25.0 ceiling, and the local JSON-index reproduction. Every changed line was reviewed and every command above was run and its output confirmed before requesting review.
