### PR TITLE
[Data] Make BigQuery client construction injectable

### DIFF
--- a/doc/source/data/api/loading_data.rst
+++ b/doc/source/data/api/loading_data.rst
@@ -43,6 +43,8 @@ BigQuery
    :toctree: doc/
 
    read_bigquery
+   BigQueryClientProvider
+   DefaultBigQueryClientProvider
 
 Binary
 ^^^^^^

--- a/python/ray/data/__init__.py
+++ b/python/ray/data/__init__.py
@@ -36,6 +36,8 @@ from ray.data.datasource import (
 from ray.data.iterator import DataIterator, DatasetIterator
 from ray.data.preprocessor import Preprocessor
 from ray.data.read_api import (  # noqa: F401
+    BigQueryClientProvider,  # noqa: F401
+    DefaultBigQueryClientProvider,  # noqa: F401
     KafkaAuthConfig,  # noqa: F401
     from_arrow,
     from_arrow_refs,
@@ -209,7 +211,9 @@ __all__ = [
     "Catalog",
     "ReaderFormat",
     "ResolvedSource",
+    "BigQueryClientProvider",
     "DatabricksUnityCatalog",
+    "DefaultBigQueryClientProvider",
     "KafkaAuthConfig",
     "Preprocessor",
 ]

--- a/python/ray/data/_internal/datasource/bigquery_client_provider.py
+++ b/python/ray/data/_internal/datasource/bigquery_client_provider.py
@@ -1,0 +1,228 @@
+"""BigQuery client providers for Ray Data.
+
+This module provides client abstraction for the Google Cloud clients used by
+:func:`ray.data.read_bigquery` and :meth:`ray.data.Dataset.write_bigquery`,
+allowing callers to supply credentials, endpoints, and other client options
+instead of relying on Application Default Credentials.
+"""
+
+import logging
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING, Any, Dict, Optional
+
+from ray.util.annotations import PublicAPI
+
+if TYPE_CHECKING:
+    from google.api_core.client_options import ClientOptions
+    from google.auth.credentials import Credentials
+    from google.cloud import bigquery, bigquery_storage
+
+logger = logging.getLogger(__name__)
+
+
+def _create_user_agent() -> str:
+    import ray
+
+    return f"ray/{ray.__version__}"
+
+
+def _create_client_info():
+    from google.api_core.client_info import ClientInfo
+
+    return ClientInfo(
+        user_agent=_create_user_agent(),
+    )
+
+
+def _create_client_info_gapic():
+    from google.api_core.gapic_v1.client_info import ClientInfo
+
+    return ClientInfo(
+        user_agent=_create_user_agent(),
+    )
+
+
+@PublicAPI(stability="alpha")
+class BigQueryClientProvider(ABC):
+    """Abstract base class for providing BigQuery clients.
+
+    Ray Data uses two Google Cloud clients for BigQuery: a ``bigquery.Client``
+    for control-plane calls (running queries, creating datasets, loading
+    tables) and a ``bigquery_storage.BigQueryReadClient`` for the bulk reads
+    performed by each read task. Implement this class to control how both are
+    constructed -- for example, to supply explicit credentials, a regional
+    endpoint, or a custom retry policy.
+
+    Subclasses must implement:
+        - ``_build_client()``: Constructs the ``bigquery.Client``.
+        - ``_build_read_client()``: Constructs the ``BigQueryReadClient``.
+
+    Provider instances are pickled and shipped to Ray workers, so they must be
+    serializable. Google's clients are *not* serializable, which is why the
+    provider -- rather than a client instance -- is the injected unit. Build
+    clients inside ``_build_client`` / ``_build_read_client`` rather than in
+    ``__init__``; clients cached by this base class are dropped from the
+    pickled state and rebuilt on the worker.
+
+    Example:
+        .. testcode::
+            :skipif: True
+
+            import ray
+            from ray.data import BigQueryClientProvider
+
+            class ImpersonatedClientProvider(BigQueryClientProvider):
+                def __init__(self, project_id, service_account):
+                    self._project_id = project_id
+                    self._service_account = service_account
+
+                def _credentials(self):
+                    import google.auth
+                    from google.auth import impersonated_credentials
+
+                    source, _ = google.auth.default()
+                    return impersonated_credentials.Credentials(
+                        source_credentials=source,
+                        target_principal=self._service_account,
+                        target_scopes=["https://www.googleapis.com/auth/bigquery"],
+                    )
+
+                def _build_client(self):
+                    from google.cloud import bigquery
+
+                    return bigquery.Client(
+                        project=self._project_id, credentials=self._credentials()
+                    )
+
+                def _build_read_client(self):
+                    from google.cloud import bigquery_storage
+
+                    return bigquery_storage.BigQueryReadClient(
+                        credentials=self._credentials()
+                    )
+
+            ds = ray.data.read_bigquery(
+                project_id="my_project",
+                dataset="my_dataset.my_table",
+                client_provider=ImpersonatedClientProvider(
+                    "my_project", "svc@my_project.iam.gserviceaccount.com"
+                ),
+            )
+    """
+
+    def get_client(self) -> "bigquery.Client":
+        """Get the BigQuery control-plane client, building it on first use.
+
+        Returns:
+            A ``google.cloud.bigquery.Client``.
+        """
+        client = getattr(self, "_cached_client", None)
+        if client is None:
+            client = self._build_client()
+            self._cached_client = client
+        return client
+
+    def get_read_client(self) -> "bigquery_storage.BigQueryReadClient":
+        """Get the BigQuery Storage Read client, building it on first use.
+
+        Returns:
+            A ``google.cloud.bigquery_storage.BigQueryReadClient``.
+        """
+        client = getattr(self, "_cached_read_client", None)
+        if client is None:
+            client = self._build_read_client()
+            self._cached_read_client = client
+        return client
+
+    @abstractmethod
+    def _build_client(self) -> "bigquery.Client":
+        """Construct a new BigQuery control-plane client."""
+        ...
+
+    @abstractmethod
+    def _build_read_client(self) -> "bigquery_storage.BigQueryReadClient":
+        """Construct a new BigQuery Storage Read client."""
+        ...
+
+    def __getstate__(self) -> Dict[str, Any]:
+        # Google's clients aren't serializable, so cached clients are dropped
+        # here and lazily rebuilt by whichever process unpickles the provider.
+        state = self.__dict__.copy()
+        state.pop("_cached_client", None)
+        state.pop("_cached_read_client", None)
+        return state
+
+
+@PublicAPI(stability="alpha")
+class DefaultBigQueryClientProvider(BigQueryClientProvider):
+    """The client provider used when none is supplied.
+
+    Builds clients the way Ray Data always has -- Application Default
+    Credentials, tagged with a Ray user agent -- while allowing explicit
+    credentials and client options to be passed through.
+
+    Args:
+        project_id: The Google Cloud project the control-plane client bills to.
+            If ``None``, the client infers the project from the environment.
+        credentials: Credentials to use for both clients. If ``None``,
+            Application Default Credentials are used. Credentials are pickled
+            along with this provider, so they must be serializable; if yours
+            aren't, subclass :class:`BigQueryClientProvider` and construct them
+            in ``_build_client`` instead.
+        client_options: ``google.api_core.client_options.ClientOptions``
+            applied to both clients, for example to set ``api_endpoint`` or
+            ``quota_project_id``.
+        client_kwargs: Additional keyword arguments passed to
+            ``bigquery.Client``. Takes precedence over the arguments above.
+        read_client_kwargs: Additional keyword arguments passed to
+            ``bigquery_storage.BigQueryReadClient``. Takes precedence over the
+            arguments above.
+    """
+
+    def __init__(
+        self,
+        project_id: Optional[str] = None,
+        *,
+        credentials: Optional["Credentials"] = None,
+        client_options: Optional["ClientOptions"] = None,
+        client_kwargs: Optional[Dict[str, Any]] = None,
+        read_client_kwargs: Optional[Dict[str, Any]] = None,
+    ):
+        self._project_id = project_id
+        self._credentials = credentials
+        self._client_options = client_options
+        self._client_kwargs = dict(client_kwargs or {})
+        self._read_client_kwargs = dict(read_client_kwargs or {})
+
+    def _common_kwargs(self, overrides: Dict[str, Any]) -> Dict[str, Any]:
+        kwargs = dict(overrides)
+        if self._credentials is not None:
+            kwargs.setdefault("credentials", self._credentials)
+        if self._client_options is not None:
+            kwargs.setdefault("client_options", self._client_options)
+        return kwargs
+
+    def _build_client(self) -> "bigquery.Client":
+        from google.cloud import bigquery
+
+        kwargs = self._common_kwargs(self._client_kwargs)
+        kwargs.setdefault("project", self._project_id)
+        kwargs.setdefault("client_info", _create_client_info())
+        return bigquery.Client(**kwargs)
+
+    def _build_read_client(self) -> "bigquery_storage.BigQueryReadClient":
+        from google.cloud import bigquery_storage
+
+        kwargs = self._common_kwargs(self._read_client_kwargs)
+        kwargs.setdefault("client_info", _create_client_info_gapic())
+        return bigquery_storage.BigQueryReadClient(**kwargs)
+
+
+def resolve_client_provider(
+    client_provider: Optional[BigQueryClientProvider],
+    project_id: Optional[str],
+) -> BigQueryClientProvider:
+    """Return ``client_provider``, or the default provider if it's ``None``."""
+    if client_provider is not None:
+        return client_provider
+    return DefaultBigQueryClientProvider(project_id=project_id)

--- a/python/ray/data/_internal/datasource/bigquery_datasink.py
+++ b/python/ray/data/_internal/datasource/bigquery_datasink.py
@@ -11,7 +11,10 @@ if TYPE_CHECKING:
     import pyarrow as pa
 
 import ray
-from ray.data._internal.datasource import bigquery_datasource
+from ray.data._internal.datasource.bigquery_client_provider import (
+    BigQueryClientProvider,
+    resolve_client_provider,
+)
 from ray.data._internal.execution.interfaces import TaskContext
 from ray.data._internal.remote_fn import cached_remote_fn
 from ray.data._internal.util import _check_import
@@ -31,6 +34,7 @@ class BigQueryDatasink(Datasink[None]):
         dataset: str,
         max_retry_cnt: int = DEFAULT_MAX_RETRY_CNT,
         overwrite_table: Optional[bool] = True,
+        client_provider: Optional[BigQueryClientProvider] = None,
     ) -> None:
         _check_import(self, module="google.cloud", package="bigquery")
         _check_import(self, module="google.cloud", package="bigquery_storage")
@@ -40,6 +44,7 @@ class BigQueryDatasink(Datasink[None]):
         self.dataset = dataset
         self.max_retry_cnt = max_retry_cnt
         self.overwrite_table = overwrite_table
+        self.client_provider = resolve_client_provider(client_provider, project_id)
 
     def on_write_start(self, schema: Optional["pa.Schema"] = None) -> None:
         from google.api_core import exceptions
@@ -48,7 +53,7 @@ class BigQueryDatasink(Datasink[None]):
             raise ValueError("project_id and dataset are required args")
 
         # Set up datasets to write
-        client = bigquery_datasource._create_client(project_id=self.project_id)
+        client = self.client_provider.get_client()
         dataset_id = self.dataset.split(".", 1)[0]
         try:
             client.get_dataset(dataset_id)
@@ -74,13 +79,18 @@ class BigQueryDatasink(Datasink[None]):
         blocks: Iterable[Block],
         ctx: TaskContext,
     ) -> None:
-        def _write_single_block(block: Block, project_id: str, dataset: str) -> None:
+        def _write_single_block(
+            block: Block,
+            dataset: str,
+            client_provider: BigQueryClientProvider,
+        ) -> None:
             from google.api_core import exceptions
             from google.cloud import bigquery
 
             block = BlockAccessor.for_block(block).to_arrow()
 
-            client = bigquery_datasource._create_client(project_id=project_id)
+            # Built on the worker; the client itself isn't serializable.
+            client = client_provider.get_client()
             job_config = bigquery.LoadJobConfig(autodetect=True)
             job_config.source_format = bigquery.SourceFormat.PARQUET
             job_config.write_disposition = bigquery.WriteDisposition.WRITE_APPEND
@@ -126,7 +136,7 @@ class BigQueryDatasink(Datasink[None]):
         # Launch a remote task for each block within this write task
         ray.get(
             [
-                _write_single_block.remote(block, self.project_id, self.dataset)
+                _write_single_block.remote(block, self.dataset, self.client_provider)
                 for block in blocks
                 if BlockAccessor.for_block(block).num_rows() > 0
             ]

--- a/python/ray/data/_internal/datasource/bigquery_datasource.py
+++ b/python/ray/data/_internal/datasource/bigquery_datasource.py
@@ -1,6 +1,10 @@
 import logging
 from typing import TYPE_CHECKING, List, Optional
 
+from ray.data._internal.datasource.bigquery_client_provider import (
+    BigQueryClientProvider,
+    resolve_client_provider,
+)
 from ray.data._internal.util import _check_import
 from ray.data.block import Block, BlockMetadata
 from ray.data.datasource.datasource import Datasource, ReadTask
@@ -11,51 +15,13 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-def _create_user_agent() -> str:
-    import ray
-
-    return f"ray/{ray.__version__}"
-
-
-def _create_client_info():
-    from google.api_core.client_info import ClientInfo
-
-    return ClientInfo(
-        user_agent=_create_user_agent(),
-    )
-
-
-def _create_client_info_gapic():
-    from google.api_core.gapic_v1.client_info import ClientInfo
-
-    return ClientInfo(
-        user_agent=_create_user_agent(),
-    )
-
-
-def _create_client(project_id: str):
-    from google.cloud import bigquery
-
-    return bigquery.Client(
-        project=project_id,
-        client_info=_create_client_info(),
-    )
-
-
-def _create_read_client():
-    from google.cloud import bigquery_storage
-
-    return bigquery_storage.BigQueryReadClient(
-        client_info=_create_client_info_gapic(),
-    )
-
-
 class BigQueryDatasource(Datasource):
     def __init__(
         self,
         project_id: str,
         dataset: Optional[str] = None,
         query: Optional[str] = None,
+        client_provider: Optional[BigQueryClientProvider] = None,
     ):
         _check_import(self, module="google.cloud", package="bigquery")
         _check_import(self, module="google.cloud", package="bigquery_storage")
@@ -64,6 +30,7 @@ class BigQueryDatasource(Datasource):
         self._project_id = project_id
         self._dataset = dataset
         self._query = query
+        self._client_provider = resolve_client_provider(client_provider, project_id)
 
         if query is not None and dataset is not None:
             raise ValueError(
@@ -79,24 +46,29 @@ class BigQueryDatasource(Datasource):
     ) -> List[ReadTask]:
         from google.cloud import bigquery_storage
 
+        # Bind the provider to a local so the read tasks close over it rather
+        # than over ``self``, and build the read client on the worker -- the
+        # client itself isn't serializable.
+        client_provider = self._client_provider
+
         def _read_single_partition(stream) -> Block:
-            client = _create_read_client()
+            client = client_provider.get_read_client()
             reader = client.read_rows(stream.name)
             return reader.to_arrow()
 
         if self._query:
-            query_client = _create_client(project_id=self._project_id)
+            query_client = self._client_provider.get_client()
             query_job = query_client.query(self._query)
             query_job.result()
             destination = str(query_job.destination)
             dataset_id = destination.split(".")[-2]
             table_id = destination.split(".")[-1]
         else:
-            self._validate_dataset_table_exist(self._project_id, self._dataset)
+            self._validate_dataset_table_exist(self._dataset)
             dataset_id = self._dataset.split(".")[0]
             table_id = self._dataset.split(".")[1]
 
-        bqs_client = _create_read_client()
+        bqs_client = self._client_provider.get_read_client()
         table = f"projects/{self._project_id}/datasets/{dataset_id}/tables/{table_id}"
 
         if parallelism == -1:
@@ -142,10 +114,10 @@ class BigQueryDatasource(Datasource):
     def estimate_inmemory_data_size(self) -> Optional[int]:
         return None
 
-    def _validate_dataset_table_exist(self, project_id: str, dataset: str) -> None:
+    def _validate_dataset_table_exist(self, dataset: str) -> None:
         from google.api_core import exceptions
 
-        client = _create_client(project_id=project_id)
+        client = self._client_provider.get_client()
         dataset_id = dataset.split(".")[0]
         try:
             client.get_dataset(dataset_id)

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -36,6 +36,9 @@ from ray.data._internal.dataset_repr import (
     build_dataset_ascii_repr,
     build_dataset_summary_repr,
 )
+from ray.data._internal.datasource.bigquery_client_provider import (
+    BigQueryClientProvider,
+)
 from ray.data._internal.datasource.bigquery_datasink import BigQueryDatasink
 from ray.data._internal.datasource.clickhouse_datasink import (
     ClickHouseDatasink,
@@ -6154,6 +6157,7 @@ class Dataset:
         overwrite_table: Optional[bool] = True,
         ray_remote_args: Dict[str, Any] = None,
         concurrency: Optional[int] = None,
+        client_provider: Optional[BigQueryClientProvider] = None,
     ) -> None:
         """Write the dataset to a BigQuery dataset table.
 
@@ -6193,6 +6197,11 @@ class Dataset:
                 to control number of tasks to run concurrently. This doesn't change the
                 total number of tasks run. By default, concurrency is dynamically
                 decided based on the available resources.
+            client_provider: A :class:`~ray.data.BigQueryClientProvider` that builds
+                the BigQuery clients used for this write. Use it to supply explicit
+                credentials, a custom endpoint, or other client options. Defaults to
+                :class:`~ray.data.DefaultBigQueryClientProvider`, which uses
+                Application Default Credentials.
         """  # noqa: E501
         if ray_remote_args is None:
             ray_remote_args = {}
@@ -6212,6 +6221,7 @@ class Dataset:
             dataset=dataset,
             max_retry_cnt=max_retry_cnt,
             overwrite_table=overwrite_table,
+            client_provider=client_provider,
         )
         self.write_datasink(
             datasink,

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -24,6 +24,10 @@ from ray._private.auto_init_hook import wrap_auto_init
 from ray.data._internal.compute import ComputeStrategy
 from ray.data._internal.datasource.audio_datasource import AudioDatasource
 from ray.data._internal.datasource.avro_datasource import AvroDatasource
+from ray.data._internal.datasource.bigquery_client_provider import (  # noqa: F401
+    BigQueryClientProvider,
+    DefaultBigQueryClientProvider,
+)
 from ray.data._internal.datasource.bigquery_datasource import BigQueryDatasource
 from ray.data._internal.datasource.binary_datasource import BinaryDatasource
 from ray.data._internal.datasource.clickhouse_datasource import ClickHouseDatasource
@@ -1284,6 +1288,7 @@ def read_bigquery(
     dataset: Optional[str] = None,
     query: Optional[str] = None,
     *,
+    client_provider: Optional[BigQueryClientProvider] = None,
     parallelism: int = -1,
     num_cpus: Optional[float] = None,
     num_gpus: Optional[float] = None,
@@ -1326,6 +1331,28 @@ def read_bigquery(
                 query="SELECT * FROM `bigquery-public-data.samples.gsod` LIMIT 1000",
             )
 
+        To authenticate with something other than Application Default
+        Credentials, or to point the clients at a specific endpoint, pass a
+        ``client_provider``:
+
+        .. testcode::
+            :skipif: True
+
+            import ray
+            from google.oauth2 import service_account
+            from ray.data import DefaultBigQueryClientProvider
+
+            credentials = service_account.Credentials.from_service_account_file(
+                "/path/to/key.json"
+            )
+            ds = ray.data.read_bigquery(
+                project_id="my_project",
+                dataset="my_dataset.my_table",
+                client_provider=DefaultBigQueryClientProvider(
+                    project_id="my_project", credentials=credentials
+                ),
+            )
+
     Args:
         project_id: The name of the associated Google Cloud Project that hosts the dataset to read.
             For more information, see `Creating and Managing Projects <https://cloud.google.com/resource-manager/docs/creating-managing-projects>`_.
@@ -1333,6 +1360,11 @@ def read_bigquery(
             Both the dataset_id and table_id must exist otherwise an exception will be raised.
         query: The SQL query to execute. `query` and `dataset` are mutually exclusive.
             If `query` is provided, the query result is read as the dataset.
+        client_provider: A :class:`~ray.data.BigQueryClientProvider` that builds the
+            BigQuery clients used for this read. Use it to supply explicit
+            credentials, a custom endpoint, or other client options. Defaults to
+            :class:`~ray.data.DefaultBigQueryClientProvider`, which uses Application
+            Default Credentials.
         parallelism: This argument is deprecated. Use ``override_num_blocks`` argument.
         num_cpus: The number of CPUs to reserve for each parallel read worker.
         num_gpus: The number of GPUs to reserve for each parallel read worker. For
@@ -1353,7 +1385,12 @@ def read_bigquery(
         Dataset producing rows from the results of executing the query (or reading the entire dataset)
         on the specified BigQuery dataset.
     """  # noqa: E501
-    datasource = BigQueryDatasource(project_id=project_id, dataset=dataset, query=query)
+    datasource = BigQueryDatasource(
+        project_id=project_id,
+        dataset=dataset,
+        query=query,
+        client_provider=client_provider,
+    )
     return read_datasource(
         datasource,
         num_cpus=num_cpus,

--- a/python/ray/data/tests/datasource/test_bigquery.py
+++ b/python/ray/data/tests/datasource/test_bigquery.py
@@ -1,3 +1,4 @@
+import pickle
 from typing import Iterator
 from unittest import mock
 
@@ -10,6 +11,10 @@ from google.cloud.bigquery import job
 from google.cloud.bigquery_storage_v1.types import stream as gcbqs_stream
 
 import ray
+from ray.data._internal.datasource.bigquery_client_provider import (
+    BigQueryClientProvider,
+    DefaultBigQueryClientProvider,
+)
 from ray.data._internal.datasource.bigquery_datasink import BigQueryDatasink
 from ray.data._internal.datasource.bigquery_datasource import BigQueryDatasource
 from ray.data._internal.execution.interfaces.task_context import TaskContext
@@ -276,6 +281,151 @@ class TestWriteBigQuery:
         # write() always calls ray.get(), but with an empty list since the
         # zero-row block is filtered out (no remote write tasks launched).
         ray_get_mock.assert_called_once_with([])
+
+
+class _CountingClientProvider(BigQueryClientProvider):
+    """A provider that records how many clients it built.
+
+    Delegates to ``bigquery.Client`` / ``BigQueryReadClient``, which the autouse
+    fixtures above replace with mocks.
+    """
+
+    def __init__(self):
+        self.build_client_calls = 0
+        self.build_read_client_calls = 0
+
+    def _build_client(self):
+        self.build_client_calls += 1
+        return bigquery.Client(project=_TEST_GCP_PROJECT_ID)
+
+    def _build_read_client(self):
+        self.build_read_client_calls += 1
+        return bigquery_storage.BigQueryReadClient()
+
+
+class TestBigQueryClientProvider:
+    """Tests for injecting BigQuery clients via a client provider."""
+
+    def test_default_provider_forwards_credentials_and_options(
+        self, bq_client_full_mock, bqs_client_full_mock
+    ):
+        credentials = mock.Mock(name="credentials")
+        client_options = mock.Mock(name="client_options")
+        provider = DefaultBigQueryClientProvider(
+            project_id=_TEST_GCP_PROJECT_ID,
+            credentials=credentials,
+            client_options=client_options,
+        )
+
+        provider.get_client()
+        _, kwargs = bq_client_full_mock.call_args
+        assert kwargs["project"] == _TEST_GCP_PROJECT_ID
+        assert kwargs["credentials"] is credentials
+        assert kwargs["client_options"] is client_options
+        assert kwargs["client_info"].user_agent.startswith("ray/")
+
+        provider.get_read_client()
+        _, kwargs = bqs_client_full_mock.call_args
+        assert kwargs["credentials"] is credentials
+        assert kwargs["client_options"] is client_options
+        assert kwargs["client_info"].user_agent.startswith("ray/")
+
+    def test_default_provider_kwargs_take_precedence(self, bq_client_full_mock):
+        override = mock.Mock(name="override_credentials")
+        provider = DefaultBigQueryClientProvider(
+            project_id=_TEST_GCP_PROJECT_ID,
+            credentials=mock.Mock(name="credentials"),
+            client_kwargs={"credentials": override, "location": "us-central1"},
+        )
+
+        provider.get_client()
+        _, kwargs = bq_client_full_mock.call_args
+        assert kwargs["credentials"] is override
+        assert kwargs["location"] == "us-central1"
+
+    def test_clients_are_built_once_and_cached(self):
+        provider = _CountingClientProvider()
+
+        assert provider.get_client() is provider.get_client()
+        assert provider.get_read_client() is provider.get_read_client()
+        assert provider.build_client_calls == 1
+        assert provider.build_read_client_calls == 1
+
+    def test_cached_clients_are_dropped_when_serialized(self):
+        """Google's clients aren't picklable, so they must not be pickled.
+
+        See https://github.com/ray-project/ray/issues/65614.
+        """
+        provider = _CountingClientProvider()
+        provider.get_client()
+        provider.get_read_client()
+
+        unpickled = pickle.loads(pickle.dumps(provider))
+
+        assert "_cached_client" not in unpickled.__dict__
+        assert "_cached_read_client" not in unpickled.__dict__
+        # The clients are rebuilt on demand in the receiving process.
+        assert unpickled.build_client_calls == 1
+        unpickled.get_client()
+        assert unpickled.build_client_calls == 2
+
+    def test_read_uses_injected_provider(self):
+        provider = _CountingClientProvider()
+        bq_ds = BigQueryDatasource(
+            project_id=_TEST_GCP_PROJECT_ID,
+            dataset=_TEST_BQ_DATASET,
+            client_provider=provider,
+        )
+
+        read_tasks_list = bq_ds.get_read_tasks(2)
+
+        assert len(read_tasks_list) == 2
+        assert provider.build_client_calls == 1
+        assert provider.build_read_client_calls == 1
+
+    def test_read_tasks_do_not_capture_a_client(self):
+        """Read tasks must carry the provider, not a live client."""
+        provider = _CountingClientProvider()
+        bq_ds = BigQueryDatasource(
+            project_id=_TEST_GCP_PROJECT_ID,
+            dataset=_TEST_BQ_DATASET,
+            client_provider=provider,
+        )
+        bq_ds.get_read_tasks(1)
+
+        # The datasource is shipped to workers, so it must survive a round-trip
+        # even after the driver has already built its clients.
+        restored = pickle.loads(pickle.dumps(bq_ds))
+        assert "_cached_read_client" not in restored._client_provider.__dict__
+
+    def test_write_uses_injected_provider(self):
+        provider = _CountingClientProvider()
+        bq_datasink = BigQueryDatasink(
+            project_id=_TEST_GCP_PROJECT_ID,
+            dataset=_TEST_BQ_DATASET,
+            client_provider=provider,
+        )
+
+        bq_datasink.on_write_start()
+        assert provider.build_client_calls == 1
+
+        # The datasink is shipped to write tasks, so it must survive a
+        # round-trip after the driver has already built its client.
+        restored = pickle.loads(pickle.dumps(bq_datasink))
+        assert "_cached_client" not in restored.client_provider.__dict__
+
+    def test_defaults_to_default_provider(self):
+        bq_ds = BigQueryDatasource(
+            project_id=_TEST_GCP_PROJECT_ID,
+            dataset=_TEST_BQ_DATASET,
+        )
+        assert isinstance(bq_ds._client_provider, DefaultBigQueryClientProvider)
+
+        bq_datasink = BigQueryDatasink(
+            project_id=_TEST_GCP_PROJECT_ID,
+            dataset=_TEST_BQ_DATASET,
+        )
+        assert isinstance(bq_datasink.client_provider, DefaultBigQueryClientProvider)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

`ray.data.read_bigquery` and `Dataset.write_bigquery` build their Google Cloud clients through hardcoded private module-level factories in `bigquery_datasource.py`:

```python
def _create_client(project_id: str):
    from google.cloud import bigquery
    return bigquery.Client(project=project_id, client_info=_create_client_info())

def _create_read_client():
    from google.cloud import bigquery_storage
    return bigquery_storage.BigQueryReadClient(client_info=_create_client_info_gapic())
```

All five call sites reach these directly — including `BigQueryDatasink`, which reaches across modules into `bigquery_datasource._create_client`. There is no seam for a caller to influence client construction, so today it is impossible to supply explicit credentials (only Application Default Credentials work), set `client_options` for a regional or Private Service Connect endpoint, set a `quota_project_id`, or configure retries and timeouts. The Storage Read API client is worse off than the control-plane client: `_create_read_client()` takes no arguments at all.

This PR introduces a `BigQueryClientProvider` abstraction and threads an optional `client_provider` through both public APIs. Omitting it leaves behaviour byte-for-byte unchanged.

## Related issues

Closes #65614

## Additional information

### Why a provider rather than a client instance

The obvious API would accept a live `bigquery.Client`. That cannot work here: `BigQueryDatasource` and `BigQueryDatasink` are pickled and shipped to workers, and Google's clients are not serializable — this is the root cause of #45197 (`cannot pickle 'google._upb._message.Descriptor' object`). So the provider is the injected unit. `BigQueryClientProvider` caches the clients it builds and drops them in `__getstate__`, so any subclass is serializable by default and each process lazily rebuilds its own clients.

This mirrors the `DatabricksCredentialProvider` pattern already in `ray/data/_internal/datasource/databricks_credentials.py`.

### API

```python
class BigQueryClientProvider(ABC):
    def get_client(self) -> bigquery.Client: ...            # cached, control plane
    def get_read_client(self) -> BigQueryReadClient: ...    # cached, data plane
    @abstractmethod
    def _build_client(self) -> bigquery.Client: ...
    @abstractmethod
    def _build_read_client(self) -> BigQueryReadClient: ...
```

`DefaultBigQueryClientProvider` preserves current behaviour (ADC + the Ray user-agent `client_info`) and additionally accepts `credentials`, `client_options`, `client_kwargs`, and `read_client_kwargs`:

```python
ds = ray.data.read_bigquery(
    project_id="my_project",
    dataset="my_dataset.my_table",
    client_provider=DefaultBigQueryClientProvider(
        project_id="my_project", credentials=credentials
    ),
)
```

Both classes are exported from `ray.data`, annotated `@PublicAPI(stability="alpha")`, and added to the API docs.

### Backwards compatibility

`client_provider` is keyword-only on `read_bigquery` (it falls after the existing `*`). `Dataset.write_bigquery` has no `*` in its signature, so `client_provider` was appended **last**, after `concurrency`, rather than placed next to the related arguments — inserting it mid-list would break positional callers.

The private `_create_client` / `_create_read_client` / `_create_client_info*` helpers moved out of `bigquery_datasource` into the new module. They are underscore-private and were only referenced from these two files.

### Testing

Eight tests added in `TestBigQueryClientProvider` covering credential and client-option forwarding, kwargs precedence, client caching, cache-dropping across a pickle round-trip, and the read and write paths using an injected provider. The pickle tests are the ones that matter for correctness here, since a provider that serialized its clients would fail on the worker rather than on the driver.

```
python -m pytest python/ray/data/tests/datasource/test_bigquery.py
32 passed  (24 pre-existing + 8 new)
```

Environment caveat, stated plainly: I do not have a full source build of Ray's C extension on this machine, and the master test conftest chain imports symbols that a nightly `_raylet.so` does not export. The run above was therefore executed against the working-tree `ray/data` on a nightly Ray core, with the three `conftest` star-imports at the top of the test file stripped. The tests themselves and the code under test are unmodified. **`//python/ray/data:test_bigquery` under a real build — i.e. this PR's CI — is the authority, and I will confirm against it once CI reports.**

Lint is clean: `pre-commit run --files <changed files>` passes all hooks (ruff, ruff-isort, black, pydoclint, vale, semgrep, docstyle, import order). `ci/lint/check_api_annotations.py` is satisfied — both new public classes carry `@PublicAPI`.

### Duplicate-work check

Per `AGENTS.md`, I checked before starting. No open PR touches the BigQuery datasource or datasink (`gh pr list --search "bigquery"` returns only #63070, an unrelated Kinetica connector). The three open BigQuery issues are unrelated to client construction: #44941 (import error), #54288 (docs wording on the 10 GB warning), #45197 (pickling — related as evidence for the design constraint above, but not addressed by this PR).

### AI assistance

AI assistance was used to research and implement this change.
