### PR TITLE
[ci][doc] Build the docs with 2 Sphinx workers on Read the Docs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -87,10 +87,32 @@ build:
         echo "[global]" > ~/.config/pip/pip.conf
         echo "retries = 10" >> ~/.config/pip/pip.conf
         cat ~/.config/pip/pip.conf
+    # Build with fewer Sphinx workers than there are CPUs.
+    #
+    # doc/Makefile defaults SPHINX_JOBS to auto, one write worker per CPU.
+    # This builder has 4 CPUs and a 7,130,316,800 byte cgroup memory ceiling
+    # (about 6.64 GiB, the documented Business limit), and each worker holds
+    # its own copy of the build environment. At -j auto the build peaked at
+    # 6,503,370,752 bytes on a run that passed and 6,371,254,272 on one that
+    # was OOM-killed, leaving roughly 600 MB of headroom either way. When the
+    # kernel kills a write worker the parent Sphinx process reports only a
+    # bare EOFError from multiprocessing/connection.py, naming no document,
+    # and the document it dies on moves from build to build.
+    #
+    # At SPHINX_JOBS=2 the same build peaked at 5,566,427,136 bytes with
+    # memory.events oom_kill 0, so headroom goes from about 600 MB to about
+    # 1.5 GiB. The cost is wall clock: a paired run measured 349 seconds at
+    # -j auto against 620 seconds at 2 on one builder, and the 2 arm had a
+    # warm cache, so treat that as a lower bound on the slowdown.
+    #
+    # Only this job sets it. Local builds and the Buildkite doc build keep
+    # -j auto, so nothing off this builder pays for the reduced parallelism.
+    # Raising the RtD memory limit would let the parallelism come back; that
+    # is a separate ask to Read the Docs, not a change in this repo.
     build:
       html:
         - |
-          make -C doc html HTMLDIR="$READTHEDOCS_OUTPUT/html"
+          make -C doc html HTMLDIR="$READTHEDOCS_OUTPUT/html" SPHINX_JOBS=2
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -2,11 +2,20 @@
 #
 
 # You can set these variables from the command line.
+
+# Number of parallel Sphinx workers, passed straight to sphinx-build -j.
+# "auto" is one worker per CPU, which is what Sphinx does by default and what
+# every caller except Read the Docs still gets. Each worker holds its own copy
+# of the build environment, so write-phase memory scales with this number.
+# Override it to a smaller value on a builder with a hard memory ceiling; see
+# the html job in .readthedocs.yaml for the one caller that does.
+SPHINX_JOBS ?= auto
+
 # Allow linkcheck to run without treating warnings as errors; -W will
 # fast-fail if enabled; it's better to gather the whole list of bad links at once.
-SPHINXOPTS    = -a -E -W -j auto
-LOCALSPHINXOPTS = -W -j auto
-LINKCHECKOPTS = -a -E -j auto
+SPHINXOPTS    = -a -E -W -j $(SPHINX_JOBS)
+LOCALSPHINXOPTS = -W -j $(SPHINX_JOBS)
+LINKCHECKOPTS = -a -E -j $(SPHINX_JOBS)
 # RtD-faithful build: our full-build options plus the two flags Read the Docs
 # adds to its synthesized html command (-T full tracebacks, -D language=en).
 RTDSPHINXOPTS = $(SPHINXOPTS) -T -D language=en


### PR DESCRIPTION
## Summary

Read the Docs builds intermittently fail with a bare `EOFError` and no failing document named:

```
File ".../multiprocessing/connection.py", line 399, in _recv
    raise EOFError
EOFError

make: *** [Makefile:91: html] Error 2
```

The kernel OOM-kills one of Sphinx's parallel write workers, and the parent process has nothing better to report than the broken pipe. This caps the worker count on the Read the Docs builder, which is the only builder with a hard memory ceiling.

Two changes:

- `doc/Makefile` gains `SPHINX_JOBS ?= auto`, feeding `sphinx-build -j`. The default keeps today's behavior for every existing caller.
- The `.readthedocs.yaml` html job passes `SPHINX_JOBS=2`.

## The mechanism

The builder has 4 CPUs and a cgroup `memory.max` of 7,130,316,800 bytes, about 6.64 GiB, which matches the memory limit Read the Docs documents for Business. `-j auto` forks one write worker per CPU and each worker carries its own copy of the build environment, so the write phase costs memory in proportion to the job count.

Measured on the builder, with `memory.events` read immediately after the build:

| Job count | `memory.peak` | Headroom under the ceiling | `oom_kill` | Result |
|---|---|---|---|---|
| `auto` (4) | 6,371,254,272 | ~759 MB | 1 | failed, `EOFError` |
| `auto` (4) | 6,503,370,752 | ~627 MB | 0 | passed |
| 2 | 5,566,427,136 | ~1,564 MB | 0 | passed |

The two `-j auto` rows are the important pair: the run that was killed peaked *lower* than the run that passed. There is no threshold being crossed. The build simply runs about 600 MB under a hard ceiling with four workers allocating independently, and whether a given run survives depends on the timing of individual allocations. That is also why the document Sphinx dies on moves between builds, which is what makes the failure read as a content problem when it isn't.

Dropping to 2 workers roughly doubles the headroom, from about 600 MB to about 1.5 GiB.

## Why this is worth doing rather than waiting

The parallelism is recent, not long-standing. Read the Docs' own Sphinx invocation adds `-j auto` only for projects carrying the opt-in `BUILD_IN_PARALLEL` feature flag, so RtD was building Ray's docs serially. #64277 pointed `build.jobs.build.html` at `make -C doc html`, which inherited the Makefile's `-j auto` — a flag that until then only the Buildkite doc build used. #64599 then made every preview a full clean `-a -E` build. Neither change was wrong on its own; together they put four write workers and a thin memory margin on the one builder that can't absorb them.

Some things that this is *not*, all checked:

- **Not content growth.** The Sphinx environment went from 4058 documents on a passing build to 4087 on a failing one. 0.7% can't move a build across a ceiling.
- **Not dependency drift.** `doc/requirements-doc.lock.txt` is fully hash-pinned and unchanged across the window.
- **Not worker overcommit.** Sphinx resolves `-j auto` through `multiprocessing.cpu_count`, which is neither affinity- nor cgroup-aware, so it can in principle fork more workers than the container can run. On this builder `nproc` and `nproc --all` both report 4, so that isn't happening.
- **Not host contention.** The ceiling is a per-build cgroup limit, not host pressure, so this isn't other builds crowding the machine.

## Cost

Wall clock. A paired run on one builder measured 349 seconds at `-j auto` against 620 seconds at `SPHINX_JOBS=2`, about 78% slower. The `SPHINX_JOBS=2` arm ran with a warm cache, so treat 78% as a lower bound.

That cost is confined to Read the Docs. `SPHINX_JOBS` defaults to `auto`, so local builds and the Buildkite doc build are untouched. Verified with `make -n`: the default still renders `-j auto`, the override renders `-j 2`, and because `RTDSPHINXOPTS` and `LINKCHECKOPTS` derive from the same variable, the override also reaches `linkcheck`, `rtd-build`, and `rtd-fallback`. That last part matters for when the incremental cache path in #64277 is re-enabled — the cap will apply there too without another change.

## Why 2 rather than 3

2 is the value with a measured peak and a clean `oom_kill 0`. 3 would cost less wall clock and is plausibly enough, but it hasn't been measured, and at 3 workers the expected headroom lands between the two figures above, closer to the margin that is already producing intermittent kills. Given the failure mode is timing-dependent rather than threshold-dependent, the point of the change is durable headroom rather than getting just back under a line. If the wall-clock cost proves painful, 3 is the obvious thing to measure next.

## Follow-up

Read the Docs documents the memory limit as upgradable on Business. Raising it would let the parallelism come back and undo the wall-clock cost. That's a separate ask to Read the Docs rather than a change in this repo, and it's worth making regardless of this PR.

#65631 is the measurement PR that produced the numbers above. It can be closed once this lands; the `SPHINX_JOBS` plumbing it carried is included here, and its diagnostic wrapper was always meant to come back out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
