### PR TITLE
[RLlib] Type from_checkpoint return as Self

### DIFF
--- a/rllib/utils/checkpoints.py
+++ b/rllib/utils/checkpoints.py
@@ -11,6 +11,7 @@ from typing import Any, Collection, Dict, List, Optional, Tuple, Union
 
 import pyarrow.fs
 from packaging import version
+from typing_extensions import Self
 
 import ray
 import ray.cloudpickle as pickle
@@ -429,7 +430,7 @@ class Checkpointable(abc.ABC):
         path: Union[str, pathlib.Path],
         filesystem: Optional["pyarrow.fs.FileSystem"] = None,
         **kwargs,
-    ) -> "Checkpointable":
+    ) -> Self:
         """Creates a new Checkpointable instance from the given location and returns it.
 
         Args:


### PR DESCRIPTION
## Description
Annotates Checkpointable.from_checkpoint with typing_extensions.Self so type checkers infer the concrete subclass returned by subclass calls.

## Related issues
Fixes #65610

## Additional information
Validation:
- Focused checkpoint exception tests: 7 passed
- Ruff, Black, trailing-whitespace, and end-of-file pre-commit hooks: passed
- Mypy inference check: CustomCheckpointable.from_checkpoint revealed as CustomCheckpointable