### PR TITLE
[ci] Stop routing the intersphinx directory to the core docs example step

### DIFF
--- a/.buildkite/test.rules.test.txt
+++ b/.buildkite/test.rules.test.txt
@@ -219,6 +219,13 @@ doc/source/llms_txt_summary.txt: doc
 # The shared notebook runner stays on the catch-all core step by design; see
 # the comment on the catch-all rule in test.rules.txt.
 doc/test_myst_doc.py: core_doc
+# Intersphinx snapshots are build inputs, so they route to the build. refresh.py
+# is the case the dedicated rule exists for: without it the `doc/*.py` catch-all
+# claimed it and started the core docs example step. README.md beside them is
+# prose and stays unrouted, which is what the third case locks in.
+doc/source/_intersphinx/python.inv: doc
+doc/source/_intersphinx/refresh.py: doc
+doc/source/_intersphinx/README.md:
 python/deplocks/docs/docbuild_depset_py3.11.lock: doc doc_api python_dependencies
 ci/raydepsets/configs/docs.depsets.yaml: doc doc_api python_dependencies
 # Redirect YAML selects the dedicated lightweight check and nothing else: no

--- a/.buildkite/test.rules.txt
+++ b/.buildkite/test.rules.txt
@@ -478,6 +478,32 @@ doc/external/
 @ ml_doc
 ;
 
+# Committed intersphinx inventory snapshots and the script that refreshes them.
+# The `.inv` files are live build inputs: `intersphinx_mapping` in
+# doc/source/conf.py resolves each target's local `_intersphinx/<name>.inv`
+# ahead of its remote URL, so a truncated or stale snapshot changes what
+# cross-references resolve. But they are read as inventories, not as pages --
+# `exclude_patterns` drops `_intersphinx/**` from the source tree -- and no
+# bazel target names this directory, so there is nothing here for a docs
+# example step to execute. Route the whole directory to `doc`, the tag that
+# selects the documentation build, and to nothing else.
+#
+# Two things were wrong before this rule existed. `refresh.py` fell through to
+# the `doc/*.py` catch-all below, whose `*` crosses `/`, and so started the core
+# docs example step -- a large-instance, three-invocation bazel run -- for a
+# standalone maintenance script that nothing imports and no target covers. The
+# `.inv` files fell past it to the broad `doc/` skip and emitted no tag at all,
+# so refreshing an inventory, which is the routine maintenance this directory
+# exists for, triggered no build. The premerge gate for an inventory change is
+# the Read the Docs `-W` build, which runs outside tag selection; `doc` is what
+# gives the postmerge documentation build coverage here.
+#
+# README.md is already skipped by the `doc/*.md` prose rule further up, so this
+# rule only ever sees the snapshots and the script.
+doc/source/_intersphinx/
+@ doc
+;
+
 # Starter-template sources and the notebook authoring boilerplate. Sphinx never
 # reads any of these: `exclude_patterns` in doc/source/conf.py drops
 # `templates/*` from the build outright, and `_templates/template.ipynb` is a


### PR DESCRIPTION
## Why are these changes needed?

Editing anything in `doc/source/_intersphinx/` starts `:ray: core: docs example tests`, and there is nothing in that directory for the step to run.

`refresh.py` matches the `doc/*.py` catch-all near the bottom of `.buildkite/test.rules.txt`. Patterns there go through `fnmatch`, whose `*` crosses `/`, so `doc/*.py` claims `doc/source/_intersphinx/refresh.py` and emits `core_doc`. That selects a `large` instance running three `test_in_docker` invocations over `//python/ray/...` and `//doc/...` on `corebuild-py3.10`. Nothing imports that script, no bazel target names the directory, and `exclude_patterns` in `conf.py` drops `_intersphinx/**` from the source tree, so the step has no target there to execute. Observed on #65644, whose only `.py` change outside `conf.py` is a one-line edit to `refresh.py`.

The `.inv` snapshots have the opposite problem. They match neither the prose-and-image skip near the top nor the `.py`/`.ipynb` catch-all, so they fall through to the broad `doc/` skip and emit no tag at all. They are live build inputs: `intersphinx_mapping` resolves each target's local `_intersphinx/<name>.inv` ahead of its remote URL, so a truncated or stale snapshot changes what cross-references resolve. Refreshing one, which is the routine maintenance this directory exists for, triggered no documentation build.

## What this changes

One directory rule ahead of the catch-all, routing `doc/source/_intersphinx/` to `doc` and nothing else. `README.md` is already claimed by the `doc/*.md` prose rule further up, so the rule only ever sees the snapshots and the script.

`refresh.py` rides along on the directory rule rather than getting its own skip. `doc` is cheap, the directory is small and homogeneous, and a per-file split here would rot the next time the directory grows a helper.

On premerge, `doc` selects `doc: test llms.txt extension`; `doc: build` and `doc: linkcheck` both carry `skip-on-premerge`. So the PR-time gate for an inventory change remains the Read the Docs `-W` build, which runs outside tag selection entirely. What this rule buys is postmerge documentation-build coverage where there was none.

`conf.py` is not implicated. It matches the autodoc-machinery block and emits `doc doc_api`, which is correct and cheap.

## Related issue number

Diagnosed while reviewing CI on #65644.

## Checks

- [x] I've signed off every commit (`-s`).
- [x] I've included any doc changes needed for the change. The rationale lives in the rule comment, per the convention in this file.
- Testing strategy
   - [x] Unit tests. Three cases added to `.buildkite/test.rules.test.txt` covering a snapshot, `refresh.py`, and the unrouted `README.md`. All 131 cases in that file and both `//ci/pipeline:test_doc_api_rules_sync` cases pass.
   - [ ] Release tests
   - [x] Differential sweep. Evaluated both rules files before and after against every tracked file in the repo. The only tag changes are the 28 files under `doc/source/_intersphinx/`: `refresh.py` moves from `core_doc` to `doc`, and the 26 snapshots plus `.gitattributes` move from no tag to `doc`. Nothing else in the tree changes, which is the check that matters for a file that decides CI for every PR.
