### PR TITLE
[CI] Out-of-tree build path for the arrow-rs Parquet crate (draft: packaging analysis for #65117)

### DIFF
--- a/.buildkite/data.rayci.yml
+++ b/.buildkite/data.rayci.yml
@@ -27,6 +27,20 @@ steps:
       PYTHON: "{{array.python}}"
     tags: cibase
 
+  # Layers the Rust arrow-rs Parquet decoder on top of datalbuild. Separate
+  # image so rustc/cargo and the crates.io fetch stay out of every other data
+  # image; see ci/docker/dataarrowrs.build.Dockerfile for the rationale.
+  - name: dataarrowrsbuild-multipy
+    label: "wanda: dataarrowrsbuild-py{{array.python}}"
+    wanda: ci/docker/dataarrowrs.build.wanda.yaml
+    array:
+      python:
+        - "3.10"
+    env:
+      PYTHON: "{{array.python}}"
+    depends_on: datalbuild-multipy(python=3.10)
+    tags: cibase
+
   - name: datanbuild-multipy
     wanda: ci/docker/datan.build.wanda.yaml
     env:
@@ -76,7 +90,7 @@ steps:
         --workers "$${BUILDKITE_PARALLEL_JOB_COUNT}"
         --worker-id "$${BUILDKITE_PARALLEL_JOB}" --parallelism-per-worker 3
         --build-name data17build-py3.10 --python-version 3.10
-        --except-tags data_integration,doctest,data_non_parallel,dask,needs_credentials,tensorflow_datasets,cudf
+        --except-tags data_integration,doctest,data_non_parallel,dask,needs_credentials,tensorflow_datasets,cudf,arrow_rs
     depends_on: data17build-multipy(python=3.10)
 
   - label: ":database: data: tensorflow-datasets tests"
@@ -116,7 +130,7 @@ steps:
         --workers "$${BUILDKITE_PARALLEL_JOB_COUNT}"
         --worker-id "$${BUILDKITE_PARALLEL_JOB}" --parallelism-per-worker 3
         --build-name datalbuild-py3.10 --python-version 3.10
-        --except-tags data_integration,doctest,data_non_parallel,dask,needs_credentials,tensorflow_datasets,cudf
+        --except-tags data_integration,doctest,data_non_parallel,dask,needs_credentials,tensorflow_datasets,cudf,arrow_rs
     depends_on: datalbuild-multipy(python=3.10)
 
   - label: ":database: data: arrow v23 tests (data_non_parallel)"
@@ -135,6 +149,21 @@ steps:
         --except-tags data_non_parallel_postmerge_only,cudf
     depends_on: datalbuild-multipy(python=3.10)
 
+  # The arrow-rs reader's tests only run against an image that actually has the
+  # native extension. Without a dedicated target + image they are doubly
+  # unreachable: the test module opens with
+  # `pytest.importorskip("ray_data_arrow_rs")`, and (as of PR #65117) it has no
+  # py_test target at all -- so `//python/ray/data/...` never even enumerates it.
+  - label: ":database: data: arrow-rs parquet reader tests"
+    tags:
+      - data
+    instance_type: medium
+    commands:
+      - bazel run //ci/ray_ci:test_in_docker -- //python/ray/data/... data
+        --build-name dataarrowrsbuild-py3.10 --python-version 3.10
+        --only-tags arrow_rs
+    depends_on: dataarrowrsbuild-multipy(python=3.10)
+
   - label: ":database: data: arrow v23 py{{array.python}} tests ({{array.worker_id}})"
     key: datal_python_tests
     if: build.pull_request.labels includes "continuous-build" || pipeline.id == "0189e759-8c96-4302-b6b5-b4274406bf89" || pipeline.id == "018f4f1e-1b73-4906-9802-92422e3badaa"
@@ -145,7 +174,7 @@ steps:
       - bazel run //ci/ray_ci:test_in_docker -- //python/ray/data/... //python/ray/air/... data
         --workers 2 --worker-id {{array.worker_id}} --parallelism-per-worker 3
         --build-name datalbuild-py{{array.python}} --python-version {{array.python}}
-        --except-tags data_integration,doctest,data_non_parallel,dask,needs_credentials,tensorflow_datasets,cudf
+        --except-tags data_integration,doctest,data_non_parallel,dask,needs_credentials,tensorflow_datasets,cudf,arrow_rs
     depends_on: datalbuild-multipy($)
     array:
       python: ["3.12"]
@@ -179,7 +208,7 @@ steps:
         --workers "$${BUILDKITE_PARALLEL_JOB_COUNT}"
         --worker-id "$${BUILDKITE_PARALLEL_JOB}" --parallelism-per-worker 3
         --build-name datanbuild-py3.10 --python-version 3.10
-        --except-tags data_integration,doctest,data_non_parallel,dask,needs_credentials,tensorflow_datasets,cudf
+        --except-tags data_integration,doctest,data_non_parallel,dask,needs_credentials,tensorflow_datasets,cudf,arrow_rs
     depends_on: datanbuild-multipy
     soft_fail: true
 

--- a/.buildkite/data.rayci.yml
+++ b/.buildkite/data.rayci.yml
@@ -156,7 +156,7 @@ steps:
   # py_test target at all -- so `//python/ray/data/...` never even enumerates it.
   - label: ":database: data: arrow-rs parquet reader tests"
     tags:
-      - data
+      - arrow_rs
     instance_type: medium
     commands:
       - bazel run //ci/ray_ci:test_in_docker -- //python/ray/data/... data

--- a/.buildkite/test.rules.test.txt
+++ b/.buildkite/test.rules.test.txt
@@ -15,6 +15,10 @@ ci/pipeline/test_conditional_testing.py: tools
 # === Ray Libraries ===
 
 python/ray/data/__init__.py: data
+python/ray/data/_internal/datasource_v2/readers/arrow_rs_parquet_file_reader.py: arrow_rs data
+python/ray/data/tests/datasource/test_arrow_rs_parquet_reader.py: arrow_rs data
+rust/ray_data_arrow_rs/src/lib.rs: arrow_rs data
+ci/docker/dataarrowrs.build.wanda.yaml: arrow_rs data
 python/ray/air/__init__.py: ml train train_gpu tune data linux_wheels
 python/ray/llm/llm.py: llm
 python/ray/workflow/workflow.py: workflow

--- a/.buildkite/test.rules.txt
+++ b/.buildkite/test.rules.txt
@@ -38,6 +38,7 @@
 ! data dask serve ml tune train train_gpu llm rllib rllib_gpu rllib_directly
 ! linux_wheels macos_wheels docker doc doc_api doc_redirects python_dependencies min_build tools windows
 ! release_tests spark_on_ray rocksdb_tests redis_tests sandbox_tests
+! arrow_rs
 ! core_doc data_doc ml_doc rllib_doc serve_doc
 
 # Per-team API reference pages. Editing these can change the documented public
@@ -109,6 +110,22 @@ doc/source/llm/
 doc/source/data/doc_code/working-with-llms/
 ci/docker/llm.build.Dockerfile
 @ llm
+;
+
+# Must precede the python/ray/data/ rule below: first match wins, and that rule
+# emits only `data`, so a change to the crate or its reader would never select the
+# arrow-rs job. Emits `data` as well so the ordinary data suite still runs -- the
+# reader is on the read_parquet path whether or not the flag is on.
+#
+# Note `arrow_rs` is also the name of the bazel tag on the py_test target. Same
+# word, two namespaces: this one picks the Buildkite step, that one picks the test.
+rust/
+ci/build/build-arrow-rs-wheel.sh
+ci/docker/dataarrowrs.build.Dockerfile
+ci/docker/dataarrowrs.build.wanda.yaml
+python/ray/data/_internal/datasource_v2/readers/arrow_rs_parquet_file_reader.py
+python/ray/data/tests/datasource/test_arrow_rs_parquet_reader.py
+@ arrow_rs data
 ;
 
 python/ray/data/

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -49,6 +49,8 @@
 
 # Ray data.
 /python/ray/data/ @ray-project/ray-data
+# Native arrow-rs Parquet decoder consumed by ray.data.
+/rust/ @ray-project/ray-data
 /doc/source/data/ @ray-project/ray-data @ray-project/ray-docs
 /python/ray/dashboard/modules/data/ @ray-project/ray-data
 /python/ray/dashboard/modules/metrics/dashboards/data_dashboard_panels.py @ray-project/ray-data

--- a/ci/build/RUST-PACKAGING-OPTIONS.md
+++ b/ci/build/RUST-PACKAGING-OPTIONS.md
@@ -137,9 +137,41 @@ Both are packaging-independent and worth fixing regardless of the path chosen:
   `//python/ray/data/...` never enumerates it. The tests cannot run even if the
   extension were installed.
 
+Worth noting this is not a one-draft oversight: **#65406, the further-along A/B
+branch, does not add an `arrow_rs` target either** — its `BUILD.bazel` patch contains
+zero `arrow_rs` mentions. Across the whole effort the test file has never been
+registered with Bazel.
+
 This change adds the `py_test` target (tagged `arrow_rs`), excludes that tag from
 the general data jobs so they cannot silently skip it, and adds a dedicated job
 that runs it against an image where the extension is actually present.
+
+## The parquet-crate patch changes the calculus
+
+PR [#65406](https://github.com/ray-project/ray/pull/65406) (the A/B treatment arm,
+stacked on #64985) carries
+`release/nightly_tests/dataset/arrow_rs_probe/patch_crate_parquet.sh` plus
+`patches/parquet-59.1.0-dict-reserve.diff` — a **local patch to the third-party
+`parquet` crate**, pre-sizing the values buffer in
+`OffsetBuffer::extend_from_dictionary`. It is applied by vendoring the crate source
+out of the cargo registry cache and pointing `[patch.crates-io]` at it from a
+build-local `.cargo/config.toml`. The script is explicit that `vendor/` and `.cargo/`
+are never committed.
+
+That is fine for an experiment. But if the patch proves to be a real win, it becomes a
+**standing fork requirement**, and that materially strengthens the out-of-tree case:
+
+- A dedicated repo can carry a proper forked-and-pinned dependency — a git dependency
+  on a fork with its own tag, or a vendored tree with a documented rebase process.
+- Doing the same inside `ray` means either committing a vendored copy of `parquet`
+  into the Ray tree, or shipping a `[patch.crates-io]` that every Ray wheel build must
+  resolve — on top of the crates.io fetch that the mirror work has not covered yet.
+- `Cargo.lock` loses its `parquet` checksum line under the patch (the script backs the
+  lock up and restores it on `REVERT` precisely because of this), so the
+  reproducibility story that makes the committed lock meaningful weakens.
+
+Ask about this explicitly: **is the patch load-bearing for the performance numbers?**
+If yes, out-of-tree stops being merely preferable and becomes close to required.
 
 ## Notes for the crate itself
 

--- a/ci/build/RUST-PACKAGING-OPTIONS.md
+++ b/ci/build/RUST-PACKAGING-OPTIONS.md
@@ -1,0 +1,161 @@
+# Packaging Rust extensions in Ray
+
+Working notes on how a PyO3/Rust extension can ship with Ray, written while
+reviewing [#65117](https://github.com/ray-project/ray/pull/65117) (a flag-gated
+arrow-rs Parquet reader for Ray Data). Ray does not package any Rust today, so
+this records what the build system actually permits, what it does not, and why.
+
+## Where Ray's build stands today
+
+| Fact | Where to verify |
+| --- | --- |
+| `python/` has **no `pyproject.toml`**; the build is legacy `setup.py`/setuptools | `ls python/` |
+| Root `pyproject.toml` has **no `[build-system]` table** — only `[tool.ruff]`, `[tool.mypy]`, `requires-python` | `pyproject.toml` |
+| `setup.py` **compiles nothing**. Native artifacts come from Bazel and are `shutil.copy`'d into `build_lib` | `pip_run()` / `copy_file()` in `python/setup.py` |
+| `has_ext_modules()` returns `True` purely to force a platform wheel | `python/setup.py` |
+| **No Rust toolchain anywhere** — `build-manylinux-forge.sh` installs bazelisk, node 14, JDK 8 only | zero hits for `cargo|rustup|maturin|rustc` under `ci/`, `docker/` |
+| Wheel matrix: linux x86_64 + aarch64, macOS x86_64 + arm64, Windows × py3.10–3.14 | `python/build-wheel-*.sh` |
+| Precedent for a second wheel from this repo: `ray-cpp` | `RAY_INSTALL_CPP=1`, `RayCppBdistWheel` in `python/setup.py` |
+| Precedent for a **separately-published native wheel consumed as a dependency**: `ray-haproxy` | `python/requirements.txt`; `setup_spec.extras["serve"]` |
+
+`ray-haproxy` is the important one. It is built in
+[ray-project/ray-haproxy](https://github.com/ray-project/ray-haproxy) by a GitHub
+Actions matrix, inside the same manylinux2014 container tag Ray pins, published
+to PyPI via trusted publishing as `py3-none-manylinux_2_17_{x86_64,aarch64}`,
+then consumed here as one line:
+
+```
+ray-haproxy>=2.8.25,<2.9.0; sys_platform == 'linux'
+```
+
+which flows through raydepsets into every `requirements_compiled*.txt` and
+`deplocks/ci/*.lock`. The plumbing to consume an out-of-tree native wheel is
+already built and in production.
+
+## `rules_rust` is not available to Ray
+
+Ray's C++ comes from Bazel, so building the crate as another Bazel target and
+letting `pip_run()` copy the `.so` — exactly how `_raylet.so` is handled — looks
+like the natural fit. It is not currently possible:
+
+- Ray is on Bazel **7.5.0** in **WORKSPACE mode**: `.bazelrc` line 1 is
+  `common --noenable_bzlmod`, and there is no `MODULE.bazel`.
+- `rules_rust` **removed WORKSPACE support entirely** in
+  [PR #4005](https://github.com/bazelbuild/rules_rust/pull/4005) (merged
+  2026-05-01, shipped in **0.71.0**). Current is 0.73.0.
+- Releases 0.71.0–0.72.0 shipped `http_archive` snippets that do not work;
+  [PR #4180](https://github.com/bazelbuild/rules_rust/pull/4180) removed them
+  from the template.
+- The last WORKSPACE-capable release is **0.70.0** (2026-04-22) — a stale, dead
+  branch.
+- **`rules_rust_pyo3` — the piece actually needed — has never had a WORKSPACE
+  path in any release.** It is a Bazel module by construction:
+  `module(name = "rules_rust_pyo3")` with `bazel_dep(rules_python)` and a bzlmod
+  `use_extension` for its pyo3 crates. At 0.70.0 it pins pyo3 0.28.2.
+
+Bazel 7 does support bzlmod (it is default-on; Ray opted out) and supports hybrid
+`MODULE.bazel` + `WORKSPACE` mode, so a narrow path exists: enable bzlmod, add a
+minimal `MODULE.bazel` for `rules_rust` + `rules_rust_pyo3`, keep everything else
+in WORKSPACE. But flipping bzlmod changes how existing deps resolve (`rules_cc`,
+protobuf, `bazel_skylib`, `rules_python`), which is the classic way to break a
+large C++ build. Bazel 9 removes WORKSPACE, so Ray must migrate eventually —
+just not on one reader's schedule.
+
+**Conclusion: blocked on bzlmod migration. Revisit after.**
+
+## Why not build Rust inside the `ray` wheel
+
+Beyond `rules_rust`, in-tree compilation via `setuptools-rust` (the only Rust
+integration that works with a legacy `setup.py`) requires:
+
+1. Adding a `[build-system]` table, or pre-installing `setuptools-rust` in every
+   build environment, since there is no isolated-build metadata to declare it in.
+2. Adding `rustc` to the manylinux forge, the macOS build hosts, and Windows.
+3. Absorbing a multi-minute cold `cargo` build per platform — `parquet` +
+   `arrow` + `object_store` at `opt-level=3, lto=true, codegen-units=1`. **Bazel's
+   remote cache does not cover cargo.**
+4. A crates.io story compatible with the CodeArtifact/pip-mirror work: cargo is a
+   third package ecosystem fetching at build time, needing `CARGO_NET_*`,
+   `source.crates-io.replace-with`, or a vendored `vendor/` tree.
+5. License attribution for the crate graph (the PR's `Cargo.lock` is 2,637 lines)
+   and CVE scanning that understands crates. `ray-haproxy` carries a
+   `THIRD_PARTY_LICENSES` file and a `grype --fail-on high` gate for this reason.
+
+It also forces the binary on every Ray user, and a single wheel cannot be
+linux-only. For an **optional, flag-gated** reader that is the wrong trade.
+
+Note that `pyca/cryptography`, long the flagship `setuptools-rust` user, has
+since migrated to `build-backend = "maturin"`.
+
+## What the ecosystem does
+
+| Project | Layout | Backend | How Python gets the Rust |
+| --- | --- | --- | --- |
+| **polars** | `py-polars/` in monorepo | **`setuptools.build_meta`** | `dependencies = ["polars-runtime-32 == 1.43.2"]`; `rt64`/`rtcompat` extras select alternative runtime wheels |
+| **pydantic** | separate repo | maturin | `pydantic-core==2.48.0` exact pin |
+| **delta-rs** | `python/` in monorepo | maturin | one wheel; `pyo3-arrow` for the Arrow boundary |
+| **datafusion-python** | separate repo | maturin | one wheel; pyo3 0.29, arrow 59, object_store 0.13.1 |
+| **tokenizers** | `bindings/python/` | maturin | one wheel |
+| **cryptography** | `src/rust/` | maturin (was setuptools-rust) | one wheel |
+
+**polars is the direct precedent for Ray's situation:** the Python-facing package
+is built by plain setuptools with no Rust toolchain involved, and the compiled
+extension is a *separately published, exact-pinned wheel*. Selecting between
+runtime builds via extras is exactly the shape an optional native reader wants.
+
+Nobody in this list buries the crate inside the Python package tree — they all
+use a sibling `python/`, `py-*/`, or `bindings/` directory. #65117 currently
+places it at `python/ray/data/_internal/datasource_v2/native/ray_data_arrow_rs/`,
+**with its own `pyproject.toml`**, which is a hazard for `pip install -e python/`,
+sdist builds, and any tool that walks up to the nearest `pyproject.toml`.
+
+## Recommended sequence
+
+1. **Merge the Python side flag-off.** The reader, PyArrow fallback, metrics and
+   `DataContext` flag can land as inert code — the import is lazy inside
+   `_arrow_rs_supported`. Move the crate to a repo-root `rust/`.
+2. **Build the wheel once in CI; install it where it is needed.** Implemented in
+   this change: `ci/build/build-arrow-rs-wheel.sh` plus a layered
+   `dataarrowrsbuild` image. crates.io is touched by one cached image build
+   rather than by every image, and the artifact produced is the same one a PyPI
+   package would ship.
+3. **Split into `ray-project/ray-data-arrow-rs`** on the `ray-haproxy` pattern:
+   tag-driven GH Actions matrix over manylinux2014 x86_64/aarch64, abi3 wheels,
+   `cargo-audit`/grype gate, `THIRD_PARTY_LICENSES` via `cargo-about`, PyPI
+   trusted publishing. Ray side becomes one line in `extras["data"]`.
+4. **Revisit `rules_rust`** only if the reader becomes non-optional, and only
+   after the bzlmod migration.
+
+## Test-coverage gaps in #65117 as it stands
+
+Both are packaging-independent and worth fixing regardless of the path chosen:
+
+- `python/ray/data/tests/datasource/test_arrow_rs_parquet_reader.py` (2,643 lines)
+  opens with `pytest.importorskip("ray_data_arrow_rs")`, so it **skips silently**
+  wherever the extension is absent — which is everywhere in premerge.
+- The PR adds **no `BUILD.bazel` target** for that file, so
+  `//python/ray/data/...` never enumerates it. The tests cannot run even if the
+  extension were installed.
+
+This change adds the `py_test` target (tagged `arrow_rs`), excludes that tag from
+the general data jobs so they cannot silently skip it, and adds a dedicated job
+that runs it against an image where the extension is actually present.
+
+## Notes for the crate itself
+
+- **pyo3 0.22 → 0.29.** 0.22 is seven releases behind; free-threaded support
+  landed in 0.23. `datafusion-python` — the closest architectural twin — is on
+  0.29 with the same arrow 59 / object_store 0.13.1 pins, so only pyo3 is
+  off-trend. abi3 wheels do not load on free-threaded builds, so if Ray ever
+  ships `cp314t` a separate non-abi3 build is required. (Ray does not build
+  `cp314t` today.)
+- **`abi3-py39` is doing real work:** one binary per platform serves every
+  CPython ≥3.9, making the matrix 5 wheels rather than 25. `build-arrow-rs-wheel.sh`
+  asserts the wheel tag stays `abi3` so this cannot silently regress.
+- **The Arrow C Stream / PyCapsule boundary is the right call** — with only
+  `arrow`'s `ffi` feature there is no pyarrow ABI coupling, so one build serves
+  all pyarrow versions. This is what makes out-of-tree packaging clean. Consider
+  the `pyo3-arrow` crate (used by delta-rs) instead of hand-rolling it.
+- **Pin the API before the first release.** The crate's README lists
+  `decode_budget_bytes`, `k`, `fetch_window_mb` as unexposed; those are API
+  surface, and a `>=0.1,<0.2` bound is only honest once the signature settles.

--- a/ci/build/build-arrow-rs-wheel.sh
+++ b/ci/build/build-arrow-rs-wheel.sh
@@ -1,0 +1,104 @@
+#!/bin/bash
+# build-arrow-rs-wheel.sh -- Build an abi3 wheel for the `ray_data_arrow_rs`
+# native Parquet decoder.
+#
+# WHY THIS EXISTS
+# ---------------
+# Ray cannot build Rust in-tree today:
+#   * python/ has no pyproject.toml -- the build is legacy setup.py/setuptools,
+#     so maturin cannot be Ray's build backend.
+#   * setup.py compiles nothing; native artifacts come from Bazel and are
+#     shutil.copy'd into build_lib by pip_run(). Rust would be the first thing
+#     setuptools actually builds.
+#   * rules_rust is not an option: Ray is on Bazel 7.5.0 in WORKSPACE mode
+#     (.bazelrc: `common --noenable_bzlmod`, no MODULE.bazel), and rules_rust
+#     removed WORKSPACE support in 0.71.0. The piece we would actually need,
+#     rules_rust_pyo3, has never had a WORKSPACE path in any release.
+#
+# So the crate is built ONCE here, into a normal wheel, and everything
+# downstream (CI images, release BYOD images) just `pip install`s that wheel.
+# crates.io is touched by this one script rather than by every image build --
+# which keeps the network surface to a single known hole while the CodeArtifact
+# /pip-mirror work catches up.
+#
+# The wheel this produces is deliberately THE SAME ARTIFACT a future
+# `ray-data-arrow-rs` PyPI package would ship, just from a different index. That
+# makes this a dress rehearsal for the long-term split rather than throwaway
+# scaffolding.
+#
+# ABI3: the crate builds against pyo3's `abi3-py39` feature, so ONE binary per
+# platform works on every CPython >= 3.9. The matrix is 1 wheel per platform,
+# not 1 per (platform x python version).
+#
+# Usage:
+#   ci/build/build-arrow-rs-wheel.sh [OUTPUT_DIR]
+#
+# Environment:
+#   CRATE_DIR       -- crate source dir (default: rust/ray_data_arrow_rs)
+#   RUST_TOOLCHAIN  -- rust toolchain to install/use (default: stable)
+#   MATURIN_VERSION -- maturin version to pin (default: 1.14.1)
+#   CARGO_HOME      -- honoured if preset, so callers can mount a cargo cache
+
+set -exuo pipefail
+
+OUTPUT_DIR="${1:-${PWD}/.whl-arrow-rs}"
+CRATE_DIR="${CRATE_DIR:-rust/ray_data_arrow_rs}"
+RUST_TOOLCHAIN="${RUST_TOOLCHAIN:-stable}"
+MATURIN_VERSION="${MATURIN_VERSION:-1.14.1}"
+
+if [[ ! -f "${CRATE_DIR}/Cargo.toml" ]]; then
+  echo "error: no Cargo.toml under ${CRATE_DIR}" >&2
+  echo "       (expected the crate at the repo-root rust/ directory; set CRATE_DIR to override)" >&2
+  exit 1
+fi
+
+# --- Rust toolchain -------------------------------------------------------
+# None of Ray's build images ship rustc: ci/build/build-manylinux-forge.sh
+# installs bazelisk, node and the JDK only, and there is not a single
+# cargo/rustup/rustc reference anywhere under ci/ or docker/.
+if ! command -v cargo >/dev/null 2>&1; then
+  export CARGO_HOME="${CARGO_HOME:-${HOME}/.cargo}"
+  export RUSTUP_HOME="${RUSTUP_HOME:-${HOME}/.rustup}"
+  curl -sSf https://sh.rustup.rs -o /tmp/rustup-init.sh
+  sh /tmp/rustup-init.sh -y --profile minimal --default-toolchain "${RUST_TOOLCHAIN}" --no-modify-path
+  rm -f /tmp/rustup-init.sh
+fi
+export PATH="${CARGO_HOME:-${HOME}/.cargo}/bin:${PATH}"
+cargo --version
+rustc --version
+
+# Fail fast rather than silently resolving a different dependency set than the
+# one that was reviewed. The committed Cargo.lock is the reproducibility story.
+if [[ ! -f "${CRATE_DIR}/Cargo.lock" ]]; then
+  echo "error: ${CRATE_DIR}/Cargo.lock is missing; refusing to build unpinned" >&2
+  exit 1
+fi
+
+# --- Build ----------------------------------------------------------------
+mkdir -p "${OUTPUT_DIR}"
+pip install --no-cache-dir "maturin==${MATURIN_VERSION}"
+
+# --locked: build exactly the reviewed Cargo.lock, never re-resolve.
+maturin build \
+  --release \
+  --locked \
+  --manifest-path "${CRATE_DIR}/Cargo.toml" \
+  --out "${OUTPUT_DIR}"
+
+# --- Verify ---------------------------------------------------------------
+# An abi3 build must be tagged abi3, not cp3XX -- if the feature silently
+# stopped applying we would start needing one wheel per Python version and
+# nothing would tell us until an install failed on another interpreter.
+shopt -s nullglob
+wheels=("${OUTPUT_DIR}"/*.whl)
+if [[ ${#wheels[@]} -ne 1 ]]; then
+  echo "error: expected exactly 1 wheel in ${OUTPUT_DIR}, got ${#wheels[@]}" >&2
+  exit 1
+fi
+wheel="${wheels[0]}"
+if [[ "$(basename "${wheel}")" != *"abi3"* ]]; then
+  echo "error: ${wheel} is not an abi3 wheel -- did the pyo3 abi3-py39 feature get dropped?" >&2
+  exit 1
+fi
+
+echo "built ${wheel}"

--- a/ci/docker/dataarrowrs.build.Dockerfile
+++ b/ci/docker/dataarrowrs.build.Dockerfile
@@ -1,0 +1,58 @@
+# syntax=docker/dockerfile:1.3-labs
+#
+# Layers the `ray_data_arrow_rs` native Parquet decoder on top of the existing
+# data CI image. Kept as a SEPARATE image, deliberately, so that:
+#
+#   1. rustc/cargo and the crates.io fetch stay out of datalbuild/data17build.
+#      Only the arrow-rs test job pays the cost; every other data test job is
+#      untouched.
+#   2. crates.io enters the CI network surface in exactly one image build, whose
+#      cache key is the crate source (see `srcs` in the wanda yaml), so it
+#      rebuilds only when the crate actually changes. That is one known hole for
+#      the CodeArtifact/pip-mirror work to close, not N.
+#   3. The wheel built here is the same artifact a future `ray-data-arrow-rs`
+#      PyPI package would publish -- so this image is a dress rehearsal for the
+#      long-term repo split, not throwaway scaffolding.
+#
+# Without this, python/ray/data/tests/datasource/test_arrow_rs_parquet_reader.py
+# opens with `pytest.importorskip("ray_data_arrow_rs")` and its entire test
+# module SILENTLY SKIPS in premerge -- green CI over zero coverage.
+
+ARG DOCKER_IMAGE_BASE_BUILD=cr.ray.io/rayproject/datalbuild-py3.10
+FROM $DOCKER_IMAGE_BASE_BUILD
+
+ARG PYTHON=3.10
+
+SHELL ["/bin/bash", "-ice"]
+
+COPY ci/build/build-arrow-rs-wheel.sh /home/ray/ci/build/build-arrow-rs-wheel.sh
+COPY rust/ray_data_arrow_rs /home/ray/rust/ray_data_arrow_rs
+
+RUN <<EOF
+#!/bin/bash
+
+set -ex
+
+cd /home/ray
+
+# Build the abi3 wheel. Several minutes cold: arrow/parquet/object_store at
+# opt-level=3 + lto=true + codegen-units=1. Bazel's remote cache does not cover
+# cargo, which is precisely why this is a cached Docker layer rather than a step
+# inside the Ray wheel build.
+CRATE_DIR=rust/ray_data_arrow_rs \
+  bash ci/build/build-arrow-rs-wheel.sh /home/ray/.whl-arrow-rs
+
+# Install into the image env. --no-deps: the crate has no Python dependencies,
+# and must not be allowed to perturb the depset the base image pinned.
+uv pip install --system --no-deps /home/ray/.whl-arrow-rs/*.whl
+
+# Fail the IMAGE build loudly if the extension is not importable, so a partial
+# build surfaces here instead of as a silent mass `importorskip` at test time --
+# which would look identical to a green run.
+python -c "import ray_data_arrow_rs as m; assert hasattr(m, 'read_row_groups'), dir(m)"
+
+# Discard the toolchain and build tree: rustup + cargo registry + target/ is
+# ~2GB, and nothing at test time needs a compiler.
+rm -r -f /home/ray/.cargo /home/ray/.rustup /home/ray/rust /home/ray/.whl-arrow-rs
+
+EOF

--- a/ci/docker/dataarrowrs.build.wanda.yaml
+++ b/ci/docker/dataarrowrs.build.wanda.yaml
@@ -1,0 +1,11 @@
+name: "dataarrowrsbuild-py$PYTHON"
+froms: ["cr.ray.io/rayproject/datalbuild-py$PYTHON"]
+dockerfile: ci/docker/dataarrowrs.build.Dockerfile
+srcs:
+  - ci/build/build-arrow-rs-wheel.sh
+  - rust/ray_data_arrow_rs/
+build_args:
+  - DOCKER_IMAGE_BASE_BUILD=cr.ray.io/rayproject/datalbuild-py$PYTHON
+  - PYTHON=$PYTHON
+tags:
+  - cr.ray.io/rayproject/dataarrowrsbuild-py$PYTHON

--- a/python/ray/data/BUILD.bazel
+++ b/python/ray/data/BUILD.bazel
@@ -106,6 +106,25 @@ py_test_module_list(
 )
 
 py_test(
+    name = "test_arrow_rs_parquet_reader",
+    size = "large",
+    srcs = ["tests/datasource/test_arrow_rs_parquet_reader.py"],
+    tags = [
+        # Only runs in the dataarrowrsbuild image, which is the only one with the
+        # native `ray_data_arrow_rs` extension installed. Excluded from the
+        # general data jobs via --except-tags so they do not silently
+        # importorskip the whole module and report green.
+        "arrow_rs",
+        "exclusive",
+        "team:data",
+    ],
+    deps = [
+        ":conftest",
+        "//:ray_lib",
+    ],
+)
+
+py_test(
     name = "test_arrow",
     size = "small",
     srcs = ["tests/datasource/test_arrow.py"],

--- a/release/ray_release/byod/byod_arrow_rs_parquet.sh
+++ b/release/ray_release/byod/byod_arrow_rs_parquet.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# Install the `ray_data_arrow_rs` native Parquet decoder into a release-test
+# BYOD image, so tests that read Parquet exercise the Rust reader instead of
+# PyArrow. Runs as a Docker RUN layer at IMAGE BUILD time (has internet).
+#
+# DIFFERENCES FROM THE VERSION IN PR #65117
+# -----------------------------------------
+# That version did:
+#     curl -sL https://github.com/<author>/ray/archive/refs/heads/<branch>.tar.gz
+#     pip3 install /tmp/ray-<branch>/<crate subdir>
+# i.e. every release-test image independently installed a Rust toolchain and
+# compiled the crate from a mutable branch head on a personal fork. That means:
+#   * the artifact under test is whatever that branch pointed at when the image
+#     happened to build -- not reproducible, and not reviewable;
+#   * a fork going away, or being force-pushed, silently changes or breaks the
+#     release suite;
+#   * every image build pays the full arrow/parquet compile and hits crates.io.
+#
+# This version installs a prebuilt, pinned wheel -- the same artifact
+# ci/build/build-arrow-rs-wheel.sh produces for CI, and the same one a future
+# `ray-data-arrow-rs` PyPI release would ship. Set ARROW_RS_WHEEL_URL to a
+# pinned object; the fallback path builds from the in-repo crate so this still
+# works before any wheel has been published.
+set -exo pipefail
+
+# Pin to an immutable artifact (commit-SHA-keyed, not a branch). Override in the
+# test definition to bump.
+ARROW_RS_WHEEL_URL="${ARROW_RS_WHEEL_URL:-}"
+
+if [[ -n "${ARROW_RS_WHEEL_URL}" ]]; then
+  pip3 install --no-cache-dir --no-deps "${ARROW_RS_WHEEL_URL}"
+else
+  # No published wheel yet: build from the crate in this checkout. Same script
+  # CI uses, so the toolchain/pin/verification logic lives in exactly one place.
+  echo "ARROW_RS_WHEEL_URL unset -- building from the in-repo crate" >&2
+  CRATE_DIR="${CRATE_DIR:-rust/ray_data_arrow_rs}" \
+    bash ci/build/build-arrow-rs-wheel.sh /tmp/whl-arrow-rs
+  pip3 install --no-cache-dir --no-deps /tmp/whl-arrow-rs/*.whl
+fi
+
+# Fail the image build loudly if the crate is not importable or is a partial
+# build, so it surfaces here rather than as a scanner error at test run time.
+python3 -c "import ray_data_arrow_rs as m; assert hasattr(m, 'read_row_groups'), dir(m)"


### PR DESCRIPTION
> **Draft / not for merge.** Exploratory branch for my own review of #65117, which
> introduces the first Rust code into Ray. Opening it as a draft so the analysis and
> the CI wiring are reviewable side by side. Nothing here should land as-is: the
> `dataarrowrsbuild` image expects the crate at a repo-root `rust/ray_data_arrow_rs/`,
> which is a **proposed relocation** of where #65117 currently puts it, so CI on this
> branch will not go green standalone.

## Why

#65117 adds a flag-gated arrow-rs Parquet reader — Ray's first Rust. Ray packages no
Rust today, so before reviewing the reader itself I worked out what the build system
actually permits. Full write-up in `ci/build/RUST-PACKAGING-OPTIONS.md`.

## The three things worth knowing

**1. `rules_rust` is not available to us.** This was the option I expected to
recommend, since Bazel already produces `_raylet.so` and `setup.py` just copies it.

- Ray is on Bazel **7.5.0** in **WORKSPACE mode** — `.bazelrc:1` is
  `common --noenable_bzlmod`, no `MODULE.bazel`.
- `rules_rust` **removed WORKSPACE support entirely** in
  [PR #4005](https://github.com/bazelbuild/rules_rust/pull/4005) (merged 2026-05-01,
  shipped 0.71.0). Current is 0.73.0; 0.71–0.72 even advertised broken `http_archive`
  snippets, cleaned up in [#4180](https://github.com/bazelbuild/rules_rust/pull/4180).
- Last WORKSPACE-capable release is **0.70.0** (2026-04-22) — a dead branch.
- **`rules_rust_pyo3`, the piece we'd actually need, has never had a WORKSPACE path in
  any release.** It's a Bazel module by construction.

Hybrid `MODULE.bazel` + `WORKSPACE` is technically possible on Bazel 7, but flipping
bzlmod changes how `rules_cc` / protobuf / `bazel_skylib` / `rules_python` resolve.
Not on one reader's schedule. **Blocked until the bzlmod migration.**

**2. Building Rust inside the `ray` wheel is the wrong trade for an optional reader.**
`setuptools-rust` is the only integration that works with a legacy `setup.py`, but it
needs a `[build-system]` table we don't have, `rustc` on the manylinux + macOS +
Windows builders, a multi-minute cold cargo build per platform that **Bazel's remote
cache cannot cover**, a crates.io story compatible with the CodeArtifact/pip-mirror
work, and license/CVE handling for a 2,637-line `Cargo.lock`. It also forces the
binary on every Ray user. (Note `pyca/cryptography`, the flagship setuptools-rust
user, has since moved to maturin.)

**3. The ecosystem answer is a separately published wheel — and we already do this.**
`polars` is the direct precedent: `py-polars/pyproject.toml` uses
`build-backend = "setuptools.build_meta"` with **no Rust in it**, and depends on
`polars-runtime-32 == 1.43.2`, with `rt64`/`rtcompat` extras selecting alternative
runtime wheels. Same shape for `pydantic` → `pydantic-core==2.48.0`.

And `ray-haproxy` already proves Ray can consume such a wheel: built in
[ray-project/ray-haproxy](https://github.com/ray-project/ray-haproxy) inside the same
manylinux2014 tag we pin, published to PyPI via trusted publishing, consumed as one
line in `extras["serve"]` that flows through raydepsets into every
`requirements_compiled*.txt` and `deplocks/ci/*.lock`.

## What this branch implements

The interim step on that path — build the wheel once, install it where needed:

- **`ci/build/build-arrow-rs-wheel.sh`** — one pinned abi3 wheel via `maturin build
  --release --locked`. Asserts the wheel tag stays `abi3`, because `abi3-py39` is what
  keeps the matrix at 5 wheels instead of 25 and a silent regression there wouldn't
  surface until an install failed on another interpreter.
- **`ci/docker/dataarrowrs.build.{wanda.yaml,Dockerfile}`** — layers the extension on
  top of `datalbuild`. Deliberately a separate image: `rustc` and the crates.io fetch
  stay out of every other data image, and crates.io enters CI in exactly **one** cached
  build keyed on the crate source. One known hole for the mirror work to close, not N.
- **`release/ray_release/byod/byod_arrow_rs_parquet.sh`** — installs the pinned wheel.
  The version in #65117 `curl`s a **mutable branch head from a personal fork** and
  compiles it in every release-test image, so the artifact under test isn't
  reproducible and a force-push silently changes the release suite.

The wheel produced is the same artifact a future `ray-data-arrow-rs` PyPI package
would ship — a dress rehearsal for the split, not throwaway scaffolding.

## Two coverage gaps in #65117, independent of packaging

`test_arrow_rs_parquet_reader.py` (2,643 lines) is **doubly unreachable**:

1. #65117 adds **no `BUILD.bazel` target** for it, so `//python/ray/data/...` never
   enumerates it — it cannot run at all.
2. It opens with `pytest.importorskip("ray_data_arrow_rs")`, so it would **skip
   silently** even if it did, which is indistinguishable from a green run.

Fixed here: adds the `py_test` target under an `arrow_rs` tag, adds that tag to the
general data jobs' `--except-tags` so they can't silently skip it, and adds a job that
runs it against an image where the extension is present.

## Notes for the crate

- **pyo3 0.22 → 0.29.** Seven releases behind; free-threaded support landed in 0.23.
  `datafusion-python` — the closest architectural twin — is on pyo3 0.29 with the *same*
  `arrow 59` / `object_store 0.13.1` pins, so only pyo3 is off-trend.
- **The Arrow C Stream / PyCapsule boundary is the right call.** With only `arrow`'s
  `ffi` feature there's no pyarrow ABI coupling, so one build serves all pyarrow
  versions — this is precisely what makes out-of-tree packaging clean. Consider the
  `pyo3-arrow` crate (delta-rs uses it) rather than hand-rolling it.
- **Move the crate out of `python/ray/`.** A nested `pyproject.toml` under the `ray`
  package tree is a hazard for `pip install -e python/`, sdists, and anything that
  walks up to the nearest `pyproject.toml`. Every project surveyed (polars, delta-rs,
  tokenizers, datafusion-python) uses a sibling `py-*/`, `python/`, or `bindings/` dir.

## Two things the sibling PRs surfaced

Found while running the duplicate check, both worth raising in review:

**#65406 patches the `parquet` crate.** It carries
`arrow_rs_probe/patches/parquet-59.1.0-dict-reserve.diff`, applied by vendoring the
registry source and pointing `[patch.crates-io]` at it from a build-local
`.cargo/config.toml`. Fine for an experiment — but if that patch is load-bearing for
the performance numbers it becomes a **standing fork requirement**, which a dedicated
repo can carry properly (fork + tag, or a vendored tree with a rebase process) and the
Ray tree really cannot, especially layered on a crates.io fetch the mirror work
hasn't covered. It also costs `Cargo.lock` its `parquet` checksum line — the script
backs the lock up and restores it on `REVERT` for exactly that reason — which weakens
the reproducibility the committed lock exists to provide. **Worth asking directly
whether the patch is load-bearing;** if it is, out-of-tree stops being merely
preferable.

**The missing test target is systemic, not a one-draft slip.** #65406's `BUILD.bazel`
patch contains **zero** `arrow_rs` mentions either. Across the whole effort the
2,643-line test file has never been registered with Bazel.

---

## Contribution policy disclosure

Per `AGENTS.md`:

- **AI assistance was used** for the research and for drafting the CI wiring in this
  branch.
- **Not a duplicate.** `gh pr list --search` over `arrow-rs` / `rules_rust` /
  `rust packaging` / `maturin` / `pyo3` returns no other PR addressing Rust
  *packaging*. The related open PRs are all the reader/benchmark effort itself —
  #65117 (the reader), #65217 and #65407 (PyArrow baseline arms), #65406 (A/B
  treatment arm, stacked on #64985). None of them changes how Rust is built or
  shipped, which is the only thing this branch touches.
- **Tests run:** `pre-commit run` on the changed files — buildifier, buildifier-lint,
  shellcheck and semgrep all **Passed** (see commit). YAML parse-checked with
  `yaml.safe_load` for `.buildkite/data.rayci.yml` and the wanda config. The
  `dataarrowrsbuild` image and the new `arrow_rs` test job are **not yet executed** —
  they cannot be until the crate lands at `rust/ray_data_arrow_rs/`, which is why this
  is a draft and not a merge candidate.
- **Not for merge.** This is a review aid, not a change request. A human needs to
  own and defend any part of it that is proposed for real.
