### PR TITLE
[ci] Keep the job-local package index out of `requirements_compiled.txt`

### DIFF
--- a/ci/ci.sh
+++ b/ci/ci.sh
@@ -39,7 +39,11 @@ compile_pip_dependencies() {
     python -c "import torch" 2>/dev/null && HAS_TORCH=1
     pip install --no-cache-dir numpy torch
 
-    pip-compile --verbose --resolver=backtracking \
+    # pip-compile writes whatever index it used into the lockfile. Keep CI's temporary
+    # mirror URL out, or the regenerated file stops matching the committed one.
+    env -u PIP_INDEX_URL -u PIP_EXTRA_INDEX_URL -u PIP_TRUSTED_HOST \
+      -u UV_INDEX_URL -u UV_EXTRA_INDEX_URL -u UV_INSECURE_HOST \
+      pip-compile --verbose --resolver=backtracking \
       --pip-args --no-deps --strip-extras --no-header \
       --unsafe-package ray \
       --unsafe-package pip \


### PR DESCRIPTION
## Description
`pip-compile` bakes whatever index it used into the file it writes. Since #65578 that's CI's per-job mirror URL, so the regenerated lockfile never matches the committed one and the step fails. Unsetting the index vars for that command keeps the header canonical.

## Related issues
Resolves `pip-compile dependencies` [step](https://buildkite.com/ray-project/premerge/builds/72282/table) in https://github.com/ray-project/ray/pull/65351.

## Validation
`pip-compile dependencies` [step](https://buildkite.com/ray-project/premerge/builds/72323/canvas?sid=01a02668-48bd-45a5-96f8-12929b8c0deb&tab=output) passes after cp'ing this fix.

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
