### PR TITLE
Add perf metrics for 2.58.0

### DIFF
--- a/release/perf_metrics/benchmarks/many_actors.json
+++ b/release/perf_metrics/benchmarks/many_actors.json
@@ -1,31 +1,31 @@
 {
-    "_dashboard_memory_usage_mb": 103.878656,
+    "_dashboard_memory_usage_mb": 120.651776,
     "_dashboard_test_success": true,
-    "_peak_memory": 4.24,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n4039\t1.65GiB\t/home/ray/anaconda3/lib/python3.10/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/\n6384\t0.81GiB\tpython distributed/test_many_actors.py\n3153\t0.69GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n4247\t0.29GiB\tray-dashboard-NodeHead-0 (/home/ray/anaconda3/bin/python3.10 -c \"from multiprocessing.spawn import s\n4704\t0.16GiB\tray::DashboardAgent\n3359\t0.12GiB\t/app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/_main/infra/dataplane/web\n1398\t0.12GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n4168\t0.09GiB\t/home/ray/anaconda3/bin/python3.10 /home/ray/anaconda3/lib/python3.10/site-packages/ray/dashboard/da\n4706\t0.09GiB\tray::RuntimeEnvAgent\n6512\t0.08GiB\tray::DashboardTester.run",
-    "actors_per_second": 575.2367632651517,
+    "_peak_memory": 4.17,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n1681\t4.54GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n4119\t1.5GiB\t/home/ray/anaconda3/lib/python3.10/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/\n5432\t0.81GiB\tpython distributed/test_many_actors.py\n3293\t0.79GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n4335\t0.31GiB\tray-dashboard-NodeHead-0 (/home/ray/anaconda3/bin/python3.10 -c \"from multiprocessing.spawn import s\n601\t0.27GiB\t/app/go/infra/anyscaled/anyscaled_/anyscaled_shim --cloud_provider=aws\n4791\t0.19GiB\tray::DashboardAgent\n3493\t0.13GiB\t/app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/_main/infra/dataplane/web\n4250\t0.12GiB\t/home/ray/anaconda3/bin/python3.10 /home/ray/anaconda3/lib/python3.10/site-packages/ray/dashboard/da\n4793\t0.09GiB\tray::RuntimeEnvAgent",
+    "actors_per_second": 575.4552115567288,
     "num_actors": 10000,
     "perf_metrics": [
         {
             "perf_metric_name": "actors_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 575.2367632651517
+            "perf_metric_value": 575.4552115567288
         },
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 9.881
+            "perf_metric_value": 9.378
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 1495.388
+            "perf_metric_value": 1604.549
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 5021.808
+            "perf_metric_value": 3575.026
         }
     ],
-    "time": 17.384146213531494
+    "time": 17.377547025680542
 }

--- a/release/perf_metrics/benchmarks/many_nodes.json
+++ b/release/perf_metrics/benchmarks/many_nodes.json
@@ -1,14 +1,14 @@
 {
-    "_dashboard_memory_usage_mb": 103.510016,
+    "_dashboard_memory_usage_mb": 140.095488,
     "_dashboard_test_success": true,
-    "_peak_memory": 10.66,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n3989\t0.53GiB\t/home/ray/anaconda3/lib/python3.10/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/\n3087\t0.36GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n9017\t0.18GiB\tpython distributed/test_many_tasks.py --num-tasks=1000\n4192\t0.16GiB\tray-dashboard-NodeHead-0 (/home/ray/anaconda3/bin/python3.10 -c \"from multiprocessing.spawn import s\n4667\t0.15GiB\tray::DashboardAgent\n3228\t0.12GiB\t/app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/_main/infra/dataplane/web\n1350\t0.12GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n5093\t0.09GiB\tray::StateAPIGeneratorActor.start\n4669\t0.09GiB\tray::RuntimeEnvAgent\n4195\t0.09GiB\tray-dashboard-StateHead-0 (/home/ray/anaconda3/bin/python3.10 -c \"from multiprocessing.spawn import",
+    "_peak_memory": 10.7,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n4114\t0.5GiB\t/home/ray/anaconda3/lib/python3.10/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/\n3265\t0.41GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n10449\t0.17GiB\tpython distributed/test_many_tasks.py --num-tasks=1000\n4800\t0.17GiB\tray::DashboardAgent\n4325\t0.17GiB\tray-dashboard-NodeHead-0 (/home/ray/anaconda3/bin/python3.10 -c \"from multiprocessing.spawn import s\n1317\t0.15GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n3259\t0.13GiB\t/app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/_main/infra/dataplane/web\n4245\t0.12GiB\t/home/ray/anaconda3/bin/python3.10 /home/ray/anaconda3/lib/python3.10/site-packages/ray/dashboard/da\n4323\t0.1GiB\tray-dashboard-EventHead-0 (/home/ray/anaconda3/bin/python3.10 -c \"from multiprocessing.spawn import\n6513\t0.09GiB\tray::StateAPIGeneratorActor.start",
     "num_tasks": 1000,
     "perf_metrics": [
         {
             "perf_metric_name": "tasks_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 372.4894970726082
+            "perf_metric_value": 385.5788517330624
         },
         {
             "perf_metric_name": "used_cpus_by_deadline",
@@ -18,20 +18,20 @@
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 5.563
+            "perf_metric_value": 8.032
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 21.245
+            "perf_metric_value": 41.814
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 73.808
+            "perf_metric_value": 57.05
         }
     ],
-    "tasks_per_second": 372.4894970726082,
-    "time": 302.68463945388794,
+    "tasks_per_second": 385.5788517330624,
+    "time": 302.59350323677063,
     "used_cpus": 250.0
 }

--- a/release/perf_metrics/benchmarks/many_pgs.json
+++ b/release/perf_metrics/benchmarks/many_pgs.json
@@ -1,31 +1,31 @@
 {
-    "_dashboard_memory_usage_mb": 80.777216,
+    "_dashboard_memory_usage_mb": 104.357888,
     "_dashboard_test_success": true,
-    "_peak_memory": 2.75,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n4151\t0.85GiB\t/home/ray/anaconda3/lib/python3.10/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/\n3187\t0.69GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n5491\t0.39GiB\tpython distributed/test_many_pgs.py\n602\t0.26GiB\t/app/go/infra/anyscaled/anyscaled_/anyscaled_shim --cloud_provider=aws\n4355\t0.15GiB\tray-dashboard-NodeHead-0 (/home/ray/anaconda3/bin/python3.10 -c \"from multiprocessing.spawn import s\n4810\t0.14GiB\tray::DashboardAgent\n3412\t0.12GiB\t/app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/_main/infra/dataplane/web\n1412\t0.12GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n4812\t0.09GiB\tray::RuntimeEnvAgent\n4283\t0.08GiB\t/home/ray/anaconda3/bin/python3.10 /home/ray/anaconda3/lib/python3.10/site-packages/ray/dashboard/da",
+    "_peak_memory": 2.74,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n1370\t4.36GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n4098\t0.77GiB\t/home/ray/anaconda3/lib/python3.10/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/\n3133\t0.68GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n5425\t0.39GiB\tpython distributed/test_many_pgs.py\n608\t0.27GiB\t/app/go/infra/anyscaled/anyscaled_/anyscaled_shim --cloud_provider=aws\n4772\t0.18GiB\tray::DashboardAgent\n4310\t0.15GiB\tray-dashboard-NodeHead-0 (/home/ray/anaconda3/bin/python3.10 -c \"from multiprocessing.spawn import s\n3471\t0.13GiB\t/app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/_main/infra/dataplane/web\n4229\t0.11GiB\t/home/ray/anaconda3/bin/python3.10 /home/ray/anaconda3/lib/python3.10/site-packages/ray/dashboard/da\n4774\t0.09GiB\tray::RuntimeEnvAgent",
     "num_pgs": 1000,
     "perf_metrics": [
         {
             "perf_metric_name": "pgs_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 80.5479506142037
+            "perf_metric_value": 77.83217078176452
         },
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 5.549
+            "perf_metric_value": 6.24
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 123.178
+            "perf_metric_value": 291.633
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 1232.673
+            "perf_metric_value": 2176.677
         }
     ],
-    "pgs_per_second": 80.5479506142037,
-    "time": 12.414965152740479
+    "pgs_per_second": 77.83217078176452,
+    "time": 12.84815764427185
 }

--- a/release/perf_metrics/benchmarks/many_tasks.json
+++ b/release/perf_metrics/benchmarks/many_tasks.json
@@ -1,14 +1,14 @@
 {
-    "_dashboard_memory_usage_mb": 109.01504,
+    "_dashboard_memory_usage_mb": 136.548352,
     "_dashboard_test_success": true,
-    "_peak_memory": 4.19,
-    "_peak_process_memory": "PID\tMEM\tCOMMAND\n4034\t1.5GiB\t/home/ray/anaconda3/lib/python3.10/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/\n7860\t0.64GiB\tpython distributed/test_many_tasks.py --num-tasks=10000\n4242\t0.4GiB\tray-dashboard-NodeHead-0 (/home/ray/anaconda3/bin/python3.10 -c \"from multiprocessing.spawn import s\n3440\t0.4GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n4245\t0.17GiB\tray-dashboard-StateHead-0 (/home/ray/anaconda3/bin/python3.10 -c \"from multiprocessing.spawn import\n4699\t0.13GiB\tray::DashboardAgent\n3116\t0.12GiB\t/app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/_main/infra/dataplane/web\n1354\t0.11GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n4164\t0.1GiB\t/home/ray/anaconda3/bin/python3.10 /home/ray/anaconda3/lib/python3.10/site-packages/ray/dashboard/da\n8043\t0.09GiB\tray::StateAPIGeneratorActor.start",
+    "_peak_memory": 3.9,
+    "_peak_process_memory": "PID\tMEM\tCOMMAND\n4128\t0.98GiB\t/home/ray/anaconda3/lib/python3.10/site-packages/ray/core/src/ray/gcs/gcs_server --log_dir=/tmp/ray/\n5465\t0.73GiB\tpython distributed/test_many_tasks.py --num-tasks=10000\n4340\t0.51GiB\tray-dashboard-NodeHead-0 (/home/ray/anaconda3/bin/python3.10 -c \"from multiprocessing.spawn import s\n3248\t0.4GiB\tvector --watch-config --log-format json --config-yaml /etc/vector/vector.yaml\n4343\t0.18GiB\tray-dashboard-StateHead-0 (/home/ray/anaconda3/bin/python3.10 -c \"from multiprocessing.spawn import\n4796\t0.15GiB\tray::DashboardAgent\n3581\t0.13GiB\t/app/infra/dataplane/webterminal/webterminal_sidecar_image.binary.runfiles/_main/infra/dataplane/web\n4259\t0.12GiB\t/home/ray/anaconda3/bin/python3.10 /home/ray/anaconda3/lib/python3.10/site-packages/ray/dashboard/da\n1416\t0.11GiB\t/app/product/go/infra/anyscaled/anyscaled_/anyscaled startv2 --control_plane_url=https://console.any\n5656\t0.09GiB\tray::StateAPIGeneratorActor.start",
     "num_tasks": 10000,
     "perf_metrics": [
         {
             "perf_metric_name": "tasks_per_second",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 394.485537053648
+            "perf_metric_value": 679.1218473741691
         },
         {
             "perf_metric_name": "used_cpus_by_deadline",
@@ -18,20 +18,20 @@
         {
             "perf_metric_name": "dashboard_p50_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 5.626
+            "perf_metric_value": 4.222
         },
         {
             "perf_metric_name": "dashboard_p95_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 539.129
+            "perf_metric_value": 509.775
         },
         {
             "perf_metric_name": "dashboard_p99_latency_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 821.172
+            "perf_metric_value": 788.732
         }
     ],
-    "tasks_per_second": 394.485537053648,
-    "time": 325.34947180747986,
+    "tasks_per_second": 679.1218473741691,
+    "time": 314.7248980998993,
     "used_cpus": 2500.0
 }

--- a/release/perf_metrics/metadata.json
+++ b/release/perf_metrics/metadata.json
@@ -1,1 +1,1 @@
-{"release_version": "2.57.0"}
+{"release_version": "2.58.0"}

--- a/release/perf_metrics/microbenchmark.json
+++ b/release/perf_metrics/microbenchmark.json
@@ -1,283 +1,283 @@
 {
     "1_1_actor_calls_async": [
-        8186.409763644163,
-        486.5307476289957
+        8094.2260254689545,
+        707.0619710608702
     ],
     "1_1_actor_calls_concurrent": [
-        5284.869670924241,
-        124.34422351130499
+        5187.193159330975,
+        85.06655445803841
     ],
     "1_1_actor_calls_sync": [
-        1762.981738621782,
-        30.020607171834822
+        1846.1936742961207,
+        43.94470160130632
     ],
     "1_1_async_actor_calls_async": [
-        4316.252934983355,
-        244.42668329991048
+        4736.447432402996,
+        247.78106901642775
     ],
     "1_1_async_actor_calls_sync": [
-        1431.6733545471534,
-        29.528161597975707
+        1333.3942865801073,
+        27.060896086615443
     ],
     "1_1_async_actor_calls_with_args_async": [
-        2787.1513643694384,
-        94.73319485213824
+        3031.8167069314627,
+        119.5170056305336
     ],
     "1_n_actor_calls_async": [
-        7290.9981617147205,
-        109.80643807629221
+        7288.790924093237,
+        204.35850125294286
     ],
     "1_n_async_actor_calls_async": [
-        6593.858018500617,
-        50.10711194322327
+        6718.36682767359,
+        123.43249616756623
     ],
     "client__1_1_actor_calls_async": [
-        1092.036489331336,
-        21.251398497292133
+        1011.6564673574112,
+        47.827767446604426
     ],
     "client__1_1_actor_calls_concurrent": [
-        1084.8717687413014,
-        10.829594843788104
+        1000.9359447158477,
+        48.93233078620189
     ],
     "client__1_1_actor_calls_sync": [
-        565.7541836789418,
-        9.292877526993491
+        471.10200399969307,
+        11.53121641174535
     ],
     "client__get_calls": [
-        1278.569826688682,
-        14.088477736189011
+        1185.5602045767582,
+        72.69177940245271
     ],
     "client__put_calls": [
-        889.5329862378343,
-        11.620405625510138
+        848.0729808839194,
+        23.019574719412276
     ],
     "client__put_gigabytes": [
-        0.09831584527705356,
-        0.00023628170361922253
+        0.09735769295584877,
+        0.00012461091977483205
     ],
     "client__tasks_and_get_batch": [
-        0.9961826702031711,
-        0.022938571970378286
+        0.9837742253161064,
+        0.024749144332186453
     ],
     "client__tasks_and_put_batch": [
-        12454.124196972278,
-        116.27942566772052
+        12555.231404190981,
+        169.73890002720302
     ],
     "multi_client_put_calls_Plasma_Store": [
-        13244.105950746582,
-        112.3717261116124
+        13246.715124165396,
+        355.12027016409996
     ],
     "multi_client_put_gigabytes": [
-        25.381910497853127,
-        0.6742332658538565
+        36.37387248852827,
+        8.831558228540151
     ],
     "multi_client_tasks_async": [
-        20040.412649086153,
-        2431.055244583116
+        20039.936841581017,
+        2606.18125002163
     ],
     "n_n_actor_calls_async": [
-        23595.113141483285,
-        685.4980586704168
+        23486.472941833294,
+        281.6746317977487
     ],
     "n_n_actor_calls_with_arg_async": [
-        13039.93450305723,
-        164.59369993875492
+        12631.542267554785,
+        355.80559193289486
     ],
     "n_n_async_actor_calls_async": [
-        21466.85058122358,
-        526.1864549109472
+        21193.739315106726,
+        573.4275385199624
     ],
     "perf_metrics": [
         {
             "perf_metric_name": "single_client_get_calls_Plasma_Store",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 13365.861980877578
+            "perf_metric_value": 14475.926548278901
         },
         {
             "perf_metric_name": "single_client_put_calls_Plasma_Store",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 3835.5368509218897
+            "perf_metric_value": 3832.376634277673
         },
         {
             "perf_metric_name": "multi_client_put_calls_Plasma_Store",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 13244.105950746582
+            "perf_metric_value": 13246.715124165396
         },
         {
             "perf_metric_name": "single_client_put_gigabytes",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 16.486982160932076
+            "perf_metric_value": 15.187653730186867
         },
         {
             "perf_metric_name": "single_client_tasks_and_get_batch",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 7.359631180965369
+            "perf_metric_value": 6.6540420898154675
         },
         {
             "perf_metric_name": "multi_client_put_gigabytes",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 25.381910497853127
+            "perf_metric_value": 36.37387248852827
         },
         {
             "perf_metric_name": "single_client_get_object_containing_10k_refs",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 11.636464936390913
+            "perf_metric_value": 8.917427418167577
         },
         {
             "perf_metric_name": "single_client_wait_1k_refs",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 5.151820832614535
+            "perf_metric_value": 4.864679789608971
         },
         {
             "perf_metric_name": "single_client_tasks_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 805.0151398744031
+            "perf_metric_value": 811.1303849696787
         },
         {
             "perf_metric_name": "single_client_tasks_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 7532.807888515144
+            "perf_metric_value": 7174.684387734689
         },
         {
             "perf_metric_name": "multi_client_tasks_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 20040.412649086153
+            "perf_metric_value": 20039.936841581017
         },
         {
             "perf_metric_name": "1_1_actor_calls_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1762.981738621782
+            "perf_metric_value": 1846.1936742961207
         },
         {
             "perf_metric_name": "1_1_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 8186.409763644163
+            "perf_metric_value": 8094.2260254689545
         },
         {
             "perf_metric_name": "1_1_actor_calls_concurrent",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 5284.869670924241
+            "perf_metric_value": 5187.193159330975
         },
         {
             "perf_metric_name": "1_n_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 7290.9981617147205
+            "perf_metric_value": 7288.790924093237
         },
         {
             "perf_metric_name": "n_n_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 23595.113141483285
+            "perf_metric_value": 23486.472941833294
         },
         {
             "perf_metric_name": "n_n_actor_calls_with_arg_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 13039.93450305723
+            "perf_metric_value": 12631.542267554785
         },
         {
             "perf_metric_name": "1_1_async_actor_calls_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1431.6733545471534
+            "perf_metric_value": 1333.3942865801073
         },
         {
             "perf_metric_name": "1_1_async_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 4316.252934983355
+            "perf_metric_value": 4736.447432402996
         },
         {
             "perf_metric_name": "1_1_async_actor_calls_with_args_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 2787.1513643694384
+            "perf_metric_value": 3031.8167069314627
         },
         {
             "perf_metric_name": "1_n_async_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 6593.858018500617
+            "perf_metric_value": 6718.36682767359
         },
         {
             "perf_metric_name": "n_n_async_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 21466.85058122358
+            "perf_metric_value": 21193.739315106726
         },
         {
             "perf_metric_name": "placement_group_create/removal",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 685.2610263762494
+            "perf_metric_value": 675.9295309326174
         },
         {
             "perf_metric_name": "client__get_calls",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1278.569826688682
+            "perf_metric_value": 1185.5602045767582
         },
         {
             "perf_metric_name": "client__put_calls",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 889.5329862378343
+            "perf_metric_value": 848.0729808839194
         },
         {
             "perf_metric_name": "client__put_gigabytes",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 0.09831584527705356
+            "perf_metric_value": 0.09735769295584877
         },
         {
             "perf_metric_name": "client__tasks_and_put_batch",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 12454.124196972278
+            "perf_metric_value": 12555.231404190981
         },
         {
             "perf_metric_name": "client__1_1_actor_calls_sync",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 565.7541836789418
+            "perf_metric_value": 471.10200399969307
         },
         {
             "perf_metric_name": "client__1_1_actor_calls_async",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1092.036489331336
+            "perf_metric_value": 1011.6564673574112
         },
         {
             "perf_metric_name": "client__1_1_actor_calls_concurrent",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 1084.8717687413014
+            "perf_metric_value": 1000.9359447158477
         },
         {
             "perf_metric_name": "client__tasks_and_get_batch",
             "perf_metric_type": "THROUGHPUT",
-            "perf_metric_value": 0.9961826702031711
+            "perf_metric_value": 0.9837742253161064
         }
     ],
     "placement_group_create/removal": [
-        685.2610263762494,
-        13.311054672654826
+        675.9295309326174,
+        5.9553259965004735
     ],
     "single_client_get_calls_Plasma_Store": [
-        13365.861980877578,
-        53.56537524402756
+        14475.926548278901,
+        95.48795883474875
     ],
     "single_client_get_object_containing_10k_refs": [
-        11.636464936390913,
-        0.12467210613607298
+        8.917427418167577,
+        0.13871428236514557
     ],
     "single_client_put_calls_Plasma_Store": [
-        3835.5368509218897,
-        36.88280252113266
+        3832.376634277673,
+        50.85474260199841
     ],
     "single_client_put_gigabytes": [
-        16.486982160932076,
-        7.479877025042128
+        15.187653730186867,
+        7.046492183041437
     ],
     "single_client_tasks_and_get_batch": [
-        7.359631180965369,
-        0.5093000051388014
+        6.6540420898154675,
+        0.515232358105774
     ],
     "single_client_tasks_async": [
-        7532.807888515144,
-        350.78157707571137
+        7174.684387734689,
+        345.33721923478487
     ],
     "single_client_tasks_sync": [
-        805.0151398744031,
-        4.947216886404141
+        811.1303849696787,
+        31.773840361438086
     ],
     "single_client_wait_1k_refs": [
-        5.151820832614535,
-        0.12973753812448197
+        4.864679789608971,
+        0.07026071536947254
     ]
 }

--- a/release/perf_metrics/scalability/object_store.json
+++ b/release/perf_metrics/scalability/object_store.json
@@ -1,12 +1,12 @@
 {
-    "broadcast_time": 12.227769943000013,
+    "broadcast_time": 15.248129470999999,
     "num_nodes": 50,
     "object_size": 1073741824,
     "perf_metrics": [
         {
             "perf_metric_name": "time_to_broadcast_1073741824_bytes_to_50_nodes",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 12.227769943000013
+            "perf_metric_value": 15.248129470999999
         }
     ]
 }

--- a/release/perf_metrics/scalability/single_node.json
+++ b/release/perf_metrics/scalability/single_node.json
@@ -1,8 +1,8 @@
 {
-    "args_time": 11.455117911999992,
-    "get_time": 15.232457393000004,
+    "args_time": 11.077386925000006,
+    "get_time": 15.641607194999992,
     "large_object_size": 107374182400,
-    "large_object_time": 23.115384712000008,
+    "large_object_time": 23.303509843,
     "num_args": 10000,
     "num_get_args": 10000,
     "num_queued": 1000000,
@@ -11,30 +11,30 @@
         {
             "perf_metric_name": "10000_args_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 11.455117911999992
+            "perf_metric_value": 11.077386925000006
         },
         {
             "perf_metric_name": "3000_returns_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 3.682571508999999
+            "perf_metric_value": 3.559587253999993
         },
         {
             "perf_metric_name": "10000_get_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 15.232457393000004
+            "perf_metric_value": 15.641607194999992
         },
         {
             "perf_metric_name": "1000000_queued_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 117.105490623
+            "perf_metric_value": 117.120874476
         },
         {
             "perf_metric_name": "107374182400_large_object_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 23.115384712000008
+            "perf_metric_value": 23.303509843
         }
     ],
-    "queued_time": 117.105490623,
-    "returns_time": 3.682571508999999,
+    "queued_time": 117.120874476,
+    "returns_time": 3.559587253999993,
     "success": "1"
 }

--- a/release/perf_metrics/stress_tests/stress_test_dead_actors.json
+++ b/release/perf_metrics/stress_tests/stress_test_dead_actors.json
@@ -1,13 +1,13 @@
 {
-    "avg_iteration_time": 1.0499977922439576,
-    "max_iteration_time": 2.2114224433898926,
-    "min_iteration_time": 0.16539263725280762,
+    "avg_iteration_time": 1.0815906953811645,
+    "max_iteration_time": 3.5237433910369873,
+    "min_iteration_time": 0.046437978744506836,
     "perf_metrics": [
         {
             "perf_metric_name": "avg_iteration_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 1.0499977922439576
+            "perf_metric_value": 1.0815906953811645
         }
     ],
-    "total_time": 104.99990391731262
+    "total_time": 108.15919184684753
 }

--- a/release/perf_metrics/stress_tests/stress_test_many_tasks.json
+++ b/release/perf_metrics/stress_tests/stress_test_many_tasks.json
@@ -3,44 +3,44 @@
         {
             "perf_metric_name": "stage_0_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 7.086855411529541
+            "perf_metric_value": 7.4279701709747314
         },
         {
             "perf_metric_name": "stage_1_avg_iteration_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 14.038756632804871
+            "perf_metric_value": 14.088277506828309
         },
         {
             "perf_metric_name": "stage_2_avg_iteration_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 34.95041303634643
+            "perf_metric_value": 35.62842493057251
         },
         {
             "perf_metric_name": "stage_3_creation_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 1.732691764831543
+            "perf_metric_value": 1.6627838611602783
         },
         {
             "perf_metric_name": "stage_3_time",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 2363.575121164322
+            "perf_metric_value": 2372.078004837036
         },
         {
             "perf_metric_name": "stage_4_spread",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 0.2916004517821898
+            "perf_metric_value": 0.294463310198033
         }
     ],
-    "stage_0_time": 7.086855411529541,
-    "stage_1_avg_iteration_time": 14.038756632804871,
-    "stage_1_max_iteration_time": 14.964024543762207,
-    "stage_1_min_iteration_time": 12.448106288909912,
-    "stage_1_time": 140.38762545585632,
-    "stage_2_avg_iteration_time": 34.95041303634643,
-    "stage_2_max_iteration_time": 36.673638582229614,
-    "stage_2_min_iteration_time": 34.362250328063965,
-    "stage_2_time": 174.7525782585144,
-    "stage_3_creation_time": 1.732691764831543,
-    "stage_3_time": 2363.575121164322,
-    "stage_4_spread": 0.2916004517821898
+    "stage_0_time": 7.4279701709747314,
+    "stage_1_avg_iteration_time": 14.088277506828309,
+    "stage_1_max_iteration_time": 14.81465768814087,
+    "stage_1_min_iteration_time": 12.657217741012573,
+    "stage_1_time": 140.88283801078796,
+    "stage_2_avg_iteration_time": 35.62842493057251,
+    "stage_2_max_iteration_time": 37.54865860939026,
+    "stage_2_min_iteration_time": 34.85753512382507,
+    "stage_2_time": 178.14268445968628,
+    "stage_3_creation_time": 1.6627838611602783,
+    "stage_3_time": 2372.078004837036,
+    "stage_4_spread": 0.294463310198033
 }

--- a/release/perf_metrics/stress_tests/stress_test_placement_group.json
+++ b/release/perf_metrics/stress_tests/stress_test_placement_group.json
@@ -1,16 +1,16 @@
 {
-    "avg_pg_create_time_ms": 1.7500006561557806,
-    "avg_pg_remove_time_ms": 1.497989546546467,
+    "avg_pg_create_time_ms": 1.7538635525522477,
+    "avg_pg_remove_time_ms": 1.517630687687757,
     "perf_metrics": [
         {
             "perf_metric_name": "avg_pg_create_time_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 1.7500006561557806
+            "perf_metric_value": 1.7538635525522477
         },
         {
             "perf_metric_name": "avg_pg_remove_time_ms",
             "perf_metric_type": "LATENCY",
-            "perf_metric_value": 1.497989546546467
+            "perf_metric_value": 1.517630687687757
         }
     ]
 }


### PR DESCRIPTION
```
REGRESSION 23.37%: single_client_get_object_containing_10k_refs (THROUGHPUT) regresses from 11.636464936390913 to 8.917427418167577 in microbenchmark.json
REGRESSION 16.73%: client__1_1_actor_calls_sync (THROUGHPUT) regresses from 565.7541836789418 to 471.10200399969307 in microbenchmark.json
REGRESSION 9.59%: single_client_tasks_and_get_batch (THROUGHPUT) regresses from 7.359631180965369 to 6.6540420898154675 in microbenchmark.json
REGRESSION 7.88%: single_client_put_gigabytes (THROUGHPUT) regresses from 16.486982160932076 to 15.187653730186867 in microbenchmark.json
REGRESSION 7.74%: client__1_1_actor_calls_concurrent (THROUGHPUT) regresses from 1084.8717687413014 to 1000.9359447158477 in microbenchmark.json
REGRESSION 7.36%: client__1_1_actor_calls_async (THROUGHPUT) regresses from 1092.036489331336 to 1011.6564673574112 in microbenchmark.json
REGRESSION 7.27%: client__get_calls (THROUGHPUT) regresses from 1278.569826688682 to 1185.5602045767582 in microbenchmark.json
REGRESSION 6.86%: 1_1_async_actor_calls_sync (THROUGHPUT) regresses from 1431.6733545471534 to 1333.3942865801073 in microbenchmark.json
REGRESSION 5.57%: single_client_wait_1k_refs (THROUGHPUT) regresses from 5.151820832614535 to 4.864679789608971 in microbenchmark.json
REGRESSION 4.75%: single_client_tasks_async (THROUGHPUT) regresses from 7532.807888515144 to 7174.684387734689 in microbenchmark.json
REGRESSION 4.66%: client__put_calls (THROUGHPUT) regresses from 889.5329862378343 to 848.0729808839194 in microbenchmark.json
REGRESSION 3.37%: pgs_per_second (THROUGHPUT) regresses from 80.5479506142037 to 77.83217078176452 in benchmarks/many_pgs.json
REGRESSION 3.13%: n_n_actor_calls_with_arg_async (THROUGHPUT) regresses from 13039.93450305723 to 12631.542267554785 in microbenchmark.json
REGRESSION 1.85%: 1_1_actor_calls_concurrent (THROUGHPUT) regresses from 5284.869670924241 to 5187.193159330975 in microbenchmark.json
REGRESSION 1.36%: placement_group_create/removal (THROUGHPUT) regresses from 685.2610263762494 to 675.9295309326174 in microbenchmark.json
REGRESSION 1.27%: n_n_async_actor_calls_async (THROUGHPUT) regresses from 21466.85058122358 to 21193.739315106726 in microbenchmark.json
REGRESSION 1.25%: client__tasks_and_get_batch (THROUGHPUT) regresses from 0.9961826702031711 to 0.9837742253161064 in microbenchmark.json
REGRESSION 1.13%: 1_1_actor_calls_async (THROUGHPUT) regresses from 8186.409763644163 to 8094.2260254689545 in microbenchmark.json
REGRESSION 0.97%: client__put_gigabytes (THROUGHPUT) regresses from 0.09831584527705356 to 0.09735769295584877 in microbenchmark.json
REGRESSION 0.46%: n_n_actor_calls_async (THROUGHPUT) regresses from 23595.113141483285 to 23486.472941833294 in microbenchmark.json
REGRESSION 0.08%: single_client_put_calls_Plasma_Store (THROUGHPUT) regresses from 3835.5368509218897 to 3832.376634277673 in microbenchmark.json
REGRESSION 0.03%: 1_n_actor_calls_async (THROUGHPUT) regresses from 7290.9981617147205 to 7288.790924093237 in microbenchmark.json
REGRESSION 0.00%: multi_client_tasks_async (THROUGHPUT) regresses from 20040.412649086153 to 20039.936841581017 in microbenchmark.json
REGRESSION 136.76%: dashboard_p95_latency_ms (LATENCY) regresses from 123.178 to 291.633 in benchmarks/many_pgs.json
REGRESSION 96.82%: dashboard_p95_latency_ms (LATENCY) regresses from 21.245 to 41.814 in benchmarks/many_nodes.json
REGRESSION 76.58%: dashboard_p99_latency_ms (LATENCY) regresses from 1232.673 to 2176.677 in benchmarks/many_pgs.json
REGRESSION 44.38%: dashboard_p50_latency_ms (LATENCY) regresses from 5.563 to 8.032 in benchmarks/many_nodes.json
REGRESSION 24.70%: time_to_broadcast_1073741824_bytes_to_50_nodes (LATENCY) regresses from 12.227769943000013 to 15.248129470999999 in scalability/object_store.json
REGRESSION 12.45%: dashboard_p50_latency_ms (LATENCY) regresses from 5.549 to 6.24 in benchmarks/many_pgs.json
REGRESSION 7.30%: dashboard_p95_latency_ms (LATENCY) regresses from 1495.388 to 1604.549 in benchmarks/many_actors.json
REGRESSION 4.81%: stage_0_time (LATENCY) regresses from 7.086855411529541 to 7.4279701709747314 in stress_tests/stress_test_many_tasks.json
REGRESSION 3.01%: avg_iteration_time (LATENCY) regresses from 1.0499977922439576 to 1.0815906953811645 in stress_tests/stress_test_dead_actors.json
REGRESSION 2.69%: 10000_get_time (LATENCY) regresses from 15.232457393000004 to 15.641607194999992 in scalability/single_node.json
REGRESSION 1.94%: stage_2_avg_iteration_time (LATENCY) regresses from 34.95041303634643 to 35.62842493057251 in stress_tests/stress_test_many_tasks.json
REGRESSION 1.31%: avg_pg_remove_time_ms (LATENCY) regresses from 1.497989546546467 to 1.517630687687757 in stress_tests/stress_test_placement_group.json
REGRESSION 0.98%: stage_4_spread (LATENCY) regresses from 0.2916004517821898 to 0.294463310198033 in stress_tests/stress_test_many_tasks.json
REGRESSION 0.81%: 107374182400_large_object_time (LATENCY) regresses from 23.115384712000008 to 23.303509843 in scalability/single_node.json
REGRESSION 0.36%: stage_3_time (LATENCY) regresses from 2363.575121164322 to 2372.078004837036 in stress_tests/stress_test_many_tasks.json
REGRESSION 0.35%: stage_1_avg_iteration_time (LATENCY) regresses from 14.038756632804871 to 14.088277506828309 in stress_tests/stress_test_many_tasks.json
REGRESSION 0.22%: avg_pg_create_time_ms (LATENCY) regresses from 1.7500006561557806 to 1.7538635525522477 in stress_tests/stress_test_placement_group.json
REGRESSION 0.01%: 1000000_queued_time (LATENCY) regresses from 117.105490623 to 117.120874476 in scalability/single_node.json
```