### PR TITLE
[serve] Deflake test_consistent_hash_router

### DIFF
--- a/python/ray/serve/tests/test_consistent_hash_router.py
+++ b/python/ray/serve/tests/test_consistent_hash_router.py
@@ -242,7 +242,10 @@ class TestOverflowToFallback:
                 max_backoff_s=0.1,
             ),
             num_replicas=3,
-            max_ongoing_requests=1,
+            # Not 1: a replica retires a finished request only after replying, so a
+            # cap of 1 leaves the primary reporting itself full for a few ms and
+            # pushes the next same-session request to a fallback.
+            max_ongoing_requests=5,
             ray_actor_options={"num_cpus": 0},
         )
         class BlockingApp:

--- a/python/ray/serve/tests/test_consistent_hash_router.py
+++ b/python/ray/serve/tests/test_consistent_hash_router.py
@@ -7,13 +7,12 @@ import pytest
 import ray
 from ray import serve
 from ray._common.test_utils import SignalActor, wait_for_condition
-from ray.serve._private.constants import SERVE_NAMESPACE
 from ray.serve._private.test_utils import (
     check_running,
     get_application_url,
     skip_if_haproxy,
 )
-from ray.serve.config import RequestRouterConfig, gRPCOptions
+from ray.serve.config import RequestRouterConfig
 from ray.serve.context import _get_internal_replica_context
 from ray.serve.generated import serve_pb2, serve_pb2_grpc
 
@@ -312,21 +311,10 @@ class TestProtocolStickiness:
         assert len(session_replicas) == 1, f"sess_http_42 drifted: {session_replicas}"
         assert len(other_replicas) == 1, f"sess_http_99 drifted: {other_replicas}"
 
-    def test_grpc_same_session_sticky(self, ray_cluster):
-        cluster = ray_cluster
-        cluster.add_node(num_cpus=2)
-        cluster.connect(namespace=SERVE_NAMESPACE)
-
-        serve.start(
-            grpc_options=gRPCOptions(
-                port=9000,
-                grpc_servicer_functions=[
-                    "ray.serve.generated.serve_pb2_grpc."
-                    "add_UserDefinedServiceServicer_to_server",
-                ],
-            ),
-        )
-
+    def test_grpc_same_session_sticky(self, serve_instance):
+        # Uses the shared instance rather than its own cluster: that fixture already
+        # serves gRPC on 9000 with this servicer, and a second cluster here would
+        # shut down the shared one that the rest of the file still depends on.
         @serve.deployment(
             request_router_config=RequestRouterConfig(
                 request_router_class=ROUTER_CLASS,


### PR DESCRIPTION
`test_consistent_hash_router` fails intermittently on the `serve: same event loop tests` CI shard. Two unrelated problems, one commit each.

### 1. A sticky-session test raced the replica's own bookkeeping

`test_sticky_returns_to_primary_after_drain` sets `max_ongoing_requests=1`, sends a request, waits for the answer, then immediately sends more requests on the same session and expects them all to land on the same replica.

When a replica finishes a request it sends the answer back before it marks itself free again. For a few milliseconds it still reports one request in flight, and with a limit of exactly 1 that makes it look full. The router then does the right thing and sends the next request to the fallback replica. The session moves, and the test fails.

That gap is normally too short to matter. On this shard user code shares the replica's event loop, and with three test targets per worker competing for CPU it stretches long enough to lose the race (measured median 2.9ms, max 5.9ms). This is not a timing flake a longer timeout would fix. At a limit of 1 the assertion simply isn't true.

Raising the limit to 5 in this one test removes the dependency. Requests are sent one at a time, so at most one stale count is ever outstanding and the replica always stays eligible. The test still verifies what it is named for, that the session returns to the same replica. `test_overflow_when_primary_saturated` keeps the limit of 1, because it genuinely needs a full replica: both of its requests are in flight at once.

### 2. The gRPC test shut down the Serve instance the other tests share

Seven tests in this file use a shared Serve instance that lives for the whole session. `test_grpc_same_session_sticky` instead started its own Ray cluster, and that fixture's teardown calls `ray.shutdown()`, which disconnects the shared instance too. At the end of the session, cleanup for the shared instance found no Serve client, tried to start a brand new Ray head node, and timed out waiting for it. That surfaces as `ERROR at teardown` and a red build, in roughly one run in eight.

The extra cluster was never needed. The shared instance already serves gRPC on port 9000 with the servicer this test uses, so the test now runs on it like the other seven.
