### PR TITLE
[Data] Export task USS distribution metrics

### DIFF
--- a/python/ray/dashboard/modules/metrics/dashboards/data_dashboard_panels.py
+++ b/python/ray/dashboard/modules/metrics/dashboards/data_dashboard_panels.py
@@ -431,6 +431,21 @@ FAILED_TASKS_PANEL = Panel(
     stack=False,
 )
 
+MAX_USS_PER_TASK_PANEL = Panel(
+    id=91,
+    title="Max Task USS Memory per Operator",
+    description="Maximum unique set size (USS) memory usage in bytes among completed tasks for each operator.",
+    unit="bytes",
+    targets=[
+        Target(
+            expr='max(ray_data_max_uss_bytes_max{{{global_filters}, operator=~"$Operator"}}) by (dataset, operator)',
+            legend="Max Task USS: {{dataset}}, {{operator}}",
+        )
+    ],
+    fill=0,
+    stack=False,
+)
+
 TASK_THROUGHPUT_BY_NODE_PANEL = Panel(
     id=46,
     title="Task Throughput (by Node)",
@@ -1479,6 +1494,7 @@ DATA_GRAFANA_ROWS = [
             TASK_COMPLETION_TIME_WITHOUT_BACKPRESSURE_PANEL,
             TASK_OUTPUT_BACKPRESSURE_TIME_PANEL,
             TASK_SUBMISSION_BACKPRESSURE_PANEL,
+            MAX_USS_PER_TASK_PANEL,
             TASK_THROUGHPUT_BY_NODE_PANEL,
             TASKS_WITH_OUTPUT_PANEL,
             SUBMITTED_TASKS_PANEL,

--- a/python/ray/data/_internal/execution/interfaces/op_runtime_metrics.py
+++ b/python/ray/data/_internal/execution/interfaces/op_runtime_metrics.py
@@ -53,6 +53,7 @@ class MetricsType(Enum):
     Gauge = 1
     Histogram = 2
     Unsupported = 3
+    Distribution = 4
 
 
 @dataclass(frozen=True)
@@ -892,20 +893,11 @@ class OpRuntimeMetrics(metaclass=OpRuntimesMetricsMeta):
     @metric_property(
         description="Distribution of max USS bytes across tasks.",
         metrics_group=MetricsGroup.TASKS,
-        metrics_type=MetricsType.Unsupported,
+        metrics_type=MetricsType.Distribution,
+        metrics_args={"statistics": ("mean", "max")},
     )
     def max_uss_bytes(self) -> DistributionTracker:
         return self._max_uss_bytes
-
-    @metric_property(
-        description="Average USS usage of tasks.",
-        metrics_group=MetricsGroup.TASKS,
-    )
-    def average_max_uss_per_task(self) -> Optional[float]:
-        """Average max USS usage of tasks."""
-        if self.max_uss_bytes.num_samples == 0:
-            return None
-        return self.max_uss_bytes.mean
 
     def on_input_received(self, input: RefBundle):
         """Callback when the operator receives a new input."""

--- a/python/ray/data/_internal/execution/interfaces/op_runtime_metrics.py
+++ b/python/ray/data/_internal/execution/interfaces/op_runtime_metrics.py
@@ -894,7 +894,6 @@ class OpRuntimeMetrics(metaclass=OpRuntimesMetricsMeta):
         description="Distribution of max USS bytes across tasks.",
         metrics_group=MetricsGroup.TASKS,
         metrics_type=MetricsType.Distribution,
-        metrics_args={"statistics": ("mean", "max")},
     )
     def max_uss_bytes(self) -> DistributionTracker:
         return self._max_uss_bytes

--- a/python/ray/data/_internal/issue_detection/detectors/high_memory_detector.py
+++ b/python/ray/data/_internal/issue_detection/detectors/high_memory_detector.py
@@ -81,19 +81,20 @@ class HighMemoryIssueDetector(IssueDetector):
             if not isinstance(op, MapOperator):
                 continue
 
-            if op.metrics.average_max_uss_per_task is None:
+            max_uss_bytes = op.metrics.max_uss_bytes
+            if max_uss_bytes.num_samples == 0:
                 continue
 
             remote_args = op._get_dynamic_ray_remote_args()
             safe_memory_per_task = get_safe_default_logical_memory(remote_args)
 
             if (
-                op.metrics.average_max_uss_per_task > self._initial_memory_requests[op]
-                and op.metrics.average_max_uss_per_task >= safe_memory_per_task
+                max_uss_bytes.mean > self._initial_memory_requests[op]
+                and max_uss_bytes.mean >= safe_memory_per_task
             ):
                 message = HIGH_MEMORY_PERIODIC_WARNING.format(
                     op_name=op.name,
-                    memory_per_task=memory_string(op.metrics.average_max_uss_per_task),
+                    memory_per_task=memory_string(max_uss_bytes.mean),
                     initial_memory_request=memory_string(
                         self._initial_memory_requests[op]
                     ),

--- a/python/ray/data/_internal/stats.py
+++ b/python/ray/data/_internal/stats.py
@@ -57,7 +57,7 @@ STATS_ACTOR_NAME = "datasets_stats_actor"
 STATS_ACTOR_NAMESPACE = "_dataset_stats_actor"
 UNKNOWN = "unknown"
 UNKNOWN_UUID = "unknown_uuid"
-_DISTRIBUTION_METRIC_STATISTICS = ("mean", "max")
+DISTRIBUTION_METRIC_STATISTICS = ("mean", "max")
 
 
 StatsDict = Dict[str, List[BlockStats]]
@@ -709,7 +709,7 @@ class _StatsActor:
                         description=f"{metric_description} ({statistic})",
                         tag_keys=tag_keys,
                     )
-                    for statistic in _DISTRIBUTION_METRIC_STATISTICS
+                    for statistic in DISTRIBUTION_METRIC_STATISTICS
                 }
         return metrics
 

--- a/python/ray/data/_internal/stats.py
+++ b/python/ray/data/_internal/stats.py
@@ -673,7 +673,7 @@ class _StatsActor:
 
     def _create_prometheus_metrics_for_execution_metrics(
         self, metrics_group: MetricsGroup, tag_keys: Tuple[str, ...]
-    ) -> Dict[str, Metric]:
+    ) -> Dict[str, Union[Metric, Dict[str, Gauge]]]:
         metrics = {}
         for metric in OpRuntimeMetrics.get_metrics():
             if not metric.metrics_group == metrics_group:
@@ -701,6 +701,15 @@ class _StatsActor:
                     description=metric_description,
                     tag_keys=tag_keys,
                 )
+            elif metric.metrics_type == MetricsType.Distribution:
+                metrics[metric.name] = {
+                    statistic: Gauge(
+                        f"{metric_name}_{statistic}",
+                        description=f"{metric_description} ({statistic})",
+                        tag_keys=tag_keys,
+                    )
+                    for statistic in metric.metrics_args["statistics"]
+                }
         return metrics
 
     def _create_prometheus_metrics_for_per_node_metrics(self) -> Dict[str, Gauge]:
@@ -723,14 +732,14 @@ class _StatsActor:
     def update_execution_metrics(
         self,
         dataset_tag: str,
-        op_metrics: List[Dict[str, int | float]],
+        op_metrics: List[Dict[str, Any]],
         operator_tags: List[str],
         state: Dict[str, Any],
         per_node_metrics: Optional[Dict[str, Dict[str, int | float]]] = None,
     ):
         def _record(
-            prom_metric: Metric,
-            value: Union[int, float, List[int]],
+            prom_metric: Union[Metric, Dict[str, Gauge]],
+            value: Any,
             tags: Dict[str, str] = None,
         ):
             if isinstance(prom_metric, Gauge):
@@ -740,6 +749,13 @@ class _StatsActor:
             elif isinstance(prom_metric, Histogram):
                 if isinstance(value, RuntimeMetricsHistogram):
                     value.export_to(prom_metric, tags)
+            elif isinstance(prom_metric, dict) and isinstance(value, dict):
+                if value.get("num_samples", 0) == 0:
+                    return
+                for statistic, gauge in prom_metric.items():
+                    statistic_value = value.get(statistic)
+                    if statistic_value is not None:
+                        gauge.set(statistic_value, tags)
 
         for stats, operator_tag in zip(op_metrics, operator_tags):
             tags = self._create_tags(dataset_tag, operator_tag)

--- a/python/ray/data/_internal/stats.py
+++ b/python/ray/data/_internal/stats.py
@@ -57,6 +57,7 @@ STATS_ACTOR_NAME = "datasets_stats_actor"
 STATS_ACTOR_NAMESPACE = "_dataset_stats_actor"
 UNKNOWN = "unknown"
 UNKNOWN_UUID = "unknown_uuid"
+_DISTRIBUTION_METRIC_STATISTICS = ("mean", "max")
 
 
 StatsDict = Dict[str, List[BlockStats]]
@@ -708,7 +709,7 @@ class _StatsActor:
                         description=f"{metric_description} ({statistic})",
                         tag_keys=tag_keys,
                     )
-                    for statistic in metric.metrics_args["statistics"]
+                    for statistic in _DISTRIBUTION_METRIC_STATISTICS
                 }
         return metrics
 

--- a/python/ray/data/_internal/stats.py
+++ b/python/ray/data/_internal/stats.py
@@ -750,7 +750,7 @@ class _StatsActor:
                 if isinstance(value, RuntimeMetricsHistogram):
                     value.export_to(prom_metric, tags)
             elif isinstance(prom_metric, dict) and isinstance(value, dict):
-                if value.get("num_samples", 0) == 0:
+                if value.get("num_samples") == 0:
                     return
                 for statistic, gauge in prom_metric.items():
                     statistic_value = value.get(statistic)

--- a/python/ray/data/tests/test_issue_detection.py
+++ b/python/ray/data/tests/test_issue_detection.py
@@ -226,7 +226,9 @@ def test_high_memory_detection(
         data_context=ctx,
         ray_remote_args={"memory": configured_memory},
     )
-    map_operator._metrics = MagicMock(average_max_uss_per_task=actual_memory)
+    map_operator._metrics = MagicMock()
+    map_operator._metrics.max_uss_bytes.num_samples = 1
+    map_operator._metrics.max_uss_bytes.mean = actual_memory
     topology = {input_data_buffer: MagicMock(), map_operator: MagicMock()}
 
     operators = list(topology.keys())

--- a/python/ray/data/tests/test_op_runtime_metrics.py
+++ b/python/ray/data/tests/test_op_runtime_metrics.py
@@ -17,11 +17,13 @@ from ray.data.block import BlockExecStats, BlockMetadata, TaskExecWorkerStats
 from ray.data.context import DataContext
 
 
-def test_average_max_uss_per_task():
+def test_max_uss_bytes_distribution():
     op = MagicMock()
     op.data_context.enable_get_object_locations_for_metrics = False
     metrics = OpRuntimeMetrics(op)
-    assert metrics.average_max_uss_per_task is None
+    assert metrics.max_uss_bytes.num_samples == 0
+    assert metrics.max_uss_bytes.mean == 0
+    assert metrics.max_uss_bytes.max is None
 
     input_bundle = RefBundle([], owns_blocks=False, schema=None)
 
@@ -33,7 +35,9 @@ def test_average_max_uss_per_task():
         TaskExecWorkerStats(task_wall_time_s=1.0, max_uss_bytes=100),
         TaskExecDriverStats(task_output_backpressure_s=0),
     )
-    assert metrics.average_max_uss_per_task == 100
+    assert metrics.max_uss_bytes.num_samples == 1
+    assert metrics.max_uss_bytes.mean == 100
+    assert metrics.max_uss_bytes.max == 100
 
     # Submit and finish second task with USS of 300 bytes.
     metrics.on_task_submitted(1, input_bundle)
@@ -43,7 +47,9 @@ def test_average_max_uss_per_task():
         TaskExecWorkerStats(task_wall_time_s=1.0, max_uss_bytes=300),
         TaskExecDriverStats(task_output_backpressure_s=0),
     )
-    assert metrics.average_max_uss_per_task == 200  # (100 + 300) / 2
+    assert metrics.max_uss_bytes.num_samples == 2
+    assert metrics.max_uss_bytes.mean == 200  # (100 + 300) / 2
+    assert metrics.max_uss_bytes.max == 300
 
 
 def test_task_completion_time_histogram():

--- a/python/ray/data/tests/test_stats.py
+++ b/python/ray/data/tests/test_stats.py
@@ -56,7 +56,6 @@ from ray.data.block import BlockExecStats, BlockStats, CustomOpStats
 from ray.data.context import DataContext
 from ray.data.tests.util import column_udf
 from ray.tests.conftest import *  # noqa
-from ray.util.metrics import Gauge
 
 
 @dataclass(frozen=True)
@@ -2006,51 +2005,6 @@ def test_stats_actor_iter_metrics():
     assert final_stats == ds_stats
     assert update_fn.call_args_list[-1].args[1] == f"dataset_{ds._uuid}_0"
     assert update_fn.call_args_list[-1].args[2] is None
-
-
-def test_stats_actor_exports_distribution_metrics():
-    """Distribution snapshots export mean/max Gauges and skip empty snapshots."""
-    # _StatsActor is wrapped by @ray.remote; instantiate its Python class locally.
-    actor = _StatsActor.__ray_metadata__.modified_class()
-
-    # Distribution metrics create one Gauge for each exported statistic.
-    metrics = actor.execution_metrics_tasks["max_uss_bytes"]
-    assert set(metrics) == {"mean", "max"}
-    for statistic, metric in metrics.items():
-        assert isinstance(metric, Gauge)
-        assert metric.info["name"] == f"data_max_uss_bytes_{statistic}"
-        assert metric.info["tag_keys"] == ("dataset", "operator")
-
-    actor.update_dataset = MagicMock()
-
-    with (
-        patch.object(metrics["mean"], "set") as set_mean,
-        patch.object(metrics["max"], "set") as set_max,
-    ):
-        # Empty distributions must not overwrite previously exported values.
-        actor.update_execution_metrics(
-            "dataset_1",
-            [{"max_uss_bytes": {"num_samples": 0, "mean": 0, "max": None}}],
-            ["MapBatches_1"],
-            {},
-        )
-        set_mean.assert_not_called()
-        set_max.assert_not_called()
-
-        # Non-empty snapshots export each statistic with the operator tags.
-        actor.update_execution_metrics(
-            "dataset_1",
-            [{"max_uss_bytes": {"mean": 200, "max": 300}}],
-            ["MapBatches_1"],
-            {},
-        )
-
-    set_mean.assert_called_once_with(
-        200, {"dataset": "dataset_1", "operator": "MapBatches_1"}
-    )
-    set_max.assert_called_once_with(
-        300, {"dataset": "dataset_1", "operator": "MapBatches_1"}
-    )
 
 
 @pytest.mark.parametrize(

--- a/python/ray/data/tests/test_stats.py
+++ b/python/ray/data/tests/test_stats.py
@@ -2009,8 +2009,11 @@ def test_stats_actor_iter_metrics():
 
 
 def test_stats_actor_exports_distribution_metrics():
+    """Distribution snapshots export mean/max Gauges and skip empty snapshots."""
+    # _StatsActor is wrapped by @ray.remote; instantiate its Python class locally.
     actor = _StatsActor.__ray_metadata__.modified_class()
 
+    # Distribution metrics create one Gauge for each exported statistic.
     metrics = actor.execution_metrics_tasks["max_uss_bytes"]
     assert set(metrics) == {"mean", "max"}
     for statistic, metric in metrics.items():
@@ -2024,6 +2027,7 @@ def test_stats_actor_exports_distribution_metrics():
         patch.object(metrics["mean"], "set") as set_mean,
         patch.object(metrics["max"], "set") as set_max,
     ):
+        # Empty distributions must not overwrite previously exported values.
         actor.update_execution_metrics(
             "dataset_1",
             [{"max_uss_bytes": {"num_samples": 0, "mean": 0, "max": None}}],
@@ -2033,6 +2037,7 @@ def test_stats_actor_exports_distribution_metrics():
         set_mean.assert_not_called()
         set_max.assert_not_called()
 
+        # Non-empty snapshots export each statistic with the operator tags.
         actor.update_execution_metrics(
             "dataset_1",
             [{"max_uss_bytes": {"mean": 200, "max": 300}}],

--- a/python/ray/data/tests/test_stats.py
+++ b/python/ray/data/tests/test_stats.py
@@ -56,6 +56,7 @@ from ray.data.block import BlockExecStats, BlockStats, CustomOpStats
 from ray.data.context import DataContext
 from ray.data.tests.util import column_udf
 from ray.tests.conftest import *  # noqa
+from ray.util.metrics import Gauge
 
 
 @dataclass(frozen=True)
@@ -353,7 +354,6 @@ def gen_expected_metrics(
             "'average_rows_outputs_per_task': N",
             "'op_task_duration_stats': {'num_samples': N, 'mean': N, 'variance': N, 'min': N, 'max': N, 'pN': P, 'pN': P, 'pN': P, 'pN': P, 'pN': P, 'pN': P}",
             "'max_uss_bytes': H",
-            "'average_max_uss_per_task': H",
             "'num_inputs_received': N",
             "'num_row_inputs_received': N",
             "'bytes_inputs_received': N",
@@ -443,7 +443,6 @@ def gen_expected_metrics(
             "'average_rows_outputs_per_task': None",
             "'op_task_duration_stats': {'num_samples': Z, 'mean': Z, 'variance': Z, 'min': None, 'max': None, 'pN': P, 'pN': P, 'pN': P, 'pN': P, 'pN': P, 'pN': P}",
             "'max_uss_bytes': H",
-            "'average_max_uss_per_task': H",
             "'num_inputs_received': N",
             "'num_row_inputs_received': N",
             "'bytes_inputs_received': N",
@@ -635,11 +634,6 @@ def canonicalize(
     # Replace tabs with spaces.
     canonicalized_stats = re.sub("\t", "    ", canonicalized_stats)
 
-    canonicalized_stats = re.sub(
-        r"(average_max_uss_per_task:|'average_max_uss_per_task':) (?:N|Z|None)\b",
-        r"\g<1> H",
-        canonicalized_stats,
-    )
     # Percentile values in DistributionTracker dicts can be None (when datasketches
     # is not installed) or a number (canonicalized to N). Normalize to P.
     canonicalized_stats = re.sub(
@@ -932,7 +926,6 @@ def test_dataset__repr__(ray_start_regular_shared, restore_data_context):
         "      average_rows_outputs_per_task: N,\n"
         "      op_task_duration_stats: {'num_samples': N, 'mean': N, 'variance': N, 'min': N, 'max': N, 'pN': P, 'pN': P, 'pN': P, 'pN': P, 'pN': P, 'pN': P},\n"
         "      max_uss_bytes: H,\n"
-        "      average_max_uss_per_task: H,\n"
         "      num_inputs_received: N,\n"
         "      num_row_inputs_received: N,\n"
         "      bytes_inputs_received: N,\n"
@@ -1097,7 +1090,6 @@ def test_dataset__repr__(ray_start_regular_shared, restore_data_context):
         "      average_rows_outputs_per_task: N,\n"
         "      op_task_duration_stats: {'num_samples': N, 'mean': N, 'variance': N, 'min': N, 'max': N, 'pN': P, 'pN': P, 'pN': P, 'pN': P, 'pN': P, 'pN': P},\n"
         "      max_uss_bytes: H,\n"
-        "      average_max_uss_per_task: H,\n"
         "      num_inputs_received: N,\n"
         "      num_row_inputs_received: N,\n"
         "      bytes_inputs_received: N,\n"
@@ -1215,7 +1207,6 @@ def test_dataset__repr__(ray_start_regular_shared, restore_data_context):
         "            average_rows_outputs_per_task: N,\n"
         "            op_task_duration_stats: {'num_samples': N, 'mean': N, 'variance': N, 'min': N, 'max': N, 'pN': P, 'pN': P, 'pN': P, 'pN': P, 'pN': P, 'pN': P},\n"
         "            max_uss_bytes: H,\n"
-        "            average_max_uss_per_task: H,\n"
         "            num_inputs_received: N,\n"
         "            num_row_inputs_received: N,\n"
         "            bytes_inputs_received: N,\n"
@@ -2015,6 +2006,46 @@ def test_stats_actor_iter_metrics():
     assert final_stats == ds_stats
     assert update_fn.call_args_list[-1].args[1] == f"dataset_{ds._uuid}_0"
     assert update_fn.call_args_list[-1].args[2] is None
+
+
+def test_stats_actor_exports_distribution_metrics():
+    actor = _StatsActor.__ray_metadata__.modified_class()
+
+    metrics = actor.execution_metrics_tasks["max_uss_bytes"]
+    assert set(metrics) == {"mean", "max"}
+    for statistic, metric in metrics.items():
+        assert isinstance(metric, Gauge)
+        assert metric.info["name"] == f"data_max_uss_bytes_{statistic}"
+        assert metric.info["tag_keys"] == ("dataset", "operator")
+
+    actor.update_dataset = MagicMock()
+
+    with (
+        patch.object(metrics["mean"], "set") as set_mean,
+        patch.object(metrics["max"], "set") as set_max,
+    ):
+        actor.update_execution_metrics(
+            "dataset_1",
+            [{"max_uss_bytes": {"num_samples": 0, "mean": 0, "max": None}}],
+            ["MapBatches_1"],
+            {},
+        )
+        set_mean.assert_not_called()
+        set_max.assert_not_called()
+
+        actor.update_execution_metrics(
+            "dataset_1",
+            [{"max_uss_bytes": {"num_samples": 2, "mean": 200, "max": 300}}],
+            ["MapBatches_1"],
+            {},
+        )
+
+    set_mean.assert_called_once_with(
+        200, {"dataset": "dataset_1", "operator": "MapBatches_1"}
+    )
+    set_max.assert_called_once_with(
+        300, {"dataset": "dataset_1", "operator": "MapBatches_1"}
+    )
 
 
 @pytest.mark.parametrize(

--- a/python/ray/data/tests/test_stats.py
+++ b/python/ray/data/tests/test_stats.py
@@ -2035,7 +2035,7 @@ def test_stats_actor_exports_distribution_metrics():
 
         actor.update_execution_metrics(
             "dataset_1",
-            [{"max_uss_bytes": {"num_samples": 2, "mean": 200, "max": 300}}],
+            [{"max_uss_bytes": {"mean": 200, "max": 300}}],
             ["MapBatches_1"],
             {},
         )


### PR DESCRIPTION
## Description

Expose the existing `OpRuntimeMetrics.max_uss_bytes` distribution as the Prometheus Gauges `ray_data_max_uss_bytes_mean` and `ray_data_max_uss_bytes_max`, and add a "Max Task USS Memory per Operator" chart to the Ray Data dashboard's Tasks row.

Ray Data already records each completed task's peak unique set size (USS) in a `DistributionTracker`, but this distribution was marked as unsupported for Prometheus export. Consequently, users couldn't query the operator-level maximum from Prometheus or visualize it in the Data dashboard.

This change introduces `MetricsType.Distribution`. A distribution metric declares which summary statistics to export through the existing `metrics_args` metadata; `_StatsActor` creates one Gauge per statistic and updates those Gauges from the serialized distribution snapshot. `max_uss_bytes` exports `mean` and `max`.

The previous scalar `average_max_uss_per_task` property is removed. The `issue_detector` now reads `max_uss_bytes.mean` directly.

## Additional information

<img width="1440" height="778" alt="image" src="https://github.com/user-attachments/assets/d9dc583e-6db3-42a2-b12d-dc9a8e490b27" />


