### PR TITLE
Remove signal handler override from SGLang engine #61894

### DIFF
--- a/python/ray/llm/_internal/serve/engines/sglang/sglang_engine.py
+++ b/python/ray/llm/_internal/serve/engines/sglang/sglang_engine.py
@@ -11,7 +11,6 @@ provide feedback at https://github.com/ray-project/ray/issues/61114.
 import copy
 import json
 import logging
-import signal
 import time
 import uuid
 from typing import (
@@ -133,20 +132,7 @@ class SGLangServer:
                     "deployment/replica labels."
                 )
 
-        # TODO(issue-61108): remove this once sglang#18752 is merged and included
-        # in the minimum supported SGLang version for this example.
-        original_signal_func = signal.signal
-
-        def noop_signal_handler(sig, action):
-            # Returns default handler to satisfy signal.signal() return signature
-            return signal.SIG_DFL
-
-        try:
-            # Override signal.signal with our no-op function
-            signal.signal = noop_signal_handler
-            self.engine = Engine(**self.engine_kwargs)
-        finally:
-            signal.signal = original_signal_func
+        self.engine = Engine(**self.engine_kwargs)
 
     @staticmethod
     def _build_sampling_params(request: Any) -> dict[str, Any]:


### PR DESCRIPTION
## Description

This PR removes the signal handler workaround from `SGLangServer.__init__` that was monkey-patching `signal.signal` during SGLang engine initialization.

## Why

The workaround was originally added because SGLang installed its own signal handlers during engine initialization, which interfered with Ray's signal handling.

This issue has been fixed upstream in [[sgl-project/sglang#18752](https://github.com/sgl-project/sglang/pull/18752)](https://github.com/sgl-project/sglang/pull/18752). The fix has been merged and is included in the minimum supported SGLang version.

The existing TODO comment referenced issue #61108, and the removal of this workaround is tracked in #61894.

## Changes

* Removed the unused `signal` import.
* Removed the signal handler override/monkey-patching code.
* Simplified SGLang engine initialization to:

```python
self.engine = Engine(**self.engine_kwargs)
```

## Related Issues

* Closes #61894

## Testing

* Verified that the SGLang engine initializes correctly without the signal handler workaround.
* Existing SGLang integration tests should continue to pass.
* No new tests were added because this change only removes obsolete workaround code.