### PR TITLE
[Core] Handle concurrent GCS poll shutdown

### DIFF
--- a/python/ray/_private/gcs_pubsub.py
+++ b/python/ray/_private/gcs_pubsub.py
@@ -137,24 +137,19 @@ class _AioSubscriber(_SubscriberBase):
                 self._poll_call(req, timeout=timeout)
             )
             close = get_or_create_event_loop().create_task(self._close.wait())
-            done, pending = await asyncio.wait(
+            done, _ = await asyncio.wait(
                 [poll, close], timeout=timeout, return_when=asyncio.FIRST_COMPLETED
             )
-            # Cancel unfinished tasks to prevent memory leaks. Multiple tasks can be
-            # in `done` even with FIRST_COMPLETED, so do not assume exactly one task
-            # completed.
-            for task in pending:
-                task.cancel()
-                try:
-                    await task
-                except asyncio.CancelledError:
-                    pass
+            # cancel() is a no-op on already-finished tasks. Cancel both
+            # unconditionally and drain together so pending work stops promptly and
+            # non-CancelledError failures (e.g. grpc.RpcError on timeout) cannot
+            # escape cleanup. Multiple tasks can be in `done` even with
+            # FIRST_COMPLETED, so do not assume exactly one task completed.
+            poll.cancel()
+            close.cancel()
+            await asyncio.gather(poll, close, return_exceptions=True)
 
             if close in done:
-                # The poll result is no longer needed, but retrieve an exception if
-                # both tasks completed to avoid an unhandled-task warning.
-                if poll in done and not poll.cancelled():
-                    poll.exception()
                 break
             if poll not in done:
                 # Request timed out or subscriber closed.

--- a/python/ray/_private/gcs_pubsub.py
+++ b/python/ray/_private/gcs_pubsub.py
@@ -137,14 +137,26 @@ class _AioSubscriber(_SubscriberBase):
                 self._poll_call(req, timeout=timeout)
             )
             close = get_or_create_event_loop().create_task(self._close.wait())
-            done, others = await asyncio.wait(
+            done, pending = await asyncio.wait(
                 [poll, close], timeout=timeout, return_when=asyncio.FIRST_COMPLETED
             )
-            # Cancel the other task if needed to prevent memory leak.
-            other_task = others.pop()
-            if not other_task.done():
-                other_task.cancel()
-            if poll not in done or close in done:
+            # Cancel unfinished tasks to prevent memory leaks. Multiple tasks can be
+            # in `done` even with FIRST_COMPLETED, so do not assume exactly one task
+            # completed.
+            for task in pending:
+                task.cancel()
+                try:
+                    await task
+                except asyncio.CancelledError:
+                    pass
+
+            if close in done:
+                # The poll result is no longer needed, but retrieve an exception if
+                # both tasks completed to avoid an unhandled-task warning.
+                if poll in done and not poll.cancelled():
+                    poll.exception()
+                break
+            if poll not in done:
                 # Request timed out or subscriber closed.
                 break
             try:

--- a/python/ray/tests/test_gcs_pubsub.py
+++ b/python/ray/tests/test_gcs_pubsub.py
@@ -111,6 +111,25 @@ async def test_aio_poll_handles_poll_and_close_completing_together():
     await subscriber._poll()
 
 
+@pytest.mark.asyncio
+async def test_aio_poll_timeout_swallows_pending_poll_errors():
+    """Timed-out cleanup must not re-raise errors from cancelled poll tasks."""
+    subscriber = object.__new__(_AioSubscriber)
+    subscriber._queue = deque()
+    subscriber._close = asyncio.Event()
+    subscriber._poll_request = lambda: None
+
+    async def poll_call(req, timeout=None):
+        try:
+            await asyncio.sleep(3600)
+        except asyncio.CancelledError:
+            # Simulate a late failure that can surface while draining cancellation.
+            raise RuntimeError("late poll failure") from None
+
+    subscriber._poll_call = poll_call
+    await subscriber._poll(timeout=0.01)
+
+
 def test_two_subscribers(ray_start_regular):
     """Tests concurrently subscribing to two channels work."""
 

--- a/python/ray/tests/test_gcs_pubsub.py
+++ b/python/ray/tests/test_gcs_pubsub.py
@@ -2,11 +2,13 @@ import asyncio
 import re
 import sys
 import threading
+from collections import deque
 
 import pytest
 
 import ray
 from ray._private.gcs_pubsub import (
+    _AioSubscriber,
     GcsAioResourceUsageSubscriber,
 )
 
@@ -91,6 +93,22 @@ async def test_aio_poll_no_leaks(ray_start_regular):
         assert len(asyncio.all_tasks()) < 10
 
     await subscriber.close()
+
+
+@pytest.mark.asyncio
+async def test_aio_poll_handles_poll_and_close_completing_together():
+    """Poll and close can both complete before asyncio.wait returns."""
+    subscriber = object.__new__(_AioSubscriber)
+    subscriber._queue = deque()
+    subscriber._close = asyncio.Event()
+    subscriber._close.set()
+    subscriber._poll_request = lambda: None
+
+    async def poll_call(req, timeout=None):
+        return None
+
+    subscriber._poll_call = poll_call
+    await subscriber._poll()
 
 
 def test_two_subscribers(ray_start_regular):


### PR DESCRIPTION
## Summary

Fixes #65672.

`_AioSubscriber._poll` assumed `asyncio.wait(..., return_when=FIRST_COMPLETED)` leaves exactly one task pending and called `others.pop()`. Poll and close can complete in the same event-loop turn, leaving no pending task and raising `KeyError`.

This change:

- cancels and awaits every pending task;
- handles poll, close, and simultaneous completion explicitly;
- retrieves a completed poll exception when close wins;
- adds a regression test for simultaneous completion.

## Test plan

- `ruff check python/ray/_private/gcs_pubsub.py python/ray/tests/test_gcs_pubsub.py`
- Python compilation of both changed files
- `git diff --check`

The focused Ray pytest is blocked locally because the compiled Ray runtime is unavailable.