### PR TITLE
[Serve] Cancel metrics tasks after shutdown timeout

### DIFF
--- a/python/ray/serve/_private/metrics_utils.py
+++ b/python/ray/serve/_private/metrics_utils.py
@@ -76,30 +76,43 @@ class MetricsPusher:
         """
 
         wait_for_stop_event = asyncio.create_task(self.stop_event.wait())
-        while True:
-            if wait_for_stop_event.done():
-                return
+        try:
+            while True:
+                if wait_for_stop_event.done():
+                    return
 
-            try:
-                task_func = self._tasks[name].task_func
-                # Check if the function is a coroutine function
-                if asyncio.iscoroutinefunction(task_func):
-                    await task_func()
-                else:
-                    task_func()
-            except Exception as e:
-                logger.exception(f"Failed to run metrics task '{name}': {e}")
+                try:
+                    task_func = self._tasks[name].task_func
+                    # Check if the function is a coroutine function
+                    if asyncio.iscoroutinefunction(task_func):
+                        await task_func()
+                    else:
+                        task_func()
+                except Exception as e:
+                    logger.exception(f"Failed to run metrics task '{name}': {e}")
 
-            sleep_task = asyncio.create_task(
-                self._async_sleep(self._tasks[name].interval_s)
-            )
-            await asyncio.wait(
-                [sleep_task, wait_for_stop_event],
-                return_when=asyncio.FIRST_COMPLETED,
-            )
-
-            if not sleep_task.done():
-                sleep_task.cancel()
+                sleep_task = asyncio.create_task(
+                    self._async_sleep(self._tasks[name].interval_s)
+                )
+                try:
+                    await asyncio.wait(
+                        [sleep_task, wait_for_stop_event],
+                        return_when=asyncio.FIRST_COMPLETED,
+                    )
+                finally:
+                    if not sleep_task.done():
+                        sleep_task.cancel()
+                        try:
+                            await sleep_task
+                        except asyncio.CancelledError:
+                            pass
+        finally:
+            if not wait_for_stop_event.done():
+                wait_for_stop_event.cancel()
+                try:
+                    await wait_for_stop_event
+                except asyncio.CancelledError:
+                    pass
 
     def register_or_update_task(
         self,
@@ -135,10 +148,14 @@ class MetricsPusher:
 
         self.stop_event.set()
         if self._async_tasks:
-            await asyncio.wait(
+            _, pending = await asyncio.wait(
                 list(self._async_tasks.values()),
                 timeout=METRICS_PUSHER_GRACEFUL_SHUTDOWN_TIMEOUT_S,
             )
+            for task in pending:
+                task.cancel()
+            if pending:
+                await asyncio.gather(*pending, return_exceptions=True)
 
         self._tasks.clear()
         self._async_tasks.clear()

--- a/python/ray/serve/tests/unit/test_metrics_utils.py
+++ b/python/ray/serve/tests/unit/test_metrics_utils.py
@@ -1,5 +1,6 @@
 import asyncio
 import sys
+from unittest.mock import patch
 
 import pytest
 
@@ -143,6 +144,33 @@ class TestMetricsPusher:
             assert state["B"] == i + 1
 
         await metrics_pusher.graceful_shutdown()
+
+    @pytest.mark.asyncio
+    async def test_graceful_shutdown_cancels_hung_task(self):
+        started = asyncio.Event()
+        cancelled = asyncio.Event()
+
+        async def hung_task():
+            started.set()
+            try:
+                await asyncio.Event().wait()
+            finally:
+                cancelled.set()
+
+        metrics_pusher = MetricsPusher()
+        metrics_pusher.start()
+        metrics_pusher.register_or_update_task("hung", hung_task, 1)
+        await started.wait()
+
+        with patch(
+            "ray.serve._private.metrics_utils."
+            "METRICS_PUSHER_GRACEFUL_SHUTDOWN_TIMEOUT_S",
+            0.01,
+        ):
+            await metrics_pusher.graceful_shutdown()
+
+        assert cancelled.is_set()
+        assert metrics_pusher._async_tasks == {}
 
 
 def assert_timeseries_equal(actual, expected):


### PR DESCRIPTION
## Summary

Fixes #65673.

`MetricsPusher.graceful_shutdown` waited for background metric tasks up to the graceful timeout, then dropped its references to tasks that were still running. A hung metric callback could therefore survive shutdown and retain Serve state.

This change:

- cancels and awaits tasks that remain pending after the graceful timeout;
- cleans up the internal stop-event waiter when `metrics_task` is cancelled;
- preserves the existing bounded graceful-shutdown behavior;
- adds a regression test with a deliberately hanging async metric callback.

## Test plan

- `ruff check python/ray/serve/_private/metrics_utils.py python/ray/serve/tests/unit/test_metrics_utils.py`
- `black --check python/ray/serve/_private/metrics_utils.py python/ray/serve/tests/unit/test_metrics_utils.py`
- Python compilation of both changed files
- `git diff --check`

The focused Ray pytest is blocked locally because the compiled Ray runtime is unavailable.