### PR TITLE
[data] Make checkpoint restore pluggable via CheckpointConfig checkpoint_filter_cls / checkpoint_manager_cls

### DIFF
--- a/python/ray/data/_internal/planner/checkpoint/plan_read_op.py
+++ b/python/ray/data/_internal/planner/checkpoint/plan_read_op.py
@@ -59,7 +59,8 @@ def create_checkpoint_filter_op(
     if info.type == fs.FileType.NotFound:
         return physical_input_op
 
-    checkpoint_manager = IdColumnCheckpointManager(
+    manager_cls = checkpoint_config.checkpoint_manager_cls or IdColumnCheckpointManager
+    checkpoint_manager = manager_cls(
         checkpoint_config=checkpoint_config,
         data_context=data_context,
     )

--- a/python/ray/data/_internal/planner/checkpoint/plan_read_op.py
+++ b/python/ray/data/_internal/planner/checkpoint/plan_read_op.py
@@ -129,7 +129,10 @@ class _CheckpointFilterFn:
 
     def init_checkpoint_filter(self):
         """Called once per actor worker to materialize the filter."""
-        self._filter = NumpyArrayBasedCheckpointFilter(self._config, self._ref)
+        filter_cls = (
+            self._config.checkpoint_filter_cls or NumpyArrayBasedCheckpointFilter
+        )
+        self._filter = filter_cls(self._config, self._ref)
 
     def __call__(self, blocks: Iterable[Block], ctx: TaskContext) -> Iterable[Block]:
         assert self._filter is not None, "checkpoint filter was not initialized!"

--- a/python/ray/data/checkpoint/__init__.py
+++ b/python/ray/data/checkpoint/__init__.py
@@ -21,7 +21,7 @@ def __getattr__(name: str) -> type:
     # Lazily import filter/manager classes to avoid a circular import:
     # checkpoint_filter -> ray.data.context -> this package.
     if name in _LAZY_EXPORTS:
-        from ray.data.checkpoint import checkpoint_filter
+        from . import checkpoint_filter
 
         return getattr(checkpoint_filter, name)
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/python/ray/data/checkpoint/__init__.py
+++ b/python/ray/data/checkpoint/__init__.py
@@ -1,3 +1,18 @@
 from .interfaces import CheckpointBackend, CheckpointConfig
 
-__all__ = ["CheckpointConfig", "CheckpointBackend"]
+__all__ = [
+    "CheckpointConfig",
+    "CheckpointBackend",
+    "CheckpointFilter",
+    "NumpyArrayBasedCheckpointFilter",
+]
+
+
+def __getattr__(name):
+    # Lazily import filter classes to avoid a circular import:
+    # checkpoint_filter -> ray.data.context -> this package.
+    if name in ("CheckpointFilter", "NumpyArrayBasedCheckpointFilter"):
+        from ray.data.checkpoint import checkpoint_filter
+
+        return getattr(checkpoint_filter, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/python/ray/data/checkpoint/__init__.py
+++ b/python/ray/data/checkpoint/__init__.py
@@ -1,4 +1,18 @@
+from typing import TYPE_CHECKING
+
 from .interfaces import CheckpointBackend, CheckpointConfig
+
+if TYPE_CHECKING:
+    # Static-only imports so type checkers see the lazily-exported names
+    # below; at runtime they are resolved by ``__getattr__`` instead, to
+    # avoid a circular import: checkpoint_filter -> ray.data.context ->
+    # this package.
+    from .checkpoint_filter import (  # noqa: F401
+        CheckpointFilter,
+        CheckpointManager,
+        IdColumnCheckpointManager,
+        NumpyArrayBasedCheckpointFilter,
+    )
 
 __all__ = [
     "CheckpointConfig",
@@ -18,8 +32,7 @@ _LAZY_EXPORTS = (
 
 
 def __getattr__(name: str) -> type:
-    # Lazily import filter/manager classes to avoid a circular import:
-    # checkpoint_filter -> ray.data.context -> this package.
+    # See the TYPE_CHECKING block above for why these are lazy.
     if name in _LAZY_EXPORTS:
         from . import checkpoint_filter
 

--- a/python/ray/data/checkpoint/__init__.py
+++ b/python/ray/data/checkpoint/__init__.py
@@ -4,14 +4,23 @@ __all__ = [
     "CheckpointConfig",
     "CheckpointBackend",
     "CheckpointFilter",
+    "CheckpointManager",
+    "IdColumnCheckpointManager",
     "NumpyArrayBasedCheckpointFilter",
 ]
 
+_LAZY_EXPORTS = (
+    "CheckpointFilter",
+    "CheckpointManager",
+    "IdColumnCheckpointManager",
+    "NumpyArrayBasedCheckpointFilter",
+)
+
 
 def __getattr__(name):
-    # Lazily import filter classes to avoid a circular import:
+    # Lazily import filter/manager classes to avoid a circular import:
     # checkpoint_filter -> ray.data.context -> this package.
-    if name in ("CheckpointFilter", "NumpyArrayBasedCheckpointFilter"):
+    if name in _LAZY_EXPORTS:
         from ray.data.checkpoint import checkpoint_filter
 
         return getattr(checkpoint_filter, name)

--- a/python/ray/data/checkpoint/__init__.py
+++ b/python/ray/data/checkpoint/__init__.py
@@ -17,7 +17,7 @@ _LAZY_EXPORTS = (
 )
 
 
-def __getattr__(name):
+def __getattr__(name: str) -> type:
     # Lazily import filter/manager classes to avoid a circular import:
     # checkpoint_filter -> ray.data.context -> this package.
     if name in _LAZY_EXPORTS:

--- a/python/ray/data/checkpoint/checkpoint_filter.py
+++ b/python/ray/data/checkpoint/checkpoint_filter.py
@@ -387,16 +387,24 @@ class CheckpointFilter(abc.ABC):
     """Abstract class which defines the interface for filtering checkpointed rows
     based on varying backends.
 
-    Subclasses passed as ``CheckpointConfig.checkpoint_filter_cls`` must have a
-    constructor accepting ``(checkpoint_config, checkpointed_ids_ref)``, where
-    ``checkpointed_ids_ref`` is an ``ObjectRef`` to the sorted NumPy array of
-    checkpointed IDs. The class is instantiated once per checkpoint filter
-    actor on a remote worker, so it must be serializable (or importable) there.
+    Subclasses passed as ``CheckpointConfig.checkpoint_filter_cls`` are
+    constructed with ``(checkpoint_config, checkpoint_ref)``, where
+    ``checkpoint_ref`` is the ``ObjectRef`` returned by the checkpoint
+    manager's ``load_checkpoint`` (by default, a sorted NumPy array of
+    checkpointed IDs). Subclasses that define their own constructor must
+    accept the same two arguments. The class is instantiated once per
+    checkpoint filter actor on a remote worker, so it must be serializable
+    (or importable) there.
     """
 
-    def __init__(self, config: CheckpointConfig):
+    def __init__(
+        self,
+        config: CheckpointConfig,
+        checkpoint_ref: Optional[ObjectRef] = None,
+    ):
         self.ckpt_config = config
         self.id_column = self.ckpt_config.id_column
+        self.checkpoint_ref = checkpoint_ref
 
     @abstractmethod
     def filter_rows_for_block(self, block: Block) -> Block:
@@ -424,7 +432,7 @@ class NumpyArrayBasedCheckpointFilter(CheckpointFilter):
         checkpoint_config: CheckpointConfig,
         checkpoint_ref: ObjectRef[np.ndarray],
     ):
-        super().__init__(checkpoint_config)
+        super().__init__(checkpoint_config, checkpoint_ref)
         self.checkpointed_ids = ray.get(checkpoint_ref)
         assert isinstance(self.checkpointed_ids, np.ndarray)
 

--- a/python/ray/data/checkpoint/checkpoint_filter.py
+++ b/python/ray/data/checkpoint/checkpoint_filter.py
@@ -22,6 +22,7 @@ from ray.data.checkpoint.util import build_pending_checkpoint_trie
 from ray.data.context import DataContext
 from ray.data.datasource.path_util import _unwrap_protocol
 from ray.types import ObjectRef
+from ray.util.annotations import DeveloperAPI
 
 logger = logging.getLogger(__name__)
 
@@ -369,9 +370,16 @@ class IdColumnCheckpointManager(CheckpointManager):
     """Manager for regular ID columns."""
 
 
+@DeveloperAPI
 class CheckpointFilter(abc.ABC):
     """Abstract class which defines the interface for filtering checkpointed rows
     based on varying backends.
+
+    Subclasses passed as ``CheckpointConfig.checkpoint_filter_cls`` must have a
+    constructor accepting ``(checkpoint_config, checkpointed_ids_ref)``, where
+    ``checkpointed_ids_ref`` is an ``ObjectRef`` to the sorted NumPy array of
+    checkpointed IDs. The class is instantiated once per checkpoint filter
+    actor on a remote worker, so it must be serializable (or importable) there.
     """
 
     def __init__(self, config: CheckpointConfig):
@@ -391,6 +399,7 @@ class CheckpointFilter(abc.ABC):
         raise NotImplementedError
 
 
+@DeveloperAPI
 class NumpyArrayBasedCheckpointFilter(CheckpointFilter):
     """CheckpointFilter for batch-based backends.
 

--- a/python/ray/data/checkpoint/checkpoint_filter.py
+++ b/python/ray/data/checkpoint/checkpoint_filter.py
@@ -167,8 +167,19 @@ def convert_and_sort_checkpointed_ids(
     return checkpointed_ids_ndarray, checkpoint_size
 
 
+@DeveloperAPI
 class CheckpointManager(abc.ABC):
-    """Manage checkpoint data."""
+    """Manage checkpoint data.
+
+    Subclasses passed as ``CheckpointConfig.checkpoint_manager_cls`` must have
+    a constructor accepting ``(checkpoint_config=..., data_context=...)``
+    keyword arguments, and their ``load_checkpoint`` must return an
+    ``(ObjectRef, int)`` tuple: the ref is passed opaquely to the configured
+    ``CheckpointFilter`` class's constructor, and the int (size in bytes) is
+    used for the per-actor memory reservation of the filter actors. Returning
+    ``(None, 0)`` means there is no checkpoint data to restore from, and the
+    checkpoint filter operator is not added to the plan.
+    """
 
     def __init__(
         self,
@@ -366,6 +377,7 @@ class CheckpointManager(abc.ABC):
         pass
 
 
+@DeveloperAPI
 class IdColumnCheckpointManager(CheckpointManager):
     """Manager for regular ID columns."""
 

--- a/python/ray/data/checkpoint/interfaces.py
+++ b/python/ray/data/checkpoint/interfaces.py
@@ -8,7 +8,10 @@ import pyarrow
 from ray.util.annotations import DeveloperAPI, PublicAPI
 
 if TYPE_CHECKING:
-    from ray.data.checkpoint.checkpoint_filter import CheckpointFilter
+    from ray.data.checkpoint.checkpoint_filter import (
+        CheckpointFilter,
+        CheckpointManager,
+    )
     from ray.data.datasource import PathPartitionFilter
 
 
@@ -71,9 +74,20 @@ class CheckpointConfig:
             subclass used to filter out already-checkpointed rows during
             restoration. The class is instantiated once per checkpoint filter
             actor with ``(checkpoint_config, checkpointed_ids_ref)``, where
-            ``checkpointed_ids_ref`` is an ``ObjectRef`` to the sorted NumPy
-            array of checkpointed IDs. Defaults to
+            ``checkpointed_ids_ref`` is the ``ObjectRef`` returned by the
+            checkpoint manager's ``load_checkpoint`` (by default, a sorted
+            NumPy array of checkpointed IDs). Defaults to
             :class:`~ray.data.checkpoint.NumpyArrayBasedCheckpointFilter`.
+        checkpoint_manager_cls: Override the
+            :class:`~ray.data.checkpoint.CheckpointManager` subclass used to
+            load checkpoint data during restoration. The class is instantiated
+            on the driver with ``(checkpoint_config=..., data_context=...)``
+            and its ``load_checkpoint`` must return an ``(ObjectRef, int)``
+            tuple: the ref is passed opaquely to ``checkpoint_filter_cls``,
+            and the int (size in bytes) feeds the per-actor memory
+            reservation. Typically customized together with
+            ``checkpoint_filter_cls``. Defaults to
+            :class:`~ray.data.checkpoint.IdColumnCheckpointManager`.
     """
 
     DEFAULT_CHECKPOINT_PATH_BUCKET_ENV_VAR = "RAY_DATA_CHECKPOINT_PATH_BUCKET"
@@ -93,6 +107,7 @@ class CheckpointConfig:
         write_num_threads: int = 3,
         checkpoint_path_partition_filter: Optional["PathPartitionFilter"] = None,
         checkpoint_filter_cls: Optional[Type["CheckpointFilter"]] = None,
+        checkpoint_manager_cls: Optional[Type["CheckpointManager"]] = None,
     ):
         self.id_column: Optional[str] = id_column
 
@@ -112,6 +127,18 @@ class CheckpointConfig:
                 raise InvalidCheckpointingConfig(
                     "`checkpoint_filter_cls` must be a subclass of "
                     f"`CheckpointFilter`, but got {checkpoint_filter_cls}"
+                )
+
+        if checkpoint_manager_cls is not None:
+            from ray.data.checkpoint.checkpoint_filter import CheckpointManager
+
+            if not (
+                isinstance(checkpoint_manager_cls, type)
+                and issubclass(checkpoint_manager_cls, CheckpointManager)
+            ):
+                raise InvalidCheckpointingConfig(
+                    "`checkpoint_manager_cls` must be a subclass of "
+                    f"`CheckpointManager`, but got {checkpoint_manager_cls}"
                 )
 
         if override_backend is not None:
@@ -135,6 +162,7 @@ class CheckpointConfig:
         self.write_num_threads: int = write_num_threads
         self.checkpoint_path_partition_filter = checkpoint_path_partition_filter
         self.checkpoint_filter_cls = checkpoint_filter_cls
+        self.checkpoint_manager_cls = checkpoint_manager_cls
         self.checkpoint_actor_pool_min_size = self.CHECKPOINT_ACTOR_POOL_MIN_SIZE
         self.checkpoint_actor_pool_max_size = self.CHECKPOINT_ACTOR_POOL_MAX_SIZE
         self.checkpoint_actor_memory_bytes = self.CHECKPOINT_ACTOR_MEMORY_BYTES

--- a/python/ray/data/checkpoint/interfaces.py
+++ b/python/ray/data/checkpoint/interfaces.py
@@ -1,3 +1,4 @@
+import inspect
 import os
 import warnings
 from enum import Enum
@@ -44,6 +45,32 @@ class CheckpointBackend(Enum):
     Note, when using this backend, the checkpoint path must be a network-mounted
     file system (e.g. `/mnt/cluster_storage/`).
     """
+
+
+def _validate_checkpoint_cls(cls: type, base_cls: type, param_name: str) -> None:
+    """Validate that ``cls`` is a concrete subclass of ``base_cls``.
+
+    Args:
+        cls: The user-provided class to validate.
+        base_cls: The required base class.
+        param_name: The ``CheckpointConfig`` parameter name, for error messages.
+
+    Raises:
+        InvalidCheckpointingConfig: if ``cls`` is not a subclass of
+            ``base_cls``, or is abstract (so instantiation would fail later
+            inside a remote worker instead of at config construction).
+    """
+    if not (isinstance(cls, type) and issubclass(cls, base_cls)):
+        raise InvalidCheckpointingConfig(
+            f"`{param_name}` must be a subclass of `{base_cls.__name__}`, "
+            f"but got {cls}"
+        )
+    if inspect.isabstract(cls):
+        raise InvalidCheckpointingConfig(
+            f"`{param_name}` must be a concrete class, but {cls} is abstract "
+            "(it does not implement all abstract methods of "
+            f"`{base_cls.__name__}`)"
+        )
 
 
 @PublicAPI(stability="beta")
@@ -120,26 +147,16 @@ class CheckpointConfig:
         if checkpoint_filter_cls is not None:
             from ray.data.checkpoint.checkpoint_filter import CheckpointFilter
 
-            if not (
-                isinstance(checkpoint_filter_cls, type)
-                and issubclass(checkpoint_filter_cls, CheckpointFilter)
-            ):
-                raise InvalidCheckpointingConfig(
-                    "`checkpoint_filter_cls` must be a subclass of "
-                    f"`CheckpointFilter`, but got {checkpoint_filter_cls}"
-                )
+            _validate_checkpoint_cls(
+                checkpoint_filter_cls, CheckpointFilter, "checkpoint_filter_cls"
+            )
 
         if checkpoint_manager_cls is not None:
             from ray.data.checkpoint.checkpoint_filter import CheckpointManager
 
-            if not (
-                isinstance(checkpoint_manager_cls, type)
-                and issubclass(checkpoint_manager_cls, CheckpointManager)
-            ):
-                raise InvalidCheckpointingConfig(
-                    "`checkpoint_manager_cls` must be a subclass of "
-                    f"`CheckpointManager`, but got {checkpoint_manager_cls}"
-                )
+            _validate_checkpoint_cls(
+                checkpoint_manager_cls, CheckpointManager, "checkpoint_manager_cls"
+            )
 
         if override_backend is not None:
             warnings.warn(

--- a/python/ray/data/checkpoint/interfaces.py
+++ b/python/ray/data/checkpoint/interfaces.py
@@ -1,13 +1,14 @@
 import os
 import warnings
 from enum import Enum
-from typing import TYPE_CHECKING, Optional, Tuple
+from typing import TYPE_CHECKING, Optional, Tuple, Type
 
 import pyarrow
 
 from ray.util.annotations import DeveloperAPI, PublicAPI
 
 if TYPE_CHECKING:
+    from ray.data.checkpoint.checkpoint_filter import CheckpointFilter
     from ray.data.datasource import PathPartitionFilter
 
 
@@ -66,6 +67,13 @@ class CheckpointConfig:
             completed rows.
         checkpoint_path_partition_filter: Filter for checkpoint files to load during
             restoration when reading from `checkpoint_path`.
+        checkpoint_filter_cls: Override the :class:`~ray.data.checkpoint.CheckpointFilter`
+            subclass used to filter out already-checkpointed rows during
+            restoration. The class is instantiated once per checkpoint filter
+            actor with ``(checkpoint_config, checkpointed_ids_ref)``, where
+            ``checkpointed_ids_ref`` is an ``ObjectRef`` to the sorted NumPy
+            array of checkpointed IDs. Defaults to
+            :class:`~ray.data.checkpoint.NumpyArrayBasedCheckpointFilter`.
     """
 
     DEFAULT_CHECKPOINT_PATH_BUCKET_ENV_VAR = "RAY_DATA_CHECKPOINT_PATH_BUCKET"
@@ -84,6 +92,7 @@ class CheckpointConfig:
         override_backend: Optional[CheckpointBackend] = None,
         write_num_threads: int = 3,
         checkpoint_path_partition_filter: Optional["PathPartitionFilter"] = None,
+        checkpoint_filter_cls: Optional[Type["CheckpointFilter"]] = None,
     ):
         self.id_column: Optional[str] = id_column
 
@@ -92,6 +101,18 @@ class CheckpointConfig:
                 "Checkpoint ID column must be a non-empty string, "
                 f"but got {self.id_column}"
             )
+
+        if checkpoint_filter_cls is not None:
+            from ray.data.checkpoint.checkpoint_filter import CheckpointFilter
+
+            if not (
+                isinstance(checkpoint_filter_cls, type)
+                and issubclass(checkpoint_filter_cls, CheckpointFilter)
+            ):
+                raise InvalidCheckpointingConfig(
+                    "`checkpoint_filter_cls` must be a subclass of "
+                    f"`CheckpointFilter`, but got {checkpoint_filter_cls}"
+                )
 
         if override_backend is not None:
             warnings.warn(
@@ -113,6 +134,7 @@ class CheckpointConfig:
         self.delete_checkpoint_on_success: bool = delete_checkpoint_on_success
         self.write_num_threads: int = write_num_threads
         self.checkpoint_path_partition_filter = checkpoint_path_partition_filter
+        self.checkpoint_filter_cls = checkpoint_filter_cls
         self.checkpoint_actor_pool_min_size = self.CHECKPOINT_ACTOR_POOL_MIN_SIZE
         self.checkpoint_actor_pool_max_size = self.CHECKPOINT_ACTOR_POOL_MAX_SIZE
         self.checkpoint_actor_memory_bytes = self.CHECKPOINT_ACTOR_MEMORY_BYTES

--- a/python/ray/data/checkpoint/interfaces.py
+++ b/python/ray/data/checkpoint/interfaces.py
@@ -100,8 +100,8 @@ class CheckpointConfig:
         checkpoint_filter_cls: Override the :class:`~ray.data.checkpoint.CheckpointFilter`
             subclass used to filter out already-checkpointed rows during
             restoration. The class is instantiated once per checkpoint filter
-            actor with ``(checkpoint_config, checkpointed_ids_ref)``, where
-            ``checkpointed_ids_ref`` is the ``ObjectRef`` returned by the
+            actor with ``(checkpoint_config, checkpoint_ref)``, where
+            ``checkpoint_ref`` is the ``ObjectRef`` returned by the
             checkpoint manager's ``load_checkpoint`` (by default, a sorted
             NumPy array of checkpointed IDs). Defaults to
             :class:`~ray.data.checkpoint.NumpyArrayBasedCheckpointFilter`.

--- a/python/ray/data/tests/test_checkpoint.py
+++ b/python/ray/data/tests/test_checkpoint.py
@@ -278,6 +278,22 @@ class TestCheckpointConfig:
         assert config.filesystem is fs
         assert config.backend is CheckpointBackend.CLOUD_OBJECT_STORAGE
 
+    @pytest.mark.parametrize("filter_cls", [1, "not_a_class", int])
+    def test_invalid_checkpoint_filter_cls(self, filter_cls, local_path):
+        with pytest.raises(
+            InvalidCheckpointingConfig,
+            match="`checkpoint_filter_cls` must be a subclass of `CheckpointFilter`",
+        ):
+            CheckpointConfig(ID_COL, local_path, checkpoint_filter_cls=filter_cls)
+
+    def test_valid_checkpoint_filter_cls(self, local_path):
+        assert CheckpointConfig(ID_COL, local_path).checkpoint_filter_cls is None
+
+        config = CheckpointConfig(
+            ID_COL, local_path, checkpoint_filter_cls=NumpyArrayBasedCheckpointFilter
+        )
+        assert config.checkpoint_filter_cls is NumpyArrayBasedCheckpointFilter
+
 
 @pytest.mark.parametrize(
     "backend,fs,data_path",
@@ -376,6 +392,46 @@ def test_checkpoint_end_to_end(
         f"Expected only non-checkpointed IDs {expected_remaining_ids}, "
         f"but got {actual_output}"
     )
+
+
+def test_custom_checkpoint_filter_cls(
+    ray_start_10_cpus_shared, generate_sample_data_csv, tmp_path
+):
+    """A custom `checkpoint_filter_cls` replaces the default filter during restore."""
+
+    class NoOpCheckpointFilter(NumpyArrayBasedCheckpointFilter):
+        def filter_rows_for_block(self, block):
+            # Keep every row, including already-checkpointed ones.
+            return block
+
+    ctx = ray.data.DataContext.get_current()
+    ckpt_path = os.path.join(tmp_path, "ckpt")
+    ctx.checkpoint_config = CheckpointConfig(
+        id_column=ID_COL,
+        checkpoint_path=ckpt_path,
+        checkpoint_filter_cls=NoOpCheckpointFilter,
+    )
+
+    csv_file = generate_sample_data_csv()
+
+    # Pre-populate the checkpoint dir. The default filter would drop these IDs
+    # on restore; the no-op filter must keep them.
+    checkpointed_ids = list(range(SAMPLE_DATA_NUM_ROWS // 2))
+    os.makedirs(ckpt_path, exist_ok=True)
+    pq.write_table(
+        pa.table({ID_COL: checkpointed_ids}),
+        os.path.join(ckpt_path, "pre_checkpoint.parquet"),
+    )
+
+    output_path = os.path.join(tmp_path, "output")
+    ds = ray.data.read_csv(csv_file)
+    ds.write_parquet(output_path)
+
+    # Disable checkpointing before reading back to avoid filtering.
+    ctx.checkpoint_config = None
+    ds_readback = ray.data.read_parquet(output_path)
+    actual_output = sorted([row[ID_COL] for row in ds_readback.iter_rows()])
+    assert actual_output == list(range(SAMPLE_DATA_NUM_ROWS))
 
 
 @pytest.mark.parametrize(

--- a/python/ray/data/tests/test_checkpoint.py
+++ b/python/ray/data/tests/test_checkpoint.py
@@ -310,6 +310,21 @@ class TestCheckpointConfig:
         )
         assert config.checkpoint_manager_cls is IdColumnCheckpointManager
 
+    def test_abstract_checkpoint_filter_cls(self, local_path):
+        """The abstract base class (or a still-abstract subclass) is rejected
+        at config construction instead of failing inside a filter actor."""
+        from ray.data.checkpoint.checkpoint_filter import CheckpointFilter
+
+        class StillAbstractFilter(CheckpointFilter):
+            pass
+
+        for cls in [CheckpointFilter, StillAbstractFilter]:
+            with pytest.raises(
+                InvalidCheckpointingConfig,
+                match="`checkpoint_filter_cls` must be a concrete class",
+            ):
+                CheckpointConfig(ID_COL, local_path, checkpoint_filter_cls=cls)
+
 
 @pytest.mark.parametrize(
     "backend,fs,data_path",

--- a/python/ray/data/tests/test_checkpoint.py
+++ b/python/ray/data/tests/test_checkpoint.py
@@ -429,8 +429,12 @@ def test_custom_checkpoint_filter_cls(
     ray_start_10_cpus_shared, generate_sample_data_csv, tmp_path
 ):
     """A custom `checkpoint_filter_cls` replaces the default filter during restore."""
+    from ray.data.checkpoint.checkpoint_filter import CheckpointFilter
 
-    class NoOpCheckpointFilter(NumpyArrayBasedCheckpointFilter):
+    # Subclasses the ABC directly without defining `__init__`, so this also
+    # verifies that the inherited base constructor accepts the
+    # `(checkpoint_config, checkpoint_ref)` call from the filter actor.
+    class NoOpCheckpointFilter(CheckpointFilter):
         def filter_rows_for_block(self, block):
             # Keep every row, including already-checkpointed ones.
             return block

--- a/python/ray/data/tests/test_checkpoint.py
+++ b/python/ray/data/tests/test_checkpoint.py
@@ -294,6 +294,22 @@ class TestCheckpointConfig:
         )
         assert config.checkpoint_filter_cls is NumpyArrayBasedCheckpointFilter
 
+    @pytest.mark.parametrize("manager_cls", [1, "not_a_class", int])
+    def test_invalid_checkpoint_manager_cls(self, manager_cls, local_path):
+        with pytest.raises(
+            InvalidCheckpointingConfig,
+            match="`checkpoint_manager_cls` must be a subclass of `CheckpointManager`",
+        ):
+            CheckpointConfig(ID_COL, local_path, checkpoint_manager_cls=manager_cls)
+
+    def test_valid_checkpoint_manager_cls(self, local_path):
+        assert CheckpointConfig(ID_COL, local_path).checkpoint_manager_cls is None
+
+        config = CheckpointConfig(
+            ID_COL, local_path, checkpoint_manager_cls=IdColumnCheckpointManager
+        )
+        assert config.checkpoint_manager_cls is IdColumnCheckpointManager
+
 
 @pytest.mark.parametrize(
     "backend,fs,data_path",
@@ -416,6 +432,47 @@ def test_custom_checkpoint_filter_cls(
 
     # Pre-populate the checkpoint dir. The default filter would drop these IDs
     # on restore; the no-op filter must keep them.
+    checkpointed_ids = list(range(SAMPLE_DATA_NUM_ROWS // 2))
+    os.makedirs(ckpt_path, exist_ok=True)
+    pq.write_table(
+        pa.table({ID_COL: checkpointed_ids}),
+        os.path.join(ckpt_path, "pre_checkpoint.parquet"),
+    )
+
+    output_path = os.path.join(tmp_path, "output")
+    ds = ray.data.read_csv(csv_file)
+    ds.write_parquet(output_path)
+
+    # Disable checkpointing before reading back to avoid filtering.
+    ctx.checkpoint_config = None
+    ds_readback = ray.data.read_parquet(output_path)
+    actual_output = sorted([row[ID_COL] for row in ds_readback.iter_rows()])
+    assert actual_output == list(range(SAMPLE_DATA_NUM_ROWS))
+
+
+def test_custom_checkpoint_manager_cls(
+    ray_start_10_cpus_shared, generate_sample_data_csv, tmp_path
+):
+    """A custom `checkpoint_manager_cls` replaces the default manager during restore."""
+
+    class EmptyCheckpointManager(IdColumnCheckpointManager):
+        def load_checkpoint(self, data_file_dir=None, data_file_filesystem=None):
+            # Report no checkpoint data, so no filter operator is added.
+            return None, 0
+
+    ctx = ray.data.DataContext.get_current()
+    ckpt_path = os.path.join(tmp_path, "ckpt")
+    ctx.checkpoint_config = CheckpointConfig(
+        id_column=ID_COL,
+        checkpoint_path=ckpt_path,
+        checkpoint_manager_cls=EmptyCheckpointManager,
+    )
+
+    csv_file = generate_sample_data_csv()
+
+    # Pre-populate the checkpoint dir. The default manager would load these
+    # IDs and filter them out on restore; the custom manager reports no
+    # checkpoint data, so every row must be written.
     checkpointed_ids = list(range(SAMPLE_DATA_NUM_ROWS // 2))
     os.makedirs(ckpt_path, exist_ok=True)
     pq.write_table(


### PR DESCRIPTION
## Why are these changes needed?

The checkpoint restore path currently hardcodes its two concrete classes — `IdColumnCheckpointManager` (loads checkpointed IDs) and `NumpyArrayBasedCheckpointFilter` (filters blocks against them) — even though both ABCs (`CheckpointManager`, `CheckpointFilter`) already define the interfaces. This PR makes the restore path pluggable via two optional `CheckpointConfig` fields, `checkpoint_manager_cls` and `checkpoint_filter_cls`, mirroring the existing pluggability pattern on the write side (`CheckpointWriter.create` dispatches on config).

Motivation: the restore path is the main scalability pressure point for large datasets (see #60200, #61509). Concretely, to checkpoint a 10B+ row partitioned Parquet dataset, the current design doesn't scale — all checkpointed IDs are coalesced and sorted into a single in-memory array (~80 GB at 10B uint64 IDs). Supporting that scale requires checkpointing that takes advantage of the dataset's partitioning: a custom manager loads checkpoint IDs as per-partition shards instead of one array, and a matching custom filter checks each block only against its shard. This PR exposes the interfaces for that customization without changing default behavior; today it requires forking or monkeypatching internals.

Changes:
- `CheckpointConfig(checkpoint_filter_cls=..., checkpoint_manager_cls=...)`: both optional, validated to be subclasses of their respective ABCs, default `None` (existing behavior unchanged).
- `create_checkpoint_filter_op` resolves the manager class and `_CheckpointFilterFn.init_checkpoint_filter` resolves the filter class from the config; covers both the V1 `Read` and V2 `ReadFiles` paths since both go through `create_checkpoint_filter_op`.
- `CheckpointFilter`, `NumpyArrayBasedCheckpointFilter`, `CheckpointManager`, and `IdColumnCheckpointManager` are annotated `@DeveloperAPI` and lazily re-exported from `ray.data.checkpoint` (lazy to avoid the `checkpoint_filter -> ray.data.context -> ray.data.checkpoint` import cycle).
- The contracts are documented on the ABCs and in the `CheckpointConfig` docstring: the filter is constructed per actor with `(checkpoint_config, checkpointed_ids_ref)`; the manager is constructed on the driver with `(checkpoint_config=..., data_context=...)` and its `load_checkpoint` returns `(ObjectRef, int)` — the ref is passed opaquely to the filter, the size feeds the per-actor memory reservation, and `(None, 0)` skips the filter operator entirely.

Not duplicating existing work: no open PR touches checkpoint filter pluggability (searched `gh pr list` for CheckpointFilter/checkpoint filter). Related-but-different open issues: #60704 asks for custom *placement* of the filter in the plan, #54520 for per-op config — this PR is complementary to both (it changes *which* filter runs, not where).

## Related issue number

Related: #60200, #61509, #60704

## Checks

- [x] I've signed off every commit (DCO).
- [x] I've run pre-commit hooks (`pre-commit run --files ...`) — all hooks pass (semgrep skipped: unsupported on Linux ARM64 locally).
- [x] Tests:
  - `pytest python/ray/data/tests/test_checkpoint.py` run locally: 68 passed, 3 failed — the 3 (`test_partial_failure_no_duplicates{,_partitioned,_row_based}`) fail identically on unmodified master in this environment (`ModuleNotFoundError: No module named 'test_checkpoint'` from the mid-test `ray.init()` when pytest runs from the repo root) and all 3 pass on both master and this branch when run from `python/ray/data/tests/`. Not related to this change.
  - New tests (10, all passing): `TestCheckpointConfig::test_{invalid,valid}_checkpoint_filter_cls` and `test_{invalid,valid}_checkpoint_manager_cls` (config validation), `test_custom_checkpoint_filter_cls` (end-to-end: a no-op filter subclass keeps already-checkpointed rows, proving the custom class is instantiated in the filter actor), and `test_custom_checkpoint_manager_cls` (end-to-end: a manager subclass returning `(None, 0)` skips filtering despite checkpoint data being present, proving the custom manager drives the restore).
- [x] AI assistance was used for this change (Claude Code); the submitting human has reviewed every changed line and run the tests locally.

Notes for reviewers:
- Validation rejects abstract classes (`inspect.isabstract`) in addition to the usual `issubclass` check. This is stricter than Ray's other pluggable-class params (`ExecutionCallback`, `ShuffleAggregation`), which are instantiated on the driver right after validation and so fail loudly on their own. Here the filter class is serialized to and instantiated inside **remote filter actors**, so without early validation an abstract class only fails deep in the actor pool as a confusing crash/retry loop — validating at `CheckpointConfig` construction surfaces the mistake immediately on the driver.
- `DeveloperAPI` classes aren't required by the API-discrepancy check, so no `doc/source/data/api/checkpoint.rst` entry is included; happy to add one if preferred.
- The dict-form `DataContext.checkpoint_config` path (`CheckpointConfig(**value)`) picks up the new kwargs automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
