### PR TITLE
[serve] Enable model multiplexing for direct ingress deployments

### DIFF
--- a/python/ray/serve/_private/deploy_utils.py
+++ b/python/ray/serve/_private/deploy_utils.py
@@ -84,17 +84,6 @@ def deploy_args_to_deployment_info(
     deployment_config = DeploymentConfig.from_proto_bytes(deployment_config_proto_bytes)
 
     if ingress and RAY_SERVE_ENABLE_DIRECT_INGRESS:
-        # Model multiplexing relies on the multiplexed model ID being propagated through
-        # the proxy, which direct ingress bypasses (the model ID is never populated).
-        # Only the *statically* detectable case is caught here; dynamically-initialized
-        # multiplexing is caught at replica initialization.
-        if uses_multiplexing:
-            raise RayServeException(
-                f'Ingress deployment "{deployment_name}" in application "{app_name}" uses '
-                "model multiplexing (`@serve.multiplexed`), which is not supported on the "
-                "ingress deployment when direct ingress or HAProxy is enabled."
-            )
-
         # Floor the timeout so the controller's force-kill can't cut the
         # direct-ingress drain (min draining period) short.
         floor_s = (

--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -107,6 +107,7 @@ from ray.serve._private.constants import (
     SERVE_LOG_REQUEST_ID,
     SERVE_LOG_ROUTE,
     SERVE_LOGGER_NAME,
+    SERVE_MULTIPLEXED_MODEL_ID,
     SERVE_NAMESPACE,
     USER_HEALTH_CHECK_PROBE_INTERVAL_S,
     USER_HEALTH_CHECK_PROBE_MAX_FAIL,
@@ -176,7 +177,6 @@ from ray.serve._private.tracing_utils import (
 from ray.serve._private.usage import ServeUsageTag
 from ray.serve._private.utils import (
     Semaphore,
-    _callable_uses_multiplexing,
     asyncio_grpc_exception_handler,
     check_obj_ref_ready_nowait,
     compress_metric_report,
@@ -1848,25 +1848,6 @@ class Replica:
         if self._initialization_latency is None:
             self._initialization_latency = time.time() - self._initialization_start_time
 
-    def _raise_if_multiplexing_with_direct_ingress(self):
-        """Reject model multiplexing on the ingress deployment under direct ingress.
-
-        Model multiplexing relies on the multiplexed model ID being propagated through
-        the proxy, which direct ingress bypasses (the model ID is never populated).
-
-        This runs after the user callable is initialized so it also catches
-        multiplexing that is wired up dynamically in the constructor (e.g.
-        `self._load_model = serve.multiplexed(...)(fn)`), which is invisible to the
-        static check performed at deploy time.
-        """
-        if self._ingress and RAY_SERVE_ENABLE_DIRECT_INGRESS:
-            if _callable_uses_multiplexing(self._user_callable_wrapper._callable):
-                raise RuntimeError(
-                    "Model multiplexing (`@serve.multiplexed`) is not supported on the "
-                    "ingress deployment when direct ingress or HAProxy is enabled "
-                    "(RAY_SERVE_ENABLE_DIRECT_INGRESS)."
-                )
-
     async def initialize(
         self,
         deployment_config: Optional[DeploymentConfig],
@@ -1890,7 +1871,6 @@ class Replica:
                     self._user_callable_asgi_app = (
                         await self._user_callable_wrapper.initialize_callable()
                     )
-                    self._raise_if_multiplexing_with_direct_ingress()
                     self._user_callable_wrapper.start_user_loop_watchdog(
                         self._event_loop
                     )
@@ -3150,6 +3130,11 @@ class Replica:
         request_disconnect_disabled = parse_disconnect_disabled_header(headers)
         request_timeout_s = self._parse_request_timeout(headers)
         session_id = parse_session_id_header(headers)
+        multiplexed_model_id = ""
+        for key, value in headers.items():
+            if key.decode().lower().replace("-", "_") == SERVE_MULTIPLEXED_MODEL_ID:
+                multiplexed_model_id = value.decode()
+                break
 
         request_metadata = RequestMetadata(
             request_id=request_id,
@@ -3157,8 +3142,7 @@ class Replica:
             call_method="__call__",
             route=self._determine_http_route(scope),
             app_name=self._deployment_id.app_name,
-            # TODO(edoakes): populate the multiplexed model ID.
-            multiplexed_model_id="",
+            multiplexed_model_id=multiplexed_model_id,
             session_id=session_id,
             is_streaming=True,
             _request_protocol=RequestProtocol.HTTP,

--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -2608,6 +2608,7 @@ class Replica:
         c = RayServegRPCContext(context)
         request_id = c.request_id() or generate_request_id()
         c.set_trailing_metadata([("request_id", request_id)])
+        multiplexed_model_id = c.multiplexed_model_id() or ""
 
         # If the request targets a different application, return NOT_FOUND.
         # If no application is specified, serve this replica's app.
@@ -2643,8 +2644,7 @@ class Replica:
             _request_protocol=RequestProtocol.GRPC,
             grpc_context=c,
             app_name=self._deployment_id.app_name,
-            # TODO(edoakes): populate this.
-            multiplexed_model_id="",
+            multiplexed_model_id=multiplexed_model_id,
             route=self._deployment_id.app_name,
             tracing_context=self.get_grpc_tracing_context(c),
             is_streaming=is_streaming,

--- a/python/ray/serve/grpc_util.py
+++ b/python/ray/serve/grpc_util.py
@@ -164,6 +164,10 @@ class RayServegRPCContext:
         """
         return self._invocation_metadata_dict.get("application")
 
+    def multiplexed_model_id(self) -> Optional[str]:
+        """Accesses the multiplexed model ID for the RPC, if provided."""
+        return self._invocation_metadata_dict.get("multiplexed_model_id")
+
     def traceparent(self) -> Optional[str]:
         """Accesses the traceparent for the RPC.
 

--- a/python/ray/serve/tests/test_config_files/grpc_deployment.py
+++ b/python/ray/serve/tests/test_config_files/grpc_deployment.py
@@ -40,10 +40,8 @@ class GrpcDeployment:
 g = GrpcDeployment.options(name="grpc-deployment").bind()
 
 
-# NOTE: model multiplexing is kept on a separate deployment (not the shared `g`)
-# because it is not supported on the ingress deployment when direct ingress /
-# HAProxy is enabled (the multiplexed model ID is not propagated to the replica).
-# Tests that exercise it must be skipped under those modes.
+# Model multiplexing is kept on a separate deployment from the shared `g` so tests can
+# exercise model-specific behavior independently.
 @serve.deployment
 class MultiplexedGrpcDeployment:
     def __call__(self, user_message):

--- a/python/ray/serve/tests/test_direct_ingress.py
+++ b/python/ray/serve/tests/test_direct_ingress.py
@@ -33,6 +33,7 @@ from ray.serve._private.constants import (
     RAY_SERVE_ENABLE_HA_PROXY,
     SERVE_DEFAULT_APP_NAME,
     SERVE_HTTP_REQUEST_TIMEOUT_S_HEADER,
+    SERVE_MULTIPLEXED_MODEL_ID,
     SERVE_NAMESPACE,
 )
 from ray.serve._private.deployment_info import DeploymentInfo
@@ -48,7 +49,6 @@ from ray.serve._private.test_utils import (
 from ray.serve.autoscaling_policy import default_autoscaling_policy
 from ray.serve.config import ProxyLocation
 from ray.serve.context import _get_global_client
-from ray.serve.exceptions import RayServeException
 from ray.serve.generated import serve_pb2, serve_pb2_grpc
 from ray.serve.generated.serve_pb2 import DeploymentRoute
 from ray.serve.schema import (
@@ -410,18 +410,14 @@ def test_http_request_id(_skip_if_ff_not_enabled, serve_instance, use_fastapi: b
     assert r.text == "TEST-HEADER" and r.text == r.headers["x-request-id"]
 
 
-def test_multiplexed_model_id(_skip_if_ff_not_enabled, serve_instance):
-    pytest.skip("TODO: test that sends a MM ID and checks that it's set correctly")
-
-
-def test_multiplexing_on_ingress_not_supported(_skip_if_ff_not_enabled, serve_instance):
-    """Model multiplexing on the ingress deployment is unsupported with direct ingress.
-
-    The multiplexed model ID is propagated through the proxy, which direct ingress
-    bypasses, so deploying such an app is rejected at build time with a clear error.
-    """
-
-    @serve.deployment(name="multiplexed-ingress")
+@pytest.mark.parametrize(
+    "header_name",
+    [SERVE_MULTIPLEXED_MODEL_ID, SERVE_MULTIPLEXED_MODEL_ID.replace("_", "-")],
+)
+def test_multiplexed_model_id(
+    _skip_if_ff_not_enabled, serve_instance, header_name: str
+):
+    @serve.deployment
     class MultiplexedIngress:
         @serve.multiplexed(max_num_models_per_replica=2)
         async def load_model(self, model_id: str) -> str:
@@ -430,8 +426,13 @@ def test_multiplexing_on_ingress_not_supported(_skip_if_ff_not_enabled, serve_in
         async def __call__(self, request: Request) -> str:
             return await self.load_model(serve.get_multiplexed_model_id())
 
-    with pytest.raises(RayServeException, match="model multiplexing"):
-        serve.run(MultiplexedIngress.bind())
+    serve.run(MultiplexedIngress.bind())
+    response = httpx.get(
+        get_application_url("HTTP", from_proxy_manager=True),
+        headers={header_name: "adapter"},
+    )
+    assert response.status_code == 200, response.text
+    assert response.text == "adapter"
 
 
 def test_health_check(_skip_if_ff_not_enabled, serve_instance):

--- a/python/ray/serve/tests/test_direct_ingress.py
+++ b/python/ray/serve/tests/test_direct_ingress.py
@@ -44,6 +44,7 @@ from ray.serve._private.test_utils import (
     get_application_url,
     get_application_urls,
     ping_grpc_list_applications,
+    ping_grpc_model_multiplexing,
     send_signal_on_cancellation,
 )
 from ray.serve.autoscaling_policy import default_autoscaling_policy
@@ -59,6 +60,7 @@ from ray.serve.schema import (
     ServeInstanceDetails,
 )
 from ray.serve.tests.conftest import TEST_GRPC_SERVICER_FUNCTIONS
+from ray.serve.tests.test_config_files.grpc_deployment import multiplexed_g
 
 
 @ray.remote
@@ -433,6 +435,16 @@ def test_multiplexed_model_id(
     )
     assert response.status_code == 200, response.text
     assert response.text == "adapter"
+
+
+def test_grpc_multiplexed_model_id(_skip_if_ff_not_enabled, serve_instance):
+    serve.run(multiplexed_g)
+    for grpc_url in get_application_urls("gRPC", from_proxy_manager=True):
+        channel = grpc.insecure_channel(grpc_url)
+        try:
+            ping_grpc_model_multiplexing(channel, SERVE_DEFAULT_APP_NAME)
+        finally:
+            channel.close()
 
 
 def test_health_check(_skip_if_ff_not_enabled, serve_instance):

--- a/python/ray/serve/tests/unit/test_proxy_request_response.py
+++ b/python/ray/serve/tests/unit/test_proxy_request_response.py
@@ -227,6 +227,10 @@ class TestgRPCProxyRequest:
         assert proxy_request.app_name == application
         assert proxy_request.request_id == request_id
         assert proxy_request.multiplexed_model_id == multiplexed_model_id
+        assert (
+            proxy_request.ray_serve_grpc_context.multiplexed_model_id()
+            == multiplexed_model_id
+        )
         assert proxy_request.session_id == session_id
         assert proxy_request.is_route_request is False
         assert proxy_request.is_health_request is False


### PR DESCRIPTION
## Description
- Enable model multiplexing for direct-ingress deployments over both HTTP and gRPC.
- Remove the deployment-time and runtime rejections that prevented a multiplexed direct-ingress app from running.
- At the direct ASGI entry point, recognize both `serve_multiplexed_model_id` and proxy-normalized `serve-multiplexed-model-id`, then store the value in `RequestMetadata.multiplexed_model_id`.
- At the direct gRPC entry point, read `multiplexed_model_id` from gRPC invocation metadata and store it in `RequestMetadata.multiplexed_model_id`.

### Client usage

```python
# HTTP
response = httpx.get(
    direct_ingress_url,
    headers={"serve_multiplexed_model_id": "multiplex-model-id"},
)
```

```python
# gRPC
response = stub.Method2(
    request,
    metadata=(
        ("application", "default"),
        ("multiplexed_model_id", "multiplex-model-id"),
    ),
)
```

## Related issues
Stack: This PR -> https://github.com/ray-project/ray/pull/65679 -> https://github.com/ray-project/ray/pull/66170 -> https://github.com/ray-project/ray/pull/65680 -> `KVAwareRouter` LoRA support.

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
