### PR TITLE
[Core] Retry placement group cleanup while node is alive

### DIFF
--- a/src/ray/gcs/BUILD.bazel
+++ b/src/ray/gcs/BUILD.bazel
@@ -315,6 +315,7 @@ ray_cc_library(
         ":gcs_placement_group",
         ":gcs_table_storage",
         "//src/ray/asio:instrumented_io_context",
+        "//src/ray/common:grpc_util",
         "//src/ray/common:id",
         "//src/ray/raylet/scheduling:cluster_resource_scheduler",
         "//src/ray/raylet/scheduling:scheduling_context",

--- a/src/ray/gcs/gcs_placement_group_scheduler.cc
+++ b/src/ray/gcs/gcs_placement_group_scheduler.cc
@@ -22,6 +22,7 @@
 #include <vector>
 
 #include "ray/asio/asio_util.h"
+#include "ray/common/grpc_util.h"
 
 namespace ray {
 namespace gcs {
@@ -255,26 +256,15 @@ void GcsPlacementGroupScheduler::CommitResources(
 void GcsPlacementGroupScheduler::RemovePlacementGroupBundles(
     const PlacementGroupID &placement_group_id,
     const std::vector<std::shared_ptr<const BundleSpecification>> &bundle_specs,
-    const std::optional<std::shared_ptr<const ray::rpc::GcsNodeInfo>> &node,
-    int max_retry,
-    int current_retry_count) {
+    const NodeID &node_id) {
   if (bundle_specs.empty()) {
     RAY_LOG(WARNING) << "RemovePlacementGroupBundles called on empty bundle list.";
     return;
   }
+  const auto node = gcs_node_manager_.GetAliveNode(node_id);
   if (!node.has_value()) {
     RAY_LOG(INFO) << "Node for placement group " << placement_group_id
                   << " has already been removed. Remove request will be ignored.";
-    return;
-  }
-
-  auto node_id = NodeID::FromBinary(node.value()->node_id());
-
-  if (max_retry == current_retry_count) {
-    RAY_LOG(ERROR) << "Failed to remove " << bundle_specs.size()
-                   << " bundle(s) for placement group " << placement_group_id
-                   << " at node " << node_id
-                   << " because the max retry count is reached.";
     return;
   }
 
@@ -286,36 +276,29 @@ void GcsPlacementGroupScheduler::RemovePlacementGroupBundles(
   raylet_client->RemovePlacementGroupBundles(
       placement_group_id,
       bundle_specs,
-      [this,
-       placement_group_id,
-       bundle_specs,
-       node_id,
-       node,
-       max_retry,
-       current_retry_count](const Status &status,
-                            const rpc::RemovePlacementGroupBundlesReply &reply) {
+      [this, placement_group_id, bundle_specs, node_id](
+          const Status &status, const rpc::RemovePlacementGroupBundlesReply &reply) {
         if (status.ok()) {
           RAY_LOG(INFO) << "Finished removing " << bundle_specs.size()
                         << " bundle(s) for placement group " << placement_group_id
                         << " at node " << node_id;
         } else {
-          // We couldn't delete the pg resources because of network issue. Retry.
+          if (!IsGrpcRetryableStatus(status)) {
+            RAY_LOG(ERROR) << "Failed to remove " << bundle_specs.size()
+                           << " bundle(s) for placement group " << placement_group_id
+                           << " at node " << node_id
+                           << " with a non-retryable status: " << status;
+            return;
+          }
           RAY_LOG(WARNING) << "Failed to remove " << bundle_specs.size()
                            << " bundle(s) for placement group " << placement_group_id
-                           << " at node " << node_id << ". Status: " << status;
+                           << " at node " << node_id
+                           << " with a transient status: " << status
+                           << ". Retrying while the node remains alive.";
           execute_after(
               io_context_,
-              [this,
-               placement_group_id,
-               bundle_specs,
-               node,
-               max_retry,
-               current_retry_count] {
-                RemovePlacementGroupBundles(placement_group_id,
-                                            bundle_specs,
-                                            node,
-                                            max_retry,
-                                            current_retry_count + 1);
+              [this, placement_group_id, bundle_specs, node_id] {
+                RemovePlacementGroupBundles(placement_group_id, bundle_specs, node_id);
               },
               std::chrono::milliseconds(1000) /* milliseconds */);
         }
@@ -683,11 +666,7 @@ void GcsPlacementGroupScheduler::DestroyPlacementGroupPreparedBundleResources(
     RAY_LOG(INFO) << "Removing all prepared bundles of a placement group, id is "
                   << placement_group_id;
     for (auto &entry : GroupBundlesByNode(*leasing_bundle_locations)) {
-      RemovePlacementGroupBundles(placement_group_id,
-                                  entry.second,
-                                  gcs_node_manager_.GetAliveNode(entry.first),
-                                  /*max_retry*/ 5,
-                                  /*current_retry_count*/ 0);
+      RemovePlacementGroupBundles(placement_group_id, entry.second, entry.first);
     }
   }
 }
@@ -705,11 +684,7 @@ void GcsPlacementGroupScheduler::DestroyPlacementGroupCommittedBundleResources(
     RAY_LOG(INFO) << "Removing all committed bundles of a placement group, id is "
                   << placement_group_id;
     for (auto &entry : GroupBundlesByNode(*committed_bundle_locations)) {
-      RemovePlacementGroupBundles(placement_group_id,
-                                  entry.second,
-                                  gcs_node_manager_.GetAliveNode(entry.first),
-                                  /*max_retry*/ 5,
-                                  /*current_retry_count*/ 0);
+      RemovePlacementGroupBundles(placement_group_id, entry.second, entry.first);
     }
     committed_bundle_location_index_.Erase(placement_group_id);
     cluster_resource_scheduler_.GetClusterResourceManager()

--- a/src/ray/gcs/gcs_placement_group_scheduler.h
+++ b/src/ray/gcs/gcs_placement_group_scheduler.h
@@ -387,15 +387,11 @@ class GcsPlacementGroupScheduler : public GcsPlacementGroupSchedulerInterface {
   ///
   /// \param placement_group_id The placement group whose bundles are being removed.
   /// \param bundle_specs Bundles to remove on the node.
-  /// \param node The node that the bundles are being removed from.
-  /// \param max_retry The maximum times the remove request can be retried.
-  /// \param current_retry_count The number of times the remove request has been retried.
+  /// \param node_id The node that the bundles are being removed from.
   void RemovePlacementGroupBundles(
       const PlacementGroupID &placement_group_id,
       const std::vector<std::shared_ptr<const BundleSpecification>> &bundle_specs,
-      const std::optional<std::shared_ptr<const ray::rpc::GcsNodeInfo>> &node,
-      int max_retry,
-      int current_retry_count);
+      const NodeID &node_id);
 
   /// Get an existing lease client or connect a new one or connect a new one.
   std::shared_ptr<RayletClientInterface> GetOrConnectRayletClient(

--- a/src/ray/gcs/tests/gcs_placement_group_scheduler_test.cc
+++ b/src/ray/gcs/tests/gcs_placement_group_scheduler_test.cc
@@ -16,8 +16,10 @@
 
 #include <gtest/gtest.h>
 
+#include <chrono>
 #include <list>
 #include <memory>
+#include <thread>
 #include <utility>
 #include <vector>
 
@@ -591,6 +593,72 @@ TEST_F(GcsPlacementGroupSchedulerTest, DestroyPlacementGroup) {
   // Subsequent destroy request should not do anything.
   scheduler_->DestroyPlacementGroupBundleResourcesIfExists(placement_group_id);
   ASSERT_FALSE(raylet_clients_[0]->GrantRemovePlacementGroupBundles());
+}
+
+TEST_F(GcsPlacementGroupSchedulerTest, DestroyPlacementGroupRetriesWhileNodeAlive) {
+  auto node = GenNodeInfo();
+  AddNode(node);
+
+  auto placement_group = std::make_shared<GcsPlacementGroup>(
+      GenCreatePlacementGroupRequest(), "", counter_, clock_);
+  scheduler_->ScheduleUnplacedBundles(SchedulePgRequest{
+      placement_group,
+      [this](std::shared_ptr<GcsPlacementGroup> placement_group, bool) {
+        absl::MutexLock lock(&placement_group_requests_mutex_);
+        failure_placement_groups_.emplace_back(std::move(placement_group));
+      },
+      [this](std::shared_ptr<GcsPlacementGroup> placement_group) {
+        absl::MutexLock lock(&placement_group_requests_mutex_);
+        success_placement_groups_.emplace_back(std::move(placement_group));
+      }});
+
+  ASSERT_TRUE(raylet_clients_[0]->GrantPrepareBundleResources());
+  WaitPendingDone(raylet_clients_[0]->commit_callbacks, 1);
+  ASSERT_TRUE(raylet_clients_[0]->GrantCommitBundleResources());
+  WaitPlacementGroupPendingDone(1, GcsPlacementGroupStatus::SUCCESS);
+
+  scheduler_->DestroyPlacementGroupBundleResourcesIfExists(
+      placement_group->GetPlacementGroupID());
+
+  const auto unavailable = Status::RpcError("unavailable", grpc::StatusCode::UNAVAILABLE);
+  for (int attempt = 0; attempt < 5; ++attempt) {
+    WaitPendingDone(raylet_clients_[0]->remove_pg_bundles_callbacks, 1);
+    ASSERT_TRUE(raylet_clients_[0]->GrantRemovePlacementGroupBundles(unavailable));
+  }
+
+  // GCS still considers the raylet alive, so the cleanup obligation must
+  // survive the fixed retry threshold.
+  WaitPendingDone(raylet_clients_[0]->remove_pg_bundles_callbacks, 1);
+  ASSERT_EQ(raylet_clients_[0]->num_remove_pg_bundles_requested, 6);
+
+  // Once GCS knows the node is dead, the pending cleanup obligation can stop.
+  RemoveNode(node);
+  ASSERT_TRUE(raylet_clients_[0]->GrantRemovePlacementGroupBundles(unavailable));
+  std::this_thread::sleep_for(std::chrono::milliseconds(1500));
+  EXPECT_EQ(raylet_clients_[0]->num_remove_pg_bundles_requested, 6);
+  EXPECT_TRUE(raylet_clients_[0]->remove_pg_bundles_callbacks.empty());
+}
+TEST_F(GcsPlacementGroupSchedulerTest, DestroyPlacementGroupStopsAfterNonRetryableError) {
+  auto node = GenNodeInfo();
+  AddNode(node);
+
+  auto placement_group = std::make_shared<GcsPlacementGroup>(
+      GenCreatePlacementGroupRequest(), "", counter_, clock_);
+  ScheduleUnplacedBundles(placement_group);
+  ASSERT_TRUE(raylet_clients_[0]->GrantPrepareBundleResources());
+  WaitPendingDone(raylet_clients_[0]->commit_callbacks, 1);
+  ASSERT_TRUE(raylet_clients_[0]->GrantCommitBundleResources());
+  WaitPlacementGroupPendingDone(1, GcsPlacementGroupStatus::SUCCESS);
+
+  scheduler_->DestroyPlacementGroupBundleResourcesIfExists(
+      placement_group->GetPlacementGroupID());
+  WaitPendingDone(raylet_clients_[0]->remove_pg_bundles_callbacks, 1);
+  ASSERT_TRUE(raylet_clients_[0]->GrantRemovePlacementGroupBundles(
+      Status::Invalid("non-retryable")));
+  std::this_thread::sleep_for(std::chrono::milliseconds(1500));
+
+  EXPECT_EQ(raylet_clients_[0]->num_remove_pg_bundles_requested, 1);
+  EXPECT_TRUE(raylet_clients_[0]->remove_pg_bundles_callbacks.empty());
 }
 
 TEST_F(GcsPlacementGroupSchedulerTest, DestroyCancelledPlacementGroup) {

--- a/src/ray/raylet_rpc_client/fake_raylet_client.h
+++ b/src/ray/raylet_rpc_client/fake_raylet_client.h
@@ -221,8 +221,7 @@ class FakeRayletClient : public RayletClientInterface {
     }
   }
 
-  bool GrantRemovePlacementGroupBundles(bool success = true) {
-    Status status = Status::OK();
+  bool GrantRemovePlacementGroupBundles(const Status &status = Status::OK()) {
     RemovePlacementGroupBundlesReply reply;
     if (remove_pg_bundles_callbacks.size() == 0) {
       return false;


### PR DESCRIPTION
## Description

Placement-group destruction currently abandons `RemovePlacementGroupBundles` after five failed RPC attempts, even when GCS still considers the target raylet alive. Because the committed bundle-location indexes are erased as soon as cleanup starts, exhausting that fixed retry budget can leave resources stranded on a live raylet.

This change keeps the cleanup obligation alive across retryable `UNAVAILABLE` and `UNKNOWN` failures. Each retry re-resolves the node through `GcsNodeManager`, and cleanup stops only after an acknowledgement, a non-retryable error, or GCS observes that the node is dead.

The retry remains scheduler-local and preserves the existing one-second delay. Maintainer feedback is welcome on whether this path should instead use the generic retryable gRPC client or capped exponential backoff.

## Related issues

Fixes #64696
Related to #54332

## Additional information

This does not duplicate #65476: that PR releases prepared bundles when placement-group cancellation races with in-flight Prepare RPCs; this PR covers committed/prepared bundle removal being permanently abandoned after repeated transient Remove RPC failures.

No public API or wire-format changes.

### Tests

- Baseline regression on `master`: deterministically failed after exactly five requests with `actual: 5 vs 5` and `max retry count is reached`.
- `bazel test //src/ray/gcs/tests:gcs_placement_group_scheduler_test --test_filter=GcsPlacementGroupSchedulerTest.DestroyPlacementGroupRetriesWhileNodeAlive:GcsPlacementGroupSchedulerTest.DestroyPlacementGroupStopsAfterNonRetryableError --runs_per_test=3 --test_output=errors --nocache_test_results --jobs=8` — passed 3/3 runs; 8.7s average, 0.0s deviation.
- `bazel test //src/ray/gcs/tests:gcs_placement_group_scheduler_test //src/ray/gcs/tests:gcs_placement_group_manager_test --test_output=errors --nocache_test_results --jobs=8` — passed: 39/39 scheduler tests and 28/28 manager tests.
- `pre-commit run clang-format --files src/ray/gcs/gcs_placement_group_scheduler.cc src/ray/gcs/gcs_placement_group_scheduler.h src/ray/gcs/tests/gcs_placement_group_scheduler_test.cc src/ray/raylet_rpc_client/fake_raylet_client.h` — passed with the repository-pinned clang-format v12.0.1.
- `buildifier-v8.0.1 -mode=check -lint=warn src/ray/gcs/BUILD.bazel` — passed.
- `git diff --check` — passed.

### AI assistance

AI assistance was used to help audit duplicates, implement the change, and run validation. I reviewed every changed line, understand the change end-to-end, and ran the relevant tests locally.