### PR TITLE
[common] Fixes stale placement-group entries in `BundleLocationIndex::Erase(const NodeID &node_id)`

### DIFF
--- a/src/ray/common/bundle_location_index.cc
+++ b/src/ray/common/bundle_location_index.cc
@@ -90,6 +90,9 @@ bool BundleLocationIndex::Erase(const NodeID &node_id) {
       auto pg_bundle_it = pg_bundle_locations->find(bundle_id);
       if (pg_bundle_it != pg_bundle_locations->end()) {
         pg_bundle_locations->erase(pg_bundle_it);
+        if (pg_bundle_locations->empty()) {
+          placement_group_to_bundle_locations_.erase(placement_group_it);
+        }
       }
     }
   }

--- a/src/ray/common/tests/bundle_location_index_test.cc
+++ b/src/ray/common/tests/bundle_location_index_test.cc
@@ -93,4 +93,23 @@ TEST_F(BundleLocationIndexTest, BesicTest) {
   ASSERT_EQ(*(pg_location_index.GetBundleLocation(bundle_1)), node_1);
 }
 
+TEST_F(BundleLocationIndexTest, EraseNodeRemovesEmptyPlacementGroupEntry) {
+  BundleLocationIndex pg_location_index;
+
+  auto bundle_locations = std::make_shared<BundleLocations>();
+  (*bundle_locations)[bundle_0] = std::make_pair(node_0, nullptr);
+  (*bundle_locations)[bundle_1] = std::make_pair(node_0, nullptr);
+  pg_location_index.AddOrUpdateBundleLocations(bundle_locations);
+
+  auto pg_bundles_location = pg_location_index.GetBundleLocations(pg_1);
+  ASSERT_TRUE(pg_bundles_location);
+  ASSERT_EQ((*pg_bundles_location)->size(), 2);
+
+  ASSERT_TRUE(pg_location_index.Erase(node_0));
+  ASSERT_FALSE(pg_location_index.GetBundleLocation(bundle_0));
+  ASSERT_FALSE(pg_location_index.GetBundleLocation(bundle_1));
+  ASSERT_FALSE(pg_location_index.GetBundleLocationsOnNode(node_0));
+  ASSERT_FALSE(pg_location_index.GetBundleLocations(pg_1));
+}
+
 }  // namespace ray


### PR DESCRIPTION

## Summary

This PR fixes stale placement-group entries in `BundleLocationIndex::Erase(const NodeID &node_id)`.

Previously, erasing a node removed the node's bundles from each placement group's bundle-location map, but did not remove the placement-group entry itself when the map became empty. This meant `GetBundleLocations(placement_group_id)` could still return an empty bundle map after all bundles for that placement group had been removed.

The fix removes the placement-group entry from `placement_group_to_bundle_locations_` once its bundle-location map becomes empty during node erasure.

## Changes

- Fixes #65683 
- Update `BundleLocationIndex::Erase(const NodeID &node_id)` to erase the placement-group entry when its bundle-location map becomes empty.
- Add a regression test, `EraseNodeRemovesEmptyPlacementGroupEntry`, that verifies:
  - multiple bundles for the same placement group can be added on one node;
  - erasing that node removes the individual bundle locations;
  - the node entry is removed from `node_to_leased_bundles_`;
  - the now-empty placement-group entry is removed from `placement_group_to_bundle_locations_`.

## Why This Is Needed

Keeping an empty placement-group entry makes the index report that bundle locations still exist for a placement group even after all of its bundles have been removed by node cleanup. Removing the empty entry keeps placement-group and node indexes consistent and avoids stale state being returned to callers.

## Tests

Not run as part of generating this description.

Suggested targeted test:

```bash
bazel test //src/ray/common/tests:bundle_location_index_test
```
