### PR TITLE
[Core][Jobs] Use the worker-local GCS client in JobSupervisor

### DIFF
--- a/python/ray/dashboard/modules/job/job_manager.py
+++ b/python/ray/dashboard/modules/job/job_manager.py
@@ -73,8 +73,6 @@ class JobManager:
         self._gcs_client = gcs_client
         self._logs_dir = logs_dir
         self._job_info_client = JobInfoStorageClient(gcs_client, logs_dir)
-        self._gcs_address = gcs_client.address
-        self._cluster_id_hex = gcs_client.cluster_id.hex()
         self._log_client = JobLogStorageClient()
         self._supervisor_actor_cls = ray.remote(JobSupervisor)
         self._timeout_check_timer = timeout_check_timer or Timer()
@@ -603,8 +601,6 @@ class JobManager:
                 submission_id,
                 entrypoint,
                 metadata or {},
-                self._gcs_address,
-                self._cluster_id_hex,
                 self._logs_dir,
             )
             supervisor.run.remote(

--- a/python/ray/dashboard/modules/job/job_supervisor.py
+++ b/python/ray/dashboard/modules/job/job_supervisor.py
@@ -18,7 +18,6 @@ from ray._private.accelerators.npu import NOSET_ASCEND_RT_VISIBLE_DEVICES_ENV_VA
 from ray._private.accelerators.nvidia_gpu import NOSET_CUDA_VISIBLE_DEVICES_ENV_VAR
 from ray._private.runtime_env.constants import RAY_JOB_CONFIG_JSON_ENV_VAR
 from ray._private.utils import remove_ray_internal_flags_from_env
-from ray._raylet import GcsClient
 from ray.actor import ActorHandle
 from ray.dashboard.modules.job.common import (
     JOB_ID_METADATA_KEY,
@@ -73,12 +72,13 @@ class JobSupervisor:
         job_id: str,
         entrypoint: str,
         user_metadata: Dict[str, str],
-        gcs_address: str,
-        cluster_id_hex: str,
         logs_dir: Optional[str] = None,
     ):
         self._job_id = job_id
-        gcs_client = GcsClient(address=gcs_address, cluster_id=cluster_id_hex)
+        # Reuse the GCS client of the worker process hosting this actor. A client
+        # built from the creating head's address stays pinned to that address and
+        # cannot reconnect after the head is replaced.
+        gcs_client = ray._private.worker.global_worker.gcs_client
         self._job_info_client = JobInfoStorageClient(gcs_client, logs_dir)
         self._log_client = JobLogStorageClient()
         self._entrypoint = entrypoint

--- a/python/ray/dashboard/modules/job/tests/test_job_manager.py
+++ b/python/ray/dashboard/modules/job/tests/test_job_manager.py
@@ -475,6 +475,45 @@ async def test_job_manager_network_fault_tolerance(
     )
 
 
+class _StaleAddressGcsClient:
+    """Wraps a live GcsClient but reports an address that nothing is listening on.
+
+    Models a head replacement: the JobManager's own client keeps working through
+    the stable service, while the address it recorded at construction is dead.
+    """
+
+    def __init__(self, client, address: str):
+        self._client = client
+        self.address = address
+
+    def __getattr__(self, name):
+        return getattr(self._client, name)
+
+
+@pytest.mark.asyncio
+async def test_job_succeeds_when_manager_gcs_address_is_stale(
+    call_ray_start, tmp_path  # noqa: F811
+):
+    """A job must reach SUCCEEDED even if the address the JobManager recorded is
+    no longer reachable.
+
+    The supervisor runs on a worker whose own GCS client reconnects through the
+    stable head service, so it must not depend on the creating head's address.
+    """
+    ray.init(address=call_ray_start)
+    live_client = ray._private.worker.global_worker.gcs_client
+    # Port 1 is reserved and never bound, so any client built from this address
+    # cannot reach GCS.
+    job_manager = JobManager(
+        _StaleAddressGcsClient(live_client, "127.0.0.1:1"), tmp_path
+    )
+
+    job_id = await job_manager.submit_job(entrypoint="echo hello")
+    await async_wait_for_condition(
+        check_job_succeeded, job_manager=job_manager, job_id=job_id
+    )
+
+
 @pytest.fixture
 def shared_ray_instance():
     # Remove ray address for test ray cluster in case we have


### PR DESCRIPTION
Fixes #65608.

## Problem

`JobManager` records the head's GCS address at construction and passes it to
every detached `JobSupervisor`, which builds its own `GcsClient` from it:

```python
# job_manager.py
self._gcs_address = gcs_client.address
...
supervisor = self._supervisor_actor_cls.options(...).remote(
    submission_id, entrypoint, metadata or {}, self._gcs_address, self._cluster_id_hex, self._logs_dir,
)

# job_supervisor.py
gcs_client = GcsClient(address=gcs_address, cluster_id=cluster_id_hex)
```

With GCS fault tolerance the head pod can be replaced while a job keeps running
on a worker. The worker's raylet and CoreWorker reconnect through the stable head
service, but the supervisor's separately constructed client stays pinned to the
old address. When the entrypoint exits with code 0, `put_status(SUCCEEDED)` times
out, the broad exception handler writes `FAILED`, and the job is reported as
`JOB_SUPERVISOR_ACTOR_DIED` despite having succeeded.

## Fix

Use the GCS client already configured for the worker process hosting the actor,
which reconnects through the stable head service:

```python
gcs_client = ray._private.worker.global_worker.gcs_client
```

`gcs_address` and `cluster_id_hex` existed only to build that client, so they are
removed from the supervisor's signature and from the `JobManager` side. The same
file already uses worker-local state a few lines below
(`ray._private.worker.global_worker.node`), so this follows existing practice
here. Net -4 lines.

## Not a duplicate

`#65027` also concerns jobs during GCS failover, but patches `job_manager.py`'s
monitor loop to retry transient gRPC errors. This patches `job_supervisor.py`'s
client construction. They are complementary: retries in the monitor cannot help a
supervisor whose own client is pinned to an address nothing is listening on.

No other open PR references #65608. `gh pr list --search "job_supervisor"` and
`--search "JobSupervisor gcs"` surfaced only #65006, #47166, #61099 and #65027,
none of which touch this client construction.

## Testing

Added `test_job_succeeds_when_manager_gcs_address_is_stale` in
`python/ray/dashboard/modules/job/tests/test_job_manager.py`. The full reported
path needs KubeRay with GCS FT and a head replacement; the essential condition is
that the address the manager recorded is unusable while the worker's own client
still works. `_StaleAddressGcsClient` wraps the live client and reports
`127.0.0.1:1`, which is reserved and never bound.

```
python -m pytest python/ray/dashboard/modules/job/tests/test_job_manager.py -k stale -q
```

- on master: `1 failed` — the supervisor cannot persist the terminal status
- with this change: `1 passed` in 12.70s

Surrounding tests that exercise supervisor construction, job submission,
supervisor logging and the existing failover path:

```
python -m pytest python/ray/dashboard/modules/job/tests/test_job_manager.py -q -p no:randomly \
  -k "stale or network_fault_tolerance or supervisor_log_json or supervisor_logs_saved \
      or submit_no_ray_address or get_all_job_info"

7 passed, 63 deselected in 82.54s
```

Lint, using the repo's own configuration:

```
pre-commit run --files python/ray/dashboard/modules/job/job_supervisor.py \
  python/ray/dashboard/modules/job/job_manager.py \
  python/ray/dashboard/modules/job/tests/test_job_manager.py

ruff / pydoclint / black / Ray docstyle / semgrep / import order: all Passed
```

I did not get a clean full-module run locally: `test_job_manager.py` in its
entirety stalls on this machine shortly after start (pytest idle at 0% CPU, no
Ray processes alive) both with and without this change, so it looks unrelated to
it. Happy to run anything specific a reviewer wants.

Ray installed as `ray[default]` 2.58.0 with `python/ray/setup-dev.py` symlinks;
tested on macOS (Apple silicon).

## Out of scope

The `except Exception` handler in `JobSupervisor.run` reclassifies a failure to
*persist* an already-known result as `JOB_ENTRYPOINT_COMMAND_START_ERROR`. That
is a real second defect, but transient-error handling in this area is the subject
of #65027, so it is left alone here to avoid a collision.

## AI usage

AI assistance was used for the investigation, the code change, and the test. I
reviewed every changed line, ran the commands above myself, and can explain and
defend the change.
