### PR TITLE
[core][gcs] Bound retained finished job metadata

### DIFF
--- a/doc/source/cluster/running-applications/job-submission/sdk.rst
+++ b/doc/source/cluster/running-applications/job-submission/sdk.rst
@@ -163,7 +163,7 @@ See the :ref:`SDK API Reference <ray-job-submission-sdk-ref>` for more details.
 
 The Ray Jobs API metadata above is stored separately from the core driver records used
 by the :ref:`State API <state-api-overview-ref>`. GCS retains a bounded history of
-finished driver records (100,000 by default). You can change the bound with the
+finished driver records (10,000 by default). You can change the bound with the
 ``RAY_maximum_gcs_dead_job_cached_count`` environment variable. Records still needed by
 live actors, including detached actors, remain pinned until their final reference is
 released. After a driver record is evicted, a submission job remains available through

--- a/doc/source/cluster/running-applications/job-submission/sdk.rst
+++ b/doc/source/cluster/running-applications/job-submission/sdk.rst
@@ -161,6 +161,14 @@ Job information (status and associated metadata) is stored on the cluster indefi
 To delete this information, you may call ``client.delete_job(job_id)`` for any job that is already in a terminal state.
 See the :ref:`SDK API Reference <ray-job-submission-sdk-ref>` for more details.
 
+The Ray Jobs API metadata above is stored separately from the core driver records used
+by the :ref:`State API <state-api-overview-ref>`. GCS retains a bounded history of
+finished driver records (100,000 by default). You can change the bound with the
+``RAY_maximum_gcs_dead_job_cached_count`` environment variable. Records still needed by
+live actors, including detached actors, remain pinned until their final reference is
+released. After a driver record is evicted, a submission job remains available through
+the Ray Jobs API, but its ``job_id`` and driver details may no longer be available.
+
 Dependency Management
 ---------------------
 

--- a/doc/source/ray-observability/reference/system-metrics.rst
+++ b/doc/source/ray-observability/reference/system-metrics.rst
@@ -42,6 +42,9 @@ Ray exports a number of system metrics, which provide introspection into the sta
    * - `ray_placement_groups`
      - `State`
      - Current number of placement groups by state. The State label (e.g., PENDING, CREATED, REMOVED) describes the state of the placement group. See `rpc::PlacementGroupTable <https://github.com/ray-project/ray/blob/e85355b9b593742b4f5cb72cab92051980fa73d3/src/ray/protobuf/gcs.proto#L517>`_ for more information.
+   * - `ray_gcs_finished_job_evictions_total`
+     - None
+     - Cumulative number of finished driver records evicted from the GCS job table by the configured retention limit.
    * - `ray_memory_manager_worker_eviction_total`
      - `Type`, `Name`
      - The number of tasks and actors killed by the Ray Out of Memory killer (https://docs.ray.io/en/master/ray-core/scheduling/ray-oom-prevention.html) broken down by types (whether it is tasks or actors) and names (name of tasks and actors).

--- a/doc/source/ray-observability/user-guides/cli-sdk.rst
+++ b/doc/source/ray-observability/user-guides/cli-sdk.rst
@@ -740,7 +740,7 @@ through the APIs because they are already garbage collected.
     For example, Ray periodically garbage collects DEAD state Actor data to reduce memory usage.
     It also retains a bounded history of dead Workers and finished Jobs, and cleans up the
     FINISHED state of Tasks when its lineage goes out of scope. The default GCS limits are
-    100,000 dead Workers and 100,000 finished Jobs. Operational Job records that are still
+    100,000 dead Workers and 10,000 finished Jobs. Operational Job records that are still
     referenced by live actors are not garbage collected until those references are released.
 
 API Reference

--- a/doc/source/ray-observability/user-guides/cli-sdk.rst
+++ b/doc/source/ray-observability/user-guides/cli-sdk.rst
@@ -738,7 +738,10 @@ through the APIs because they are already garbage collected.
 
     Do not to rely on this API to obtain correct information on finished resources.
     For example, Ray periodically garbage collects DEAD state Actor data to reduce memory usage.
-    Or it cleans up the FINISHED state of Tasks when its lineage goes out of scope.
+    It also retains a bounded history of dead Workers and finished Jobs, and cleans up the
+    FINISHED state of Tasks when its lineage goes out of scope. The default GCS limits are
+    100,000 dead Workers and 100,000 finished Jobs. Operational Job records that are still
+    referenced by live actors are not garbage collected until those references are released.
 
 API Reference
 ~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -469,7 +469,7 @@ RAY_CONFIG(uint32_t, maximum_gcs_destroyed_actor_cached_count, 100000)
 /// their final reference is released.
 /// JobTableData contains variable-sized job config, runtime environment, entrypoint,
 /// and user metadata. Its serialized and deserialized footprint is workload-dependent.
-RAY_CONFIG(uint32_t, maximum_gcs_dead_job_cached_count, 100000)
+RAY_CONFIG(uint32_t, maximum_gcs_dead_job_cached_count, 10000)
 /// Maximum number of dead workers in GCS server memory cache.
 /// WorkerTableData entry ≈ ~130B serialized (~400-800B deserialized).
 /// Worst-case footprint: 100,000 x ~130B-800B =~ 13-80MB

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -464,6 +464,12 @@ RAY_CONFIG(double, gcs_create_placement_group_retry_multiplier, 1.5)
 /// ActorTableData entry ≈ 200-400B serialize (~600B-1.5KB deserialized).
 /// Worst-case footprint: 100,000 x ~600B-1.5KB =~ 60-150MB
 RAY_CONFIG(uint32_t, maximum_gcs_destroyed_actor_cached_count, 100000)
+/// Maximum number of finished jobs retained in the GCS job table for observability.
+/// Finished jobs that are still referenced by actors are exempt from the limit until
+/// their final reference is released.
+/// JobTableData contains variable-sized job config, runtime environment, entrypoint,
+/// and user metadata. Its serialized and deserialized footprint is workload-dependent.
+RAY_CONFIG(uint32_t, maximum_gcs_dead_job_cached_count, 100000)
 /// Maximum number of dead workers in GCS server memory cache.
 /// WorkerTableData entry ≈ ~130B serialized (~400-800B deserialized).
 /// Worst-case footprint: 100,000 x ~130B-800B =~ 13-80MB

--- a/src/ray/gcs/BUILD.bazel
+++ b/src/ray/gcs/BUILD.bazel
@@ -275,6 +275,7 @@ ray_cc_library(
         ":gcs_table_storage",
         ":grpc_service_interfaces",
         "//src/ray/common:protobuf_utils",
+        "//src/ray/common:ray_config",
         "//src/ray/common:runtime_env",
         "//src/ray/core_worker_rpc_client:core_worker_client_pool",
         "//src/ray/observability:metric_interface",

--- a/src/ray/gcs/gcs_function_manager.h
+++ b/src/ray/gcs/gcs_function_manager.h
@@ -14,6 +14,9 @@
 
 #pragma once
 
+#include <functional>
+#include <utility>
+
 #include "absl/container/flat_hash_map.h"
 #include "ray/asio/instrumented_io_context.h"
 #include "ray/common/constants.h"
@@ -43,6 +46,15 @@ class GCSFunctionManager {
 
   void AddJobReference(const JobID &job_id) { job_counter_[job_id]++; }
 
+  bool HasJobReference(const JobID &job_id) const {
+    return job_counter_.contains(job_id);
+  }
+
+  void SetJobReferenceReleasedCallback(
+      std::function<void(const JobID &)> job_reference_released_callback) {
+    job_reference_released_callback_ = std::move(job_reference_released_callback);
+  }
+
   void RemoveJobReference(const JobID &job_id) {
     auto iter = job_counter_.find(job_id);
     if (iter == job_counter_.end()) {
@@ -54,6 +66,9 @@ class GCSFunctionManager {
     if (iter->second == 0) {
       job_counter_.erase(job_id);
       RemoveExportedFunctions(job_id);
+      if (job_reference_released_callback_) {
+        job_reference_released_callback_(job_id);
+      }
     }
   }
 
@@ -76,6 +91,10 @@ class GCSFunctionManager {
   /// 1. The job/driver has exited, AND 2. All detached actors from the job are dead.
   /// When count reaches zero, function/actor metadata cleanup is triggered.
   absl::flat_hash_map<JobID, size_t> job_counter_;
+
+  /// Invoked when a finished job no longer has an operational reference. This allows
+  /// observability-only metadata to become eligible for retention eviction.
+  std::function<void(const JobID &)> job_reference_released_callback_;
 };
 
 }  // namespace gcs

--- a/src/ray/gcs/gcs_function_manager.h
+++ b/src/ray/gcs/gcs_function_manager.h
@@ -44,17 +44,21 @@ class GCSFunctionManager {
                               instrumented_io_context &io_context)
       : kv_(kv), io_context_(io_context) {}
 
+  /// Add an operational reference that requires this job's metadata to remain available.
   void AddJobReference(const JobID &job_id) { job_counter_[job_id]++; }
 
+  /// Return whether the job still has any operational references.
   bool HasJobReference(const JobID &job_id) const {
     return job_counter_.contains(job_id);
   }
 
+  /// Set the callback invoked when a job loses its final operational reference.
   void SetJobReferenceReleasedCallback(
       std::function<void(const JobID &)> job_reference_released_callback) {
     job_reference_released_callback_ = std::move(job_reference_released_callback);
   }
 
+  /// Remove one operational reference, cleaning up job metadata at reference count zero.
   void RemoveJobReference(const JobID &job_id) {
     auto iter = job_counter_.find(job_id);
     if (iter == job_counter_.end()) {

--- a/src/ray/gcs/gcs_job_manager.cc
+++ b/src/ray/gcs/gcs_job_manager.cc
@@ -52,23 +52,28 @@ void GcsJobManager::RestoreFinishedJobs(const GcsInitData &gcs_init_data) {
     const int64_t end_time_ms = job_table_data.end_time() != 0
                                     ? static_cast<int64_t>(job_table_data.end_time())
                                     : job_table_data.timestamp();
-    // Initialize() restores one reference for the driver. Actor initialization has
-    // already restored any actor references, so releasing the driver reference here
-    // leaves only the operational references that must pin the job config.
-    function_manager_.RemoveJobReference(job_id);
-    TrackFinishedJob(job_id, end_time_ms);
+    if (TrackFinishedJob(job_id, end_time_ms)) {
+      // Initialize() restores one reference for the driver. Actor initialization has
+      // already restored any actor references, so releasing the driver reference here
+      // leaves only the operational references that must pin the job config.
+      function_manager_.RemoveJobReference(job_id);
+    }
   }
   TrimFinishedJobs();
 }
 
-void GcsJobManager::TrackFinishedJob(const JobID &job_id, int64_t end_time_ms) {
+bool GcsJobManager::TrackFinishedJob(const JobID &job_id, int64_t end_time_ms) {
   if (!finished_job_end_times_.emplace(job_id, end_time_ms).second) {
-    return;
+    return false;
   }
   if (!function_manager_.HasJobReference(job_id)) {
     evictable_finished_jobs_.emplace(FinishedJobSortKey{end_time_ms, job_id.Binary()},
                                      job_id);
   }
+  // A newly finished job may itself be pinned, but it can still push an older,
+  // unreferenced job over the retention cap.
+  TrimFinishedJobs();
+  return true;
 }
 
 void GcsJobManager::OnJobReferenceReleased(const JobID &job_id) {
@@ -95,7 +100,7 @@ void GcsJobManager::TrimFinishedJobs() {
   const size_t batch_size = std::min(
       overflow,
       std::max<size_t>(1, RayConfig::instance().maximum_gcs_deletion_batch_size()));
-  std::vector<std::pair<FinishedJobSortKey, JobID>> entries_to_evict;
+  std::vector<FinishedJobEvictionCandidate> entries_to_evict;
   entries_to_evict.reserve(batch_size);
 
   while (finished_job_end_times_.size() > cap && entries_to_evict.size() < batch_size &&
@@ -111,41 +116,136 @@ void GcsJobManager::TrimFinishedJobs() {
       continue;
     }
 
-    finished_job_end_times_.erase(job_id);
-    entries_to_evict.emplace_back(sort_key, job_id);
+    entries_to_evict.push_back({sort_key, job_id, {}});
   }
 
   if (entries_to_evict.empty()) {
     return;
   }
 
+  finished_job_cleanup_in_progress_ = true;
+  LoadFinishedJobsForEviction(std::move(entries_to_evict));
+}
+
+void GcsJobManager::LoadFinishedJobsForEviction(
+    std::vector<FinishedJobEvictionCandidate> candidates) {
+  RAY_CHECK(!candidates.empty());
+  auto shared_candidates =
+      std::make_shared<std::vector<FinishedJobEvictionCandidate>>(std::move(candidates));
+  auto pending_loads = std::make_shared<size_t>(shared_candidates->size());
+  auto load_failed = std::make_shared<bool>(false);
+
+  for (size_t index = 0; index < shared_candidates->size(); index++) {
+    const auto job_id = (*shared_candidates)[index].job_id;
+    gcs_table_storage_.JobTable().Get(
+        job_id,
+        {[this, shared_candidates, pending_loads, load_failed, index, job_id](
+             const Status &status, std::optional<rpc::JobTableData> job_data) {
+           RAY_CHECK(thread_checker_.IsOnSameThread());
+           if (!status.ok() || !job_data.has_value()) {
+             RAY_LOG(ERROR).WithField(job_id)
+                 << "Failed to load a finished job selected for eviction: " << status;
+             *load_failed = true;
+           } else {
+             (*shared_candidates)[index].job_data = std::move(*job_data);
+           }
+
+           RAY_CHECK(*pending_loads > 0);
+           if (--(*pending_loads) != 0) {
+             return;
+           }
+
+           if (*load_failed) {
+             for (const auto &candidate : *shared_candidates) {
+               if (!function_manager_.HasJobReference(candidate.job_id)) {
+                 evictable_finished_jobs_.emplace(candidate.sort_key, candidate.job_id);
+               }
+             }
+             finished_job_cleanup_in_progress_ = false;
+             return;
+           }
+
+           DeleteFinishedJobs(std::move(*shared_candidates));
+         },
+         io_context_});
+  }
+}
+
+void GcsJobManager::DeleteFinishedJobs(
+    std::vector<FinishedJobEvictionCandidate> candidates) {
+  std::vector<FinishedJobEvictionCandidate> entries_to_evict;
+  entries_to_evict.reserve(candidates.size());
+  for (auto &candidate : candidates) {
+    if (!function_manager_.HasJobReference(candidate.job_id)) {
+      entries_to_evict.push_back(std::move(candidate));
+    }
+  }
+
+  if (entries_to_evict.empty()) {
+    finished_job_cleanup_in_progress_ = false;
+    TrimFinishedJobs();
+    return;
+  }
+
   std::vector<JobID> job_ids;
   job_ids.reserve(entries_to_evict.size());
   for (const auto &entry : entries_to_evict) {
-    job_ids.push_back(entry.second);
+    job_ids.push_back(entry.job_id);
   }
 
-  finished_job_cleanup_in_progress_ = true;
   gcs_table_storage_.JobTable().BatchDelete(
       job_ids,
       {[this, entries_to_evict = std::move(entries_to_evict)](const Status &status) {
-         finished_job_cleanup_in_progress_ = false;
          if (!status.ok()) {
            RAY_LOG(ERROR) << "Failed to evict a batch of finished jobs: " << status;
-           for (const auto &[sort_key, job_id] : entries_to_evict) {
-             finished_job_end_times_.emplace(job_id, sort_key.first);
-             if (!function_manager_.HasJobReference(job_id)) {
-               evictable_finished_jobs_.emplace(sort_key, job_id);
+           for (const auto &entry : entries_to_evict) {
+             if (!function_manager_.HasJobReference(entry.job_id)) {
+               evictable_finished_jobs_.emplace(entry.sort_key, entry.job_id);
              }
            }
+           finished_job_cleanup_in_progress_ = false;
            return;
          }
 
-         for (const auto &entry : entries_to_evict) {
-           cached_job_configs_.erase(entry.second);
+         auto entries_to_restore =
+             std::make_shared<std::vector<FinishedJobEvictionCandidate>>();
+         size_t num_evicted = 0;
+         for (auto &entry : entries_to_evict) {
+           if (function_manager_.HasJobReference(entry.job_id)) {
+             entries_to_restore->push_back(std::move(entry));
+             continue;
+           }
+           finished_job_end_times_.erase(entry.job_id);
+           cached_job_configs_.erase(entry.job_id);
+           num_evicted++;
          }
-         ray_metric_finished_job_evictions_total_.Record(entries_to_evict.size());
-         TrimFinishedJobs();
+         if (num_evicted > 0) {
+           ray_metric_finished_job_evictions_total_.Record(num_evicted);
+         }
+
+         if (entries_to_restore->empty()) {
+           finished_job_cleanup_in_progress_ = false;
+           TrimFinishedJobs();
+           return;
+         }
+
+         auto pending_restores = std::make_shared<size_t>(entries_to_restore->size());
+         for (const auto &entry : *entries_to_restore) {
+           gcs_table_storage_.JobTable().Put(
+               entry.job_id,
+               entry.job_data,
+               {[this, entries_to_restore, pending_restores, job_id = entry.job_id](
+                    const Status &restore_status) {
+                  RAY_CHECK_OK(restore_status)
+                      << "Failed to restore referenced job " << job_id;
+                  RAY_CHECK(*pending_restores > 0);
+                  if (--(*pending_restores) == 0) {
+                    finished_job_cleanup_in_progress_ = false;
+                    TrimFinishedJobs();
+                  }
+                },
+                io_context_});
+         }
        },
        io_context_});
 }
@@ -270,16 +370,22 @@ void GcsJobManager::MarkJobAsFinished(rpc::JobTableData job_table_data,
                      const Status &status) {
     RAY_CHECK(thread_checker_.IsOnSameThread());
 
+    bool newly_finished = false;
     if (!status.ok()) {
       RAY_LOG(ERROR).WithField(job_id) << "Failed to mark job as finished.";
     } else {
       gcs_publisher_.PublishJob(job_id, job_table_data);
       runtime_env_manager_.RemoveURIReference(job_id.Hex());
       ClearJobInfos(job_table_data);
-      TrackFinishedJob(job_id, job_table_data.end_time());
+      newly_finished = TrackFinishedJob(job_id, job_table_data.end_time());
       RAY_LOG(DEBUG).WithField(job_id) << "Marked job as finished.";
     }
-    function_manager_.RemoveJobReference(job_id);
+    // MarkJobFinished can be retried after its storage write succeeds. Release the
+    // driver's reference only for the first successful transition so retries cannot
+    // consume references held by detached actors.
+    if (newly_finished) {
+      function_manager_.RemoveJobReference(job_id);
+    }
     WriteDriverJobExportEvent(job_table_data,
                               rpc::events::DriverJobLifecycleEvent::FINISHED);
 
@@ -319,6 +425,10 @@ void GcsJobManager::HandleMarkJobFinished(rpc::MarkJobFinishedRequest request,
          RAY_CHECK(thread_checker_.IsOnSameThread());
 
          if (get_status.ok() && result) {
+           if (result->is_dead()) {
+             send_reply(Status::OK());
+             return;
+           }
            MarkJobAsFinished(*result, send_reply);
            return;
          }

--- a/src/ray/gcs/gcs_job_manager.cc
+++ b/src/ray/gcs/gcs_job_manager.cc
@@ -14,6 +14,7 @@
 
 #include "ray/gcs/gcs_job_manager.h"
 
+#include <algorithm>
 #include <limits>
 #include <memory>
 #include <string>
@@ -41,6 +42,112 @@ void GcsJobManager::Initialize(const GcsInitData &gcs_init_data) {
       running_job_start_times_.insert({job_id, job_table_data.start_time()});
     }
   }
+}
+
+void GcsJobManager::RestoreFinishedJobs(const GcsInitData &gcs_init_data) {
+  for (const auto &[job_id, job_table_data] : gcs_init_data.Jobs()) {
+    if (!job_table_data.is_dead()) {
+      continue;
+    }
+    const int64_t end_time_ms = job_table_data.end_time() != 0
+                                    ? static_cast<int64_t>(job_table_data.end_time())
+                                    : job_table_data.timestamp();
+    // Initialize() restores one reference for the driver. Actor initialization has
+    // already restored any actor references, so releasing the driver reference here
+    // leaves only the operational references that must pin the job config.
+    function_manager_.RemoveJobReference(job_id);
+    TrackFinishedJob(job_id, end_time_ms);
+  }
+  TrimFinishedJobs();
+}
+
+void GcsJobManager::TrackFinishedJob(const JobID &job_id, int64_t end_time_ms) {
+  if (!finished_job_end_times_.emplace(job_id, end_time_ms).second) {
+    return;
+  }
+  if (!function_manager_.HasJobReference(job_id)) {
+    evictable_finished_jobs_.emplace(FinishedJobSortKey{end_time_ms, job_id.Binary()},
+                                     job_id);
+  }
+}
+
+void GcsJobManager::OnJobReferenceReleased(const JobID &job_id) {
+  auto finished_job_it = finished_job_end_times_.find(job_id);
+  if (finished_job_it == finished_job_end_times_.end()) {
+    return;
+  }
+  evictable_finished_jobs_.emplace(
+      FinishedJobSortKey{finished_job_it->second, job_id.Binary()}, job_id);
+  TrimFinishedJobs();
+}
+
+void GcsJobManager::TrimFinishedJobs() {
+  if (finished_job_cleanup_in_progress_) {
+    return;
+  }
+
+  const size_t cap = RayConfig::instance().maximum_gcs_dead_job_cached_count();
+  const size_t overflow =
+      finished_job_end_times_.size() > cap ? finished_job_end_times_.size() - cap : 0;
+  if (overflow == 0) {
+    return;
+  }
+  const size_t batch_size = std::min(
+      overflow,
+      std::max<size_t>(1, RayConfig::instance().maximum_gcs_deletion_batch_size()));
+  std::vector<std::pair<FinishedJobSortKey, JobID>> entries_to_evict;
+  entries_to_evict.reserve(batch_size);
+
+  while (finished_job_end_times_.size() > cap && entries_to_evict.size() < batch_size &&
+         !evictable_finished_jobs_.empty()) {
+    auto oldest = evictable_finished_jobs_.begin();
+    const auto sort_key = oldest->first;
+    const auto job_id = oldest->second;
+    evictable_finished_jobs_.erase(oldest);
+
+    // References can be added after the job was initially marked finished. Keep its
+    // config available for detached actors and other operational users in that case.
+    if (function_manager_.HasJobReference(job_id)) {
+      continue;
+    }
+
+    finished_job_end_times_.erase(job_id);
+    entries_to_evict.emplace_back(sort_key, job_id);
+  }
+
+  if (entries_to_evict.empty()) {
+    return;
+  }
+
+  std::vector<JobID> job_ids;
+  job_ids.reserve(entries_to_evict.size());
+  for (const auto &entry : entries_to_evict) {
+    job_ids.push_back(entry.second);
+  }
+
+  finished_job_cleanup_in_progress_ = true;
+  gcs_table_storage_.JobTable().BatchDelete(
+      job_ids,
+      {[this, entries_to_evict = std::move(entries_to_evict)](const Status &status) {
+         finished_job_cleanup_in_progress_ = false;
+         if (!status.ok()) {
+           RAY_LOG(ERROR) << "Failed to evict a batch of finished jobs: " << status;
+           for (const auto &[sort_key, job_id] : entries_to_evict) {
+             finished_job_end_times_.emplace(job_id, sort_key.first);
+             if (!function_manager_.HasJobReference(job_id)) {
+               evictable_finished_jobs_.emplace(sort_key, job_id);
+             }
+           }
+           return;
+         }
+
+         for (const auto &entry : entries_to_evict) {
+           cached_job_configs_.erase(entry.second);
+         }
+         ray_metric_finished_job_evictions_total_.Record(entries_to_evict.size());
+         TrimFinishedJobs();
+       },
+       io_context_});
 }
 
 void GcsJobManager::WriteDriverJobExportEvent(
@@ -169,6 +276,7 @@ void GcsJobManager::MarkJobAsFinished(rpc::JobTableData job_table_data,
       gcs_publisher_.PublishJob(job_id, job_table_data);
       runtime_env_manager_.RemoveURIReference(job_id.Hex());
       ClearJobInfos(job_table_data);
+      TrackFinishedJob(job_id, job_table_data.end_time());
       RAY_LOG(DEBUG).WithField(job_id) << "Marked job as finished.";
     }
     function_manager_.RemoveJobReference(job_id);

--- a/src/ray/gcs/gcs_job_manager.h
+++ b/src/ray/gcs/gcs_job_manager.h
@@ -16,11 +16,14 @@
 
 #include <cstdint>
 #include <functional>
+#include <map>
 #include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "absl/container/flat_hash_map.h"
+#include "ray/common/ray_config.h"
 #include "ray/common/runtime_env_manager.h"
 #include "ray/core_worker_rpc_client/core_worker_client_pool.h"
 #include "ray/gcs/gcs_function_manager.h"
@@ -30,6 +33,7 @@
 #include "ray/gcs/grpc_service_interfaces.h"
 #include "ray/observability/ray_event_recorder_interface.h"
 #include "ray/pubsub/gcs_publisher.h"
+#include "ray/stats/metric.h"
 #include "ray/util/clock.h"
 #include "ray/util/event.h"
 #include "ray/util/thread_checker.h"
@@ -77,9 +81,20 @@ class GcsJobManager : public rpc::JobInfoGcsServiceHandler {
         running_job_gauge_(running_job_gauge),
         finished_job_counter_(finished_job_counter),
         job_duration_in_seconds_gauge_(job_duration_in_seconds_gauge),
-        clock_(clock) {}
+        clock_(clock) {
+    function_manager_.SetJobReferenceReleasedCallback(
+        [this](const JobID &job_id) { OnJobReferenceReleased(job_id); });
+  }
+
+  ~GcsJobManager() override {
+    function_manager_.SetJobReferenceReleasedCallback(nullptr);
+  }
 
   void Initialize(const GcsInitData &gcs_init_data);
+
+  /// Rebuild finished-job retention state after all operational job references have
+  /// been restored, then incrementally trim persisted history to the configured cap.
+  void RestoreFinishedJobs(const GcsInitData &gcs_init_data);
 
   void HandleAddJob(rpc::AddJobRequest request,
                     rpc::AddJobReply *reply,
@@ -124,10 +139,18 @@ class GcsJobManager : public rpc::JobInfoGcsServiceHandler {
   void RecordMetrics();
 
  private:
+  using FinishedJobSortKey = std::pair<int64_t, std::string>;
+
   void ClearJobInfos(const rpc::JobTableData &job_data);
 
   void MarkJobAsFinished(rpc::JobTableData job_table_data,
                          std::function<void(Status)> done_callback);
+
+  void TrackFinishedJob(const JobID &job_id, int64_t end_time_ms);
+
+  void OnJobReferenceReleased(const JobID &job_id);
+
+  void TrimFinishedJobs();
 
   // Used to validate invariants for threading; for example, all callbacks are executed on
   // the same thread.
@@ -139,6 +162,17 @@ class GcsJobManager : public rpc::JobInfoGcsServiceHandler {
 
   // Number of finished jobs since start of this GCS Server, used to report metrics.
   int64_t finished_jobs_count_ = 0;
+
+  /// End time for each retained finished-job record. This includes jobs pinned by a
+  /// live actor reference, which cannot be evicted safely yet.
+  absl::flat_hash_map<JobID, int64_t> finished_job_end_times_;
+
+  /// Evictable finished jobs ordered deterministically by end time and then job id.
+  std::map<FinishedJobSortKey, JobID> evictable_finished_jobs_;
+
+  /// Serializes bounded cleanup batches. Entries selected for an in-flight batch are
+  /// removed from the two indexes above and restored if storage deletion fails.
+  bool finished_job_cleanup_in_progress_ = false;
 
   GcsTableStorage &gcs_table_storage_;
   pubsub::GcsPublisher &gcs_publisher_;
@@ -164,6 +198,11 @@ class GcsJobManager : public rpc::JobInfoGcsServiceHandler {
   ray::observability::MetricInterface &finished_job_counter_;
   ray::observability::MetricInterface &job_duration_in_seconds_gauge_;
   ClockInterface &clock_;
+
+  ray::stats::Count ray_metric_finished_job_evictions_total_{
+      /*name=*/"gcs_finished_job_evictions_total",
+      /*description=*/"Number of finished job records evicted from the GCS job table.",
+      /*unit=*/""};
 };
 
 }  // namespace gcs

--- a/src/ray/gcs/gcs_job_manager.h
+++ b/src/ray/gcs/gcs_job_manager.h
@@ -141,16 +141,26 @@ class GcsJobManager : public rpc::JobInfoGcsServiceHandler {
  private:
   using FinishedJobSortKey = std::pair<int64_t, std::string>;
 
+  struct FinishedJobEvictionCandidate {
+    FinishedJobSortKey sort_key;
+    JobID job_id;
+    rpc::JobTableData job_data;
+  };
+
   void ClearJobInfos(const rpc::JobTableData &job_data);
 
   void MarkJobAsFinished(rpc::JobTableData job_table_data,
                          std::function<void(Status)> done_callback);
 
-  void TrackFinishedJob(const JobID &job_id, int64_t end_time_ms);
+  bool TrackFinishedJob(const JobID &job_id, int64_t end_time_ms);
 
   void OnJobReferenceReleased(const JobID &job_id);
 
   void TrimFinishedJobs();
+
+  void LoadFinishedJobsForEviction(std::vector<FinishedJobEvictionCandidate> candidates);
+
+  void DeleteFinishedJobs(std::vector<FinishedJobEvictionCandidate> candidates);
 
   // Used to validate invariants for threading; for example, all callbacks are executed on
   // the same thread.
@@ -170,8 +180,9 @@ class GcsJobManager : public rpc::JobInfoGcsServiceHandler {
   /// Evictable finished jobs ordered deterministically by end time and then job id.
   std::map<FinishedJobSortKey, JobID> evictable_finished_jobs_;
 
-  /// Serializes bounded cleanup batches. Entries selected for an in-flight batch are
-  /// removed from the two indexes above and restored if storage deletion fails.
+  /// Serializes bounded cleanup batches. Selected entries remain in
+  /// finished_job_end_times_ until storage deletion succeeds. Their full records are
+  /// loaded before deletion so a job that gains a reference in flight can be restored.
   bool finished_job_cleanup_in_progress_ = false;
 
   GcsTableStorage &gcs_table_storage_;

--- a/src/ray/gcs/gcs_server.cc
+++ b/src/ray/gcs/gcs_server.cc
@@ -349,6 +349,9 @@ void GcsServer::DoStart(const GcsInitData &gcs_init_data) {
       metrics_.placement_group_count_gauge);
   InitGcsActorManager(
       gcs_init_data, metrics_.actor_by_state_gauge, metrics_.gcs_actor_by_state_gauge);
+  // Actor initialization restores the references that pin operational job configs.
+  // Rebuild and trim finished-job history only after those references are available.
+  gcs_job_manager_->RestoreFinishedJobs(gcs_init_data);
   InitGcsWorkerManager(gcs_init_data);
   InitGcsTaskManager(metrics_.task_events_reported_gauge,
                      metrics_.task_events_dropped_gauge,

--- a/src/ray/gcs/tests/BUILD.bazel
+++ b/src/ray/gcs/tests/BUILD.bazel
@@ -164,6 +164,7 @@ ray_cc_test(
     deps = [
         "//:ray_mock",
         "//src/mock/ray/pubsub:mock_publisher",
+        "//src/ray/common:ray_config",
         "//src/ray/common:test_utils",
         "//src/ray/core_worker_rpc_client:core_worker_client_pool",
         "//src/ray/gcs:gcs_job_manager",

--- a/src/ray/gcs/tests/gcs_function_manager_test.cc
+++ b/src/ray/gcs/tests/gcs_function_manager_test.cc
@@ -116,4 +116,32 @@ TEST_F(GCSFunctionManagerTest, TestRemoveJobReferenceIsIdempotent) {
   EXPECT_FALSE(HasKey("fun", "FunctionsToRun:" + job_id_hex + ":key1"));
 }
 
+TEST_F(GCSFunctionManagerTest, TestJobReferenceReleasedCallback) {
+  const auto job_id = JobID::FromInt(3);
+  int callback_count = 0;
+  JobID released_job_id = JobID::Nil();
+  function_manager_->SetJobReferenceReleasedCallback([&](const JobID &id) {
+    callback_count++;
+    released_job_id = id;
+  });
+
+  EXPECT_FALSE(function_manager_->HasJobReference(job_id));
+  function_manager_->AddJobReference(job_id);
+  function_manager_->AddJobReference(job_id);
+  EXPECT_TRUE(function_manager_->HasJobReference(job_id));
+
+  function_manager_->RemoveJobReference(job_id);
+  EXPECT_EQ(callback_count, 0);
+  EXPECT_TRUE(function_manager_->HasJobReference(job_id));
+
+  function_manager_->RemoveJobReference(job_id);
+  EXPECT_EQ(callback_count, 1);
+  EXPECT_EQ(released_job_id, job_id);
+  EXPECT_FALSE(function_manager_->HasJobReference(job_id));
+
+  // A duplicate release doesn't generate a duplicate callback.
+  function_manager_->RemoveJobReference(job_id);
+  EXPECT_EQ(callback_count, 1);
+}
+
 }  // namespace ray

--- a/src/ray/gcs/tests/gcs_job_manager_test.cc
+++ b/src/ray/gcs/tests/gcs_job_manager_test.cc
@@ -15,6 +15,7 @@
 #include "ray/gcs/gcs_job_manager.h"
 
 #include <algorithm>
+#include <functional>
 #include <memory>
 #include <string>
 #include <vector>
@@ -34,6 +35,21 @@
 
 namespace ray {
 
+class HookedInMemoryStoreClient : public gcs::InMemoryStoreClient {
+ public:
+  void AsyncBatchDelete(const std::string &table_name,
+                        const std::vector<std::string> &keys,
+                        Postable<void(int64_t)> callback) override {
+    gcs::InMemoryStoreClient::AsyncBatchDelete(table_name, keys, std::move(callback));
+    auto hook = batch_delete_hook;
+    if (hook) {
+      hook(table_name);
+    }
+  }
+
+  std::function<void(const std::string &)> batch_delete_hook;
+};
+
 class GcsJobManagerTest : public ::testing::Test {
  public:
   GcsJobManagerTest() : runtime_env_manager_(nullptr) {
@@ -49,7 +65,8 @@ class GcsJobManagerTest : public ::testing::Test {
 
     gcs_publisher_ = std::make_unique<pubsub::GcsPublisher>(
         std::make_unique<ray::pubsub::MockPublisher>());
-    store_client_ = std::make_shared<gcs::InMemoryStoreClient>();
+    in_memory_store_client_ = std::make_shared<HookedInMemoryStoreClient>();
+    store_client_ = in_memory_store_client_;
     gcs_table_storage_ = std::make_shared<gcs::GcsTableStorage>(store_client_);
     kv_ = std::make_unique<gcs::MockInternalKVInterface>();
     fake_kv_ = std::make_unique<gcs::FakeInternalKVInterface>();
@@ -86,8 +103,59 @@ class GcsJobManagerTest : public ::testing::Test {
   }
 
  protected:
+  void AddJob(const JobID &job_id) {
+    auto request = GenAddJobRequest(job_id, "namespace");
+    rpc::AddJobReply reply;
+    std::promise<void> promise;
+    gcs_job_manager_->HandleAddJob(
+        *request,
+        &reply,
+        [&promise](Status status, std::function<void()>, std::function<void()>) {
+          EXPECT_TRUE(status.ok());
+          promise.set_value();
+        });
+    promise.get_future().get();
+  }
+
+  void MarkJobFinished(const JobID &job_id) {
+    rpc::MarkJobFinishedRequest request;
+    request.set_job_id(job_id.Binary());
+    rpc::MarkJobFinishedReply reply;
+    std::promise<void> promise;
+    gcs_job_manager_->HandleMarkJobFinished(
+        request,
+        &reply,
+        [&promise](Status status, std::function<void()>, std::function<void()>) {
+          EXPECT_TRUE(status.ok());
+          promise.set_value();
+        });
+    promise.get_future().get();
+  }
+
+  absl::flat_hash_map<JobID, rpc::JobTableData> GetJobs() {
+    std::promise<absl::flat_hash_map<JobID, rpc::JobTableData>> promise;
+    gcs_table_storage_->JobTable().GetAll(
+        {[&promise](absl::flat_hash_map<JobID, rpc::JobTableData> jobs) {
+           promise.set_value(std::move(jobs));
+         },
+         io_service_});
+    return promise.get_future().get();
+  }
+
+  void RemoveJobReference(const JobID &job_id) {
+    std::promise<void> promise;
+    io_service_.post(
+        [this, job_id, &promise] {
+          function_manager_->RemoveJobReference(job_id);
+          promise.set_value();
+        },
+        "GcsJobManagerTest.RemoveJobReference");
+    promise.get_future().get();
+  }
+
   instrumented_io_context io_service_;
   std::unique_ptr<std::thread> thread_io_service_;
+  std::shared_ptr<HookedInMemoryStoreClient> in_memory_store_client_;
   std::shared_ptr<gcs::StoreClient> store_client_;
   std::shared_ptr<gcs::GcsTableStorage> gcs_table_storage_;
   std::shared_ptr<pubsub::GcsPublisher> gcs_publisher_;
@@ -865,6 +933,29 @@ TEST_F(GcsJobManagerTest, TestFinishedJobEviction) {
   EXPECT_TRUE(jobs.contains(job3));
 }
 
+TEST_F(GcsJobManagerTest, TestPinnedFinishedJobTriggersEvictionOfOlderJob) {
+  RayConfig::instance().initialize(R"({"maximum_gcs_dead_job_cached_count": 1})");
+  gcs::GcsInitData gcs_init_data(*gcs_table_storage_);
+  gcs_job_manager_->Initialize(gcs_init_data);
+  gcs_job_manager_->RestoreFinishedJobs(gcs_init_data);
+
+  const auto old_job = JobID::FromInt(1);
+  const auto pinned_job = JobID::FromInt(2);
+  AddJob(old_job);
+  MarkJobFinished(old_job);
+
+  AddJob(pinned_job);
+  function_manager_->AddJobReference(pinned_job);
+  MarkJobFinished(pinned_job);
+
+  ASSERT_TRUE(WaitForCondition([this]() { return GetJobs().size() == 1; }, 2000));
+  const auto jobs = GetJobs();
+  EXPECT_FALSE(jobs.contains(old_job));
+  EXPECT_TRUE(jobs.contains(pinned_job));
+
+  RemoveJobReference(pinned_job);
+}
+
 TEST_F(GcsJobManagerTest, TestRestoreFinishedJobsUsesJobIdAsTieBreaker) {
   RayConfig::instance().initialize(R"({
     "maximum_gcs_dead_job_cached_count": 2,
@@ -1000,6 +1091,55 @@ TEST_F(GcsJobManagerTest, TestFinishedJobWithActorReferenceIsPinned) {
   EXPECT_TRUE(jobs.contains(job2));
 
   remove_job_reference(job2);
+}
+
+TEST_F(GcsJobManagerTest, TestReferenceAddedDuringEvictionRestoresJobRecord) {
+  RayConfig::instance().initialize(R"({"maximum_gcs_dead_job_cached_count": 0})");
+  gcs::GcsInitData gcs_init_data(*gcs_table_storage_);
+  gcs_job_manager_->Initialize(gcs_init_data);
+  gcs_job_manager_->RestoreFinishedJobs(gcs_init_data);
+
+  const auto job_id = JobID::FromInt(1);
+  AddJob(job_id);
+
+  std::promise<void> reference_added_promise;
+  in_memory_store_client_->batch_delete_hook =
+      [this, job_id, &reference_added_promise](const std::string &table_name) {
+        if (table_name != rpc::TablePrefix_Name(rpc::TablePrefix::JOB)) {
+          return;
+        }
+        in_memory_store_client_->batch_delete_hook = nullptr;
+        function_manager_->AddJobReference(job_id);
+        reference_added_promise.set_value();
+      };
+
+  MarkJobFinished(job_id);
+  reference_added_promise.get_future().get();
+
+  EXPECT_TRUE(WaitForCondition([this]() { return GetJobs().size() == 1; }, 2000));
+  EXPECT_TRUE(function_manager_->HasJobReference(job_id));
+  EXPECT_NE(gcs_job_manager_->GetJobConfig(job_id), nullptr);
+
+  RemoveJobReference(job_id);
+  EXPECT_TRUE(WaitForCondition([this]() { return GetJobs().empty(); }, 2000));
+}
+
+TEST_F(GcsJobManagerTest, TestMarkJobFinishedRetryKeepsActorReference) {
+  RayConfig::instance().initialize(R"({"maximum_gcs_dead_job_cached_count": 0})");
+  gcs::GcsInitData gcs_init_data(*gcs_table_storage_);
+  gcs_job_manager_->Initialize(gcs_init_data);
+  gcs_job_manager_->RestoreFinishedJobs(gcs_init_data);
+
+  const auto job_id = JobID::FromInt(1);
+  AddJob(job_id);
+  function_manager_->AddJobReference(job_id);
+
+  MarkJobFinished(job_id);
+  MarkJobFinished(job_id);
+  EXPECT_TRUE(function_manager_->HasJobReference(job_id));
+
+  RemoveJobReference(job_id);
+  EXPECT_TRUE(WaitForCondition([this]() { return GetJobs().empty(); }, 2000));
 }
 
 }  // namespace ray

--- a/src/ray/gcs/tests/gcs_job_manager_test.cc
+++ b/src/ray/gcs/tests/gcs_job_manager_test.cc
@@ -14,13 +14,16 @@
 
 #include "ray/gcs/gcs_job_manager.h"
 
+#include <algorithm>
 #include <memory>
 #include <string>
+#include <vector>
 
 #include "gtest/gtest.h"
 #include "mock/ray/gcs/gcs_kv_manager.h"
 #include "mock/ray/pubsub/publisher.h"
 #include "mock/ray/rpc/worker/core_worker_client.h"
+#include "ray/common/ray_config.h"
 #include "ray/common/test_utils.h"
 #include "ray/core_worker_rpc_client/core_worker_client_pool.h"
 #include "ray/gcs/gcs_kv_manager.h"
@@ -34,6 +37,7 @@ namespace ray {
 class GcsJobManagerTest : public ::testing::Test {
  public:
   GcsJobManagerTest() : runtime_env_manager_(nullptr) {
+    RayConfig::instance().initialize("{}");
     std::promise<bool> promise;
     thread_io_service_ = std::make_unique<std::thread>([this, &promise] {
       boost::asio::executor_work_guard<boost::asio::io_context::executor_type> work(
@@ -100,7 +104,7 @@ class GcsJobManagerTest : public ::testing::Test {
   ray::observability::FakeGauge fake_running_job_gauge_;
   ray::observability::FakeCounter fake_finished_job_counter_;
   ray::observability::FakeGauge fake_job_duration_in_seconds_gauge_;
-  Clock clock_;
+  FakeClock clock_;
 };
 
 TEST_F(GcsJobManagerTest, TestFakeInternalKV) {
@@ -800,6 +804,202 @@ TEST_F(GcsJobManagerTest, TestNodeFailure) {
   };
 
   EXPECT_TRUE(WaitForCondition(condition, 2000));
+}
+
+TEST_F(GcsJobManagerTest, TestFinishedJobEviction) {
+  RayConfig::instance().initialize(R"({
+    "maximum_gcs_dead_job_cached_count": 2,
+    "maximum_gcs_deletion_batch_size": 1
+  })");
+  gcs::GcsInitData gcs_init_data(*gcs_table_storage_);
+  gcs_job_manager_->Initialize(gcs_init_data);
+  gcs_job_manager_->RestoreFinishedJobs(gcs_init_data);
+
+  auto add_and_finish_job = [this](const JobID &job_id) {
+    clock_.AdvanceTime(absl::Milliseconds(1));
+    auto add_job_request = GenAddJobRequest(job_id, "namespace");
+    rpc::AddJobReply add_reply;
+    std::promise<void> add_promise;
+    gcs_job_manager_->HandleAddJob(
+        *add_job_request,
+        &add_reply,
+        [&add_promise](Status, std::function<void()>, std::function<void()>) {
+          add_promise.set_value();
+        });
+    add_promise.get_future().get();
+
+    rpc::MarkJobFinishedRequest finish_request;
+    finish_request.set_job_id(job_id.Binary());
+    rpc::MarkJobFinishedReply finish_reply;
+    std::promise<void> finish_promise;
+    gcs_job_manager_->HandleMarkJobFinished(
+        finish_request,
+        &finish_reply,
+        [&finish_promise](Status, std::function<void()>, std::function<void()>) {
+          finish_promise.set_value();
+        });
+    finish_promise.get_future().get();
+  };
+
+  auto get_jobs = [this]() {
+    std::promise<absl::flat_hash_map<JobID, rpc::JobTableData>> promise;
+    gcs_table_storage_->JobTable().GetAll(
+        {[&promise](absl::flat_hash_map<JobID, rpc::JobTableData> jobs) {
+           promise.set_value(std::move(jobs));
+         },
+         io_service_});
+    return promise.get_future().get();
+  };
+
+  const auto job1 = JobID::FromInt(1);
+  const auto job2 = JobID::FromInt(2);
+  const auto job3 = JobID::FromInt(3);
+  add_and_finish_job(job1);
+  add_and_finish_job(job2);
+  add_and_finish_job(job3);
+
+  ASSERT_TRUE(WaitForCondition([&get_jobs]() { return get_jobs().size() == 2; }, 2000));
+  const auto jobs = get_jobs();
+  EXPECT_FALSE(jobs.contains(job1));
+  EXPECT_TRUE(jobs.contains(job2));
+  EXPECT_TRUE(jobs.contains(job3));
+}
+
+TEST_F(GcsJobManagerTest, TestRestoreFinishedJobsUsesJobIdAsTieBreaker) {
+  RayConfig::instance().initialize(R"({
+    "maximum_gcs_dead_job_cached_count": 2,
+    "maximum_gcs_deletion_batch_size": 1
+  })");
+
+  std::vector<JobID> job_ids{JobID::FromInt(3), JobID::FromInt(1), JobID::FromInt(2)};
+  for (const auto &job_id : job_ids) {
+    rpc::JobTableData job_data;
+    job_data.set_job_id(job_id.Binary());
+    job_data.set_is_dead(true);
+    job_data.set_end_time(100);
+    std::promise<void> promise;
+    gcs_table_storage_->JobTable().Put(job_id,
+                                       job_data,
+                                       {[&promise](Status status) {
+                                          EXPECT_TRUE(status.ok());
+                                          promise.set_value();
+                                        },
+                                        io_service_});
+    promise.get_future().get();
+  }
+
+  gcs::GcsInitData gcs_init_data(*gcs_table_storage_);
+  std::promise<void> load_promise;
+  gcs_init_data.AsyncLoad({[&load_promise] { load_promise.set_value(); }, io_service_});
+  load_promise.get_future().get();
+  gcs_job_manager_->Initialize(gcs_init_data);
+  gcs_job_manager_->RestoreFinishedJobs(gcs_init_data);
+
+  std::sort(job_ids.begin(), job_ids.end(), [](const JobID &left, const JobID &right) {
+    return left.Binary() < right.Binary();
+  });
+  const auto expected_evicted_job = job_ids.front();
+
+  auto get_jobs = [this]() {
+    std::promise<absl::flat_hash_map<JobID, rpc::JobTableData>> promise;
+    gcs_table_storage_->JobTable().GetAll(
+        {[&promise](absl::flat_hash_map<JobID, rpc::JobTableData> jobs) {
+           promise.set_value(std::move(jobs));
+         },
+         io_service_});
+    return promise.get_future().get();
+  };
+  ASSERT_TRUE(WaitForCondition([&get_jobs]() { return get_jobs().size() == 2; }, 2000));
+
+  std::promise<absl::flat_hash_map<JobID, rpc::JobTableData>> jobs_promise;
+  gcs_table_storage_->JobTable().GetAll(
+      {[&jobs_promise](absl::flat_hash_map<JobID, rpc::JobTableData> jobs) {
+         jobs_promise.set_value(std::move(jobs));
+       },
+       io_service_});
+  const auto jobs = jobs_promise.get_future().get();
+  ASSERT_EQ(jobs.size(), 2);
+  EXPECT_FALSE(jobs.contains(expected_evicted_job));
+}
+
+TEST_F(GcsJobManagerTest, TestFinishedJobWithActorReferenceIsPinned) {
+  RayConfig::instance().initialize(R"({"maximum_gcs_dead_job_cached_count": 1})");
+  gcs::GcsInitData gcs_init_data(*gcs_table_storage_);
+  gcs_job_manager_->Initialize(gcs_init_data);
+  gcs_job_manager_->RestoreFinishedJobs(gcs_init_data);
+
+  auto add_and_finish_pinned_job = [this](const JobID &job_id) {
+    auto add_job_request = GenAddJobRequest(job_id, "namespace");
+    rpc::AddJobReply add_reply;
+    std::promise<void> add_promise;
+    gcs_job_manager_->HandleAddJob(
+        *add_job_request,
+        &add_reply,
+        [&add_promise](Status, std::function<void()>, std::function<void()>) {
+          add_promise.set_value();
+        });
+    add_promise.get_future().get();
+
+    // Simulate the reference held by an actor from this job. Marking the driver as
+    // finished releases only the job's own reference.
+    function_manager_->AddJobReference(job_id);
+    rpc::MarkJobFinishedRequest finish_request;
+    finish_request.set_job_id(job_id.Binary());
+    rpc::MarkJobFinishedReply finish_reply;
+    std::promise<void> finish_promise;
+    gcs_job_manager_->HandleMarkJobFinished(
+        finish_request,
+        &finish_reply,
+        [&finish_promise](Status, std::function<void()>, std::function<void()>) {
+          finish_promise.set_value();
+        });
+    finish_promise.get_future().get();
+  };
+
+  const auto job1 = JobID::FromInt(1);
+  const auto job2 = JobID::FromInt(2);
+  add_and_finish_pinned_job(job1);
+  add_and_finish_pinned_job(job2);
+
+  auto get_job_count = [this]() {
+    std::promise<size_t> promise;
+    gcs_table_storage_->JobTable().GetAll(
+        {[&promise](absl::flat_hash_map<JobID, rpc::JobTableData> jobs) {
+           promise.set_value(jobs.size());
+         },
+         io_service_});
+    return promise.get_future().get();
+  };
+  EXPECT_EQ(get_job_count(), 2);
+
+  auto remove_job_reference = [this](const JobID &job_id) {
+    std::promise<void> promise;
+    io_service_.post(
+        [this, job_id, &promise] {
+          function_manager_->RemoveJobReference(job_id);
+          promise.set_value();
+        },
+        "GcsJobManagerTest.RemoveJobReference");
+    promise.get_future().get();
+  };
+
+  // Once the first job loses its final actor reference, it becomes the oldest
+  // evictable record and the cap is enforced again.
+  remove_job_reference(job1);
+  EXPECT_TRUE(
+      WaitForCondition([&get_job_count]() { return get_job_count() == 1; }, 2000));
+
+  std::promise<absl::flat_hash_map<JobID, rpc::JobTableData>> jobs_promise;
+  gcs_table_storage_->JobTable().GetAll(
+      {[&jobs_promise](absl::flat_hash_map<JobID, rpc::JobTableData> jobs) {
+         jobs_promise.set_value(std::move(jobs));
+       },
+       io_service_});
+  const auto jobs = jobs_promise.get_future().get();
+  EXPECT_FALSE(jobs.contains(job1));
+  EXPECT_TRUE(jobs.contains(job2));
+
+  remove_job_reference(job2);
 }
 
 }  // namespace ray


### PR DESCRIPTION
## Description

Finished `JobTableData` rows are currently retained indefinitely. In persistent, high-churn clusters, Redis memory usage, full-table reads, and GCS restart loading grow with cluster lifetime rather than the useful history window.

This PR adds `maximum_gcs_dead_job_cached_count`, with a default of 10,000, to bound retained finished driver-job records. Finished jobs are ordered deterministically by end time and JobID. Overflow is deleted using the existing bounded GCS deletion batch size, and the retention index is rebuilt after a GCS restart so persisted rows and lowered limits are also covered. Successful evictions are reported through `gcs_finished_job_evictions_total`.

A finished driver does not always make its job metadata observability-only. Detached actors may outlive the driver and still need the originating job config and exported function metadata. This PR restores actor references before rebuilding finished-job retention state, pins referenced records, and makes them evictable only after the final operational reference is released.

Cleanup also handles reference changes during asynchronous deletion. It rechecks references when a deletion finishes and restores the persisted `JobTableData` without dropping the cached job config if a reference was added in flight. Retried `MarkJobFinished` requests release the driver reference only once, so they cannot consume references held by detached actors.

Ray Jobs API submission metadata remains in separate InternalKV storage. This policy bounds core State API driver history without deleting submission history, although driver details may no longer be available after the core record is evicted.

## Duplicate work

I checked issue #65692 and searched open PRs for both `#65692` and GCS finished-job retention. No other open PR addresses this change.

## Testing

- `CCACHE_FOUND=FALSE bazel test //src/ray/gcs/tests:gcs_job_manager_test --spawn_strategy=local --jobs=4 --test_output=errors` — passed
- `CCACHE_FOUND=FALSE bazel test //src/ray/gcs/tests:gcs_function_manager_test --spawn_strategy=local --jobs=4 --test_output=errors` — passed
- `pre-commit run --files src/ray/gcs/gcs_function_manager.h src/ray/gcs/gcs_job_manager.h src/ray/gcs/gcs_job_manager.cc src/ray/gcs/tests/gcs_job_manager_test.cc src/ray/common/ray_config_def.h doc/source/cluster/running-applications/job-submission/sdk.rst doc/source/ray-observability/user-guides/cli-sdk.rst` — passed
- `git diff --check` — passed

The tests cover steady-state eviction, deterministic restart ordering, actor pinning and release, eviction triggered by a newly pinned job, references added during asynchronous deletion, and idempotent job-finish retries.

## AI assistance

AI assistance was used for code inspection, implementation, tests, documentation, and drafting this PR description. The human submitter remains responsible for reviewing every changed line and defending the change.

## Related issues

Closes #65692
