### PR TITLE
[CI] Enable Bazel lint for doc BUILD files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,10 +14,10 @@ exclude: |
     src/ray/thirdparty/|
     doc/external/|
     # Excludes doc/source, except the Markdown and rST prose under doc/source/data
-  # that the `vale` hook below lints. pre-commit ANDs this top-level `exclude`
-  # with each hook's own `files`, so a bare `doc/source/` here cancelled that
-  # hook out entirely and it silently matched zero files.
-  doc/source/(?!data/.*[.](md|rst)$)|
+    # that the `vale` hook below lints and Bazel BUILD files for buildifier.
+    # pre-commit ANDs this top-level `exclude` with each hook's own `files`, so
+    # excluded BUILD files would never reach the buildifier hooks.
+    doc/source/(?!data/.*[.](md|rst)$|(?:.*/)?BUILD(?:\.bazel)?$)|
     doc/.claude/skills/sphinx-fix/tests/
   )
 repos:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -94,9 +94,9 @@ repos:
     rev: 8.0.1
     hooks:
       - id: buildifier
-        files: ^(src|cpp|python|rllib|ci|release|java)(/[^/]+)*/BUILD(\.bazel)?$|^BUILD.bazel$
+        files: ^(src|cpp|python|rllib|ci|release|java|doc)(/[^/]+)*/BUILD(\.bazel)?$|^BUILD.bazel$
       - id: buildifier-lint
-        files: ^(src|cpp|python|rllib|ci|release|java)(/[^/]+)*/BUILD(\.bazel)?$|^BUILD.bazel$
+        files: ^(src|cpp|python|rllib|ci|release|java|doc)(/[^/]+)*/BUILD(\.bazel)?$|^BUILD.bazel$
 
   - repo: https://github.com/psf/black
     rev: 22.10.0

--- a/doc/BUILD.bazel
+++ b/doc/BUILD.bazel
@@ -1,6 +1,6 @@
 load("@py_deps_py310//:requirements.bzl", ci_require = "requirement")
 load("@rules_python//python:defs.bzl", "py_test")
-load("//bazel:python.bzl", "doctest", "doctest_each", "py_test_run_all_notebooks", "py_test_run_all_subdirectory")
+load("//bazel:python.bzl", "doctest", "doctest_each", "py_test_run_all_subdirectory")
 
 exports_files(["test_myst_doc.py"])
 
@@ -180,9 +180,9 @@ py_test(
     srcs = ["source/ray-core/doc_code/runtime_env_example.py"],
     main = "source/ray-core/doc_code/runtime_env_example.py",
     tags = [
+        "custom_setup",
         "exclusive",
         "post_wheel_build",
-        "custom_setup",
         "team:core",
     ],
 )
@@ -193,9 +193,9 @@ py_test(
     srcs = ["source/ray-core/doc_code/ray_oom_prevention.py"],
     main = "source/ray-core/doc_code/ray_oom_prevention.py",
     tags = [
+        "custom_setup",
         "exclusive",
         "mem_pressure",
-        "custom_setup",
         "team:core",
     ],
 )
@@ -206,9 +206,9 @@ py_test(
     srcs = ["source/ray-core/doc_code/cgraph_profiling.py"],
     main = "source/ray-core/doc_code/cgraph_profiling.py",
     tags = [
+        "custom_setup",
         "exclusive",
         "multi_gpu",
-        "custom_setup",
         "team:core",
     ],
 )
@@ -219,9 +219,9 @@ py_test(
     srcs = ["source/ray-core/doc_code/cgraph_nccl.py"],
     main = "source/ray-core/doc_code/cgraph_nccl.py",
     tags = [
+        "custom_setup",
         "exclusive",
         "multi_gpu",
-        "custom_setup",
         "team:core",
     ],
 )
@@ -232,9 +232,9 @@ py_test(
     srcs = ["source/ray-core/doc_code/cgraph_overlap.py"],
     main = "source/ray-core/doc_code/cgraph_overlap.py",
     tags = [
+        "custom_setup",
         "exclusive",
         "multi_gpu",
-        "custom_setup",
         "team:core",
     ],
 )
@@ -256,9 +256,9 @@ py_test(
     srcs = ["source/ray-core/doc_code/direct_transport_nccl.py"],
     main = "source/ray-core/doc_code/direct_transport_nccl.py",
     tags = [
+        "custom_setup",
         "exclusive",
         "multi_gpu",
-        "custom_setup",
         "team:core",
     ],
 )
@@ -269,9 +269,9 @@ py_test(
     srcs = ["source/ray-core/doc_code/direct_transport_nixl.py"],
     main = "source/ray-core/doc_code/direct_transport_nixl.py",
     tags = [
+        "custom_setup",
         "exclusive",
         "multi_gpu",
-        "custom_setup",
         "team:core",
     ],
 )
@@ -364,6 +364,7 @@ filegroup(
 py_test_run_all_subdirectory(
     size = "large",
     include = ["source/llm/doc_code/serve/**/*.py"],
+    data = ["source/llm/doc_code/serve/qwen/llm_config_example.yaml"],
     exclude = [
         "source/llm/doc_code/serve/direct_streaming/**/*.py",
         "source/llm/doc_code/serve/multi_gpu/**/*.py",
@@ -374,7 +375,6 @@ py_test_run_all_subdirectory(
         "source/llm/doc_code/serve/custom_vllm/**/*.py",
     ],
     extra_srcs = [],
-    data = ["source/llm/doc_code/serve/qwen/llm_config_example.yaml"],
     tags = [
         "exclusive",
         "gpu",
@@ -386,21 +386,21 @@ py_test_run_all_subdirectory(
 py_test_run_all_subdirectory(
     size = "large",
     include = ["source/llm/doc_code/serve/custom_vllm/**/*.py"],
+    data = ["source/llm/doc_code/serve/custom_vllm/custom_vllm_config.yaml"],
+    env = {
+        "RAY_SERVE_LLM_ENABLE_DIRECT_STREAMING": "1",
+        "RAY_SERVE_ENABLE_HA_PROXY": "1",
+    },
     exclude = [
         "source/llm/doc_code/serve/custom_vllm/qwen3_reward_plugin/**/*.py",
         # setup.py packages the plugin; it is not a runnable example.
         "source/llm/doc_code/serve/custom_vllm/setup.py",
     ],
     extra_srcs = [],
-    data = ["source/llm/doc_code/serve/custom_vllm/custom_vllm_config.yaml"],
-    env = {
-        "RAY_SERVE_LLM_ENABLE_DIRECT_STREAMING": "1",
-        "RAY_SERVE_ENABLE_HA_PROXY": "1",
-    },
     tags = [
+        "custom_vllm_plugin",
         "exclusive",
         "gpu",
-        "custom_vllm_plugin",
         "team:llm",
     ],
 )
@@ -413,8 +413,6 @@ py_test_run_all_subdirectory(
 py_test_run_all_subdirectory(
     size = "large",
     include = ["source/llm/doc_code/serve/direct_streaming/**/*.py"],
-    exclude = [],
-    extra_srcs = [],
     data = ["source/llm/doc_code/serve/direct_streaming/direct_streaming_config.yaml"],
     env = {
         "RAY_SERVE_LLM_ENABLE_DIRECT_STREAMING": "1",
@@ -422,6 +420,8 @@ py_test_run_all_subdirectory(
         # which build_app.py rejects unless HAProxy is enabled.
         "RAY_SERVE_ENABLE_HA_PROXY": "1",
     },
+    exclude = [],
+    extra_srcs = [],
     tags = [
         "exclusive",
         "gpu",
@@ -462,7 +462,7 @@ py_test_run_all_subdirectory(
     tags = [
         "exclusive",
         "gpu",
-        "team:llm"
+        "team:llm",
     ],
 )
 
@@ -473,13 +473,13 @@ py_test_run_all_subdirectory(
 py_test_run_all_subdirectory(
     size = "medium",
     include = ["source/tune/doc_code/*.py"],
+    env = {"RAY_TRAIN_V2_ENABLED": "1"},
     exclude = [],
     extra_srcs = [],
     tags = [
         "exclusive",
         "team:ml",
     ],
-    env = {"RAY_TRAIN_V2_ENABLED": "1"},
 )
 
 # --------------------------------------------------------------------
@@ -503,8 +503,8 @@ py_test_run_all_subdirectory(
 
 py_test_run_all_subdirectory(
     size = "large",
-    env = {"RAY_TRAIN_V2_ENABLED": "1"},
     include = ["source/train/doc_code/*.py"],
+    env = {"RAY_TRAIN_V2_ENABLED": "1"},
     exclude = [
         "source/train/doc_code/hvd_trainer.py",  # CI do not have Horovod
         "source/train/doc_code/asynchronous_validation.py",  # pseudocode snippets, not runnable
@@ -541,8 +541,8 @@ py_test_run_all_subdirectory(
     exclude = [],
     extra_srcs = [],
     tags = [
-        "dask",
         "custom_setup",
+        "dask",
         "exclusive",
         "team:data",
     ],
@@ -634,10 +634,10 @@ doctest(
             "source/tune/**/*.rst",
         ],
     ),
-    tags = ["team:none"],
     # NOTE(edoakes): the global glossary and some tutorials use Ray Data,
     # so we use its pytest plugin file (which is a superset of the default).
     pytest_plugin_file = "//python/ray/data:tests/doctest_pytest_plugin.py",
+    tags = ["team:none"],
 )
 
 doctest(
@@ -658,6 +658,8 @@ doctest(
 )
 
 doctest_each(
+    # Adding to use keras 2 & tensorflow >= 2.16 (https://keras.io/getting_started)
+    env = {"TF_USE_LEGACY_KERAS": "1"},
     files = glob(
         include = [
             "source/data/**/*.md",
@@ -673,8 +675,6 @@ doctest_each(
     ),
     pytest_plugin_file = "//python/ray/data:tests/doctest_pytest_plugin.py",
     tags = ["team:data"],
-    # Adding to use keras 2 & tensorflow >= 2.16 (https://keras.io/getting_started)
-    env = {"TF_USE_LEGACY_KERAS": "1"},
 )
 
 doctest(
@@ -683,9 +683,9 @@ doctest(
         "source/data/batch_inference.rst",
         "source/data/transforming-data.rst",
     ],
+    gpu = True,
     pytest_plugin_file = "//python/ray/data:tests/doctest_pytest_plugin.py",
     tags = ["team:data"],
-    gpu = True,
 )
 
 doctest(
@@ -707,13 +707,12 @@ doctest(
 doctest(
     name = "doctest[rllib2]",
     size = "enormous",
-    files = glob(
-        include = [
-            "source/rllib/getting-started.rst",
-        ],
-    ),
+    files = ["source/rllib/getting-started.rst"],
     # TODO(elliot-barn): Re-enable once getting-started.rst doctest hang is fixed.
-    tags = ["manual", "team:rllib"],
+    tags = [
+        "manual",
+        "team:rllib",
+    ],
 )
 
 doctest(
@@ -732,7 +731,6 @@ doctest(
     ),
     tags = ["team:serve"],
 )
-
 
 doctest(
     name = "doctest[train]",
@@ -759,24 +757,23 @@ doctest(
 
 doctest(
     name = "doctest[train-gpu]",
+    env = {"RAY_TRAIN_V2_ENABLED": "0"},
     files = [
         "source/train/user-guides/data-loading-preprocessing.rst",
         "source/train/user-guides/using-accelerators.rst",
     ],
-    env = {"RAY_TRAIN_V2_ENABLED": "0"},
-    tags = ["team:ml"],
     gpu = True,
+    tags = ["team:ml"],
 )
-
 
 doctest(
     name = "doctest[tune]",
+    env = {"RAY_TRAIN_V2_ENABLED": "1"},
     files = [
         "source/tune/**/*.md",
         "source/tune/**/*.rst",
     ],
     tags = ["team:ml"],
-    env = {"RAY_TRAIN_V2_ENABLED": "1"},
 )
 
 # --------------------------------------------------------------------
@@ -795,9 +792,9 @@ filegroup(
         "source/serve/tutorials/**/ci/gce.yaml",
     ]) + [
         "//doc/source/data/examples:data_examples_ci_configs",
-        "//doc/source/tune/examples:tune_examples_ci_configs",
         "//doc/source/ray-core/examples:core_examples_ci_configs",
         "//doc/source/train/examples:train_examples_ci_configs",
+        "//doc/source/tune/examples:tune_examples_ci_configs",
     ],
     visibility = ["//release:__pkg__"],
 )

--- a/doc/source/data/examples/BUILD.bazel
+++ b/doc/source/data/examples/BUILD.bazel
@@ -3,7 +3,7 @@ load("//bazel:python.bzl", "py_test_run_all_notebooks")
 filegroup(
     name = "data_examples",
     srcs = glob(["*.ipynb"]),
-    visibility = ["//doc:__subpackages__"]
+    visibility = ["//doc:__subpackages__"],
 )
 
 # --------------------------------------------------------------------
@@ -13,16 +13,20 @@ filegroup(
 py_test_run_all_notebooks(
     size = "large",
     include = ["*.ipynb"],
-        exclude = [],
-        data = ["//doc/source/data/examples:data_examples"],
-    tags = ["exclusive", "team:data", "gpu"],
+    data = ["//doc/source/data/examples:data_examples"],
+    exclude = [],
+    tags = [
+        "exclusive",
+        "gpu",
+        "team:data",
+    ],
 )
 
 filegroup(
     name = "data_examples_ci_configs",
     srcs = glob([
         "**/ci/aws.yaml",
-        "**/ci/gce.yaml"
+        "**/ci/gce.yaml",
     ]),
     visibility = ["//doc:__pkg__"],
 )

--- a/doc/source/train/examples/BUILD.bazel
+++ b/doc/source/train/examples/BUILD.bazel
@@ -22,10 +22,9 @@ filegroup(
         "**/ci/aws.yaml",
         "**/ci/gce.yaml",
     ]) + [
+        "//doc/source/train/examples/lightning:lightning_examples_ci_configs",
         "//doc/source/train/examples/pytorch:pytorch_examples_ci_configs",
         "//doc/source/train/examples/transformers:transformers_examples_ci_configs",
-        "//doc/source/train/examples/lightning:lightning_examples_ci_configs",
     ],
     visibility = ["//doc:__pkg__"],
 )
-

--- a/doc/source/tune/examples/BUILD.bazel
+++ b/doc/source/tune/examples/BUILD.bazel
@@ -17,18 +17,18 @@ py_test_run_all_notebooks(
     size = "medium",
     include = ["*.ipynb"],
     data = ["//doc/source/tune/examples:tune_examples"],
+    env = {"RAY_TRAIN_V2_ENABLED": "1"},
     exclude = [
         "pbt_ppo_example.ipynb",
         "tune-xgboost.ipynb",
         "pbt_transformers.ipynb",  # Transformers uses legacy Tune APIs.
         "tune-aim.ipynb",  # CI does not have `aim`
         "bohb_example.ipynb",  # CI does not have bohb requirements
-   ],
+    ],
     tags = [
         "exclusive",
         "team:ml",
     ],
-    env = {"RAY_TRAIN_V2_ENABLED": "1"},
 )
 
 # GPU tests
@@ -36,13 +36,13 @@ py_test_run_all_notebooks(
     size = "large",
     include = ["tune-xgboost.ipynb"],
     data = ["//doc/source/tune/examples:tune_examples"],
+    env = {"RAY_TRAIN_V2_ENABLED": "1"},
     exclude = [],
     tags = [
         "exclusive",
         "gpu",
         "team:ml",
     ],
-    env = {"RAY_TRAIN_V2_ENABLED": "1"},
 )
 
 filegroup(


### PR DESCRIPTION
## Why

Closes #64955.
Part of #50875.

Enable `buildifier` and `buildifier-lint` coverage for the BUILD files under `doc/`, as requested in #64955.

## What changed

- Enable the buildifier hooks for `doc/**/BUILD.bazel`.
- Narrow the top-level pre-commit exclusion so BUILD files under `doc/source/` reach the buildifier hooks.
- Apply buildifier formatting and ordering fixes.
- Remove unused loads reported by the linter.
- Replace the constant glob reported by buildifier-lint.

## Validation

- Verified the combined top-level exclude and hook regex select all 10 tracked doc BUILD files for both hooks.
- buildifier v8.0.1 formatting check passes on all 10 files.
- buildifier-lint passes on all 10 files.
- `pre-commit validate-config` passes.
- `git diff --check` passes.

No unrelated changes are included.

## Contributor notes

- Duplicate check: no open Ray PR matched #64955 or the issue title immediately before starting the branch workflow.