### PR TITLE
[serve] Fail on runtime changes to http_options, grpc_options, and proxy_location

### DIFF
--- a/doc/source/serve/api/index.md
+++ b/doc/source/serve/api/index.md
@@ -182,6 +182,7 @@ The deprecated `RayServeHandle` and `RayServeSyncHandle` APIs have been fully re
    serve.grpc_util.RayServegRPCContext
    serve.grpc_util.gRPCInputStream
    serve.exceptions.BackPressureError
+   serve.exceptions.RayServeConfigException
    serve.exceptions.RayServeException
    serve.exceptions.RequestCancelledError
    serve.exceptions.gRPCStatusError

--- a/doc/source/serve/api/index.md
+++ b/doc/source/serve/api/index.md
@@ -205,7 +205,7 @@ The Serve REST API is exposed at the same port as the Ray dashboard. The dashboa
 
 Declaratively deploys a list of Serve applications. If Serve is already running on the Ray cluster, removes all applications not listed in the new config. If Serve is not running on the Ray cluster, starts Serve. See [multi-app config schema](serve-rest-api-config-schema) for the request's JSON schema.
 
-`proxy_location`, `http_options`, and `grpc_options` are global to the cluster and fixed when Serve starts. If Serve is already running and the config sets any of them to a different value, the whole request is rejected with a `400` naming each field, and no applications are deployed. Omitting a field is not a request to change it.
+`proxy_location`, `http_options`, and `grpc_options` are global to the cluster and fixed when Serve starts. If Serve is already running and the config sets any of them to a different value, Serve rejects the whole request with a `400` that names each field and deploys no applications. Omitting a field isn't a request to change it.
 
 **Example Request**:
 

--- a/doc/source/serve/api/index.md
+++ b/doc/source/serve/api/index.md
@@ -205,6 +205,8 @@ The Serve REST API is exposed at the same port as the Ray dashboard. The dashboa
 
 Declaratively deploys a list of Serve applications. If Serve is already running on the Ray cluster, removes all applications not listed in the new config. If Serve is not running on the Ray cluster, starts Serve. See [multi-app config schema](serve-rest-api-config-schema) for the request's JSON schema.
 
+`proxy_location`, `http_options`, and `grpc_options` are global to the cluster and fixed when Serve starts. If Serve is already running and the config sets any of them to a different value, the whole request is rejected with a `400` naming each field, and no applications are deployed. Omitting a field is not a request to change it.
+
 **Example Request**:
 
 ```http

--- a/doc/source/serve/production-guide/config.md
+++ b/doc/source/serve/production-guide/config.md
@@ -78,7 +78,7 @@ You can also configure proxy health checks and lifecycle behavior with the follo
 
 ## HTTP config 
 
-The `http_options` are as follows. Note that the HTTP config is global to your Ray cluster, and you can't update it during runtime. Applying a config that changes it while Serve is running fails with a `RayServeConfigException` instead of being ignored; shut Serve down and start it again to change these values.
+The `http_options` are as follows. Note that the HTTP config is global to your Ray cluster, and you can't update it during runtime. Applying a config that changes it while Serve is running fails with a `RayServeConfigException` instead of being ignored. To change these values, shut Serve down and start it again.
 
 - **`host`**: The host IP address for Serve's HTTP proxies. This is optional and can be omitted. By default, the `host` is set to `0.0.0.0` to expose your deployments publicly. If you're using Kubernetes, you must set `host` to `0.0.0.0` to expose your deployments outside the cluster.
 - **`port`**: The port for Serve's HTTP proxies. This parameter is optional and can be omitted. By default, the port is set to `8000`. 

--- a/doc/source/serve/production-guide/config.md
+++ b/doc/source/serve/production-guide/config.md
@@ -62,7 +62,7 @@ The file contains `proxy_location`, `http_options`, `grpc_options`, `logging_con
 
 ## Proxy config 
 
-The `proxy_location` field configures where to run proxies to handle traffic to the cluster. You can set `proxy_location` to the following values:
+The `proxy_location` field configures where to run proxies to handle traffic to the cluster. Like the HTTP and gRPC config, it's global to your Ray cluster and can't be updated at runtime. You can set `proxy_location` to the following values:
 - EveryNode (default): Run a proxy on every node in the cluster that has at least one replica actor.
 - HeadOnly: Only run a single proxy on the head node.
 - Disabled: Don't run proxies at all. Set this value if you are only making calls to your applications using deployment handles.
@@ -78,7 +78,7 @@ You can also configure proxy health checks and lifecycle behavior with the follo
 
 ## HTTP config 
 
-The `http_options` are as follows. Note that the HTTP config is global to your Ray cluster, and you can't update it during runtime.
+The `http_options` are as follows. Note that the HTTP config is global to your Ray cluster, and you can't update it during runtime. Applying a config that changes it while Serve is running fails with a `RayServeConfigException` instead of being ignored; shut Serve down and start it again to change these values.
 
 - **`host`**: The host IP address for Serve's HTTP proxies. This is optional and can be omitted. By default, the `host` is set to `0.0.0.0` to expose your deployments publicly. If you're using Kubernetes, you must set `host` to `0.0.0.0` to expose your deployments outside the cluster.
 - **`port`**: The port for Serve's HTTP proxies. This parameter is optional and can be omitted. By default, the port is set to `8000`. 
@@ -89,7 +89,7 @@ The `http_options` are as follows. Note that the HTTP config is global to your R
 
 ## gRPC config 
 
-The `grpc_options` are as follows. Note that the gRPC config is global to your Ray cluster, and you can't update it during runtime.
+The `grpc_options` are as follows. Note that the gRPC config is global to your Ray cluster, and you can't update it during runtime. As with `http_options`, applying a config that changes it while Serve is running fails instead of being ignored.
 - **`port`**: The port that the gRPC proxies listen on. These are optional settings and can be omitted. By default, the port is set to `9000`.
 - **`grpc_servicer_functions`**: List of import paths for gRPC `add_servicer_to_server` functions to add to Serve's gRPC proxy. The servicer functions need to be importable from the context of where Serve is running. This defaults to an empty list, which means the gRPC server isn't started.
 - **`request_timeout_s`**: Allows you to set the end-to-end timeout for a request before terminating and retrying at another replica. By default, there is no request timeout.

--- a/python/ray/dashboard/modules/serve/serve_head.py
+++ b/python/ray/dashboard/modules/serve/serve_head.py
@@ -156,6 +156,7 @@ class ServeHead(SubprocessModule):
     async def put_all_applications(self, req: Request) -> Response:
         from ray._common.usage.usage_lib import TagKey, record_extra_usage_tag
         from ray.serve._private.api import serve_start_async
+        from ray.serve.exceptions import RayServeConfigException
         from ray.serve.schema import ServeDeploySchema
 
         try:
@@ -171,19 +172,19 @@ class ServeHead(SubprocessModule):
         full_http_options = config.http_options.model_dump()
         grpc_options = config.grpc_options.model_dump()
 
-        async with self._controller_start_lock:
-            client = await serve_start_async(
-                http_options=full_http_options,
-                proxy_location=config.proxy_location,
-                grpc_options=grpc_options,
-                global_logging_config=config.logging_config,
-                controller_options=config.controller_options,
-            )
-
-        # Serve ignores HTTP options if it was already running when
-        # serve_start_async() is called. Therefore we validate that no
-        # existing HTTP options are updated and print warning in case they are
-        self.validate_http_options(client, full_http_options)
+        try:
+            async with self._controller_start_lock:
+                client = await serve_start_async(
+                    http_options=full_http_options,
+                    proxy_location=config.proxy_location,
+                    grpc_options=grpc_options,
+                    global_logging_config=config.logging_config,
+                    controller_options=config.controller_options,
+                )
+        except RayServeConfigException as e:
+            # Reject the whole config: applying the applications while dropping the
+            # cluster-global options is what used to make the failure silent.
+            return Response(status=400, text=str(e))
 
         try:
             if config.logging_config:
@@ -282,22 +283,6 @@ class ServeHead(SubprocessModule):
                 return self._create_json_response(
                     {"error": "Internal Server Error"}, 503
                 )
-
-    def validate_http_options(self, client, http_options):
-        divergent_http_options = []
-
-        for option, new_value in http_options.items():
-            prev_value = getattr(client.http_config, option)
-            if prev_value != new_value:
-                divergent_http_options.append(option)
-
-        if divergent_http_options:
-            logger.warning(
-                "Serve is already running on this Ray cluster and "
-                "it's not possible to update its HTTP options without "
-                "restarting it. Following options are attempted to be "
-                f"updated: {divergent_http_options}."
-            )
 
     async def get_serve_controller(self):
         """Gets the ServeController to the this cluster's Serve app.

--- a/python/ray/dashboard/modules/serve/serve_head.py
+++ b/python/ray/dashboard/modules/serve/serve_head.py
@@ -155,7 +155,10 @@ class ServeHead(SubprocessModule):
     @validate_endpoint()
     async def put_all_applications(self, req: Request) -> Response:
         from ray._common.usage.usage_lib import TagKey, record_extra_usage_tag
-        from ray.serve._private.api import serve_start_async
+        from ray.serve._private.api import (
+            declared_start_time_options,
+            serve_start_async,
+        )
         from ray.serve.exceptions import RayServeConfigException
         from ray.serve.schema import ServeDeploySchema
 
@@ -180,6 +183,7 @@ class ServeHead(SubprocessModule):
                     grpc_options=grpc_options,
                     global_logging_config=config.logging_config,
                     controller_options=config.controller_options,
+                    declared_options=declared_start_time_options(config),
                 )
         except RayServeConfigException as e:
             # Reject the whole config: applying the applications while dropping the

--- a/python/ray/dashboard/modules/serve/tests/test_serve_dashboard_2.py
+++ b/python/ray/dashboard/modules/serve/tests/test_serve_dashboard_2.py
@@ -14,6 +14,7 @@ import ray._private.ray_constants as ray_constants
 from ray import serve
 from ray._common.test_utils import wait_for_condition
 from ray._private.test_utils import generate_system_config_map
+from ray.serve.config import ProxyLocation
 from ray.serve.generated import serve_pb2, serve_pb2_grpc
 from ray.serve.schema import HTTPOptionsSchema, ServeInstanceDetails
 from ray.serve.tests.conftest import *  # noqa: F401 F403
@@ -65,15 +66,15 @@ def test_serve_namespace(ray_start_stop):
 
 
 @pytest.mark.parametrize(
-    "option,override",
+    "option,override,changed_field",
     [
-        ("proxy_location", "HeadOnly"),
-        ("http_options", {"host": "127.0.0.2"}),
-        ("http_options", {"port": 8000}),
-        ("http_options", {"root_path": "/serve_updated"}),
+        ("proxy_location", "HeadOnly", "proxy_location"),
+        ("http_options", {"host": "127.0.0.2"}, "http_options.host"),
+        ("http_options", {"port": 8001}, "http_options.port"),
+        ("http_options", {"root_path": "/serve_updated"}, "http_options.root_path"),
     ],
 )
-def test_put_with_http_options(ray_start_stop, option, override):
+def test_put_with_http_options(ray_start_stop, option, override, changed_field):
     """Submits a config with HTTP options specified.
 
     Trying to submit a config to the serve agent with the HTTP options modified:
@@ -127,6 +128,10 @@ def test_put_with_http_options(ray_start_stop, option, override):
     )
     assert put_response.status_code == 400
     assert "can't be updated at runtime" in put_response.text
+    # Only the field the config actually changed may be reported: naming a field the
+    # config left alone is how a fully-defaulted dump rejects an unchanged config.
+    assert changed_field in put_response.text
+    assert put_response.text.count("->") == 1
 
     # Fetch Serve status and confirm that HTTP options are unchanged
     get_response = requests.get(SERVE_HEAD_URL, timeout=5)
@@ -145,6 +150,40 @@ def test_put_with_http_options(ray_start_stop, option, override):
         == "4 pizzas please!"
     )
     assert requests.post("http://localhost:8000/serve/app2").text == "wonderful world"
+
+
+def test_put_omitting_global_options(ray_start_stop):
+    """A config that declares no global options isn't asking to change them.
+
+    The schema fills in every default, so this is the case that regresses into a
+    rejection if the apply is diffed against the full dump instead of what was sent.
+    """
+    world_import_path = "ray.serve.tests.test_config_files.world.DagNode"
+    app = {"name": "app1", "route_prefix": "/app1", "import_path": world_import_path}
+    deploy_config_multi_app(
+        {
+            "proxy_location": "HeadOnly",
+            "http_options": {"host": "127.0.0.1", "port": 8000, "root_path": "/serve"},
+            "applications": [app],
+        },
+        SERVE_HEAD_URL,
+    )
+    wait_for_condition(
+        lambda: requests.post("http://localhost:8000/serve/app1").text
+        == "wonderful world",
+        timeout=15,
+    )
+
+    put_response = requests.put(SERVE_HEAD_URL, json={"applications": [app]}, timeout=5)
+    assert put_response.status_code == 200, put_response.text
+
+    # The running options are untouched, not reset to the schema defaults.
+    serve_details = ServeInstanceDetails.model_validate(
+        requests.get(SERVE_HEAD_URL, timeout=5).json()
+    )
+    assert serve_details.http_options.host == "127.0.0.1"
+    assert serve_details.http_options.root_path == "/serve"
+    assert serve_details.proxy_location == ProxyLocation.HeadOnly
 
 
 def test_put_with_grpc_options(ray_start_stop):

--- a/python/ray/dashboard/modules/serve/tests/test_serve_dashboard_2.py
+++ b/python/ray/dashboard/modules/serve/tests/test_serve_dashboard_2.py
@@ -76,11 +76,10 @@ def test_serve_namespace(ray_start_stop):
 def test_put_with_http_options(ray_start_stop, option, override):
     """Submits a config with HTTP options specified.
 
-    Trying to submit a config to the serve agent with the HTTP options modified should
-    NOT fail:
+    Trying to submit a config to the serve agent with the HTTP options modified:
       - If Serve is NOT running, HTTP options will be honored when starting Serve
-      - If Serve is running, HTTP options will be ignored, and warning will be logged
-      urging users to restart Serve if they want their options to take effect
+      - If Serve is running, the request is rejected with a 400 and the running
+        options are left alone, so the change can't be silently dropped
     """
 
     pizza_import_path = "ray.serve.tests.test_config_files.pizza.serve_dag"
@@ -126,7 +125,8 @@ def test_put_with_http_options(ray_start_stop, option, override):
     put_response = requests.put(
         SERVE_HEAD_URL, json=updated_serve_config_json, timeout=5
     )
-    assert put_response.status_code == 200
+    assert put_response.status_code == 400
+    assert "can't be updated at runtime" in put_response.text
 
     # Fetch Serve status and confirm that HTTP options are unchanged
     get_response = requests.get(SERVE_HEAD_URL, timeout=5)

--- a/python/ray/serve/_private/api.py
+++ b/python/ray/serve/_private/api.py
@@ -5,7 +5,18 @@ from enum import Enum
 
 # Exists on all supported versions; pyrefly mis-resolves it at python-version 3.9.
 from types import FunctionType  # pyrefly: ignore[missing-module-attribute]
-from typing import Any, Callable, Dict, FrozenSet, List, Optional, Tuple, Union
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    FrozenSet,
+    List,
+    Optional,
+    Tuple,
+    Type,
+    TypeVar,
+    Union,
+)
 
 from pydantic import BaseModel
 
@@ -39,6 +50,8 @@ from ray.serve.schema import LoggingConfig, ServeDeploySchema, TracingConfig
 
 logger = logging.getLogger(SERVE_LOGGER_NAME)
 
+ModelT = TypeVar("ModelT", bound=BaseModel)
+
 # Reported as "<redacted>" instead of their value in the start-time config error.
 _REDACTED_FIELDS = frozenset({"http_options.ssl_keyfile_password"})
 
@@ -59,9 +72,25 @@ def _coerce_controller_options(
     )
 
 
+def _coerce_options(
+    requested: Union[None, dict, ModelT], model: Type[ModelT]
+) -> Optional[ModelT]:
+    """Validate the caller's options into `model`, or None if they sent none.
+
+    `model_fields_set` on the result is exactly the fields the caller supplied, so
+    validating here loses nothing a raw dict carried.
+    """
+    if not requested:
+        return None
+    if isinstance(requested, dict):
+        # pyrefly drops the TypeVar bound on a classmethod access; mypy accepts it.
+        return model.model_validate(requested)  # pyrefly: ignore[missing-attribute]
+    return requested
+
+
 def _diff_start_time_options(
     label: str,
-    requested: Union[None, dict, BaseModel],
+    requested: Optional[BaseModel],
     current: BaseModel,
     apply_defaults: Callable[[Any], BaseModel],
     ignore: FrozenSet[str] = frozenset(),
@@ -75,18 +104,14 @@ def _diff_start_time_options(
     through the controller's own defaulting, so an env-var default (e.g.
     RAY_SERVE_HTTP_KEEP_ALIVE_TIMEOUT_S) can't masquerade as a requested change.
     """
-    if not requested:
+    if requested is None:
         return {}
 
-    if isinstance(requested, dict):
-        provided = set(requested)
-        requested = type(current).model_validate(requested)
-    else:
-        provided = set(requested.model_fields_set)
-
-    # Unknown keys are dropped by pydantic on the start path too, so ignore them
-    # here rather than reporting a change for a field Serve never reads.
-    provided &= set(type(current).model_fields) - ignore
+    # Unknown keys are dropped by pydantic on the start path too, so they never
+    # reach `model_fields_set` and can't be reported as a change.
+    provided = set(requested.model_fields_set) & (
+        set(type(current).model_fields) - ignore
+    )
     requested = apply_defaults(requested)
     return {
         f"{label}.{field}": (getattr(current, field), getattr(requested, field))
@@ -106,7 +131,7 @@ def _describe(field: str, value: Any) -> str:
 
 
 def _requested_proxy_location(
-    http_options: Union[None, dict, HTTPOptions],
+    http_options: Optional[HTTPOptions],
     proxy_location: Union[None, str, ProxyLocation],
 ) -> Optional[ProxyLocation]:
     """The placement the caller asked for, or None if they didn't ask.
@@ -115,9 +140,7 @@ def _requested_proxy_location(
     resolves placement. It is read whether or not the caller set it, because
     `host=None` backfills it to Disabled and that is what startup resolves to.
     """
-    if isinstance(http_options, dict):
-        http_options = HTTPOptions.model_validate(http_options)
-    location = http_options.location if isinstance(http_options, HTTPOptions) else None
+    location = http_options.location if http_options is not None else None
 
     return ProxyLocation._normalize(
         location if location is not None else proxy_location
@@ -136,9 +159,11 @@ def _check_start_time_config_unchanged(
     starts, so these can only change across a restart. Failing here is what keeps
     the request from being silently dropped.
     """
+    requested_http = _coerce_options(http_options, HTTPOptions)
+    requested_grpc = _coerce_options(grpc_options, gRPCOptions)
     diff = _diff_start_time_options(
         "http_options",
-        http_options,
+        requested_http,
         client.http_config,
         configure_http_options_with_defaults,
         # `location` is reported as `proxy_location` below, against the resolved
@@ -148,7 +173,7 @@ def _check_start_time_config_unchanged(
     diff.update(
         _diff_start_time_options(
             "grpc_options",
-            grpc_options,
+            requested_grpc,
             client.grpc_config,
             set_proxy_default_grpc_options,
         )
@@ -158,7 +183,7 @@ def _check_start_time_config_unchanged(
     # in effect: direct-ingress mode overrides it, and the override isn't a change
     # any config can request or avoid.
     current_location = client.requested_proxy_location
-    requested_location = _requested_proxy_location(http_options, proxy_location)
+    requested_location = _requested_proxy_location(requested_http, proxy_location)
     if requested_location is not None and requested_location != current_location:
         diff["proxy_location"] = (current_location, requested_location)
 

--- a/python/ray/serve/_private/api.py
+++ b/python/ray/serve/_private/api.py
@@ -1,10 +1,11 @@
 import asyncio
 import inspect
 import logging
+from enum import Enum
 
 # Exists on all supported versions; pyrefly mis-resolves it at python-version 3.9.
 from types import FunctionType  # pyrefly: ignore[missing-module-attribute]
-from typing import Any, Dict, List, Tuple, Union
+from typing import Any, Callable, Dict, FrozenSet, List, Optional, Tuple, Union
 
 from pydantic import BaseModel
 
@@ -19,6 +20,8 @@ from ray.serve._private.constants import (
     SERVE_NAMESPACE,
 )
 from ray.serve._private.default_impl import get_controller_impl
+from ray.serve._private.grpc_util import set_proxy_default_grpc_options
+from ray.serve._private.http_util import configure_http_options_with_defaults
 from ray.serve.config import (
     ControllerOptions,
     HTTPOptions,
@@ -31,7 +34,7 @@ from ray.serve.context import (
     _set_global_client,
 )
 from ray.serve.deployment import Application
-from ray.serve.exceptions import RayServeException
+from ray.serve.exceptions import RayServeConfigException, RayServeException
 from ray.serve.schema import LoggingConfig, TracingConfig
 
 logger = logging.getLogger(SERVE_LOGGER_NAME)
@@ -53,28 +56,118 @@ def _coerce_controller_options(
     )
 
 
-def _check_http_options(
-    client: ServeControllerClient, http_options: Union[dict, HTTPOptions]
-) -> None:
-    if http_options:
-        client_http_options = client.http_config
-        new_http_options = (
-            http_options
-            if isinstance(http_options, HTTPOptions)
-            else HTTPOptions.model_validate(http_options)
-        )
-        different_fields = []
-        all_http_option_fields = new_http_options.__dict__
-        for field in all_http_option_fields:
-            if getattr(new_http_options, field) != getattr(client_http_options, field):
-                different_fields.append(field)
+def _diff_start_time_options(
+    label: str,
+    requested: Union[None, dict, BaseModel],
+    current: BaseModel,
+    apply_defaults: Callable[[Any], BaseModel],
+    ignore: FrozenSet[str] = frozenset(),
+) -> Dict[str, Tuple[Any, Any]]:
+    """Map "<label>.<field>" -> (current, requested) for provided fields that differ.
 
-        if len(different_fields):
-            logger.warning(
-                "The new client HTTP config differs from the existing one "
-                f"in the following fields: {different_fields}. "
-                "The new HTTP config is ignored."
-            )
+    Keys are qualified by option group because `http_options` and `grpc_options`
+    share field names (`port`).
+
+    Only fields the caller actually provided are compared, and both sides go
+    through the controller's own defaulting, so an env-var default (e.g.
+    RAY_SERVE_HTTP_KEEP_ALIVE_TIMEOUT_S) can't masquerade as a requested change.
+    """
+    if not requested:
+        return {}
+
+    if isinstance(requested, dict):
+        provided = set(requested)
+        requested = type(current).model_validate(requested)
+    else:
+        provided = set(requested.model_fields_set)
+
+    # Unknown keys are dropped by pydantic on the start path too, so ignore them
+    # here rather than reporting a change for a field Serve never reads.
+    provided &= set(type(current).model_fields) - ignore
+    requested = apply_defaults(requested)
+    return {
+        f"{label}.{field}": (getattr(current, field), getattr(requested, field))
+        for field in provided
+        if getattr(current, field) != getattr(requested, field)
+    }
+
+
+def _describe(value: Any) -> str:
+    """Render a config value for an error message, unwrapping enums."""
+    return repr(value.value if isinstance(value, Enum) else value)
+
+
+def _requested_proxy_location(
+    http_options: Union[None, dict, HTTPOptions],
+    proxy_location: Union[None, str, ProxyLocation],
+) -> Optional[ProxyLocation]:
+    """The placement the caller asked for, or None if they didn't ask.
+
+    The deprecated `HTTPOptions.location` wins over `proxy_location`, matching how
+    the controller resolves placement.
+    """
+    location = None
+    if isinstance(http_options, dict):
+        location = http_options.get("location")
+    elif isinstance(http_options, HTTPOptions) and (
+        "location" in http_options.model_fields_set
+    ):
+        location = http_options.location
+
+    return ProxyLocation._normalize(
+        location if location is not None else proxy_location
+    )
+
+
+def _check_start_time_config_unchanged(
+    client: ServeControllerClient,
+    http_options: Union[None, dict, HTTPOptions] = None,
+    grpc_options: Union[None, dict, gRPCOptions] = None,
+    proxy_location: Union[None, str, ProxyLocation] = None,
+) -> None:
+    """Raise if the caller asks to change config that is fixed at controller startup.
+
+    Serve bakes HTTP, gRPC, and proxy-placement config into the controller when it
+    starts, so these can only change across a restart. Failing here is what keeps
+    the request from being silently dropped.
+    """
+    diff = _diff_start_time_options(
+        "http_options",
+        http_options,
+        client.http_config,
+        configure_http_options_with_defaults,
+        # `location` is reported as `proxy_location` below, against the resolved
+        # placement rather than the raw (deprecated) field.
+        ignore=frozenset({"location"}),
+    )
+    diff.update(
+        _diff_start_time_options(
+            "grpc_options",
+            grpc_options,
+            client.grpc_config,
+            set_proxy_default_grpc_options,
+        )
+    )
+
+    requested_location = _requested_proxy_location(http_options, proxy_location)
+    if requested_location is not None and requested_location != client.proxy_location:
+        diff["proxy_location"] = (client.proxy_location, requested_location)
+
+    if not diff:
+        return
+
+    changes = ", ".join(
+        f"{field}: {_describe(current)} -> {_describe(requested)}"
+        for field, (current, requested) in sorted(diff.items())
+    )
+    raise RayServeConfigException(
+        "Serve is already running in this Ray cluster, and the following options "
+        f"are global to the cluster and can't be updated at runtime: {changes}. "
+        "They are fixed when the Serve controller starts. To apply them, shut Serve "
+        "down and start it again (`serve shutdown`, or restart the Ray cluster or "
+        "RayService); to keep the values Serve is running with, drop these fields "
+        "from your config."
+    )
 
 
 def _create_controller_and_proxy_refs(
@@ -188,10 +281,14 @@ async def serve_start_async(
     if client is not None:
         logger.info(
             f'Connecting to existing Serve app in namespace "{SERVE_NAMESPACE}".'
-            " New http_options/controller_options will not be applied."
+            " New controller_options will not be applied."
         )
-        if http_options:
-            _check_http_options(client, http_options)
+        _check_start_time_config_unchanged(
+            client,
+            http_options=http_options,
+            grpc_options=grpc_options,
+            proxy_location=proxy_location,
+        )
         return client
 
     # Run the blocking controller-creation helper in a worker thread so its
@@ -312,10 +409,14 @@ def serve_start(
     if client is not None:
         logger.info(
             f'Connecting to existing Serve app in namespace "{SERVE_NAMESPACE}".'
-            " New http_options/controller_options will not be applied."
+            " New controller_options will not be applied."
         )
-        if http_options:
-            _check_http_options(client, http_options)
+        _check_start_time_config_unchanged(
+            client,
+            http_options=http_options,
+            grpc_options=grpc_options,
+            proxy_location=proxy_location,
+        )
         return client
 
     controller, proxy_ready_refs = _create_controller_and_proxy_refs(

--- a/python/ray/serve/_private/api.py
+++ b/python/ray/serve/_private/api.py
@@ -35,9 +35,12 @@ from ray.serve.context import (
 )
 from ray.serve.deployment import Application
 from ray.serve.exceptions import RayServeConfigException, RayServeException
-from ray.serve.schema import LoggingConfig, TracingConfig
+from ray.serve.schema import LoggingConfig, ServeDeploySchema, TracingConfig
 
 logger = logging.getLogger(SERVE_LOGGER_NAME)
+
+# Reported as "<redacted>" instead of their value in the start-time config error.
+_REDACTED_FIELDS = frozenset({"http_options.ssl_keyfile_password"})
 
 
 def _coerce_controller_options(
@@ -92,8 +95,13 @@ def _diff_start_time_options(
     }
 
 
-def _describe(value: Any) -> str:
-    """Render a config value for an error message, unwrapping enums."""
+def _describe(field: str, value: Any) -> str:
+    """Render a config value for an error message, unwrapping enums.
+
+    Secrets are redacted because the message reaches an HTTP 400 body and user logs.
+    """
+    if field in _REDACTED_FIELDS:
+        return "<redacted>"
     return repr(value.value if isinstance(value, Enum) else value)
 
 
@@ -149,15 +157,19 @@ def _check_start_time_config_unchanged(
         )
     )
 
+    # Compared against the placement the caller originally asked for, not the one
+    # in effect: direct-ingress mode overrides it, and the override isn't a change
+    # any config can request or avoid.
+    current_location = client.requested_proxy_location
     requested_location = _requested_proxy_location(http_options, proxy_location)
-    if requested_location is not None and requested_location != client.proxy_location:
-        diff["proxy_location"] = (client.proxy_location, requested_location)
+    if requested_location is not None and requested_location != current_location:
+        diff["proxy_location"] = (current_location, requested_location)
 
     if not diff:
         return
 
     changes = ", ".join(
-        f"{field}: {_describe(current)} -> {_describe(requested)}"
+        f"{field}: {_describe(field, current)} -> {_describe(field, requested)}"
         for field, (current, requested) in sorted(diff.items())
     )
     raise RayServeConfigException(
@@ -168,6 +180,44 @@ def _check_start_time_config_unchanged(
         "RayService); to keep the values Serve is running with, drop these fields "
         "from your config."
     )
+
+
+def declared_start_time_options(config: ServeDeploySchema) -> Dict[str, Any]:
+    """The start-time options a declarative config explicitly asked for.
+
+    The declarative paths send a fully-defaulted dump to start Serve with, so
+    without this every untouched schema default would read as a requested change.
+    """
+    return {
+        "http_options": config.http_options.model_dump(exclude_unset=True),
+        "grpc_options": config.grpc_options.model_dump(exclude_unset=True),
+        "proxy_location": (
+            config.proxy_location
+            if "proxy_location" in config.model_fields_set
+            else None
+        ),
+    }
+
+
+def _connect_to_existing_client(
+    client: ServeControllerClient,
+    http_options: Union[None, dict, HTTPOptions],
+    grpc_options: Union[None, dict, gRPCOptions],
+    proxy_location: Union[None, str, ProxyLocation],
+    declared_options: Optional[Dict[str, Any]],
+) -> None:
+    """Log the connection and reject changes to config fixed at controller startup."""
+    if declared_options is None:
+        declared_options = {
+            "http_options": http_options,
+            "grpc_options": grpc_options,
+            "proxy_location": proxy_location,
+        }
+    logger.info(
+        f'Connecting to existing Serve app in namespace "{SERVE_NAMESPACE}".'
+        " New controller_options will not be applied."
+    )
+    _check_start_time_config_unchanged(client, **declared_options)
 
 
 def _create_controller_and_proxy_refs(
@@ -254,6 +304,7 @@ async def serve_start_async(
     global_tracing_config: Union[None, dict, TracingConfig] = None,
     controller_options: Union[None, dict, ControllerOptions] = None,
     proxy_location: Union[None, str, ProxyLocation] = None,
+    declared_options: Optional[Dict[str, Any]] = None,
     **kwargs,
 ) -> ServeControllerClient:
     """Initialize a serve instance asynchronously.
@@ -279,15 +330,8 @@ async def serve_start_async(
         except RayServeException:
             client = None
     if client is not None:
-        logger.info(
-            f'Connecting to existing Serve app in namespace "{SERVE_NAMESPACE}".'
-            " New controller_options will not be applied."
-        )
-        _check_start_time_config_unchanged(
-            client,
-            http_options=http_options,
-            grpc_options=grpc_options,
-            proxy_location=proxy_location,
+        _connect_to_existing_client(
+            client, http_options, grpc_options, proxy_location, declared_options
         )
         return client
 
@@ -334,6 +378,7 @@ def serve_start(
     global_tracing_config: Union[None, dict, TracingConfig] = None,
     controller_options: Union[None, dict, ControllerOptions] = None,
     proxy_location: Union[None, str, ProxyLocation] = None,
+    declared_options: Optional[Dict[str, Any]] = None,
     **kwargs,
 ) -> ServeControllerClient:
     """Initialize a serve instance.
@@ -388,6 +433,11 @@ def serve_start(
             the cluster. See ``ProxyLocation`` for supported options. Defaults
             to ``EveryNode`` when unspecified. An explicit (deprecated)
             ``HTTPOptions.location`` overrides this.
+        declared_options: The subset of the options above that the caller
+            explicitly asked for, checked against an already-running instance
+            instead of the values passed here. Declarative callers must pass
+            this (see ``declared_start_time_options``) because they send a
+            fully-defaulted config to start Serve with.
         **kwargs: Reserved for forwarding to internal controller-start hooks;
             no public keys are currently supported and unknown keys may raise.
 
@@ -407,15 +457,8 @@ def serve_start(
         except RayServeException:
             client = None
     if client is not None:
-        logger.info(
-            f'Connecting to existing Serve app in namespace "{SERVE_NAMESPACE}".'
-            " New controller_options will not be applied."
-        )
-        _check_start_time_config_unchanged(
-            client,
-            http_options=http_options,
-            grpc_options=grpc_options,
-            proxy_location=proxy_location,
+        _connect_to_existing_client(
+            client, http_options, grpc_options, proxy_location, declared_options
         )
         return client
 

--- a/python/ray/serve/_private/api.py
+++ b/python/ray/serve/_private/api.py
@@ -111,16 +111,13 @@ def _requested_proxy_location(
 ) -> Optional[ProxyLocation]:
     """The placement the caller asked for, or None if they didn't ask.
 
-    The deprecated `HTTPOptions.location` wins over `proxy_location`, matching how
-    the controller resolves placement.
+    `HTTPOptions.location` wins over `proxy_location`, matching how the controller
+    resolves placement. It is read whether or not the caller set it, because
+    `host=None` backfills it to Disabled and that is what startup resolves to.
     """
-    location = None
     if isinstance(http_options, dict):
-        location = http_options.get("location")
-    elif isinstance(http_options, HTTPOptions) and (
-        "location" in http_options.model_fields_set
-    ):
-        location = http_options.location
+        http_options = HTTPOptions.model_validate(http_options)
+    location = http_options.location if isinstance(http_options, HTTPOptions) else None
 
     return ProxyLocation._normalize(
         location if location is not None else proxy_location

--- a/python/ray/serve/_private/client.py
+++ b/python/ray/serve/_private/client.py
@@ -67,10 +67,10 @@ class ServeControllerClient:
         # Fixed for the controller's lifetime, so fetched once, in one batch.
         configs = ray.get(
             [
-                controller.get_http_config.remote(),
-                controller.get_grpc_config.remote(),
-                controller.get_requested_proxy_location.remote(),
-                controller.get_root_url.remote(),
+                self._controller.get_http_config.remote(),
+                self._controller.get_grpc_config.remote(),
+                self._controller.get_requested_proxy_location.remote(),
+                self._controller.get_root_url.remote(),
             ]
         )
         self._http_config: HTTPOptions = configs[0]

--- a/python/ray/serve/_private/client.py
+++ b/python/ray/serve/_private/client.py
@@ -69,13 +69,13 @@ class ServeControllerClient:
             [
                 controller.get_http_config.remote(),
                 controller.get_grpc_config.remote(),
-                controller.get_proxy_location.remote(),
+                controller.get_requested_proxy_location.remote(),
                 controller.get_root_url.remote(),
             ]
         )
         self._http_config: HTTPOptions = configs[0]
         self._grpc_config: gRPCOptions = configs[1]
-        self._proxy_location: Optional[ProxyLocation] = configs[2]
+        self._requested_proxy_location: ProxyLocation = configs[2]
         self._root_url = cast(str, configs[3])
 
         # Each handle has the overhead of long poll client, therefore cached.
@@ -95,8 +95,8 @@ class ServeControllerClient:
         return self._grpc_config
 
     @property
-    def proxy_location(self):
-        return self._proxy_location
+    def requested_proxy_location(self):
+        return self._requested_proxy_location
 
     def __reduce__(self):
         raise RayServeException(("Ray Serve client cannot be serialized."))

--- a/python/ray/serve/_private/client.py
+++ b/python/ray/serve/_private/client.py
@@ -27,7 +27,7 @@ from ray.serve._private.constants import (
 from ray.serve._private.deploy_utils import get_deploy_args
 from ray.serve._private.deployment_info import DeploymentInfo
 from ray.serve._private.utils import _callable_uses_multiplexing, get_random_string
-from ray.serve.config import HTTPOptions
+from ray.serve.config import HTTPOptions, ProxyLocation, gRPCOptions
 from ray.serve.exceptions import RayServeException
 from ray.serve.generated.serve_pb2 import (
     ApplicationArgs,
@@ -64,10 +64,19 @@ class ServeControllerClient:
     ):
         self._controller: Any = controller
         self._shutdown = False
-        self._http_config: HTTPOptions = ray.get(
-            self._controller.get_http_config.remote()
+        # Fixed for the controller's lifetime, so fetched once, in one batch.
+        configs = ray.get(
+            [
+                controller.get_http_config.remote(),
+                controller.get_grpc_config.remote(),
+                controller.get_proxy_location.remote(),
+                controller.get_root_url.remote(),
+            ]
         )
-        self._root_url = cast(str, ray.get(self._controller.get_root_url.remote()))
+        self._http_config: HTTPOptions = configs[0]
+        self._grpc_config: gRPCOptions = configs[1]
+        self._proxy_location: Optional[ProxyLocation] = configs[2]
+        self._root_url = cast(str, configs[3])
 
         # Each handle has the overhead of long poll client, therefore cached.
         self.handle_cache: Dict[Tuple[str, str, bool], DeploymentHandle] = dict()
@@ -80,6 +89,14 @@ class ServeControllerClient:
     @property
     def http_config(self):
         return self._http_config
+
+    @property
+    def grpc_config(self):
+        return self._grpc_config
+
+    @property
+    def proxy_location(self):
+        return self._proxy_location
 
     def __reduce__(self):
         raise RayServeException(("Ray Serve client cannot be serialized."))

--- a/python/ray/serve/_private/controller.py
+++ b/python/ray/serve/_private/controller.py
@@ -209,6 +209,11 @@ class ServeController:
 
         self._ha_proxy_enabled = RAY_SERVE_ENABLE_HA_PROXY
         self._direct_ingress_enabled = RAY_SERVE_ENABLE_DIRECT_INGRESS
+        # Captured before the mode-specific overrides below so a later config apply
+        # is diffed against what the caller asked for, not what we forced.
+        self._requested_proxy_location = (
+            http_options.location or proxy_location or ProxyLocation.EveryNode
+        )
         # Last full set of ingress-port tuples fed to update_ports (for the per-tick set-diff).
         self._last_ingress_port_tuples: set = set()
         # Last ingress membership version seen; -1 forces the first tick to run.
@@ -982,6 +987,10 @@ class ServeController:
         if self.proxy_state_manager is None:
             return None
         return self.proxy_state_manager.get_proxy_location()
+
+    def get_requested_proxy_location(self) -> ProxyLocation:
+        """Return the placement the caller asked for, before any mode override."""
+        return self._requested_proxy_location
 
     def get_grpc_config(self) -> gRPCOptions:
         """Return the gRPC proxy configuration."""

--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -122,6 +122,10 @@ def start(
           running in this Ray cluster.
         **kwargs: Reserved for forward-compatibility; passed through to the
             internal Serve start helper.
+
+    Raises:
+        RayServeConfigException: If Serve is already running and this call asks to
+          change ``proxy_location``, ``http_options``, or ``grpc_options``.
     """
     _private_api.serve_start(
         http_options=http_options,

--- a/python/ray/serve/api.py
+++ b/python/ray/serve/api.py
@@ -848,8 +848,9 @@ def _run_many(
         )
         return [b.deployment_handles[b.ingress_deployment_name] for b in built_apps]
     else:
+        # Placement is left unset so it resolves to the default (EveryNode) rather
+        # than requesting a change to an already-running instance's placement.
         client = _private_api.serve_start(
-            proxy_location=ProxyLocation.EveryNode,
             global_logging_config=None,
             controller_options=controller_options,
         )

--- a/python/ray/serve/exceptions.py
+++ b/python/ray/serve/exceptions.py
@@ -12,6 +12,13 @@ class RayServeException(Exception):
     pass
 
 
+@PublicAPI(stability="alpha")
+class RayServeConfigException(RayServeException):
+    """Raised when a config can't be applied to the running Serve instance."""
+
+    pass
+
+
 @PublicAPI(stability="stable")
 class gRPCStatusError(RayServeException):
     """Internal exception that wraps an exception with user-set gRPC status code.

--- a/python/ray/serve/scripts.py
+++ b/python/ray/serve/scripts.py
@@ -16,7 +16,7 @@ import yaml
 
 import ray
 from ray import serve
-from ray._common.network_utils import get_all_interfaces_ip, get_localhost_ip
+from ray._common.network_utils import get_all_interfaces_ip
 from ray._common.utils import import_attr
 from ray.autoscaler._private.cli_logger import cli_logger
 from ray.dashboard.modules.dashboard_sdk import parse_runtime_env_args
@@ -25,7 +25,6 @@ from ray.serve._private import api as _private_api
 from ray.serve._private.build_app import BuiltApplication, build_app
 from ray.serve._private.constants import (
     DEFAULT_GRPC_PORT,
-    DEFAULT_HTTP_HOST,
     DEFAULT_HTTP_PORT,
     SERVE_DEFAULT_APP_NAME,
     SERVE_NAMESPACE,
@@ -36,7 +35,7 @@ from ray.serve.config import (
 )
 from ray.serve.context import _get_global_client
 from ray.serve.deployment import Application, deployment_to_schema
-from ray.serve.exceptions import RayServeException
+from ray.serve.exceptions import RayServeConfigException, RayServeException
 from ray.serve.schema import (
     LoggingConfig,
     ServeApplicationSchema,
@@ -150,28 +149,28 @@ def cli():
 )
 @click.option(
     "--http-host",
-    default=DEFAULT_HTTP_HOST or get_localhost_ip(),
+    default=None,
     required=False,
     type=str,
     help="Host for HTTP proxies to listen on. Defaults to localhost.",
 )
 @click.option(
     "--http-port",
-    default=DEFAULT_HTTP_PORT,
+    default=None,
     required=False,
     type=int,
     help="Port for HTTP proxies to listen on. " f"Defaults to {DEFAULT_HTTP_PORT}.",
 )
 @click.option(
     "--proxy-location",
-    default=ProxyLocation.EveryNode,
+    default=None,
     required=False,
     type=click.Choice(list(ProxyLocation)),
     help="Location of the proxies. Defaults to EveryNode.",
 )
 @click.option(
     "--grpc-port",
-    default=DEFAULT_GRPC_PORT,
+    default=None,
     required=False,
     type=int,
     help="Port for gRPC proxies to listen on. " f"Defaults to {DEFAULT_GRPC_PORT}.",
@@ -196,17 +195,26 @@ def start(
         address=address,
         namespace=SERVE_NAMESPACE,
     )
-    serve.start(
-        proxy_location=proxy_location,
-        http_options=dict(
-            host=http_host,
-            port=http_port,
-        ),
-        grpc_options=gRPCOptions(
-            port=grpc_port,
-            grpc_servicer_functions=grpc_servicer_functions,
-        ),
-    )
+    # Only pass what was given on the command line: an unspecified flag must not
+    # read as a request to change an already-running instance's config.
+    http_options: Dict[str, Any] = {}
+    if http_host is not None:
+        http_options["host"] = http_host
+    if http_port is not None:
+        http_options["port"] = http_port
+    grpc_options: Dict[str, Any] = {}
+    if grpc_port is not None:
+        grpc_options["port"] = grpc_port
+    if grpc_servicer_functions:
+        grpc_options["grpc_servicer_functions"] = grpc_servicer_functions
+    try:
+        serve.start(
+            proxy_location=proxy_location,
+            http_options=http_options,
+            grpc_options=gRPCOptions(**grpc_options),
+        )
+    except RayServeConfigException as e:
+        raise click.ClickException(str(e))
 
 
 def _generate_config_from_file_or_import_path(
@@ -518,6 +526,7 @@ def run(
     proxy_location = None
     grpc_options = gRPCOptions()
     controller_options = None
+    declared_options = None
     # Merge http_options, grpc_options, and controller_options with the ones on
     # ServeDeploySchema.
     if is_config and isinstance(config, ServeDeploySchema):
@@ -525,13 +534,20 @@ def run(
         http_options = config.http_options.model_dump()
         grpc_options = gRPCOptions(**config.grpc_options.model_dump())
         controller_options = config.controller_options
+        declared_options = _private_api.declared_start_time_options(config)
 
-    client = _private_api.serve_start(
-        http_options=http_options,
-        proxy_location=proxy_location,
-        grpc_options=grpc_options,
-        controller_options=controller_options,
-    )
+    try:
+        client = _private_api.serve_start(
+            http_options=http_options,
+            proxy_location=proxy_location,
+            grpc_options=grpc_options,
+            controller_options=controller_options,
+            declared_options=declared_options,
+        )
+    except RayServeConfigException as e:
+        # Raised before anything was deployed, so report it as a plain CLI error
+        # rather than falling into the handler below that shuts Serve down.
+        raise click.ClickException(str(e))
 
     try:
         if is_config:

--- a/python/ray/serve/scripts.py
+++ b/python/ray/serve/scripts.py
@@ -513,7 +513,9 @@ def run(
         )
 
     http_options = {}
-    proxy_location = ProxyLocation.EveryNode
+    # Left unset so it resolves to the default (EveryNode) rather than requesting a
+    # change to an already-running instance's placement.
+    proxy_location = None
     grpc_options = gRPCOptions()
     controller_options = None
     # Merge http_options, grpc_options, and controller_options with the ones on

--- a/python/ray/serve/tests/test_api_2.py
+++ b/python/ray/serve/tests/test_api_2.py
@@ -5,6 +5,7 @@ from ray import serve
 from ray._common.network_utils import build_address
 from ray.serve._private.common import RequestProtocol
 from ray.serve._private.test_utils import get_application_urls
+from ray.serve.exceptions import RayServeConfigException
 
 
 def test_get_application_urls(serve_instance):
@@ -59,6 +60,25 @@ def test_get_application_urls_with_route_prefix(serve_instance):
     assert get_application_urls("gRPC", app_name="app1", use_localhost=False) == [
         f"{node_ip}:9000"
     ]
+
+
+def test_start_rejects_changed_global_config(serve_instance):
+    """Cluster-global config is fixed at startup, so a change must fail loudly."""
+    serve.start()  # Nothing requested.
+    serve.start(http_options={"host": "0.0.0.0"})  # Matches the running config.
+
+    with pytest.raises(
+        RayServeConfigException, match=r"http_options\.port: 8000 -> 8001"
+    ):
+        serve.start(http_options={"port": 8001})
+
+    with pytest.raises(RayServeConfigException, match="proxy_location"):
+        serve.start(proxy_location="EveryNode")
+
+    with pytest.raises(
+        RayServeConfigException, match=r"grpc_options\.port: 9000 -> 9001"
+    ):
+        serve.start(grpc_options={"port": 9001})
 
 
 if __name__ == "__main__":

--- a/python/ray/serve/tests/test_standalone.py
+++ b/python/ray/serve/tests/test_standalone.py
@@ -387,13 +387,16 @@ def test_checkpoint_isolation_namespace(ray_shutdown):
 
     address = info["address"]
 
+    # Neither driver requests a port: Serve's controller lives in the fixed
+    # SERVE_NAMESPACE, so both drivers share one instance no matter which Ray
+    # namespace they connect under, and a second port here would be a change to it.
     driver_template = """
 import ray
 from ray import serve
 
 ray.init(address="{address}", namespace="{namespace}")
 
-serve.start(http_options={{"port": {port}}})
+serve.start()
 
 @serve.deployment
 class A:
@@ -402,10 +405,10 @@ class A:
 serve.run(A.bind())"""
 
     run_string_as_driver(
-        driver_template.format(address=address, namespace="test_namespace1", port=8000)
+        driver_template.format(address=address, namespace="test_namespace1")
     )
     run_string_as_driver(
-        driver_template.format(address=address, namespace="test_namespace2", port=8001)
+        driver_template.format(address=address, namespace="test_namespace2")
     )
 
 

--- a/python/ray/serve/tests/test_standalone.py
+++ b/python/ray/serve/tests/test_standalone.py
@@ -4,7 +4,6 @@ requires a shared Serve instance.
 """
 
 import asyncio
-import logging
 import os
 import random
 import shutil
@@ -41,6 +40,7 @@ from ray.serve.config import (
     ProxyLocation,
 )
 from ray.serve.context import _get_global_client
+from ray.serve.exceptions import RayServeConfigException
 from ray.serve.schema import ServeApplicationSchema, ServeDeploySchema, TracingConfig
 from ray.serve.utils import get_trace_context
 from ray.util.state import list_actors
@@ -409,33 +409,20 @@ serve.run(A.bind())"""
     )
 
 
-def test_serve_start_different_http_checkpoint_options_warning(
-    ray_shutdown, propagate_logs, caplog
-):
-    logger = logging.getLogger("ray.serve")
-    caplog.set_level(logging.WARNING, logger="ray.serve")
-
-    warning_msg = []
-
-    class WarningHandler(logging.Handler):
-        def emit(self, record):
-            warning_msg.append(self.format(record))
-
-    logger.addHandler(WarningHandler())
-
+def test_serve_start_different_http_options_raises(ray_shutdown):
+    """HTTP config is fixed at controller startup, so a change must fail loudly."""
     ray.init(namespace="serve-test")
     serve.start()
 
     # create a different config
     test_http = dict(host="127.1.1.8", port=_get_random_port())
 
-    serve.start(http_options=test_http)
+    with pytest.raises(RayServeConfigException) as exc:
+        serve.start(http_options=test_http)
 
-    for test_config, msg in zip([["host", "port"]], warning_msg):
-        for test_msg in test_config:
-            if "Autoscaling metrics pusher thread" in msg:
-                continue
-            assert test_msg in msg
+    message = str(exc.value)
+    assert "http_options.host" in message
+    assert "http_options.port" in message
 
 
 def test_recovering_controller_no_redeploy():

--- a/python/ray/serve/tests/unit/test_start_time_config.py
+++ b/python/ray/serve/tests/unit/test_start_time_config.py
@@ -191,6 +191,25 @@ def test_proxy_location():
         _check_start_time_config_unchanged(client, proxy_location="EveryNode")
 
 
+def test_host_none_requests_disabled_placement():
+    """`host=None` backfills location=Disabled without recording it as set.
+
+    Startup resolves that to Disabled, so re-issuing the same call must not read as
+    a request to change placement to whatever `proxy_location` says.
+    """
+    client = fake_client(HTTPOptions(host=None), proxy_location=ProxyLocation.Disabled)
+    _check_start_time_config_unchanged(
+        client, http_options={"host": None}, proxy_location="EveryNode"
+    )
+    _check_start_time_config_unchanged(
+        client, http_options=HTTPOptions(host=None), proxy_location="EveryNode"
+    )
+
+    # Asking for a placement without disabling the server is still a real change.
+    with pytest.raises(RayServeConfigException, match="proxy_location"):
+        _check_start_time_config_unchanged(client, proxy_location="EveryNode")
+
+
 def test_deprecated_location_is_compared_against_resolved_placement():
     """`HTTPOptions.location` is an alias for `proxy_location` and wins over it."""
     client = fake_client(proxy_location=ProxyLocation.HeadOnly)

--- a/python/ray/serve/tests/unit/test_start_time_config.py
+++ b/python/ray/serve/tests/unit/test_start_time_config.py
@@ -9,6 +9,7 @@ from ray.serve._private.api import (
 )
 from ray.serve._private.grpc_util import set_proxy_default_grpc_options
 from ray.serve._private.http_util import configure_http_options_with_defaults
+from ray.serve._private.test_utils import skip_if_haproxy
 from ray.serve.config import HTTPOptions, ProxyLocation, gRPCOptions
 from ray.serve.exceptions import RayServeConfigException
 from ray.serve.schema import ServeDeploySchema
@@ -86,17 +87,30 @@ def test_full_schema_dump_is_not_a_change():
 
 
 def test_declarative_config_reports_only_what_it_declared():
-    """A config that omits a section must not request that section's defaults.
+    """A config that omits a section must not request that section's defaults."""
+    client = fake_client(HTTPOptions(port=8001))
+    config = ServeDeploySchema.model_validate({"applications": []})
+    _check_start_time_config_unchanged(client, **declared_start_time_options(config))
+
+    # The full dump is what the same paths pass to *start* Serve, and it does differ.
+    with pytest.raises(RayServeConfigException, match=r"http_options\.port"):
+        _check_start_time_config_unchanged(
+            client, http_options=config.http_options.model_dump()
+        )
+
+
+@skip_if_haproxy("HAProxy mode defaults host to all interfaces, as the schema does")
+def test_schema_and_internal_host_defaults_diverge():
+    """The divergence that makes the full dump reject an untouched config.
 
     `HTTPOptionsSchema.host` defaults to 0.0.0.0 while `HTTPOptions.host` defaults
-    to the loopback, so diffing the full dump rejects every declarative apply to a
-    Serve instance that was started from Python.
+    to the loopback, so a config with no http_options rejects every declarative
+    apply to a Serve instance started from Python.
     """
     client = fake_client()
     config = ServeDeploySchema.model_validate({"applications": []})
     _check_start_time_config_unchanged(client, **declared_start_time_options(config))
 
-    # The full dump is what the same paths pass to *start* Serve, and it does differ.
     with pytest.raises(RayServeConfigException, match=r"http_options\.host"):
         _check_start_time_config_unchanged(
             client, http_options=config.http_options.model_dump()

--- a/python/ray/serve/tests/unit/test_start_time_config.py
+++ b/python/ray/serve/tests/unit/test_start_time_config.py
@@ -1,0 +1,129 @@
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+from ray.serve._private.api import _check_start_time_config_unchanged
+from ray.serve._private.grpc_util import set_proxy_default_grpc_options
+from ray.serve._private.http_util import configure_http_options_with_defaults
+from ray.serve.config import HTTPOptions, ProxyLocation, gRPCOptions
+from ray.serve.exceptions import RayServeConfigException
+
+
+def fake_client(
+    http_options=None,
+    grpc_options=None,
+    proxy_location=ProxyLocation.EveryNode,
+):
+    """A client whose config went through the same defaulting as the controller's."""
+    return SimpleNamespace(
+        http_config=configure_http_options_with_defaults(http_options or HTTPOptions()),
+        grpc_config=set_proxy_default_grpc_options(grpc_options or gRPCOptions()),
+        proxy_location=proxy_location,
+    )
+
+
+def test_nothing_requested():
+    client = fake_client()
+    _check_start_time_config_unchanged(client)
+    _check_start_time_config_unchanged(client, http_options={}, grpc_options={})
+    _check_start_time_config_unchanged(client, http_options=None, proxy_location=None)
+
+
+def test_matching_options():
+    client = fake_client(HTTPOptions(host="0.0.0.0", port=8000))
+    _check_start_time_config_unchanged(client, http_options={"host": "0.0.0.0"})
+    _check_start_time_config_unchanged(
+        client, http_options=HTTPOptions(host="0.0.0.0", port=8000)
+    )
+    _check_start_time_config_unchanged(client, proxy_location="EveryNode")
+
+
+def test_changed_field_raises():
+    client = fake_client(HTTPOptions(host="0.0.0.0", port=8000))
+    with pytest.raises(RayServeConfigException) as exc:
+        _check_start_time_config_unchanged(client, http_options={"port": 8001})
+
+    message = str(exc.value)
+    assert "http_options.port: 8000 -> 8001" in message
+    assert "can't be updated at runtime" in message
+
+
+def test_every_changed_field_is_reported():
+    client = fake_client(HTTPOptions(host="0.0.0.0", port=8000))
+    with pytest.raises(RayServeConfigException) as exc:
+        _check_start_time_config_unchanged(
+            client,
+            http_options={"host": "127.0.0.1", "port": 8001},
+            grpc_options={"port": 9001},
+            proxy_location="HeadOnly",
+        )
+
+    message = str(exc.value)
+    assert "http_options.host: '0.0.0.0' -> '127.0.0.1'" in message
+    assert "http_options.port: 8000 -> 8001" in message
+    assert "grpc_options.port: 9000 -> 9001" in message
+    assert "proxy_location: 'EveryNode' -> 'HeadOnly'" in message
+
+
+def test_unset_fields_are_not_a_change():
+    """A partially-specified model must not report the fields it left alone."""
+    client = fake_client(HTTPOptions(host="0.0.0.0", port=8001))
+    _check_start_time_config_unchanged(client, http_options=HTTPOptions(port=8001))
+
+
+def test_full_schema_dump_is_not_a_change():
+    """The declarative path sends every field, including untouched defaults."""
+    from ray.serve.schema import HTTPOptionsSchema
+
+    schema = HTTPOptionsSchema()
+    client = fake_client(HTTPOptions.model_validate(schema.model_dump()))
+    _check_start_time_config_unchanged(client, http_options=schema.model_dump())
+
+
+def test_env_var_default_is_not_a_change(monkeypatch):
+    """The controller's env-var defaulting must not look like a requested change."""
+    monkeypatch.setattr(
+        "ray.serve._private.http_util.RAY_SERVE_HTTP_KEEP_ALIVE_TIMEOUT_S", 42
+    )
+    client = fake_client(HTTPOptions(keep_alive_timeout_s=5))
+    assert client.http_config.keep_alive_timeout_s == 42
+    _check_start_time_config_unchanged(client, http_options={"keep_alive_timeout_s": 5})
+
+
+def test_unknown_keys_ignored():
+    """Serve drops unknown keys when starting, so they can't be a change either."""
+    _check_start_time_config_unchanged(fake_client(), http_options={"prot": 8001})
+
+
+def test_grpc_options():
+    client = fake_client(grpc_options=gRPCOptions(port=9000))
+    _check_start_time_config_unchanged(client, grpc_options={"port": 9000})
+    with pytest.raises(
+        RayServeConfigException, match=r"grpc_options\.port: 9000 -> 9001"
+    ):
+        _check_start_time_config_unchanged(client, grpc_options={"port": 9001})
+
+
+def test_proxy_location():
+    client = fake_client(proxy_location=ProxyLocation.HeadOnly)
+    _check_start_time_config_unchanged(client, proxy_location=ProxyLocation.HeadOnly)
+    with pytest.raises(RayServeConfigException, match="proxy_location"):
+        _check_start_time_config_unchanged(client, proxy_location="EveryNode")
+
+
+def test_deprecated_location_is_compared_against_resolved_placement():
+    """`HTTPOptions.location` is an alias for `proxy_location` and wins over it."""
+    client = fake_client(proxy_location=ProxyLocation.HeadOnly)
+    _check_start_time_config_unchanged(client, http_options={"location": "HeadOnly"})
+    _check_start_time_config_unchanged(
+        client, http_options={"location": "HeadOnly"}, proxy_location="EveryNode"
+    )
+    with pytest.raises(RayServeConfigException, match="proxy_location"):
+        _check_start_time_config_unchanged(
+            client, http_options=HTTPOptions(location="EveryNode")
+        )
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-v", "-s", __file__]))

--- a/python/ray/serve/tests/unit/test_start_time_config.py
+++ b/python/ray/serve/tests/unit/test_start_time_config.py
@@ -3,11 +3,15 @@ from types import SimpleNamespace
 
 import pytest
 
-from ray.serve._private.api import _check_start_time_config_unchanged
+from ray.serve._private.api import (
+    _check_start_time_config_unchanged,
+    declared_start_time_options,
+)
 from ray.serve._private.grpc_util import set_proxy_default_grpc_options
 from ray.serve._private.http_util import configure_http_options_with_defaults
 from ray.serve.config import HTTPOptions, ProxyLocation, gRPCOptions
 from ray.serve.exceptions import RayServeConfigException
+from ray.serve.schema import ServeDeploySchema
 
 
 def fake_client(
@@ -19,7 +23,7 @@ def fake_client(
     return SimpleNamespace(
         http_config=configure_http_options_with_defaults(http_options or HTTPOptions()),
         grpc_config=set_proxy_default_grpc_options(grpc_options or gRPCOptions()),
-        proxy_location=proxy_location,
+        requested_proxy_location=proxy_location,
     )
 
 
@@ -81,6 +85,53 @@ def test_full_schema_dump_is_not_a_change():
     _check_start_time_config_unchanged(client, http_options=schema.model_dump())
 
 
+def test_declarative_config_reports_only_what_it_declared():
+    """A config that omits a section must not request that section's defaults.
+
+    `HTTPOptionsSchema.host` defaults to 0.0.0.0 while `HTTPOptions.host` defaults
+    to the loopback, so diffing the full dump rejects every declarative apply to a
+    Serve instance that was started from Python.
+    """
+    client = fake_client()
+    config = ServeDeploySchema.model_validate({"applications": []})
+    _check_start_time_config_unchanged(client, **declared_start_time_options(config))
+
+    # The full dump is what the same paths pass to *start* Serve, and it does differ.
+    with pytest.raises(RayServeConfigException, match=r"http_options\.host"):
+        _check_start_time_config_unchanged(
+            client, http_options=config.http_options.model_dump()
+        )
+
+
+def test_declarative_config_declaring_a_change_still_raises():
+    client = fake_client()
+    config = ServeDeploySchema.model_validate(
+        {"applications": [], "http_options": {"port": 8001}}
+    )
+    with pytest.raises(
+        RayServeConfigException, match=r"http_options\.port: 8000 -> 8001"
+    ):
+        _check_start_time_config_unchanged(
+            client, **declared_start_time_options(config)
+        )
+
+
+def test_declarative_config_omitting_proxy_location_is_not_a_change():
+    """`ServeDeploySchema.proxy_location` always has a value, set or not."""
+    client = fake_client(proxy_location=ProxyLocation.HeadOnly)
+    config = ServeDeploySchema.model_validate({"applications": []})
+    assert config.proxy_location == ProxyLocation.EveryNode
+    _check_start_time_config_unchanged(client, **declared_start_time_options(config))
+
+    declared = ServeDeploySchema.model_validate(
+        {"applications": [], "proxy_location": "EveryNode"}
+    )
+    with pytest.raises(RayServeConfigException, match="proxy_location"):
+        _check_start_time_config_unchanged(
+            client, **declared_start_time_options(declared)
+        )
+
+
 def test_env_var_default_is_not_a_change(monkeypatch):
     """The controller's env-var defaulting must not look like a requested change."""
     monkeypatch.setattr(
@@ -89,6 +140,20 @@ def test_env_var_default_is_not_a_change(monkeypatch):
     client = fake_client(HTTPOptions(keep_alive_timeout_s=5))
     assert client.http_config.keep_alive_timeout_s == 42
     _check_start_time_config_unchanged(client, http_options={"keep_alive_timeout_s": 5})
+
+
+def test_secrets_are_redacted():
+    """The message reaches an HTTP 400 body, so it must not echo the running value."""
+    client = fake_client(HTTPOptions(ssl_keyfile_password="running-secret"))
+    with pytest.raises(RayServeConfigException) as exc:
+        _check_start_time_config_unchanged(
+            client, http_options={"ssl_keyfile_password": "requested-secret"}
+        )
+
+    message = str(exc.value)
+    assert "http_options.ssl_keyfile_password: <redacted> -> <redacted>" in message
+    assert "running-secret" not in message
+    assert "requested-secret" not in message
 
 
 def test_unknown_keys_ignored():


### PR DESCRIPTION
## Why are these changes needed?

HTTP, gRPC, and proxy-placement config is fixed when the Serve controller starts, but asking to
change it today is silently dropped: `_check_http_options` logs a warning, `PUT
/api/serve/applications/` warns and still returns 200, and `apply_config` never reads
`config.http_options` or `config.proxy_location` at all. `proxy_location` isn't checked anywhere
and `grpc_options` produces no signal whatsoever. Users find out only when their new host, port,
or timeout turns out not to be in effect.

Now a change raises `RayServeConfigException` naming each field with its current and requested
value, and the REST PUT returns 400. The config is rejected as a whole — applying the
applications while discarding the global options is the silent failure being fixed.

## Behavior change

A config that has been silently drifting from the running HTTP config now fails the whole apply,
including its `applications`. That's the intent, but it surfaces pre-existing drift on the first
deploy after upgrade.

## Relationship to #56507

This implements the same intent as #56507, which was reverted in #60355. The revert recorded no
reason, so rather than assume, the two false-positive sources visible in that diff are addressed
here:

- **No default values change.** #56507 also flipped the `HTTPOptions.location` default
  (`HeadOnly` -> `EveryNode`), altering proxy placement for anyone not setting `proxy_location`.
  That's unnecessary now that `location` is deprecated and `_resolved_proxy_location()` falls
  back to `EveryNode`.
- **Env-var defaults can't masquerade as a requested change.** The controller overrides
  `keep_alive_timeout_s` from `RAY_SERVE_HTTP_KEEP_ALIVE_TIMEOUT_S` (and `request_timeout_s`
  similarly), and the declarative path always sends those fields, so a cluster setting either var
  would fail every apply. Both sides now go through the controller's own defaulting.

Also: only fields the caller actually provided are compared, so re-applying a partial config
isn't an error; the deprecated `HTTPOptions.location` is compared against the resolved placement,
so direct-ingress mode can't false-positive; and `serve.run()` no longer passes
`proxy_location=EveryNode` explicitly, which