### PR TITLE
[docs] Map library-owned doc directories to their owning teams

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,6 +10,13 @@
 # Authors responsible for documentation infrastructure and layout.
 # ray-ci co-owns doc CI/build config; ray-docs-reviewers is a silent fallback
 # (notifications disabled) so docs leads can unblock docs-required reviews.
+#
+# This catch-all covers cross-project meta content (ray-overview, ray-references,
+# ray-governance, ray-security, ray-contribute, apis, templates) and the doc
+# build infrastructure (_ext, _static, _templates, _includes, _intersphinx,
+# images). Content that belongs to a library maps to that library's team in the
+# sections below, so a library maintainer's approval unblocks their own docs
+# without a separate docs-team review.
 /doc/ @ray-project/ray-docs @ray-project/ray-ci @ray-project/ray-docs-reviewers
 
 # ==== Ray core ====
@@ -28,6 +35,8 @@
 
 /doc/source/cluster/ @ray-project/ray-core @ray-project/ray-docs
 /doc/source/ray-core/ @ray-project/ray-core @ray-project/ray-docs
+/doc/source/ray-observability/ @ray-project/ray-core @ray-project/ray-docs
+/doc/source/ray-more-libs/ @ray-project/ray-core @ray-project/ray-docs
 
 /doc/source/cluster/kubernetes/ @andrewsykim @ray-project/ray-core @ray-project/ray-docs
 
@@ -67,6 +76,7 @@
 
 # Ray AIR
 /python/ray/air/ @ray-project/ray-train
+/doc/source/ray-air/ @ray-project/ray-train @ray-project/ray-docs
 
 # Ray Serve
 /python/ray/serve/ @ray-project/ray-serve
@@ -81,6 +91,7 @@
 /python/ray/dashboard/modules/metrics/dashboards/serve_llm* @ray-project/ray-llm
 /python/ray/dashboard/modules/metrics/dashboards/data_llm* @ray-project/ray-llm
 /python/ray/serve/llm/ @ray-project/ray-llm
+/doc/source/llm/ @ray-project/ray-llm @ray-project/ray-docs
 /doc/source/serve/llm/ @ray-project/ray-llm @ray-project/ray-docs
 /doc/source/data/working-with-llms.rst @ray-project/ray-llm @ray-project/ray-docs
 /doc/source/data/doc_code/working-with-llms/ @ray-project/ray-llm @ray-project/ray-docs


### PR DESCRIPTION
## Summary

Documentation directories that belong to a specific library used to fall through to the `/doc/` catch-all rule in CODEOWNERS. That rule's owners are the docs teams plus `ray-ci`, so a library maintainer approving a doc change to their own feature did **not** satisfy the doc-path code-owner requirement. Those PRs stayed blocked on a separate docs-team approval even after the owning library had signed off.

This maps each library-owned content directory to its owning team, following the pattern the already-mapped directories use (`@ray-project/ray-<team> @ray-project/ray-docs`), so either the library or the docs team can unblock:

| Directory | Owner added | Grounded in |
|---|---|---|
| `doc/source/ray-observability/` | `ray-core` | observability (logging, metrics, dashboard) is core; no dedicated team, and the code falls to `/python/ray/` → `ray-core` |
| `doc/source/ray-more-libs/` | `ray-core` | integration libs (dask, modin, joblib, multiprocessing, raydp) → `/python/ray/` → `ray-core` |
| `doc/source/ray-air/` | `ray-train` | matches existing `/python/ray/air/ @ray-project/ray-train` |
| `doc/source/llm/` | `ray-llm` | matches existing `/python/ray/llm/ @ray-project/ray-llm` and the `serve/llm` doc rule |

(An earlier revision also mapped `doc/source/workflows/`, but that tree has no tracked files on `master` — Ray Workflows is deprecated — so a rule there would match nothing. Dropped after bot review flagged it.)

`ray-docs` stays as co-owner on every mapped path, so nothing that the docs team could review before it can review now; the change only lets the owning library self-unblock. Because CODEOWNERS is last-match-wins and these rules are more specific than `/doc/`, they take effect without touching any other rule.

### What intentionally stays on the catch-all

The remaining `/doc/` content is genuinely cross-project and correctly keeps the docs/CI owners: `ray-overview`, `ray-references`, `ray-governance`, `ray-security`, `ray-contribute`, `apis`, `templates`, and the build infrastructure (`_ext`, `_static`, `_templates`, `_includes`, `_intersphinx`, `images`). A comment on the catch-all rule now records that split so the boundary doesn't drift.

### Not a duplicate

No open PR or rule touches these directories in CODEOWNERS; they were simply never given a specific rule. This continues the pattern established by the existing per-library doc rules (`data`, `serve`, `train`, `tune`, `rllib`, `ray-core`, `cluster`).

### Verification

- Enumerated every `doc/source/*` content directory and confirmed each is now either mapped to a library team or intentionally on the catch-all, and that each mapped directory has tracked content on `master` (via `git ls-tree`).
- Confirmed each newly assigned team already owns the corresponding source tree in this same file, so no new team reference is introduced (GitHub validates that owner teams have repo access).
- Confirmed last-match-wins ordering: each new rule is more specific than, and appears after, the `/doc/` catch-all.

CODEOWNERS has no build/unit test; the checks above are the relevant verification.

### AI assistance

AI assistance (Claude Code) was used to draft this change. I reviewed every line and stand behind it.
