### PR TITLE
[Autoscaler] Fix phantom KubeRay worker nodes due to maxReplicas cap …

### DIFF
--- a/python/ray/autoscaler/v2/instance_manager/cloud_providers/kuberay/cloud_provider.py
+++ b/python/ray/autoscaler/v2/instance_manager/cloud_providers/kuberay/cloud_provider.py
@@ -202,8 +202,22 @@ class KubeRayProvider(ICloudInstanceProvider):
                 )
                 return
 
-            self._submit_scale_request(scale_request)
-            # Only add to processed requests if successful
+            rejected_nodes = self._submit_scale_request(scale_request)
+
+            if rejected_nodes:
+                nodes_to_reject = {
+                    node_type: min(count, shape.get(node_type, 0))
+                    for node_type, count in rejected_nodes.items()
+                    if shape.get(node_type, 0) > 0
+                }
+                if nodes_to_reject:
+                    self._add_launch_errors(
+                        nodes_to_reject,
+                        request_id,
+                        details="Launch capped by maxReplicas limit.",
+                    )
+
+            # Only add to processed requests if successful and after rejection feedback loop
             self._requests.add(request_id)
 
         except Exception as e:
@@ -350,7 +364,7 @@ class KubeRayProvider(ICloudInstanceProvider):
 
     def _submit_scale_request(
         self, scale_request: "KubeRayProvider.ScaleRequest"
-    ) -> None:
+    ) -> Dict[NodeType, int]:
         """Submits a scale request to the Kubernetes API server.
 
         This method will convert the scale request to patches and submit the patches
@@ -358,6 +372,10 @@ class KubeRayProvider(ICloudInstanceProvider):
 
         Args:
             scale_request: The scale request.
+
+        Returns:
+            A dictionary mapping node types to the number of nodes that were rejected
+            due to the maxReplicas cap.
 
         Raises:
             Exception: An exception is raised if the Kubernetes API server returns an
@@ -368,6 +386,8 @@ class KubeRayProvider(ICloudInstanceProvider):
 
         raycluster = self.ray_cluster
 
+        rejected_nodes = {}
+
         # Collect patches for replica counts.
         for node_type, num_workers in scale_request.desired_num_workers.items():
             group_index = _worker_group_index(raycluster, node_type)
@@ -376,12 +396,18 @@ class KubeRayProvider(ICloudInstanceProvider):
             # the num_workers from the scale request is multiplied by numOfHosts, so we need to divide it back.
             target_replicas = num_workers // group_num_of_hosts
             # Cap the replica count to maxReplicas.
+            original_target_replicas = target_replicas
             if group_max_replicas is not None and group_max_replicas < target_replicas:
                 logger.warning(
                     "Autoscaler attempted to create "
                     + "more than maxReplicas pods of type {}.".format(node_type)
                 )
                 target_replicas = group_max_replicas
+
+                # Calculate how many nodes were rejected due to the cap
+                rejected_replicas = original_target_replicas - target_replicas
+                if rejected_replicas > 0:
+                    rejected_nodes[node_type] = rejected_replicas * group_num_of_hosts
             # Check if we need to change the target count.
             if target_replicas == _worker_group_replicas(raycluster, group_index):
                 # No patch required.
@@ -411,12 +437,11 @@ class KubeRayProvider(ICloudInstanceProvider):
             patch = worker_delete_patch(group_index, [])
             patch_payload.append(patch)
 
-        if len(patch_payload) == 0:
-            # No patch required.
-            return
+        if len(patch_payload) > 0:
+            logger.info(f"Submitting a scale request: {scale_request}")
+            self._patch(f"rayclusters/{self._cluster_name}", patch_payload)
 
-        logger.info(f"Submitting a scale request: {scale_request}")
-        self._patch(f"rayclusters/{self._cluster_name}", patch_payload)
+        return rejected_nodes
 
     def _add_launch_errors(
         self,

--- a/python/ray/autoscaler/v2/instance_manager/cloud_providers/kuberay/cloud_provider.py
+++ b/python/ray/autoscaler/v2/instance_manager/cloud_providers/kuberay/cloud_provider.py
@@ -204,35 +204,23 @@ class KubeRayProvider(ICloudInstanceProvider):
 
             rejected_nodes = self._submit_scale_request(scale_request)
 
-            if rejected_nodes:
-                nodes_to_reject = {}
-                for node_type, count in rejected_nodes.items():
-                    requested = shape.get(node_type, 0)
-                    if requested > 0:
-                        if count >= requested:
-                            # Total cap: no instances of this type can be launched.
-                            # We can safely emit an error without failing valid instances.
-                            nodes_to_reject[node_type] = requested
-                        else:
-                            # Partial cap: some instances can be launched.
-                            # Emitting an error here would cause the reconciler to fail
-                            # ALL instances in this request_id, including the ones we
-                            # successfully patched. We must skip the error and let the
-                            # rejected portion timeout naturally in the reconciler.
-                            logger.warning(
-                                f"Partial maxReplicas cap for {node_type}: requested {requested}, "
-                                f"but {count} were rejected. Allowing valid nodes to proceed."
-                            )
-
-                if nodes_to_reject:
-                    self._add_launch_errors(
-                        nodes_to_reject,
-                        request_id,
-                        details="Launch capped by maxReplicas limit.",
-                    )
-
-            # Only add to processed requests if successful and after rejection feedback loop
+            # This request_id has been handled (full, partial, or no-op). Cache it
+            # so a replay does not add to_launch again. Instances that did not get
+            # a slot are failed below so they do not retry with this same id.
             self._requests.add(request_id)
+
+            nodes_to_reject = {}
+            for node_type, rejected in rejected_nodes.items():
+                requested = shape.get(node_type, 0)
+                if requested > 0 and rejected > 0:
+                    nodes_to_reject[node_type] = min(rejected, requested)
+
+            if nodes_to_reject:
+                self._add_launch_errors(
+                    nodes_to_reject,
+                    request_id,
+                    details="Launch capped by maxReplicas limit.",
+                )
 
         except Exception as e:
             logger.exception(f"Error launching nodes: {scale_request or 'N/A'}")

--- a/python/ray/autoscaler/v2/instance_manager/cloud_providers/kuberay/cloud_provider.py
+++ b/python/ray/autoscaler/v2/instance_manager/cloud_providers/kuberay/cloud_provider.py
@@ -205,11 +205,25 @@ class KubeRayProvider(ICloudInstanceProvider):
             rejected_nodes = self._submit_scale_request(scale_request)
 
             if rejected_nodes:
-                nodes_to_reject = {
-                    node_type: min(count, shape.get(node_type, 0))
-                    for node_type, count in rejected_nodes.items()
-                    if shape.get(node_type, 0) > 0
-                }
+                nodes_to_reject = {}
+                for node_type, count in rejected_nodes.items():
+                    requested = shape.get(node_type, 0)
+                    if requested > 0:
+                        if count >= requested:
+                            # Total cap: no instances of this type can be launched.
+                            # We can safely emit an error without failing valid instances.
+                            nodes_to_reject[node_type] = requested
+                        else:
+                            # Partial cap: some instances can be launched.
+                            # Emitting an error here would cause the reconciler to fail
+                            # ALL instances in this request_id, including the ones we
+                            # successfully patched. We must skip the error and let the
+                            # rejected portion timeout naturally in the reconciler.
+                            logger.warning(
+                                f"Partial maxReplicas cap for {node_type}: requested {requested}, "
+                                f"but {count} were rejected. Allowing valid nodes to proceed."
+                            )
+
                 if nodes_to_reject:
                     self._add_launch_errors(
                         nodes_to_reject,

--- a/python/ray/autoscaler/v2/instance_manager/reconciler.py
+++ b/python/ray/autoscaler/v2/instance_manager/reconciler.py
@@ -394,11 +394,20 @@ class Reconciler:
             )
         )
 
+        # Fail at most LaunchNodeError.count instances per (request id, type)
+        # after assigning any matching unassigned cloud instances.
+        remaining_launch_failures = {
+            key: error.count for key, error in launch_errors.items()
+        }
+
         # For each instance, try to allocate or fail the allocation.
         for instance in instances_with_launch_requests:
             # Try allocate or fail with errors.
             update_event = Reconciler._try_resolve_pending_allocation(
-                instance, unassigned_cloud_instances_by_type, launch_errors
+                instance,
+                unassigned_cloud_instances_by_type,
+                launch_errors,
+                remaining_launch_failures,
             )
             if not update_event:
                 continue
@@ -413,6 +422,7 @@ class Reconciler:
         im_instance: IMInstance,
         unassigned_cloud_instances_by_type: Dict[str, List[CloudInstance]],
         launch_errors: Dict[Tuple[str, NodeType], LaunchNodeError],
+        remaining_launch_failures: Dict[Tuple[str, NodeType], int],
     ) -> Optional[IMInstanceUpdateEvent]:
         """
         Allocate, or fail the cloud instance allocation for the instance.
@@ -422,6 +432,8 @@ class Reconciler:
             unassigned_cloud_instances_by_type: The unassigned cloud instances by type.
             launch_errors: The launch errors from the cloud provider, keyed by
                 (launch request id, node type).
+            remaining_launch_failures: Remaining number of instances to fail for
+                each (launch request id, node type), from LaunchNodeError.count.
 
         Returns:
             Instance update to ALLOCATED: if there's a matching unassigned cloud
@@ -455,11 +467,12 @@ class Reconciler:
                 ),
             )
 
-        # If there's a launch error, transition to ALLOCATION_FAILED.
-        launch_error = launch_errors.get(
-            (im_instance.launch_request_id, im_instance.instance_type)
-        )
-        if launch_error:
+        # Fail at most `count` instances for this (request id, type). The rest
+        # stay REQUESTED so a partial cap can still bind later pods.
+        launch_error_key = (im_instance.launch_request_id, im_instance.instance_type)
+        if remaining_launch_failures.get(launch_error_key, 0) > 0:
+            remaining_launch_failures[launch_error_key] -= 1
+            launch_error = launch_errors[launch_error_key]
             return IMInstanceUpdateEvent(
                 instance_id=im_instance.instance_id,
                 new_instance_status=IMInstance.ALLOCATION_FAILED,

--- a/python/ray/autoscaler/v2/instance_manager/reconciler.py
+++ b/python/ray/autoscaler/v2/instance_manager/reconciler.py
@@ -394,11 +394,15 @@ class Reconciler:
             )
         )
 
-        # Fail at most LaunchNodeError.count instances per (request id, type)
-        # after assigning any matching unassigned cloud instances.
-        remaining_launch_failures = {
-            key: error.count for key, error in launch_errors.items()
-        }
+        # Fail at most the summed LaunchNodeError.count instances per
+        # (request id, type). NodeProviderAdapter can emit several batch
+        # failures with the same key in one poll; do not keep only the last.
+        remaining_launch_failures: Dict[Tuple[str, NodeType], int] = defaultdict(int)
+        for error in cloud_provider_errors:
+            if isinstance(error, LaunchNodeError):
+                remaining_launch_failures[
+                    (error.request_id, error.node_type)
+                ] += error.count
 
         # For each instance, try to allocate or fail the allocation.
         for instance in instances_with_launch_requests:

--- a/python/ray/autoscaler/v2/tests/test_node_provider.py
+++ b/python/ray/autoscaler/v2/tests/test_node_provider.py
@@ -430,6 +430,55 @@ class KubeRayProviderIntegrationTest(unittest.TestCase):
             "value": 2,  # 1 + 1
         }
 
+    def test_launch_total_max_replicas_cap_fails_and_caches_request(self):
+        """A fully capped launch is cached and reports LaunchNodeError."""
+        self.mock_client._ray_cluster["spec"]["workerGroupSpecs"][0]["replicas"] = 1
+        self.mock_client._ray_cluster["spec"]["workerGroupSpecs"][0]["maxReplicas"] = 1
+
+        self.provider.launch(shape={"small-group": 2}, request_id="launch-cap")
+
+        assert "launch-cap" in self.provider._requests
+        assert self.mock_client._patches == {}
+
+        errors = self.provider.poll_errors()
+        assert len(errors) == 1
+        assert isinstance(errors[0], LaunchNodeError)
+        assert errors[0].request_id == "launch-cap"
+        assert errors[0].node_type == "small-group"
+        assert errors[0].count == 2
+        assert "maxReplicas" in str(errors[0])
+
+        # Replay of the same request id must not try again.
+        self.provider.launch(shape={"small-group": 2}, request_id="launch-cap")
+        assert self.provider.poll_errors() == []
+        assert self.mock_client._patches == {}
+
+    def test_launch_partial_max_replicas_cap_fails_leftover(self):
+        """A partial cap patches what fits, caches the id, and fails the leftover."""
+        self.mock_client._ray_cluster["spec"]["workerGroupSpecs"][0]["replicas"] = 1
+        self.mock_client._ray_cluster["spec"]["workerGroupSpecs"][0]["maxReplicas"] = 2
+
+        self.provider.launch(shape={"small-group": 2}, request_id="launch-partial")
+
+        assert "launch-partial" in self.provider._requests
+        patches = self.mock_client.get_patches(
+            f"rayclusters/{self.provider._cluster_name}"
+        )
+        assert patches == [
+            {
+                "op": "replace",
+                "path": "/spec/workerGroupSpecs/0/replicas",
+                "value": 2,
+            }
+        ]
+
+        errors = self.provider.poll_errors()
+        assert len(errors) == 1
+        assert isinstance(errors[0], LaunchNodeError)
+        assert errors[0].request_id == "launch-partial"
+        assert errors[0].node_type == "small-group"
+        assert errors[0].count == 1
+
     def test_terminate_node(self):
         self.provider.terminate(
             ids=["raycluster-autoscaler-worker-small-group-dkz2r"], request_id="term-1"

--- a/python/ray/autoscaler/v2/tests/test_reconciler.py
+++ b/python/ray/autoscaler/v2/tests/test_reconciler.py
@@ -331,6 +331,121 @@ class TestReconciler:
         assert instances["i-2"].status == Instance.ALLOCATION_FAILED
 
     @staticmethod
+    def test_launch_error_count_fails_only_rejected_instances(setup):
+        """
+        A LaunchNodeError.count should fail only that many REQUESTED instances
+        of the same (request id, type). Remaining instances stay REQUESTED so a
+        partial maxReplicas cap can still bind later pods.
+        """
+        instance_manager, instance_storage, _, cloud_resource_monitor = setup
+
+        instances = [
+            create_instance(
+                "i-1",
+                status=Instance.REQUESTED,
+                instance_type="type-1",
+                launch_request_id="l1",
+                status_times=[(Instance.REQUESTED, 1)],
+            ),
+            create_instance(
+                "i-2",
+                status=Instance.REQUESTED,
+                instance_type="type-1",
+                launch_request_id="l1",
+                status_times=[(Instance.REQUESTED, 2)],
+            ),
+        ]
+        TestReconciler._add_instances(instance_storage, instances)
+
+        launch_errors = [
+            LaunchNodeError(
+                request_id="l1",
+                count=1,
+                node_type="type-1",
+                timestamp_ns=1,
+            )
+        ]
+
+        Reconciler.reconcile(
+            instance_manager,
+            scheduler=MockScheduler(),
+            cloud_provider=MagicMock(),
+            cloud_resource_monitor=cloud_resource_monitor,
+            ray_cluster_resource_state=ClusterResourceState(),
+            non_terminated_cloud_instances={},
+            cloud_provider_errors=launch_errors,
+            ray_install_errors=[],
+            autoscaling_config=MockAutoscalingConfig(),
+        )
+
+        instances, _ = instance_storage.get_instances()
+        assert instances["i-1"].status == Instance.ALLOCATION_FAILED
+        assert instances["i-2"].status == Instance.REQUESTED
+
+    @staticmethod
+    def test_launch_error_count_allocates_pod_then_fails_leftover(setup):
+        """
+        When a pod is already present, assign it first and fail only the
+        leftover REQUESTED instance from LaunchNodeError.count.
+        """
+        instance_manager, instance_storage, _, cloud_resource_monitor = setup
+
+        instances = [
+            create_instance(
+                "i-1",
+                status=Instance.REQUESTED,
+                instance_type="type-1",
+                launch_request_id="l1",
+                status_times=[(Instance.REQUESTED, 1)],
+            ),
+            create_instance(
+                "i-2",
+                status=Instance.REQUESTED,
+                instance_type="type-1",
+                launch_request_id="l1",
+                status_times=[(Instance.REQUESTED, 2)],
+            ),
+        ]
+        TestReconciler._add_instances(instance_storage, instances)
+
+        launch_errors = [
+            LaunchNodeError(
+                request_id="l1",
+                count=1,
+                node_type="type-1",
+                timestamp_ns=1,
+            )
+        ]
+        cloud_instances = {
+            "c-1": CloudInstance("c-1", "type-1", True, NodeKind.WORKER),
+        }
+
+        Reconciler.reconcile(
+            instance_manager,
+            scheduler=MockScheduler(),
+            cloud_provider=MagicMock(),
+            cloud_resource_monitor=cloud_resource_monitor,
+            ray_cluster_resource_state=ClusterResourceState(),
+            non_terminated_cloud_instances=cloud_instances,
+            cloud_provider_errors=launch_errors,
+            ray_install_errors=[],
+            autoscaling_config=MockAutoscalingConfig(),
+        )
+
+        instances, _ = instance_storage.get_instances()
+        allocated = [
+            inst for inst in instances.values() if inst.status == Instance.ALLOCATED
+        ]
+        failed = [
+            inst
+            for inst in instances.values()
+            if inst.status == Instance.ALLOCATION_FAILED
+        ]
+        assert len(allocated) == 1
+        assert allocated[0].cloud_instance_id == "c-1"
+        assert len(failed) == 1
+
+    @staticmethod
     def test_reconcile_terminated_cloud_instances(setup):
 
         instance_manager, instance_storage, subscriber, cloud_resource_monitor = setup

--- a/python/ray/autoscaler/v2/tests/test_reconciler.py
+++ b/python/ray/autoscaler/v2/tests/test_reconciler.py
@@ -446,6 +446,64 @@ class TestReconciler:
         assert len(failed) == 1
 
     @staticmethod
+    def test_duplicate_launch_errors_sum_failure_counts(setup):
+        """
+        Multiple LaunchNodeError events with the same (request id, type)
+        should add their counts. NodeProviderAdapter emits one error per
+        launch batch, so overwriting would leave extra REQUESTED instances.
+        """
+        instance_manager, instance_storage, _, cloud_resource_monitor = setup
+
+        instances = [
+            create_instance(
+                "i-1",
+                status=Instance.REQUESTED,
+                instance_type="type-1",
+                launch_request_id="l1",
+                status_times=[(Instance.REQUESTED, 1)],
+            ),
+            create_instance(
+                "i-2",
+                status=Instance.REQUESTED,
+                instance_type="type-1",
+                launch_request_id="l1",
+                status_times=[(Instance.REQUESTED, 2)],
+            ),
+        ]
+        TestReconciler._add_instances(instance_storage, instances)
+
+        launch_errors = [
+            LaunchNodeError(
+                request_id="l1",
+                count=1,
+                node_type="type-1",
+                timestamp_ns=1,
+            ),
+            LaunchNodeError(
+                request_id="l1",
+                count=1,
+                node_type="type-1",
+                timestamp_ns=2,
+            ),
+        ]
+
+        Reconciler.reconcile(
+            instance_manager,
+            scheduler=MockScheduler(),
+            cloud_provider=MagicMock(),
+            cloud_resource_monitor=cloud_resource_monitor,
+            ray_cluster_resource_state=ClusterResourceState(),
+            non_terminated_cloud_instances={},
+            cloud_provider_errors=launch_errors,
+            ray_install_errors=[],
+            autoscaling_config=MockAutoscalingConfig(),
+        )
+
+        instances, _ = instance_storage.get_instances()
+        assert instances["i-1"].status == Instance.ALLOCATION_FAILED
+        assert instances["i-2"].status == Instance.ALLOCATION_FAILED
+
+    @staticmethod
     def test_reconcile_terminated_cloud_instances(setup):
 
         instance_manager, instance_storage, subscriber, cloud_resource_monitor = setup


### PR DESCRIPTION
This PR fixes a bug in the KubeRay autoscaler provider where worker pods would get stuck in a "REQUESTED" state for 600 seconds when the cluster hit the maxReplicas limit.

When the InstanceManager requested more nodes than the cap allowed, the KubeRayProvider would correctly cap the request and skip creating the Kubernetes patch ,but it was still silently recording the request as successfully processed. Because the request was cached as "successful" the InstanceManager didn't know the nodes were rejected, so it just sat there waiting for the phantom nodes to appear until the 10-minute timeout kicked in.

Related issues
Fixes #65694

Additional information
My approach and thought process: When looking into the bug, I realized the core issue wasn't the cap itself, but the lack of a feedback loop back to the InstanceManager. The provider was acting as a silent point of failure.

To fix this, I updated _submit_scale_request to calculate exactly how many nodes get rejected when the maxReplicas ceiling is hit. It now returns that count back to the launch() method. Then, inside launch(), I added a check to see if any nodes were rejected. If they were, it explicitly calls self._add_launch_errors() to bubble up a LaunchNodeError.

This instantly tells the InstanceManager that the allocation failed, so it immediately transitions the phantom nodes to ALLOCATION_FAILED instead of hanging for 10 minutes.

