### PR TITLE
[Doc][KubeRay] Sync ML sample docs to repinned base images

### DIFF
--- a/doc/source/cluster/kubernetes/examples/mobilenet-rayservice.md
+++ b/doc/source/cluster/kubernetes/examples/mobilenet-rayservice.md
@@ -24,10 +24,10 @@ Follow [this document](kuberay-operator-deploy) to install the latest stable Kub
 
 ```sh
 # Create a RayService
-kubectl apply -f https://raw.githubusercontent.com/ray-project/kuberay/v1.7.0/ray-operator/config/samples/ray-service.mobilenet.yaml
+kubectl apply -f https://raw.githubusercontent.com/ray-project/kuberay/master/ray-operator/config/samples/ray-service.mobilenet.yaml
 ```
 
-* The [mobilenet.py](https://github.com/ray-project/serve_config_examples/blob/master/mobilenet/mobilenet.py) file needs `tensorflow` as a dependency. Hence, the YAML file uses `rayproject/ray-ml` image instead of `rayproject/ray` image.
+* The [mobilenet.py](https://github.com/ray-project/serve_config_examples/blob/master/mobilenet/mobilenet.py) file needs `tensorflow` as a dependency, so the YAML file includes `tensorflow` in the runtime environment.
 * The request parsing function `starlette.requests.form()` needs `python-multipart`, so the YAML file includes `python-multipart` in the runtime environment.
 
 ## Step 4: Forward the port for Ray Serve

--- a/doc/source/cluster/kubernetes/examples/rayjob-batch-inference-example.md
+++ b/doc/source/cluster/kubernetes/examples/rayjob-batch-inference-example.md
@@ -41,12 +41,12 @@ Follow [this document](kuberay-operator-deploy) to install the latest stable Kub
 
 ## Step 2: Submit the RayJob
 
-Create the RayJob custom resource with [ray-job.batch-inference.yaml](https://github.com/ray-project/kuberay/blob/v1.7.0/ray-operator/config/samples/ray-job.batch-inference.yaml).
+Create the RayJob custom resource with [ray-job.batch-inference.yaml](https://github.com/ray-project/kuberay/blob/master/ray-operator/config/samples/ray-job.batch-inference.yaml).
 
 Download the file with `curl`:
 
 ```bash
-curl -LO https://raw.githubusercontent.com/ray-project/kuberay/v1.7.0/ray-operator/config/samples/ray-job.batch-inference.yaml
+curl -LO https://raw.githubusercontent.com/ray-project/kuberay/master/ray-operator/config/samples/ray-job.batch-inference.yaml
 ```
 
 Note that the `RayJob` spec contains a spec for the `RayCluster`. This tutorial uses a single-node cluster with 4 GPUs. For production use cases, use a multi-node cluster where the head node doesn't have GPUs, so that Ray can automatically schedule GPU workloads on worker nodes which won't interfere with critical Ray processes on the head node.
@@ -57,7 +57,7 @@ Note the following fields in the `RayJob` spec, which specify the Ray image and 
         spec:
           containers:
             - name: ray-head
-              image: rayproject/ray-ml:2.6.3-gpu
+              image: rayproject/ray:2.58.0-py311-gpu
               resources:
                 limits:
                   nvidia.com/gpu: "4"

--- a/doc/source/cluster/kubernetes/examples/stable-diffusion-rayservice.md
+++ b/doc/source/cluster/kubernetes/examples/stable-diffusion-rayservice.md
@@ -36,7 +36,7 @@ This RayService configuration contains some important settings:
         value: "worker"
         effect: "NoSchedule"
     ```
-* It includes `diffusers` in `runtime_env` since this package isn't included by default in the `ray-ml` image.
+* It includes `diffusers`, `transformers`, and `torch` in `runtime_env` since these packages aren't included by default in the `rayproject/ray` image.
 
 ## Step 4: Forward the port of Serve
 


### PR DESCRIPTION
## Why are these changes needed?

The `rayproject/ray-ml:2.46.0.0e19ea-*` tags were deleted from Docker Hub, so several KubeRay sample manifests that these docs pages instruct readers to `kubectl apply` fail at `ImagePullBackOff`. ray-project/kuberay#5194 fixes the manifests by moving them to the published `rayproject/ray:2.58.0` base image and installing the ML dependencies through the runtime environment.

This PR syncs the three Ray docs pages that reference those manifests so the prose and quoted specs match the fixed manifests:

- **`mobilenet-rayservice.md`** — fetch the manifest from `master` (it pinned the broken `v1.6.0`), and correct the note that claimed the YAML "uses the `rayproject/ray-ml` image instead of `rayproject/ray`." It now installs `tensorflow` in the runtime environment on the base image.
- **`rayjob-batch-inference-example.md`** — fetch from `master`, and quote the manifest's actual head image (`rayproject/ray:2.58.0-py311-gpu`). The page previously quoted `rayproject/ray-ml:2.6.3-gpu`, which never matched the manifest.
- **`stable-diffusion-rayservice.md`** — the page already fetches from `master`; update the runtime-environment note to list `diffusers`, `transformers`, and `torch` against the base `rayproject/ray` image.

The four other pages that reference these manifests (`distributed-checkpointing-with-gcsfuse.md`, the two `rayjob-kueue-*` pages, and `rayservice-troubleshooting.md`) already fetch from `master` and don't quote the image inline, so they pick up the fix with no edit.

## Dependency / merge order

**Merge after ray-project/kuberay#5194 lands on KubeRay `master`.** These pages fetch the manifests from `master`, and the prose here describes the post-fix state, so this PR is only accurate once #5194 is merged.

## Related issue number

Companion to ray-project/kuberay#5194 (which closes ray-project/kuberay#5123).

## Checks

- [x] I've made sure the tests are passing.
- Testing Strategy
  - [x] Manual tests
