### PR TITLE
[doc][kuberay] Document the container image registry and tag conventions

### DIFF
--- a/doc/source/cluster/kubernetes/getting-started/kuberay-operator-installation.md
+++ b/doc/source/cluster/kubernetes/getting-started/kuberay-operator-installation.md
@@ -49,3 +49,15 @@ kubectl get pods -n ray-system
 NAME                                READY   STATUS    RESTARTS   AGE
 kuberay-operator-6bc45dd644-gwtqv   1/1     Running   0          24s
 ```
+
+(kuberay-images)=
+
+## Container images
+
+KubeRay publishes its component images to [Quay.io](https://quay.io/organization/kuberay), under `quay.io/kuberay/`. Published components include `operator`, `apiserver`, `dashboard`, `historyserver`, and `collector`. Always pull from Quay.io. The `kuberay` organization on Docker Hub is a legacy mirror that stopped receiving updates in early 2024. Docker Hub also enforces [anonymous pull rate limits](https://docs.docker.com/docker-hub/download-rate-limit/) that make it a poor choice for automated environments.
+
+KubeRay tags each image three ways:
+
+* **Version tags** such as `quay.io/kuberay/operator:v1.6.0` identify a stable release. Use a version tag for anything you depend on. The operator's version tag matches the KubeRay release, so chart version `1.6.0` installs `operator:v1.6.0`.
+* **Commit tags** such as `quay.io/kuberay/operator:feeaf72` pin an image to an exact `master` commit. The tag is the short Git commit hash.
+* **The `nightly` tag** tracks the most recent `master` build. It moves with every merge, so it isn't a stable target. Use it only to try unreleased changes.

--- a/doc/source/cluster/kubernetes/getting-started/kuberay-operator-installation.md
+++ b/doc/source/cluster/kubernetes/getting-started/kuberay-operator-installation.md
@@ -54,7 +54,9 @@ kuberay-operator-6bc45dd644-gwtqv   1/1     Running   0          24s
 
 ## Container images
 
-KubeRay publishes its component images to [Quay.io](https://quay.io/organization/kuberay), under `quay.io/kuberay/`. Published components include `operator`, `apiserver`, `dashboard`, `historyserver`, and `collector`. Always pull from Quay.io. The `kuberay` organization on Docker Hub is a legacy mirror that stopped receiving updates in early 2024. Docker Hub also enforces [anonymous pull rate limits](https://docs.docker.com/docker-hub/download-rate-limit/) that make it a poor choice for automated environments.
+KubeRay publishes its own component images to [Quay.io](https://quay.io/organization/kuberay), under `quay.io/kuberay/`. Published components include `operator`, `apiserver`, `dashboard`, `historyserver`, and `collector`. These are KubeRay's own components, separate from the Ray runtime images that your Ray clusters run, such as `rayproject/ray`, which Ray distributes on Docker Hub.
+
+Always pull KubeRay images from Quay.io. The `kuberay` organization on Docker Hub is a legacy mirror that stopped receiving updates in early 2024.
 
 KubeRay tags each image three ways:
 

--- a/doc/source/cluster/kubernetes/user-guides/kuberay-history-server.md
+++ b/doc/source/cluster/kubernetes/user-guides/kuberay-history-server.md
@@ -102,6 +102,8 @@ KubeRay publishes prebuilt container images for the History Server and the colle
 * **History Server**: `quay.io/kuberay/historyserver:nightly`
 * **Collector**: `quay.io/kuberay/collector:nightly`
 
+For how KubeRay names its image tags, including stable version tags, see {ref}`kuberay-images`.
+
 To build the images from source and push them to your own registry, see [the image build and push guide](https://github.com/ray-project/kuberay/blob/master/historyserver/docs/image-build-push-guide.md).
 
 ## Deploy the History Server


### PR DESCRIPTION
Adds a "Container images" section to the KubeRay operator installation page documenting the Quay.io registry and the version, commit, and `nightly` tag conventions, and links the history server guide to it.

This content previously lived only on the KubeRay MkDocs site (`docs/deploy/images.md`), which is being retired. Verified against the current KubeRay release workflow and published Quay.io tags rather than the source page: the operator's version tag matches the Helm chart version, and the `kuberay` Docker Hub org is a legacy mirror last updated in early 2024.

Docs-only prose change. Suggest applying the `docs-go` label to skip the per-library docs example steps.
