### PR TITLE
[core][gcs][Actice-Passive] Phase 2.2 Add Active-Passive leader-election RPC gating

### DIFF
--- a/src/ray/gcs/BUILD.bazel
+++ b/src/ray/gcs/BUILD.bazel
@@ -473,6 +473,7 @@ ray_cc_library(
         "//src/ray/protobuf:gcs_service_cc_grpc",
         "//src/ray/pubsub:gcs_publisher",
         "//src/ray/pubsub:publisher",
+        "//src/ray/ray_syncer",
         # TODO(irabbani): Refactor a subset of scheduling into a shared target
         # between the GCS and Raylet.
         "//src/ray/raylet/scheduling:scheduler",

--- a/src/ray/gcs/BUILD.bazel
+++ b/src/ray/gcs/BUILD.bazel
@@ -425,6 +425,7 @@ ray_cc_library(
         "gcs_server.cc",
     ],
     hdrs = [
+        "gcs_leader_gated_handlers.h",
         "gcs_server.h",
     ],
     features = select({

--- a/src/ray/gcs/gcs_leader_gated_handlers.h
+++ b/src/ray/gcs/gcs_leader_gated_handlers.h
@@ -20,6 +20,7 @@
 
 #include "ray/common/status.h"
 #include "ray/gcs/grpc_service_interfaces.h"
+#include "ray/ray_syncer/ray_syncer.h"
 
 namespace ray {
 namespace gcs {
@@ -487,6 +488,26 @@ class LeaderGatedRayEventExportHandler
 
  private:
   rpc::events::RayEventExportGcsServiceHandler &handler_;
+  const std::function<bool()> is_leader_fn_;
+};
+
+class LeaderGatedRaySyncerHandler : public syncer::RaySyncerStreamHandler {
+ public:
+  using HandlerType = syncer::RaySyncerStreamHandler;
+  LeaderGatedRaySyncerHandler(syncer::RaySyncerStreamHandler &handler,
+                              std::function<bool()> is_leader_fn)
+      : handler_(handler), is_leader_fn_(std::move(is_leader_fn)) {}
+
+  // Allowed on passive GCS. It must not be gated because of the legitimate stream between
+  // the local raylet and the GCS on the passive head node. Any NEW method added to
+  // RaySyncerStreamHandler must decide its own leader policy here -- do not assume it can
+  // be allowed like StartSync.
+  syncer::SyncStreamReactor *StartSync(grpc::CallbackServerContext *context) override {
+    return handler_.StartSync(context);
+  }
+
+ private:
+  syncer::RaySyncerStreamHandler &handler_;
   const std::function<bool()> is_leader_fn_;
 };
 

--- a/src/ray/gcs/gcs_leader_gated_handlers.h
+++ b/src/ray/gcs/gcs_leader_gated_handlers.h
@@ -1,0 +1,575 @@
+// Copyright 2025 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <functional>
+#include <memory>
+#include <utility>
+
+#include "ray/common/status.h"
+#include "ray/gcs/grpc_service_interfaces.h"
+
+namespace ray {
+namespace gcs {
+
+// Helper macro to send reply status. Wrapped in do/while(0) so the multi-statement
+// body behaves as a single statement in any context (e.g. an unbraced if/else).
+#define GCS_PROXY_SEND_REPLY(send_reply_callback, reply, status)        \
+  do {                                                                  \
+    reply->mutable_status()->set_code(static_cast<int>(status.code())); \
+    reply->mutable_status()->set_message(status.message());             \
+    send_reply_callback(ray::Status::OK(), nullptr, nullptr);           \
+  } while (0)
+
+// =============================================================================
+// Boilerplate-reducing macros for leader-gated proxy handlers.
+//
+// Each proxy handler must override every method of its base interface. These
+// macros collapse each override to a single line so that adding a new RPC to a
+// service only requires adding one line here, and the gated/allowlisted status
+// of every RPC stays explicit and easy to audit.
+//
+// The Request and Reply arguments must be fully-qualified type names (e.g.
+// `rpc::AddJobRequest` or `rpc::autoscaler::DrainNodeRequest`).
+//
+// Naming convention:
+//   *_GATED   -> Blocked on passive GCS (returns Status::GcsPassive()).
+//   *_ALLOWED -> Always forwarded (bootstrap allowlist).
+//   *_PEER    -> Variant whose signature also takes `const std::string &grpc_peer`.
+//   *_CB      -> Gate reply is sent via the callback status instead of the reply
+//                body (used by services that report status through the callback,
+//                e.g. autoscaler).
+// =============================================================================
+
+// Gate reply written into the reply body (default GCS convention).
+#define GCS_GATED_RPC(Method, Request, Reply)                                            \
+  void Method(Request request, Reply *reply, rpc::SendReplyCallback send_reply_callback) \
+      override {                                                                         \
+    if (!is_leader_fn_()) {                                                              \
+      GCS_PROXY_SEND_REPLY(send_reply_callback, reply, Status::GcsPassive());            \
+      return;                                                                            \
+    }                                                                                    \
+    handler_.Method(std::move(request), reply, std::move(send_reply_callback));          \
+  }
+
+#define GCS_GATED_RPC_PEER(Method, Request, Reply)                             \
+  void Method(Request request,                                                 \
+              Reply *reply,                                                    \
+              rpc::SendReplyCallback send_reply_callback,                      \
+              const std::string &grpc_peer) override {                         \
+    if (!is_leader_fn_()) {                                                    \
+      GCS_PROXY_SEND_REPLY(send_reply_callback, reply, Status::GcsPassive());  \
+      return;                                                                  \
+    }                                                                          \
+    handler_.Method(                                                           \
+        std::move(request), reply, std::move(send_reply_callback), grpc_peer); \
+  }
+
+#define GCS_ALLOWED_RPC(Method, Request, Reply)                                          \
+  void Method(Request request, Reply *reply, rpc::SendReplyCallback send_reply_callback) \
+      override {                                                                         \
+    handler_.Method(std::move(request), reply, std::move(send_reply_callback));          \
+  }
+
+// Gate reply written into the callback status.
+#define GCS_GATED_RPC_CB(Method, Request, Reply)                                         \
+  void Method(Request request, Reply *reply, rpc::SendReplyCallback send_reply_callback) \
+      override {                                                                         \
+    if (!is_leader_fn_()) {                                                              \
+      send_reply_callback(Status::GcsPassive(), nullptr, nullptr);                       \
+      return;                                                                            \
+    }                                                                                    \
+    handler_.Method(std::move(request), reply, std::move(send_reply_callback));          \
+  }
+
+#define GCS_GATED_RPC_CB_PEER(Method, Request, Reply)                          \
+  void Method(Request request,                                                 \
+              Reply *reply,                                                    \
+              rpc::SendReplyCallback send_reply_callback,                      \
+              const std::string &grpc_peer) override {                         \
+    if (!is_leader_fn_()) {                                                    \
+      send_reply_callback(Status::GcsPassive(), nullptr, nullptr);             \
+      return;                                                                  \
+    }                                                                          \
+    handler_.Method(                                                           \
+        std::move(request), reply, std::move(send_reply_callback), grpc_peer); \
+  }
+
+class LeaderGatedNodeInfoHandler : public rpc::NodeInfoGcsServiceHandler {
+ public:
+  using HandlerType = rpc::NodeInfoGcsServiceHandler;
+  LeaderGatedNodeInfoHandler(
+      rpc::NodeInfoGcsServiceHandler &handler,
+      std::function<bool()> is_leader_fn,
+      std::function<void(const rpc::GcsNodeInfo &)> cache_local_node_fn)
+      : handler_(handler),
+        is_leader_fn_(std::move(is_leader_fn)),
+        cache_local_node_fn_(std::move(cache_local_node_fn)) {}
+
+  // =========================================================================
+  // Gated RPCs (Blocked on passive GCS, returns Status::GcsPassive)
+  // =========================================================================
+
+  GCS_GATED_RPC_PEER(HandleUnregisterNode,
+                     rpc::UnregisterNodeRequest,
+                     rpc::UnregisterNodeReply)
+  GCS_GATED_RPC(HandleDrainNode, rpc::DrainNodeRequest, rpc::DrainNodeReply)
+
+  // =========================================================================
+  // Bootstrap Allowlist RPCs (Allowed on passive GCS)
+  // =========================================================================
+
+  GCS_ALLOWED_RPC(HandleGetClusterId, rpc::GetClusterIdRequest, rpc::GetClusterIdReply)
+  GCS_ALLOWED_RPC(HandleCheckAlive, rpc::CheckAliveRequest, rpc::CheckAliveReply)
+  GCS_ALLOWED_RPC(HandleGetAllNodeInfo,
+                  rpc::GetAllNodeInfoRequest,
+                  rpc::GetAllNodeInfoReply)
+  GCS_ALLOWED_RPC(HandleGetAllNodeAddressAndLiveness,
+                  rpc::GetAllNodeAddressAndLivenessRequest,
+                  rpc::GetAllNodeAddressAndLivenessReply)
+
+  void HandleRegisterNode(rpc::RegisterNodeRequest request,
+                          rpc::RegisterNodeReply *reply,
+                          rpc::SendReplyCallback send_reply_callback) override {
+    // Passive GCS blocks remote worker node registrations, but allows the colocated local
+    // head node Raylet to register so that dashboard/health check services can start.
+    if (!is_leader_fn_()) {
+      const rpc::GcsNodeInfo &node_info = request.node_info();
+      if (!node_info.is_head_node()) {
+        // Reject remote worker node registrations on passive GCS
+        GCS_PROXY_SEND_REPLY(send_reply_callback, reply, Status::GcsPassive());
+        return;
+      }
+      // Cache the local head node in-memory without persisting to Redis
+      cache_local_node_fn_(node_info);
+      GCS_PROXY_SEND_REPLY(send_reply_callback, reply, Status::OK());
+      return;
+    }
+    // Forward to the underlying handler on active GCS
+    handler_.HandleRegisterNode(
+        std::move(request), reply, std::move(send_reply_callback));
+  }
+
+ private:
+  rpc::NodeInfoGcsServiceHandler &handler_;
+  const std::function<bool()> is_leader_fn_;
+  const std::function<void(const rpc::GcsNodeInfo &)> cache_local_node_fn_;
+};
+
+class LeaderGatedActorInfoHandler : public rpc::ActorInfoGcsServiceHandler {
+ public:
+  using HandlerType = rpc::ActorInfoGcsServiceHandler;
+  LeaderGatedActorInfoHandler(rpc::ActorInfoGcsServiceHandler &handler,
+                              std::function<bool()> is_leader_fn)
+      : handler_(handler), is_leader_fn_(std::move(is_leader_fn)) {}
+
+  // =========================================================================
+  // Gated RPCs (Blocked on passive GCS, returns Status::GcsPassive)
+  // =========================================================================
+
+  GCS_GATED_RPC(HandleRegisterActor, rpc::RegisterActorRequest, rpc::RegisterActorReply)
+  GCS_GATED_RPC(HandleRestartActorForLineageReconstruction,
+                rpc::RestartActorForLineageReconstructionRequest,
+                rpc::RestartActorForLineageReconstructionReply)
+  GCS_GATED_RPC(HandleCreateActor, rpc::CreateActorRequest, rpc::CreateActorReply)
+  GCS_GATED_RPC(HandleKillActorViaGcs,
+                rpc::KillActorViaGcsRequest,
+                rpc::KillActorViaGcsReply)
+  GCS_GATED_RPC(HandleReportActorOutOfScope,
+                rpc::ReportActorOutOfScopeRequest,
+                rpc::ReportActorOutOfScopeReply)
+  GCS_GATED_RPC(HandleGetActorInfo, rpc::GetActorInfoRequest, rpc::GetActorInfoReply)
+  GCS_GATED_RPC(HandleGetNamedActorInfo,
+                rpc::GetNamedActorInfoRequest,
+                rpc::GetNamedActorInfoReply)
+  GCS_GATED_RPC(HandleListNamedActors,
+                rpc::ListNamedActorsRequest,
+                rpc::ListNamedActorsReply)
+  GCS_GATED_RPC(HandleGetAllActorInfo,
+                rpc::GetAllActorInfoRequest,
+                rpc::GetAllActorInfoReply)
+
+ private:
+  rpc::ActorInfoGcsServiceHandler &handler_;
+  const std::function<bool()> is_leader_fn_;
+};
+
+class LeaderGatedJobInfoHandler : public rpc::JobInfoGcsServiceHandler {
+ public:
+  using HandlerType = rpc::JobInfoGcsServiceHandler;
+  LeaderGatedJobInfoHandler(rpc::JobInfoGcsServiceHandler &handler,
+                            std::function<bool()> is_leader_fn)
+      : handler_(handler), is_leader_fn_(std::move(is_leader_fn)) {}
+
+  // =========================================================================
+  // Gated RPCs (Blocked on passive GCS, returns Status::GcsPassive)
+  // =========================================================================
+
+  GCS_GATED_RPC(HandleAddJob, rpc::AddJobRequest, rpc::AddJobReply)
+  GCS_GATED_RPC(HandleMarkJobFinished,
+                rpc::MarkJobFinishedRequest,
+                rpc::MarkJobFinishedReply)
+  GCS_GATED_RPC(HandleGetNextJobID, rpc::GetNextJobIDRequest, rpc::GetNextJobIDReply)
+  GCS_GATED_RPC(HandleGetAllJobInfo, rpc::GetAllJobInfoRequest, rpc::GetAllJobInfoReply)
+
+  void AddJobFinishedListener(JobFinishListenerCallback listener) override {
+    handler_.AddJobFinishedListener(std::move(listener));
+  }
+
+ private:
+  rpc::JobInfoGcsServiceHandler &handler_;
+  const std::function<bool()> is_leader_fn_;
+};
+
+class LeaderGatedPlacementGroupInfoHandler
+    : public rpc::PlacementGroupInfoGcsServiceHandler {
+ public:
+  using HandlerType = rpc::PlacementGroupInfoGcsServiceHandler;
+  LeaderGatedPlacementGroupInfoHandler(rpc::PlacementGroupInfoGcsServiceHandler &handler,
+                                       std::function<bool()> is_leader_fn)
+      : handler_(handler), is_leader_fn_(std::move(is_leader_fn)) {}
+
+  // =========================================================================
+  // Gated RPCs (Blocked on passive GCS, returns Status::GcsPassive)
+  // =========================================================================
+
+  GCS_GATED_RPC(HandleCreatePlacementGroup,
+                rpc::CreatePlacementGroupRequest,
+                rpc::CreatePlacementGroupReply)
+  GCS_GATED_RPC(HandleRemovePlacementGroup,
+                rpc::RemovePlacementGroupRequest,
+                rpc::RemovePlacementGroupReply)
+  GCS_GATED_RPC(HandleGetPlacementGroup,
+                rpc::GetPlacementGroupRequest,
+                rpc::GetPlacementGroupReply)
+  GCS_GATED_RPC(HandleGetAllPlacementGroup,
+                rpc::GetAllPlacementGroupRequest,
+                rpc::GetAllPlacementGroupReply)
+  GCS_GATED_RPC(HandleWaitPlacementGroupUntilReady,
+                rpc::WaitPlacementGroupUntilReadyRequest,
+                rpc::WaitPlacementGroupUntilReadyReply)
+  GCS_GATED_RPC(HandleGetNamedPlacementGroup,
+                rpc::GetNamedPlacementGroupRequest,
+                rpc::GetNamedPlacementGroupReply)
+
+ private:
+  rpc::PlacementGroupInfoGcsServiceHandler &handler_;
+  const std::function<bool()> is_leader_fn_;
+};
+
+class LeaderGatedInternalKVHandler : public rpc::InternalKVGcsServiceHandler {
+ public:
+  using HandlerType = rpc::InternalKVGcsServiceHandler;
+  LeaderGatedInternalKVHandler(rpc::InternalKVGcsServiceHandler &handler,
+                               std::function<bool()> is_leader_fn)
+      : handler_(handler), is_leader_fn_(std::move(is_leader_fn)) {}
+
+  // =========================================================================
+  // Gated RPCs (Blocked on passive GCS, returns Status::GcsPassive)
+  // =========================================================================
+
+  GCS_GATED_RPC(HandleInternalKVPut, rpc::InternalKVPutRequest, rpc::InternalKVPutReply)
+  GCS_GATED_RPC(HandleInternalKVDel, rpc::InternalKVDelRequest, rpc::InternalKVDelReply)
+  GCS_GATED_RPC(HandleInternalKVKeys,
+                rpc::InternalKVKeysRequest,
+                rpc::InternalKVKeysReply)
+  GCS_GATED_RPC(HandleInternalKVMultiGet,
+                rpc::InternalKVMultiGetRequest,
+                rpc::InternalKVMultiGetReply)
+  GCS_GATED_RPC(HandleInternalKVExists,
+                rpc::InternalKVExistsRequest,
+                rpc::InternalKVExistsReply)
+
+  // =========================================================================
+  // Bootstrap Allowlist RPCs (Allowed on passive GCS)
+  // =========================================================================
+
+  GCS_ALLOWED_RPC(HandleInternalKVGet, rpc::InternalKVGetRequest, rpc::InternalKVGetReply)
+  GCS_ALLOWED_RPC(HandleGetInternalConfig,
+                  rpc::GetInternalConfigRequest,
+                  rpc::GetInternalConfigReply)
+
+ private:
+  rpc::InternalKVGcsServiceHandler &handler_;
+  const std::function<bool()> is_leader_fn_;
+};
+
+class LeaderGatedAutoscalerStateHandler
+    : public rpc::autoscaler::AutoscalerStateServiceHandler {
+ public:
+  using HandlerType = rpc::autoscaler::AutoscalerStateServiceHandler;
+  LeaderGatedAutoscalerStateHandler(
+      rpc::autoscaler::AutoscalerStateServiceHandler &handler,
+      std::function<bool()> is_leader_fn)
+      : handler_(handler), is_leader_fn_(std::move(is_leader_fn)) {}
+
+  // =========================================================================
+  // Gated RPCs (Blocked on passive GCS, returns Status::GcsPassive)
+  // =========================================================================
+
+  GCS_GATED_RPC_CB(HandleReportAutoscalingState,
+                   rpc::autoscaler::ReportAutoscalingStateRequest,
+                   rpc::autoscaler::ReportAutoscalingStateReply)
+  GCS_GATED_RPC_CB(HandleRequestClusterResourceConstraint,
+                   rpc::autoscaler::RequestClusterResourceConstraintRequest,
+                   rpc::autoscaler::RequestClusterResourceConstraintReply)
+  GCS_GATED_RPC_CB_PEER(HandleDrainNode,
+                        rpc::autoscaler::DrainNodeRequest,
+                        rpc::autoscaler::DrainNodeReply)
+  GCS_GATED_RPC_CB(HandleResizeRayletResourceInstances,
+                   rpc::autoscaler::ResizeRayletResourceInstancesRequest,
+                   rpc::autoscaler::ResizeRayletResourceInstancesReply)
+  GCS_GATED_RPC_CB(HandleReportClusterConfig,
+                   rpc::autoscaler::ReportClusterConfigRequest,
+                   rpc::autoscaler::ReportClusterConfigReply)
+  GCS_GATED_RPC_CB(HandleGetClusterResourceState,
+                   rpc::autoscaler::GetClusterResourceStateRequest,
+                   rpc::autoscaler::GetClusterResourceStateReply)
+  GCS_GATED_RPC_CB(HandleGetClusterStatus,
+                   rpc::autoscaler::GetClusterStatusRequest,
+                   rpc::autoscaler::GetClusterStatusReply)
+
+ private:
+  rpc::autoscaler::AutoscalerStateServiceHandler &handler_;
+  const std::function<bool()> is_leader_fn_;
+};
+
+class LeaderGatedNodeResourceInfoHandler : public rpc::NodeResourceInfoGcsServiceHandler {
+ public:
+  using HandlerType = rpc::NodeResourceInfoGcsServiceHandler;
+  LeaderGatedNodeResourceInfoHandler(rpc::NodeResourceInfoGcsServiceHandler &handler,
+                                     std::function<bool()> is_leader_fn)
+      : handler_(handler), is_leader_fn_(std::move(is_leader_fn)) {}
+
+  // =========================================================================
+  // Gated RPCs (Blocked on passive GCS, returns Status::GcsPassive)
+  //
+  // Minimal-allowlist principle: a passive GCS only allows what is strictly
+  // required to boot the local head (raylet registration + health/subscribe).
+  // All NodeResourceInfo consumers (autoscaler/state observers) are suppressed
+  // on a passive head, so none of these are needed until promotion.
+  // =========================================================================
+
+  GCS_GATED_RPC(HandleGetAllAvailableResources,
+                rpc::GetAllAvailableResourcesRequest,
+                rpc::GetAllAvailableResourcesReply)
+  GCS_GATED_RPC(HandleGetAllTotalResources,
+                rpc::GetAllTotalResourcesRequest,
+                rpc::GetAllTotalResourcesReply)
+  GCS_GATED_RPC(HandleGetDrainingNodes,
+                rpc::GetDrainingNodesRequest,
+                rpc::GetDrainingNodesReply)
+  GCS_GATED_RPC(HandleGetAllResourceUsage,
+                rpc::GetAllResourceUsageRequest,
+                rpc::GetAllResourceUsageReply)
+
+ private:
+  rpc::NodeResourceInfoGcsServiceHandler &handler_;
+  const std::function<bool()> is_leader_fn_;
+};
+
+class LeaderGatedWorkerInfoHandler : public rpc::WorkerInfoGcsServiceHandler {
+ public:
+  using HandlerType = rpc::WorkerInfoGcsServiceHandler;
+  LeaderGatedWorkerInfoHandler(rpc::WorkerInfoGcsServiceHandler &handler,
+                               std::function<bool()> is_leader_fn)
+      : handler_(handler), is_leader_fn_(std::move(is_leader_fn)) {}
+
+  // =========================================================================
+  // Gated RPCs (Blocked on passive GCS, returns Status::GcsPassive)
+  // =========================================================================
+
+  GCS_GATED_RPC(HandleReportWorkerFailure,
+                rpc::ReportWorkerFailureRequest,
+                rpc::ReportWorkerFailureReply)
+  GCS_GATED_RPC(HandleAddWorkerInfo, rpc::AddWorkerInfoRequest, rpc::AddWorkerInfoReply)
+  GCS_GATED_RPC(HandleUpdateWorkerDebuggerPort,
+                rpc::UpdateWorkerDebuggerPortRequest,
+                rpc::UpdateWorkerDebuggerPortReply)
+  GCS_GATED_RPC(HandleUpdateWorkerNumPausedThreads,
+                rpc::UpdateWorkerNumPausedThreadsRequest,
+                rpc::UpdateWorkerNumPausedThreadsReply)
+
+  // Reads are also gated: no workers run on a passive head, so nothing needs
+  // to query worker info until promotion (minimal-allowlist principle).
+  GCS_GATED_RPC(HandleGetWorkerInfo, rpc::GetWorkerInfoRequest, rpc::GetWorkerInfoReply)
+  GCS_GATED_RPC(HandleGetAllWorkerInfo,
+                rpc::GetAllWorkerInfoRequest,
+                rpc::GetAllWorkerInfoReply)
+
+ private:
+  rpc::WorkerInfoGcsServiceHandler &handler_;
+  const std::function<bool()> is_leader_fn_;
+};
+
+class LeaderGatedTaskInfoHandler : public rpc::TaskInfoGcsServiceHandler {
+ public:
+  using HandlerType = rpc::TaskInfoGcsServiceHandler;
+  LeaderGatedTaskInfoHandler(rpc::TaskInfoGcsServiceHandler &handler,
+                             std::function<bool()> is_leader_fn)
+      : handler_(handler), is_leader_fn_(std::move(is_leader_fn)) {}
+
+  // =========================================================================
+  // Gated RPCs (Blocked on passive GCS, returns Status::GcsPassive)
+  // =========================================================================
+
+  GCS_GATED_RPC(HandleAddTaskEventData,
+                rpc::AddTaskEventDataRequest,
+                rpc::AddTaskEventDataReply)
+
+  // Reads are also gated: no tasks run on a passive head, so nothing needs to
+  // query task events until promotion (minimal-allowlist principle).
+  GCS_GATED_RPC(HandleGetTaskEvents, rpc::GetTaskEventsRequest, rpc::GetTaskEventsReply)
+
+ private:
+  rpc::TaskInfoGcsServiceHandler &handler_;
+  const std::function<bool()> is_leader_fn_;
+};
+
+class LeaderGatedRuntimeEnvHandler : public rpc::RuntimeEnvGcsServiceHandler {
+ public:
+  using HandlerType = rpc::RuntimeEnvGcsServiceHandler;
+  LeaderGatedRuntimeEnvHandler(rpc::RuntimeEnvGcsServiceHandler &handler,
+                               std::function<bool()> is_leader_fn)
+      : handler_(handler), is_leader_fn_(std::move(is_leader_fn)) {}
+
+  // =========================================================================
+  // Gated RPCs (Blocked on passive GCS, returns Status::GcsPassive)
+  //
+  // Pinning a runtime env URI writes to the shared GCS KV store, so it must not
+  // run on a passive GCS.
+  // =========================================================================
+
+  GCS_GATED_RPC(HandlePinRuntimeEnvURI,
+                rpc::PinRuntimeEnvURIRequest,
+                rpc::PinRuntimeEnvURIReply)
+
+ private:
+  rpc::RuntimeEnvGcsServiceHandler &handler_;
+  const std::function<bool()> is_leader_fn_;
+};
+
+class LeaderGatedControlPlanePubSubHandler
+    : public rpc::ControlPlanePubSubGcsServiceHandler {
+ public:
+  using HandlerType = rpc::ControlPlanePubSubGcsServiceHandler;
+  LeaderGatedControlPlanePubSubHandler(rpc::ControlPlanePubSubGcsServiceHandler &handler,
+                                       std::function<bool()> is_leader_fn)
+      : handler_(handler), is_leader_fn_(std::move(is_leader_fn)) {}
+
+  // =========================================================================
+  // Gated RPCs (Blocked on passive GCS, returns Status::GcsPassive)
+  //
+  // Publishing mutates control-plane state and must be owned by the active GCS.
+  // =========================================================================
+
+  GCS_GATED_RPC(HandleGcsPublish, rpc::GcsPublishRequest, rpc::GcsPublishReply)
+
+  // =========================================================================
+  // Bootstrap Allowlist RPCs (Allowed on passive GCS)
+  //
+  // These are the ONLY pubsub RPCs allowed on a passive GCS, and they are
+  // required by the minimal boot path: the colocated local raylet calls
+  // AsyncSubscribeToNodeAddressAndLivenessChange during startup, which is
+  // implemented on top of GcsSubscriberPoll + GcsSubscriberCommandBatch (see
+  // GcsSubscriberClient in gcs_client.cc). Without them the local raylet
+  // cannot finish initialization on a passive head.
+  // =========================================================================
+
+  GCS_ALLOWED_RPC(HandleGcsSubscriberPoll,
+                  rpc::GcsSubscriberPollRequest,
+                  rpc::GcsSubscriberPollReply)
+  GCS_ALLOWED_RPC(HandleGcsSubscriberCommandBatch,
+                  rpc::GcsSubscriberCommandBatchRequest,
+                  rpc::GcsSubscriberCommandBatchReply)
+
+ private:
+  rpc::ControlPlanePubSubGcsServiceHandler &handler_;
+  const std::function<bool()> is_leader_fn_;
+};
+
+class LeaderGatedObservabilityPubSubHandler
+    : public rpc::ObservabilityPubSubServiceHandler {
+ public:
+  using HandlerType = rpc::ObservabilityPubSubServiceHandler;
+  LeaderGatedObservabilityPubSubHandler(rpc::ObservabilityPubSubServiceHandler &handler,
+                                        std::function<bool()> is_leader_fn)
+      : handler_(handler), is_leader_fn_(std::move(is_leader_fn)) {}
+
+  // =========================================================================
+  // Gated RPCs (Blocked on passive GCS, returns Status::GcsPassive)
+  //
+  // Publishing and reporting job errors mutate control-plane state and must be
+  // owned by the active GCS.
+  // =========================================================================
+
+  GCS_GATED_RPC(HandleGcsPublish, rpc::GcsPublishRequest, rpc::GcsPublishReply)
+  GCS_GATED_RPC(HandleReportJobError,
+                rpc::ReportJobErrorRequest,
+                rpc::ReportJobErrorReply)
+
+  // =========================================================================
+  // Bootstrap Allowlist RPCs (Allowed on passive GCS)
+  //
+  // Subscribe/long-poll are read-only and only touch in-process subscription
+  // bookkeeping (no shared-storage writes), mirroring the control-plane pubsub
+  // allowlist. Kept open so local observability subscribers can attach.
+  // =========================================================================
+
+  GCS_ALLOWED_RPC(HandleGcsSubscriberPoll,
+                  rpc::GcsSubscriberPollRequest,
+                  rpc::GcsSubscriberPollReply)
+  GCS_ALLOWED_RPC(HandleGcsSubscriberCommandBatch,
+                  rpc::GcsSubscriberCommandBatchRequest,
+                  rpc::GcsSubscriberCommandBatchReply)
+
+ private:
+  rpc::ObservabilityPubSubServiceHandler &handler_;
+  const std::function<bool()> is_leader_fn_;
+};
+
+class LeaderGatedRayEventExportHandler
+    : public rpc::events::RayEventExportGcsServiceHandler {
+ public:
+  using HandlerType = rpc::events::RayEventExportGcsServiceHandler;
+  LeaderGatedRayEventExportHandler(rpc::events::RayEventExportGcsServiceHandler &handler,
+                                   std::function<bool()> is_leader_fn)
+      : handler_(handler), is_leader_fn_(std::move(is_leader_fn)) {}
+
+  // =========================================================================
+  // Gated RPCs (Blocked on passive GCS, returns Status::GcsPassive)
+  //
+  // AddEvents ingests events into the task manager; no workers run on a passive
+  // head, so it is gated until promotion (minimal-allowlist principle).
+  // =========================================================================
+
+  GCS_GATED_RPC(HandleAddEvents,
+                rpc::events::AddEventsRequest,
+                rpc::events::AddEventsReply)
+
+ private:
+  rpc::events::RayEventExportGcsServiceHandler &handler_;
+  const std::function<bool()> is_leader_fn_;
+};
+
+#undef GCS_PROXY_SEND_REPLY
+#undef GCS_GATED_RPC
+#undef GCS_GATED_RPC_PEER
+#undef GCS_ALLOWED_RPC
+#undef GCS_GATED_RPC_CB
+#undef GCS_GATED_RPC_CB_PEER
+
+}  // namespace gcs
+}  // namespace ray

--- a/src/ray/gcs/gcs_leader_gated_handlers.h
+++ b/src/ray/gcs/gcs_leader_gated_handlers.h
@@ -33,25 +33,12 @@ namespace gcs {
     send_reply_callback(ray::Status::OK(), nullptr, nullptr);           \
   } while (0)
 
-// =============================================================================
-// Boilerplate-reducing macros for leader-gated proxy handlers.
-//
-// Each proxy handler must override every method of its base interface. These
-// macros collapse each override to a single line so that adding a new RPC to a
-// service only requires adding one line here, and the gated/allowlisted status
-// of every RPC stays explicit and easy to audit.
-//
-// The Request and Reply arguments must be fully-qualified type names (e.g.
-// `rpc::AddJobRequest` or `rpc::autoscaler::DrainNodeRequest`).
-//
-// Naming convention:
-//   *_GATED   -> Blocked on passive GCS (returns Status::GcsPassive()).
-//   *_ALLOWED -> Always forwarded (bootstrap allowlist).
-//   *_PEER    -> Variant whose signature also takes `const std::string &grpc_peer`.
-//   *_CB      -> Gate reply is sent via the callback status instead of the reply
-//                body (used by services that report status through the callback,
-//                e.g. autoscaler).
-// =============================================================================
+// Macros to define a leader-gated proxy handler override in one line each.
+// Request/Reply must be fully-qualified (e.g. rpc::AddJobRequest). Suffixes:
+//   *_GATED   -> blocked on passive GCS (returns Status::GcsPassive()).
+//   *_ALLOWED -> always forwarded (bootstrap allowlist).
+//   *_PEER    -> variant taking `const std::string &grpc_peer`.
+//   *_CB      -> gate status is sent via the callback, not the reply body.
 
 // Gate reply written into the reply body (default GCS convention).
 #define GCS_GATED_RPC(Method, Request, Reply)                                            \
@@ -118,18 +105,14 @@ class LeaderGatedNodeInfoHandler : public rpc::NodeInfoGcsServiceHandler {
         is_leader_fn_(std::move(is_leader_fn)),
         cache_local_node_fn_(std::move(cache_local_node_fn)) {}
 
-  // =========================================================================
-  // Gated RPCs (Blocked on passive GCS, returns Status::GcsPassive)
-  // =========================================================================
+  // Gated on passive GCS.
 
   GCS_GATED_RPC_PEER(HandleUnregisterNode,
                      rpc::UnregisterNodeRequest,
                      rpc::UnregisterNodeReply)
   GCS_GATED_RPC(HandleDrainNode, rpc::DrainNodeRequest, rpc::DrainNodeReply)
 
-  // =========================================================================
-  // Bootstrap Allowlist RPCs (Allowed on passive GCS)
-  // =========================================================================
+  // Allowed on passive GCS (bootstrap).
 
   GCS_ALLOWED_RPC(HandleGetClusterId, rpc::GetClusterIdRequest, rpc::GetClusterIdReply)
   GCS_ALLOWED_RPC(HandleCheckAlive, rpc::CheckAliveRequest, rpc::CheckAliveReply)
@@ -175,9 +158,7 @@ class LeaderGatedActorInfoHandler : public rpc::ActorInfoGcsServiceHandler {
                               std::function<bool()> is_leader_fn)
       : handler_(handler), is_leader_fn_(std::move(is_leader_fn)) {}
 
-  // =========================================================================
-  // Gated RPCs (Blocked on passive GCS, returns Status::GcsPassive)
-  // =========================================================================
+  // Gated on passive GCS.
 
   GCS_GATED_RPC(HandleRegisterActor, rpc::RegisterActorRequest, rpc::RegisterActorReply)
   GCS_GATED_RPC(HandleRestartActorForLineageReconstruction,
@@ -213,9 +194,7 @@ class LeaderGatedJobInfoHandler : public rpc::JobInfoGcsServiceHandler {
                             std::function<bool()> is_leader_fn)
       : handler_(handler), is_leader_fn_(std::move(is_leader_fn)) {}
 
-  // =========================================================================
-  // Gated RPCs (Blocked on passive GCS, returns Status::GcsPassive)
-  // =========================================================================
+  // Gated on passive GCS.
 
   GCS_GATED_RPC(HandleAddJob, rpc::AddJobRequest, rpc::AddJobReply)
   GCS_GATED_RPC(HandleMarkJobFinished,
@@ -241,9 +220,7 @@ class LeaderGatedPlacementGroupInfoHandler
                                        std::function<bool()> is_leader_fn)
       : handler_(handler), is_leader_fn_(std::move(is_leader_fn)) {}
 
-  // =========================================================================
-  // Gated RPCs (Blocked on passive GCS, returns Status::GcsPassive)
-  // =========================================================================
+  // Gated on passive GCS.
 
   GCS_GATED_RPC(HandleCreatePlacementGroup,
                 rpc::CreatePlacementGroupRequest,
@@ -276,9 +253,7 @@ class LeaderGatedInternalKVHandler : public rpc::InternalKVGcsServiceHandler {
                                std::function<bool()> is_leader_fn)
       : handler_(handler), is_leader_fn_(std::move(is_leader_fn)) {}
 
-  // =========================================================================
-  // Gated RPCs (Blocked on passive GCS, returns Status::GcsPassive)
-  // =========================================================================
+  // Gated on passive GCS.
 
   GCS_GATED_RPC(HandleInternalKVPut, rpc::InternalKVPutRequest, rpc::InternalKVPutReply)
   GCS_GATED_RPC(HandleInternalKVDel, rpc::InternalKVDelRequest, rpc::InternalKVDelReply)
@@ -292,9 +267,7 @@ class LeaderGatedInternalKVHandler : public rpc::InternalKVGcsServiceHandler {
                 rpc::InternalKVExistsRequest,
                 rpc::InternalKVExistsReply)
 
-  // =========================================================================
-  // Bootstrap Allowlist RPCs (Allowed on passive GCS)
-  // =========================================================================
+  // Allowed on passive GCS (bootstrap).
 
   GCS_ALLOWED_RPC(HandleInternalKVGet, rpc::InternalKVGetRequest, rpc::InternalKVGetReply)
   GCS_ALLOWED_RPC(HandleGetInternalConfig,
@@ -315,9 +288,7 @@ class LeaderGatedAutoscalerStateHandler
       std::function<bool()> is_leader_fn)
       : handler_(handler), is_leader_fn_(std::move(is_leader_fn)) {}
 
-  // =========================================================================
-  // Gated RPCs (Blocked on passive GCS, returns Status::GcsPassive)
-  // =========================================================================
+  // Gated on passive GCS.
 
   GCS_GATED_RPC_CB(HandleReportAutoscalingState,
                    rpc::autoscaler::ReportAutoscalingStateRequest,
@@ -353,14 +324,8 @@ class LeaderGatedNodeResourceInfoHandler : public rpc::NodeResourceInfoGcsServic
                                      std::function<bool()> is_leader_fn)
       : handler_(handler), is_leader_fn_(std::move(is_leader_fn)) {}
 
-  // =========================================================================
-  // Gated RPCs (Blocked on passive GCS, returns Status::GcsPassive)
-  //
-  // Minimal-allowlist principle: a passive GCS only allows what is strictly
-  // required to boot the local head (raylet registration + health/subscribe).
-  // All NodeResourceInfo consumers (autoscaler/state observers) are suppressed
-  // on a passive head, so none of these are needed until promotion.
-  // =========================================================================
+  // Gated: NodeResourceInfo consumers (autoscaler/state observers) are
+  // suppressed on a passive head, so none are needed until promotion.
 
   GCS_GATED_RPC(HandleGetAllAvailableResources,
                 rpc::GetAllAvailableResourcesRequest,
@@ -387,9 +352,7 @@ class LeaderGatedWorkerInfoHandler : public rpc::WorkerInfoGcsServiceHandler {
                                std::function<bool()> is_leader_fn)
       : handler_(handler), is_leader_fn_(std::move(is_leader_fn)) {}
 
-  // =========================================================================
-  // Gated RPCs (Blocked on passive GCS, returns Status::GcsPassive)
-  // =========================================================================
+  // Gated on passive GCS.
 
   GCS_GATED_RPC(HandleReportWorkerFailure,
                 rpc::ReportWorkerFailureRequest,
@@ -402,8 +365,7 @@ class LeaderGatedWorkerInfoHandler : public rpc::WorkerInfoGcsServiceHandler {
                 rpc::UpdateWorkerNumPausedThreadsRequest,
                 rpc::UpdateWorkerNumPausedThreadsReply)
 
-  // Reads are also gated: no workers run on a passive head, so nothing needs
-  // to query worker info until promotion (minimal-allowlist principle).
+  // Reads are also gated: no workers run on a passive head.
   GCS_GATED_RPC(HandleGetWorkerInfo, rpc::GetWorkerInfoRequest, rpc::GetWorkerInfoReply)
   GCS_GATED_RPC(HandleGetAllWorkerInfo,
                 rpc::GetAllWorkerInfoRequest,
@@ -421,16 +383,13 @@ class LeaderGatedTaskInfoHandler : public rpc::TaskInfoGcsServiceHandler {
                              std::function<bool()> is_leader_fn)
       : handler_(handler), is_leader_fn_(std::move(is_leader_fn)) {}
 
-  // =========================================================================
-  // Gated RPCs (Blocked on passive GCS, returns Status::GcsPassive)
-  // =========================================================================
+  // Gated on passive GCS.
 
   GCS_GATED_RPC(HandleAddTaskEventData,
                 rpc::AddTaskEventDataRequest,
                 rpc::AddTaskEventDataReply)
 
-  // Reads are also gated: no tasks run on a passive head, so nothing needs to
-  // query task events until promotion (minimal-allowlist principle).
+  // Reads are also gated: no tasks run on a passive head.
   GCS_GATED_RPC(HandleGetTaskEvents, rpc::GetTaskEventsRequest, rpc::GetTaskEventsReply)
 
  private:
@@ -445,12 +404,7 @@ class LeaderGatedRuntimeEnvHandler : public rpc::RuntimeEnvGcsServiceHandler {
                                std::function<bool()> is_leader_fn)
       : handler_(handler), is_leader_fn_(std::move(is_leader_fn)) {}
 
-  // =========================================================================
-  // Gated RPCs (Blocked on passive GCS, returns Status::GcsPassive)
-  //
-  // Pinning a runtime env URI writes to the shared GCS KV store, so it must not
-  // run on a passive GCS.
-  // =========================================================================
+  // Gated: pinning a runtime env URI writes to the shared GCS KV store.
 
   GCS_GATED_RPC(HandlePinRuntimeEnvURI,
                 rpc::PinRuntimeEnvURIRequest,
@@ -469,24 +423,11 @@ class LeaderGatedControlPlanePubSubHandler
                                        std::function<bool()> is_leader_fn)
       : handler_(handler), is_leader_fn_(std::move(is_leader_fn)) {}
 
-  // =========================================================================
-  // Gated RPCs (Blocked on passive GCS, returns Status::GcsPassive)
-  //
-  // Publishing mutates control-plane state and must be owned by the active GCS.
-  // =========================================================================
-
+  // Gated: publishing mutates control-plane state; owned by the active GCS.
   GCS_GATED_RPC(HandleGcsPublish, rpc::GcsPublishRequest, rpc::GcsPublishReply)
 
-  // =========================================================================
-  // Bootstrap Allowlist RPCs (Allowed on passive GCS)
-  //
-  // These are the ONLY pubsub RPCs allowed on a passive GCS, and they are
-  // required by the minimal boot path: the colocated local raylet calls
-  // AsyncSubscribeToNodeAddressAndLivenessChange during startup, which is
-  // implemented on top of GcsSubscriberPoll + GcsSubscriberCommandBatch (see
-  // GcsSubscriberClient in gcs_client.cc). Without them the local raylet
-  // cannot finish initialization on a passive head.
-  // =========================================================================
+  // Allowed: the local raylet's node address/liveness subscription during
+  // startup runs on top of these; without them it cannot boot on a passive head.
 
   GCS_ALLOWED_RPC(HandleGcsSubscriberPoll,
                   rpc::GcsSubscriberPollRequest,
@@ -508,25 +449,14 @@ class LeaderGatedObservabilityPubSubHandler
                                         std::function<bool()> is_leader_fn)
       : handler_(handler), is_leader_fn_(std::move(is_leader_fn)) {}
 
-  // =========================================================================
-  // Gated RPCs (Blocked on passive GCS, returns Status::GcsPassive)
-  //
-  // Publishing and reporting job errors mutate control-plane state and must be
-  // owned by the active GCS.
-  // =========================================================================
-
+  // Gated: publishing and reporting job errors mutate control-plane state.
   GCS_GATED_RPC(HandleGcsPublish, rpc::GcsPublishRequest, rpc::GcsPublishReply)
   GCS_GATED_RPC(HandleReportJobError,
                 rpc::ReportJobErrorRequest,
                 rpc::ReportJobErrorReply)
 
-  // =========================================================================
-  // Bootstrap Allowlist RPCs (Allowed on passive GCS)
-  //
-  // Subscribe/long-poll are read-only and only touch in-process subscription
-  // bookkeeping (no shared-storage writes), mirroring the control-plane pubsub
-  // allowlist. Kept open so local observability subscribers can attach.
-  // =========================================================================
+  // Allowed: read-only subscribe/long-poll, so local observability subscribers
+  // can attach (mirrors the control-plane pubsub allowlist).
 
   GCS_ALLOWED_RPC(HandleGcsSubscriberPoll,
                   rpc::GcsSubscriberPollRequest,
@@ -548,12 +478,8 @@ class LeaderGatedRayEventExportHandler
                                    std::function<bool()> is_leader_fn)
       : handler_(handler), is_leader_fn_(std::move(is_leader_fn)) {}
 
-  // =========================================================================
-  // Gated RPCs (Blocked on passive GCS, returns Status::GcsPassive)
-  //
-  // AddEvents ingests events into the task manager; no workers run on a passive
-  // head, so it is gated until promotion (minimal-allowlist principle).
-  // =========================================================================
+  // Gated: AddEvents ingests into the task manager; no workers run on a passive
+  // head, so it is gated until promotion.
 
   GCS_GATED_RPC(HandleAddEvents,
                 rpc::events::AddEventsRequest,

--- a/src/ray/gcs/gcs_leader_gated_handlers.h
+++ b/src/ray/gcs/gcs_leader_gated_handlers.h
@@ -15,7 +15,6 @@
 #pragma once
 
 #include <functional>
-#include <memory>
 #include <utility>
 
 #include "ray/common/status.h"
@@ -24,15 +23,6 @@
 
 namespace ray {
 namespace gcs {
-
-// Helper macro to send reply status. Wrapped in do/while(0) so the multi-statement
-// body behaves as a single statement in any context (e.g. an unbraced if/else).
-#define GCS_PROXY_SEND_REPLY(send_reply_callback, reply, status)        \
-  do {                                                                  \
-    reply->mutable_status()->set_code(static_cast<int>(status.code())); \
-    reply->mutable_status()->set_message(status.message());             \
-    send_reply_callback(ray::Status::OK(), nullptr, nullptr);           \
-  } while (0)
 
 // Macros to define a leader-gated proxy handler override in one line each.
 // Request/Reply must be fully-qualified (e.g. rpc::AddJobRequest). Suffixes:
@@ -46,7 +36,7 @@ namespace gcs {
   void Method(Request request, Reply *reply, rpc::SendReplyCallback send_reply_callback) \
       override {                                                                         \
     if (!is_leader_fn_()) {                                                              \
-      GCS_PROXY_SEND_REPLY(send_reply_callback, reply, Status::GcsPassive());            \
+      GCS_RPC_SEND_REPLY(send_reply_callback, reply, Status::GcsPassive());              \
       return;                                                                            \
     }                                                                                    \
     handler_.Method(std::move(request), reply, std::move(send_reply_callback));          \
@@ -58,7 +48,7 @@ namespace gcs {
               rpc::SendReplyCallback send_reply_callback,                      \
               const std::string &grpc_peer) override {                         \
     if (!is_leader_fn_()) {                                                    \
-      GCS_PROXY_SEND_REPLY(send_reply_callback, reply, Status::GcsPassive());  \
+      GCS_RPC_SEND_REPLY(send_reply_callback, reply, Status::GcsPassive());    \
       return;                                                                  \
     }                                                                          \
     handler_.Method(                                                           \
@@ -133,12 +123,12 @@ class LeaderGatedNodeInfoHandler : public rpc::NodeInfoGcsServiceHandler {
       const rpc::GcsNodeInfo &node_info = request.node_info();
       if (!node_info.is_head_node()) {
         // Reject remote worker node registrations on passive GCS
-        GCS_PROXY_SEND_REPLY(send_reply_callback, reply, Status::GcsPassive());
+        GCS_RPC_SEND_REPLY(send_reply_callback, reply, Status::GcsPassive());
         return;
       }
       // Cache the local head node in-memory without persisting to Redis
       cache_local_node_fn_(node_info);
-      GCS_PROXY_SEND_REPLY(send_reply_callback, reply, Status::OK());
+      GCS_RPC_SEND_REPLY(send_reply_callback, reply, Status::OK());
       return;
     }
     // Forward to the underlying handler on active GCS
@@ -495,8 +485,8 @@ class LeaderGatedRaySyncerHandler : public syncer::RaySyncerStreamHandler {
  public:
   using HandlerType = syncer::RaySyncerStreamHandler;
   LeaderGatedRaySyncerHandler(syncer::RaySyncerStreamHandler &handler,
-                              std::function<bool()> is_leader_fn)
-      : handler_(handler), is_leader_fn_(std::move(is_leader_fn)) {}
+                              std::function<bool()> /*is_leader_fn*/)
+      : handler_(handler) {}
 
   // Allowed on passive GCS. It must not be gated because of the legitimate stream between
   // the local raylet and the GCS on the passive head node. Any NEW method added to
@@ -508,10 +498,8 @@ class LeaderGatedRaySyncerHandler : public syncer::RaySyncerStreamHandler {
 
  private:
   syncer::RaySyncerStreamHandler &handler_;
-  const std::function<bool()> is_leader_fn_;
 };
 
-#undef GCS_PROXY_SEND_REPLY
 #undef GCS_GATED_RPC
 #undef GCS_GATED_RPC_PEER
 #undef GCS_ALLOWED_RPC

--- a/src/ray/gcs/gcs_node_manager.cc
+++ b/src/ray/gcs/gcs_node_manager.cc
@@ -40,7 +40,8 @@ GcsNodeManager::GcsNodeManager(
     observability::RayEventRecorderInterface &ray_event_recorder,
     const std::string &session_name,
     pubsub::ObservabilityPublisher *observability_publisher,
-    ClockInterface &clock)
+    ClockInterface &clock,
+    std::function<bool()> is_leader_fn)
     : gcs_publisher_(gcs_publisher),
       observability_publisher_(observability_publisher),
       gcs_table_storage_(gcs_table_storage),
@@ -50,6 +51,7 @@ GcsNodeManager::GcsNodeManager(
       ray_event_recorder_(ray_event_recorder),
       session_name_(session_name),
       clock_(clock),
+      is_leader_fn_(std::move(is_leader_fn)),
       export_event_write_enabled_(IsExportAPIEnabledNode()) {}
 
 void GcsNodeManager::WriteNodeExportEvent(const rpc::GcsNodeInfo &node_info,
@@ -159,10 +161,13 @@ void GcsNodeManager::HandleCheckAlive(rpc::CheckAliveRequest request,
                                       rpc::CheckAliveReply *reply,
                                       rpc::SendReplyCallback send_reply_callback) {
   absl::ReaderMutexLock lock(&mutex_);
+  reply->set_is_leader(is_leader_fn_());
   reply->set_ray_version(kRayVersion);
   for (const auto &id : request.node_ids()) {
     const auto node_id = NodeID::FromBinary(id);
-    const bool is_alive = alive_nodes_.contains(node_id);
+    const bool is_alive = alive_nodes_.contains(node_id) ||
+                          (passive_local_node_ != nullptr &&
+                           NodeID::FromBinary(passive_local_node_->node_id()) == node_id);
     reply->mutable_raylet_alive()->Add(is_alive);
   }
 
@@ -281,7 +286,8 @@ void GcsNodeManager::HandleGetAllNodeInfo(rpc::GetAllNodeInfoRequest request,
       continue;
     }
   }
-  const size_t total_num_nodes = alive_nodes_.size() + dead_nodes_.size();
+  const size_t total_num_nodes =
+      alive_nodes_.size() + dead_nodes_.size() + (passive_local_node_ != nullptr ? 1 : 0);
   int64_t num_added = 0;
 
   if (request.node_selectors_size() > 0 && only_node_id_filters) {
@@ -292,6 +298,10 @@ void GcsNodeManager::HandleGetAllNodeInfo(rpc::GetAllNodeInfoRequest request,
         auto iter = alive_nodes_.find(node_id);
         if (iter != alive_nodes_.end()) {
           *reply->add_node_info_list() = *iter->second;
+          ++num_added;
+        } else if (passive_local_node_ != nullptr &&
+                   NodeID::FromBinary(passive_local_node_->node_id()) == node_id) {
+          *reply->add_node_info_list() = *passive_local_node_;
           ++num_added;
         }
       }
@@ -329,6 +339,11 @@ void GcsNodeManager::HandleGetAllNodeInfo(rpc::GetAllNodeInfoRequest request,
     if (!request.has_state_filter() ||
         request.state_filter() == rpc::GcsNodeInfo::ALIVE) {
       check_and_add_head_node(alive_nodes_);
+      if (num_added == 0 && passive_local_node_ != nullptr &&
+          passive_local_node_->is_head_node()) {
+        *reply->add_node_info_list() = *passive_local_node_;
+        ++num_added;
+      }
     }
     if (num_added == 0 && (!request.has_state_filter() ||
                            request.state_filter() == rpc::GcsNodeInfo::DEAD)) {
@@ -360,13 +375,29 @@ void GcsNodeManager::HandleGetAllNodeInfo(rpc::GetAllNodeInfoRequest request,
         }
       };
 
+  auto check_and_add_passive_node = [&]() {
+    if (passive_local_node_ != nullptr && num_added < limit) {
+      NodeID node_id = NodeID::FromBinary(passive_local_node_->node_id());
+      if (!has_node_selectors || node_ids.contains(node_id) ||
+          node_names.contains(passive_local_node_->node_name()) ||
+          node_ip_addresses.contains(passive_local_node_->node_manager_address()) ||
+          (is_head_node_filter.has_value() &&
+           passive_local_node_->is_head_node() == is_head_node_filter.value())) {
+        *reply->add_node_info_list() = *passive_local_node_;
+        num_added += 1;
+      }
+    }
+  };
+
   if (request.has_state_filter()) {
     switch (request.state_filter()) {
     case rpc::GcsNodeInfo::ALIVE:
       if (!has_node_selectors) {
-        reply->mutable_node_info_list()->Reserve(alive_nodes_.size());
+        reply->mutable_node_info_list()->Reserve(
+            alive_nodes_.size() + (passive_local_node_ != nullptr ? 1 : 0));
       }
       add_to_response(alive_nodes_);
+      check_and_add_passive_node();
       break;
     case rpc::GcsNodeInfo::DEAD:
       if (!has_node_selectors) {
@@ -380,9 +411,11 @@ void GcsNodeManager::HandleGetAllNodeInfo(rpc::GetAllNodeInfoRequest request,
     }
   } else {
     if (!has_node_selectors) {
-      reply->mutable_node_info_list()->Reserve(alive_nodes_.size() + dead_nodes_.size());
+      reply->mutable_node_info_list()->Reserve(alive_nodes_.size() + dead_nodes_.size() +
+                                               (passive_local_node_ != nullptr ? 1 : 0));
     }
     add_to_response(alive_nodes_);
+    check_and_add_passive_node();
     add_to_response(dead_nodes_);
   }
 
@@ -426,6 +459,10 @@ void GcsNodeManager::GetAllNodeAddressAndLiveness(
         if (iter != alive_nodes_.end()) {
           callback(ConvertToGcsNodeAddressAndLiveness(*iter->second));
           ++num_added;
+        } else if (passive_local_node_ != nullptr &&
+                   NodeID::FromBinary(passive_local_node_->node_id()) == node_id) {
+          callback(ConvertToGcsNodeAddressAndLiveness(*passive_local_node_));
+          ++num_added;
         }
       }
       if (!state_filter.has_value() || state_filter == rpc::GcsNodeInfo::DEAD) {
@@ -451,10 +488,18 @@ void GcsNodeManager::GetAllNodeAddressAndLiveness(
         }
       };
 
+  auto check_and_add_passive_node = [&]() {
+    if (passive_local_node_ != nullptr && num_added < limit) {
+      callback(ConvertToGcsNodeAddressAndLiveness(*passive_local_node_));
+      num_added += 1;
+    }
+  };
+
   if (state_filter.has_value()) {
     switch (state_filter.value()) {
     case rpc::GcsNodeInfo::ALIVE:
       add_with_callback(alive_nodes_);
+      check_and_add_passive_node();
       break;
     case rpc::GcsNodeInfo::DEAD:
       add_with_callback(dead_nodes_);
@@ -465,6 +510,7 @@ void GcsNodeManager::GetAllNodeAddressAndLiveness(
     }
   } else {
     add_with_callback(alive_nodes_);
+    check_and_add_passive_node();
     add_with_callback(dead_nodes_);
   }
 }
@@ -550,6 +596,10 @@ bool GcsNodeManager::IsNodeDead(const ray::NodeID &node_id) const {
 
 bool GcsNodeManager::IsNodeAlive(const ray::NodeID &node_id) const {
   absl::ReaderMutexLock lock(&mutex_);
+  if (passive_local_node_ != nullptr &&
+      NodeID::FromBinary(passive_local_node_->node_id()) == node_id) {
+    return true;
+  }
   return alive_nodes_.contains(node_id);
 }
 

--- a/src/ray/gcs/gcs_node_manager.cc
+++ b/src/ray/gcs/gcs_node_manager.cc
@@ -165,6 +165,8 @@ void GcsNodeManager::HandleCheckAlive(rpc::CheckAliveRequest request,
   reply->set_ray_version(kRayVersion);
   for (const auto &id : request.node_ids()) {
     const auto node_id = NodeID::FromBinary(id);
+    // CheckAlive is un-gated on a passive GCS (cluster-bootstrap allowlist), so it
+    // must report passive_local_node_ alive for visibility only.
     const bool is_alive = alive_nodes_.contains(node_id) ||
                           (passive_local_node_ != nullptr &&
                            NodeID::FromBinary(passive_local_node_->node_id()) == node_id);
@@ -375,6 +377,8 @@ void GcsNodeManager::HandleGetAllNodeInfo(rpc::GetAllNodeInfoRequest request,
         }
       };
 
+  // GetAllNodeInfo is un-gated on a passive GCS (cluster-bootstrap allowlist), so
+  // it must surface passive_local_node_ in listings for visibility only
   auto check_and_add_passive_node = [&]() {
     if (passive_local_node_ != nullptr && num_added < limit) {
       NodeID node_id = NodeID::FromBinary(passive_local_node_->node_id());
@@ -488,6 +492,8 @@ void GcsNodeManager::GetAllNodeAddressAndLiveness(
         }
       };
 
+  // GetAllNodeAddressAndLiveness is un-gated on a passive GCS (cluster-bootstrap
+  // allowlist), so it must surface passive_local_node_. for visibility only.
   auto check_and_add_passive_node = [&]() {
     if (passive_local_node_ != nullptr && num_added < limit) {
       callback(ConvertToGcsNodeAddressAndLiveness(*passive_local_node_));
@@ -596,6 +602,9 @@ bool GcsNodeManager::IsNodeDead(const ray::NodeID &node_id) const {
 
 bool GcsNodeManager::IsNodeAlive(const ray::NodeID &node_id) const {
   absl::ReaderMutexLock lock(&mutex_);
+  // Counts passive_local_node_ as alive so the visibility RPCs un-gated on a
+  // passive GCS (CheckAlive/GetAllNodeInfo, the cluster-bootstrap allowlist) can
+  // report it.
   if (passive_local_node_ != nullptr &&
       NodeID::FromBinary(passive_local_node_->node_id()) == node_id) {
     return true;

--- a/src/ray/gcs/gcs_node_manager.cc
+++ b/src/ray/gcs/gcs_node_manager.cc
@@ -167,9 +167,7 @@ void GcsNodeManager::HandleCheckAlive(rpc::CheckAliveRequest request,
     const auto node_id = NodeID::FromBinary(id);
     // CheckAlive is un-gated on a passive GCS (cluster-bootstrap allowlist), so it
     // must report passive_local_node_ alive for visibility only.
-    const bool is_alive = alive_nodes_.contains(node_id) ||
-                          (passive_local_node_ != nullptr &&
-                           NodeID::FromBinary(passive_local_node_->node_id()) == node_id);
+    const bool is_alive = alive_nodes_.contains(node_id) || IsPassiveLocalNode(node_id);
     reply->mutable_raylet_alive()->Add(is_alive);
   }
 
@@ -288,8 +286,9 @@ void GcsNodeManager::HandleGetAllNodeInfo(rpc::GetAllNodeInfoRequest request,
       continue;
     }
   }
+  const bool has_surfaceable_passive_node = HasSurfaceablePassiveLocalNode();
   const size_t total_num_nodes =
-      alive_nodes_.size() + dead_nodes_.size() + (passive_local_node_ != nullptr ? 1 : 0);
+      alive_nodes_.size() + dead_nodes_.size() + (has_surfaceable_passive_node ? 1 : 0);
   int64_t num_added = 0;
 
   if (request.node_selectors_size() > 0 && only_node_id_filters) {
@@ -301,8 +300,7 @@ void GcsNodeManager::HandleGetAllNodeInfo(rpc::GetAllNodeInfoRequest request,
         if (iter != alive_nodes_.end()) {
           *reply->add_node_info_list() = *iter->second;
           ++num_added;
-        } else if (passive_local_node_ != nullptr &&
-                   NodeID::FromBinary(passive_local_node_->node_id()) == node_id) {
+        } else if (IsPassiveLocalNode(node_id)) {
           *reply->add_node_info_list() = *passive_local_node_;
           ++num_added;
         }
@@ -341,8 +339,7 @@ void GcsNodeManager::HandleGetAllNodeInfo(rpc::GetAllNodeInfoRequest request,
     if (!request.has_state_filter() ||
         request.state_filter() == rpc::GcsNodeInfo::ALIVE) {
       check_and_add_head_node(alive_nodes_);
-      if (num_added == 0 && passive_local_node_ != nullptr &&
-          passive_local_node_->is_head_node()) {
+      if (num_added == 0 && has_surfaceable_passive_node) {
         *reply->add_node_info_list() = *passive_local_node_;
         ++num_added;
       }
@@ -359,6 +356,23 @@ void GcsNodeManager::HandleGetAllNodeInfo(rpc::GetAllNodeInfoRequest request,
   }
 
   const bool has_node_selectors = request.node_selectors_size() > 0;
+  // True if the request has no selectors (return all nodes) or the node matches any
+  // selector by id, name, ip address, or head-node flag.
+  auto node_matches_request_filters = [&](const NodeID &node_id,
+                                          const rpc::GcsNodeInfo &node_info) {
+    return !has_node_selectors || node_ids.contains(node_id) ||
+           node_names.contains(node_info.node_name()) ||
+           node_ip_addresses.contains(node_info.node_manager_address()) ||
+           (is_head_node_filter.has_value() &&
+            node_info.is_head_node() == is_head_node_filter.value());
+  };
+  auto add_node_to_response = [&](const rpc::GcsNodeInfo &node_info) {
+    NodeID node_id = NodeID::FromBinary(node_info.node_id());
+    if (num_added < limit && node_matches_request_filters(node_id, node_info)) {
+      *reply->add_node_info_list() = node_info;
+      num_added += 1;
+    }
+  };
   auto add_to_response =
       [&](const absl::flat_hash_map<NodeID, std::shared_ptr<const rpc::GcsNodeInfo>>
               &nodes) {
@@ -366,42 +380,21 @@ void GcsNodeManager::HandleGetAllNodeInfo(rpc::GetAllNodeInfoRequest request,
           if (num_added >= limit) {
             break;
           }
-          if (!has_node_selectors || node_ids.contains(node_id) ||
-              node_names.contains(node_info_ptr->node_name()) ||
-              node_ip_addresses.contains(node_info_ptr->node_manager_address()) ||
-              (is_head_node_filter.has_value() &&
-               node_info_ptr->is_head_node() == is_head_node_filter.value())) {
-            *reply->add_node_info_list() = *node_info_ptr;
-            num_added += 1;
-          }
+          add_node_to_response(*node_info_ptr);
         }
       };
-
-  // GetAllNodeInfo is un-gated on a passive GCS (cluster-bootstrap allowlist), so
-  // it must surface passive_local_node_ in listings for visibility only
-  auto check_and_add_passive_node = [&]() {
-    if (passive_local_node_ != nullptr && num_added < limit) {
-      NodeID node_id = NodeID::FromBinary(passive_local_node_->node_id());
-      if (!has_node_selectors || node_ids.contains(node_id) ||
-          node_names.contains(passive_local_node_->node_name()) ||
-          node_ip_addresses.contains(passive_local_node_->node_manager_address()) ||
-          (is_head_node_filter.has_value() &&
-           passive_local_node_->is_head_node() == is_head_node_filter.value())) {
-        *reply->add_node_info_list() = *passive_local_node_;
-        num_added += 1;
-      }
-    }
-  };
 
   if (request.has_state_filter()) {
     switch (request.state_filter()) {
     case rpc::GcsNodeInfo::ALIVE:
       if (!has_node_selectors) {
-        reply->mutable_node_info_list()->Reserve(
-            alive_nodes_.size() + (passive_local_node_ != nullptr ? 1 : 0));
+        reply->mutable_node_info_list()->Reserve(alive_nodes_.size() +
+                                                 (has_surfaceable_passive_node ? 1 : 0));
       }
       add_to_response(alive_nodes_);
-      check_and_add_passive_node();
+      if (has_surfaceable_passive_node) {
+        add_node_to_response(*passive_local_node_);
+      }
       break;
     case rpc::GcsNodeInfo::DEAD:
       if (!has_node_selectors) {
@@ -416,10 +409,12 @@ void GcsNodeManager::HandleGetAllNodeInfo(rpc::GetAllNodeInfoRequest request,
   } else {
     if (!has_node_selectors) {
       reply->mutable_node_info_list()->Reserve(alive_nodes_.size() + dead_nodes_.size() +
-                                               (passive_local_node_ != nullptr ? 1 : 0));
+                                               (has_surfaceable_passive_node ? 1 : 0));
     }
     add_to_response(alive_nodes_);
-    check_and_add_passive_node();
+    if (has_surfaceable_passive_node) {
+      add_node_to_response(*passive_local_node_);
+    }
     add_to_response(dead_nodes_);
   }
 
@@ -451,6 +446,7 @@ void GcsNodeManager::GetAllNodeAddressAndLiveness(
     const std::function<void(rpc::GcsNodeAddressAndLiveness &&)> &callback) const {
   absl::ReaderMutexLock lock(&mutex_);
   int64_t num_added = 0;
+  const bool has_surfaceable_passive_node = HasSurfaceablePassiveLocalNode();
 
   if (!node_ids.empty()) {
     // optimized path if request only wants specific node ids
@@ -463,8 +459,7 @@ void GcsNodeManager::GetAllNodeAddressAndLiveness(
         if (iter != alive_nodes_.end()) {
           callback(ConvertToGcsNodeAddressAndLiveness(*iter->second));
           ++num_added;
-        } else if (passive_local_node_ != nullptr &&
-                   NodeID::FromBinary(passive_local_node_->node_id()) == node_id) {
+        } else if (IsPassiveLocalNode(node_id)) {
           callback(ConvertToGcsNodeAddressAndLiveness(*passive_local_node_));
           ++num_added;
         }
@@ -480,6 +475,12 @@ void GcsNodeManager::GetAllNodeAddressAndLiveness(
     return;
   }
 
+  auto add_node_address = [&](const rpc::GcsNodeInfo &node_info) {
+    if (num_added < limit) {
+      callback(ConvertToGcsNodeAddressAndLiveness(node_info));
+      num_added += 1;
+    }
+  };
   auto add_with_callback =
       [&](const absl::flat_hash_map<NodeID, std::shared_ptr<const rpc::GcsNodeInfo>>
               &nodes) {
@@ -487,25 +488,17 @@ void GcsNodeManager::GetAllNodeAddressAndLiveness(
           if (num_added >= limit) {
             break;
           }
-          callback(ConvertToGcsNodeAddressAndLiveness(*node_info_ptr));
-          num_added += 1;
+          add_node_address(*node_info_ptr);
         }
       };
-
-  // GetAllNodeAddressAndLiveness is un-gated on a passive GCS (cluster-bootstrap
-  // allowlist), so it must surface passive_local_node_. for visibility only.
-  auto check_and_add_passive_node = [&]() {
-    if (passive_local_node_ != nullptr && num_added < limit) {
-      callback(ConvertToGcsNodeAddressAndLiveness(*passive_local_node_));
-      num_added += 1;
-    }
-  };
 
   if (state_filter.has_value()) {
     switch (state_filter.value()) {
     case rpc::GcsNodeInfo::ALIVE:
       add_with_callback(alive_nodes_);
-      check_and_add_passive_node();
+      if (has_surfaceable_passive_node) {
+        add_node_address(*passive_local_node_);
+      }
       break;
     case rpc::GcsNodeInfo::DEAD:
       add_with_callback(dead_nodes_);
@@ -516,7 +509,9 @@ void GcsNodeManager::GetAllNodeAddressAndLiveness(
     }
   } else {
     add_with_callback(alive_nodes_);
-    check_and_add_passive_node();
+    if (has_surfaceable_passive_node) {
+      add_node_address(*passive_local_node_);
+    }
     add_with_callback(dead_nodes_);
   }
 }
@@ -602,13 +597,6 @@ bool GcsNodeManager::IsNodeDead(const ray::NodeID &node_id) const {
 
 bool GcsNodeManager::IsNodeAlive(const ray::NodeID &node_id) const {
   absl::ReaderMutexLock lock(&mutex_);
-  // Counts passive_local_node_ as alive so the visibility RPCs un-gated on a
-  // passive GCS (CheckAlive/GetAllNodeInfo, the cluster-bootstrap allowlist) can
-  // report it.
-  if (passive_local_node_ != nullptr &&
-      NodeID::FromBinary(passive_local_node_->node_id()) == node_id) {
-    return true;
-  }
   return alive_nodes_.contains(node_id);
 }
 
@@ -638,6 +626,25 @@ rpc::NodeDeathInfo GcsNodeManager::InferDeathInfo(const NodeID &node_id) {
         "health check failed due to missing too many heartbeats");
   }
   return death_info;
+}
+
+void GcsNodeManager::CachePassiveLocalNode(const rpc::GcsNodeInfo &node_info) {
+  RAY_CHECK(node_info.is_head_node())
+      << "CachePassiveLocalNode must only cache the local head node.";
+  NodeID node_id = NodeID::FromBinary(node_info.node_id());
+  absl::MutexLock lock(&mutex_);
+  // Check under mutex_ so the leader check and the cache write are a single critical
+  // section.
+  if (is_leader_fn_()) {
+    return;
+  }
+  if (alive_nodes_.contains(node_id) || dead_nodes_.contains(node_id)) {
+    return;
+  }
+  RAY_LOG(INFO) << "GCS server is in passive mode. Caching local head node "
+                   "registration in-memory. node_id: "
+                << node_id;
+  passive_local_node_ = std::make_shared<rpc::GcsNodeInfo>(node_info);
 }
 
 void GcsNodeManager::AddNode(std::shared_ptr<const rpc::GcsNodeInfo> node) {

--- a/src/ray/gcs/gcs_node_manager.h
+++ b/src/ray/gcs/gcs_node_manager.h
@@ -15,6 +15,7 @@
 #pragma once
 
 #include <deque>
+#include <functional>
 #include <memory>
 #include <string>
 #include <utility>
@@ -52,15 +53,17 @@ class GcsNodeManager : public rpc::NodeInfoGcsServiceHandler {
   /// \param gcs_table_storage GCS table external storage accessor.
   /// \param observability_publisher Publishes node-related errors to the observability
   /// stream (`PublishError`). Must be non-null for a live GCS server.
-  GcsNodeManager(pubsub::GcsPublisher *gcs_publisher,
-                 GcsTableStorage *gcs_table_storage,
-                 instrumented_io_context &io_context,
-                 rpc::RayletClientPool *raylet_client_pool,
-                 const ClusterID &cluster_id,
-                 observability::RayEventRecorderInterface &ray_event_recorder,
-                 const std::string &session_name,
-                 pubsub::ObservabilityPublisher *observability_publisher,
-                 ClockInterface &clock);
+  GcsNodeManager(
+      pubsub::GcsPublisher *gcs_publisher,
+      GcsTableStorage *gcs_table_storage,
+      instrumented_io_context &io_context,
+      rpc::RayletClientPool *raylet_client_pool,
+      const ClusterID &cluster_id,
+      observability::RayEventRecorderInterface &ray_event_recorder,
+      const std::string &session_name,
+      pubsub::ObservabilityPublisher *observability_publisher,
+      ClockInterface &clock,
+      std::function<bool()> is_leader_fn = []() { return true; });
 
   /// Handle register rpc request come from raylet.
   void HandleGetClusterId(rpc::GetClusterIdRequest request,
@@ -217,6 +220,27 @@ class GcsNodeManager : public rpc::NodeInfoGcsServiceHandler {
   ///
   /// \param gcs_init_data.
   void Initialize(const GcsInitData &gcs_init_data);
+
+  /// Cache the local head node in-memory while passive (called by
+  /// LeaderGatedNodeInfoHandler). Only the head node may be cached.
+  ///
+  /// \param node_info The local head node info to cache.
+  void CachePassiveLocalNode(const rpc::GcsNodeInfo &node_info) {
+    RAY_CHECK(node_info.is_head_node())
+        << "CachePassiveLocalNode must only cache the local head node.";
+    // The handler's passive check and this call are not atomic: leader election
+    // may promote this GCS in between. If we are already the leader, the promotion
+    // path owns node registration, so drop the now-redundant cache.
+    if (is_leader_fn_()) {
+      return;
+    }
+    NodeID node_id = NodeID::FromBinary(node_info.node_id());
+    RAY_LOG(INFO) << "GCS server is in passive mode. Caching local head node "
+                     "registration in-memory. node_id: "
+                  << node_id;
+    absl::MutexLock lock(&mutex_);
+    passive_local_node_ = std::make_shared<rpc::GcsNodeInfo>(node_info);
+  }
 
   std::string DebugString() const;
 
@@ -405,6 +429,8 @@ class GcsNodeManager : public rpc::NodeInfoGcsServiceHandler {
   observability::RayEventRecorderInterface &ray_event_recorder_;
   std::string session_name_;
   ClockInterface &clock_;
+  const std::function<bool()> is_leader_fn_;
+  std::shared_ptr<rpc::GcsNodeInfo> passive_local_node_;
 
   // Debug info.
   enum CountType {

--- a/src/ray/gcs/gcs_node_manager.h
+++ b/src/ray/gcs/gcs_node_manager.h
@@ -222,24 +222,18 @@ class GcsNodeManager : public rpc::NodeInfoGcsServiceHandler {
   void Initialize(const GcsInitData &gcs_init_data);
 
   /// Cache the local head node in-memory while passive (called by
-  /// LeaderGatedNodeInfoHandler). Only the head node may be cached.
+  /// LeaderGatedNodeInfoHandler). Only the head node may be cached. No-op if this GCS
+  /// is already the leader or the node is already tracked in alive_nodes_/dead_nodes_.
   ///
   /// \param node_info The local head node info to cache.
-  void CachePassiveLocalNode(const rpc::GcsNodeInfo &node_info) {
-    RAY_CHECK(node_info.is_head_node())
-        << "CachePassiveLocalNode must only cache the local head node.";
-    // The handler's passive check and this call are not atomic: leader election
-    // may promote this GCS in between. If we are already the leader, the promotion
-    // path owns node registration, so drop the now-redundant cache.
-    if (is_leader_fn_()) {
-      return;
-    }
-    NodeID node_id = NodeID::FromBinary(node_info.node_id());
-    RAY_LOG(INFO) << "GCS server is in passive mode. Caching local head node "
-                     "registration in-memory. node_id: "
-                  << node_id;
+  void CachePassiveLocalNode(const rpc::GcsNodeInfo &node_info);
+
+  /// Drop the cached passive local head node, if any.
+  /// TODO: currently only called in tests; wire it into the real promotion path
+  /// once that is implemented.
+  void ClearPassiveLocalNode() {
     absl::MutexLock lock(&mutex_);
-    passive_local_node_ = std::make_shared<rpc::GcsNodeInfo>(node_info);
+    passive_local_node_.reset();
   }
 
   std::string DebugString() const;
@@ -310,6 +304,28 @@ class GcsNodeManager : public rpc::NodeInfoGcsServiceHandler {
   /// \return the node if it is alive. Optional empty value if it is not alive.
   std::optional<std::shared_ptr<const rpc::GcsNodeInfo>> GetAliveNodeFromCache(
       const ray::NodeID &node_id) const ABSL_SHARED_LOCKS_REQUIRED(mutex_);
+
+  /// Whether a specific node id should be surfaced from the passive local node
+  /// cache by the visibility RPCs.
+  ///
+  /// \param node_id The queried node id.
+  /// \return true if the cached passive local head node has this id and is safe to
+  /// surface.
+  bool IsPassiveLocalNode(const ray::NodeID &node_id) const
+      ABSL_SHARED_LOCKS_REQUIRED(mutex_) {
+    return passive_local_node_ != nullptr &&
+           NodeID::FromBinary(passive_local_node_->node_id()) == node_id &&
+           !alive_nodes_.contains(node_id) && !dead_nodes_.contains(node_id);
+  }
+
+  /// Whether the passive local node cache currently holds a node that should be
+  /// surfaced by the visibility RPCs.
+  ///
+  /// \return true if a surfaceable passive local head node is cached.
+  bool HasSurfaceablePassiveLocalNode() const ABSL_SHARED_LOCKS_REQUIRED(mutex_) {
+    return passive_local_node_ != nullptr &&
+           IsPassiveLocalNode(NodeID::FromBinary(passive_local_node_->node_id()));
+  }
 
   /// Handle a node failure. This will mark the failed node as dead in gcs
   /// node table.
@@ -430,7 +446,13 @@ class GcsNodeManager : public rpc::NodeInfoGcsServiceHandler {
   std::string session_name_;
   ClockInterface &clock_;
   const std::function<bool()> is_leader_fn_;
-  std::shared_ptr<rpc::GcsNodeInfo> passive_local_node_;
+  /// In-memory cache of the local head node while this GCS is passive. Written by
+  /// CachePassiveLocalNode() (not persisted to Redis) and surfaced by the un-gated
+  /// visibility RPCs (CheckAlive/GetAllNodeInfo/GetAllNodeAddressAndLiveness) so the
+  /// head is visible before promotion. Cleared on promotion via ClearPassiveLocalNode();
+  /// readers also skip it once alive_nodes_/dead_nodes_ tracks the id, so it is never
+  /// double-counted.
+  std::shared_ptr<rpc::GcsNodeInfo> passive_local_node_ ABSL_GUARDED_BY(mutex_);
 
   // Debug info.
   enum CountType {

--- a/src/ray/gcs/gcs_server.cc
+++ b/src/ray/gcs/gcs_server.cc
@@ -477,12 +477,6 @@ void GcsServer::RegisterRpcServices() {
         max_rpcs));
   }
 
-  // RaySyncer is registered through the same leader-gating proxy as the other
-  // services for consistency. Its sole method StartSync is *allowed* on a passive
-  // GCS (see LeaderGatedRaySyncerHandler): it is a side-effect-free stream already
-  // scoped upstream at node registration. The proxy exists so any future method
-  // added to the service must explicitly choose its own leader policy.
-  // ray_syncer_service_ (the real handler) is created in InitRaySyncer().
   rpc_server_.RegisterService(std::make_unique<syncer::RaySyncerGrpcService>(
       MaybeGate(gated_ray_syncer_handler_, *ray_syncer_service_)));
 }

--- a/src/ray/gcs/gcs_server.cc
+++ b/src/ray/gcs/gcs_server.cc
@@ -361,10 +361,7 @@ void GcsServer::DoStart(const GcsInitData &gcs_init_data) {
   InitGcsResourceLoadPuller();
   InitUsageStatsClient();
 
-  // Register all gRPC services in one centralized place, after every manager /
-  // handler above has been constructed. Keeping registration out of the InitXxx
-  // methods makes the gated-vs-exempt decision for each service explicit and
-  // auditable, and forces new services to be added here.
+  // Register all gRPC services centrally, after every manager/handler is built.
   RegisterRpcServices();
 
   // Start RPC server when all tables have finished loading initial
@@ -402,16 +399,11 @@ void GcsServer::DoStart(const GcsInitData &gcs_init_data) {
 void GcsServer::RegisterRpcServices() {
   const int64_t max_rpcs = RayConfig::instance().gcs_max_active_rpcs_per_handler();
 
-  // ==========================================================================
-  // Leader-gated services.
-  //
-  // Each real handler is wrapped via MaybeGate() so that, on a passive GCS, the
-  // service's mutating RPCs are rejected with Status::GcsPassive() while bootstrap
-  // / read-only RPCs are still forwarded. When leader election is disabled,
-  // IsLeader() is always true, so every RPC is forwarded unchanged (identical to
-  // the pre-feature behavior). The exact gated-vs-allowed status of each RPC lives
-  // in gcs_leader_gated_handlers.h.
-  // ==========================================================================
+  // Leader-gated services: MaybeGate() wraps each handler so a passive GCS
+  // rejects mutating RPCs with Status::GcsPassive() while forwarding bootstrap/
+  // read RPCs. When leader election is off, IsLeader() is always true and every
+  // RPC is forwarded unchanged. Per-RPC gated/allowed status lives in
+  // gcs_leader_gated_handlers.h.
   rpc_server_.RegisterService(std::make_unique<rpc::NodeInfoGrpcService>(
       io_context_provider_.GetIOContext<GcsNodeManager>(),
       MaybeGate(gated_node_info_handler_,
@@ -485,17 +477,9 @@ void GcsServer::RegisterRpcServices() {
         max_rpcs));
   }
 
-  // ==========================================================================
-  // Intentionally NOT leader-gated.
-  //
-  // RaySyncer is an in-memory resource-view sync channel (a bidirectional stream,
-  // architecturally distinct from the request/response GcsService handlers above,
-  // so it does not fit the LeaderGated* proxy pattern). A passive GCS must keep
-  // receiving these updates to maintain a warm resource view; gating it would
-  // leave the passive GCS with a stale view and slow failover. It performs no
-  // shared-storage writes and has no leader-only side effects, so it is exempt by
-  // design.
-  // ==========================================================================
+  // RaySyncer is an in-memory resource-view stream (not a request/response handler).
+  // It cannot follow the above pattern to be leader gated.
+  // It has no shared-storage writes or leader-only side effects, so it is exempt.
   rpc_server_.RegisterService(std::make_unique<syncer::RaySyncerService>(
       *ray_syncer_, ray::rpc::AuthenticationTokenLoader::instance().GetToken()));
 }

--- a/src/ray/gcs/gcs_server.cc
+++ b/src/ray/gcs/gcs_server.cc
@@ -173,7 +173,10 @@ GcsServer::GcsServer(const ray::gcs::GcsServerConfig &config,
       periodical_runner_(
           PeriodicalRunner::Create(io_context_provider_.GetDefaultIOContext())),
       is_started_(false),
-      is_stopped_(false) {
+      is_stopped_(false),
+      // Leader election disabled => always the leader (legacy single-GCS behavior).
+      // Enabled => start passive; promotion to leader is wired up in a later PR.
+      is_leader_(!config.ray_leader_elect_enabled) {
   // Init GCS table storage. Note this is on the default io context, not the one with
   // GcsInternalKVManager, to avoid congestion on the latter.
   RAY_LOG(INFO) << "GCS storage type is " << storage_type_;
@@ -358,6 +361,12 @@ void GcsServer::DoStart(const GcsInitData &gcs_init_data) {
   InitGcsResourceLoadPuller();
   InitUsageStatsClient();
 
+  // Register all gRPC services in one centralized place, after every manager /
+  // handler above has been constructed. Keeping registration out of the InitXxx
+  // methods makes the gated-vs-exempt decision for each service explicit and
+  // auditable, and forces new services to be added here.
+  RegisterRpcServices();
+
   // Start RPC server when all tables have finished loading initial
   // data.
   rpc_server_.Run();
@@ -388,6 +397,107 @@ void GcsServer::DoStart(const GcsInitData &gcs_init_data) {
   }
 
   is_started_ = true;
+}
+
+void GcsServer::RegisterRpcServices() {
+  const int64_t max_rpcs = RayConfig::instance().gcs_max_active_rpcs_per_handler();
+
+  // ==========================================================================
+  // Leader-gated services.
+  //
+  // Each real handler is wrapped via MaybeGate() so that, on a passive GCS, the
+  // service's mutating RPCs are rejected with Status::GcsPassive() while bootstrap
+  // / read-only RPCs are still forwarded. When leader election is disabled,
+  // IsLeader() is always true, so every RPC is forwarded unchanged (identical to
+  // the pre-feature behavior). The exact gated-vs-allowed status of each RPC lives
+  // in gcs_leader_gated_handlers.h.
+  // ==========================================================================
+  rpc_server_.RegisterService(std::make_unique<rpc::NodeInfoGrpcService>(
+      io_context_provider_.GetIOContext<GcsNodeManager>(),
+      MaybeGate(gated_node_info_handler_,
+                *gcs_node_manager_,
+                std::function<void(const rpc::GcsNodeInfo &)>(
+                    [this](const rpc::GcsNodeInfo &node_info) {
+                      gcs_node_manager_->CachePassiveLocalNode(node_info);
+                    })),
+      max_rpcs));
+
+  rpc_server_.RegisterService(std::make_unique<rpc::NodeResourceInfoGrpcService>(
+      io_context_provider_.GetDefaultIOContext(),
+      MaybeGate(gated_node_resource_info_handler_, *gcs_resource_manager_),
+      max_rpcs));
+
+  rpc_server_.RegisterService(std::make_unique<rpc::JobInfoGrpcService>(
+      io_context_provider_.GetDefaultIOContext(),
+      MaybeGate(gated_job_info_handler_, *gcs_job_manager_),
+      max_rpcs));
+
+  rpc_server_.RegisterService(std::make_unique<rpc::ActorInfoGrpcService>(
+      io_context_provider_.GetDefaultIOContext(),
+      MaybeGate(gated_actor_info_handler_, *gcs_actor_manager_),
+      max_rpcs));
+
+  rpc_server_.RegisterService(std::make_unique<rpc::PlacementGroupInfoGrpcService>(
+      io_context_provider_.GetDefaultIOContext(),
+      MaybeGate(gated_placement_group_info_handler_, *gcs_placement_group_manager_),
+      max_rpcs));
+
+  rpc_server_.RegisterService(
+      std::make_unique<rpc::InternalKVGrpcService>(
+          io_context_provider_.GetIOContext<GcsInternalKVManager>(),
+          MaybeGate(gated_internal_kv_handler_, *kv_manager_),
+          /*max_active_rpcs_per_handler_=*/-1),
+      false /* token_auth */);
+
+  // Long-poll pubsub services: no active-RPC limit.
+  rpc_server_.RegisterService(std::make_unique<rpc::ControlPlanePubSubGrpcService>(
+      io_context_provider_.GetIOContext<pubsub::GcsPublisher>(),
+      MaybeGate(gated_control_plane_pubsub_handler_, *pubsub_handler_),
+      /*max_active_rpcs_per_handler_=*/-1));
+  rpc_server_.RegisterService(std::make_unique<rpc::ObservabilityPubSubGrpcService>(
+      io_context_provider_.GetIOContext<pubsub::ObservabilityPublisher>(),
+      MaybeGate(gated_observability_pubsub_handler_, *observability_pubsub_handler_),
+      /*max_active_rpcs_per_handler_=*/-1));
+
+  rpc_server_.RegisterService(std::make_unique<rpc::RuntimeEnvGrpcService>(
+      io_context_provider_.GetDefaultIOContext(),
+      MaybeGate(gated_runtime_env_handler_, *runtime_env_handler_),
+      /*max_active_rpcs_per_handler=*/-1));
+
+  rpc_server_.RegisterService(std::make_unique<rpc::WorkerInfoGrpcService>(
+      io_context_provider_.GetDefaultIOContext(),
+      MaybeGate(gated_worker_info_handler_, *gcs_worker_manager_),
+      max_rpcs));
+
+  rpc_server_.RegisterService(
+      std::make_unique<rpc::autoscaler::AutoscalerStateGrpcService>(
+          io_context_provider_.GetDefaultIOContext(),
+          MaybeGate(gated_autoscaler_state_handler_, *gcs_autoscaler_state_manager_),
+          max_rpcs));
+
+  {
+    auto &task_io = io_context_provider_.GetIOContext<GcsTaskManager>();
+    rpc_server_.RegisterService(std::make_unique<rpc::TaskInfoGrpcService>(
+        task_io, MaybeGate(gated_task_info_handler_, *gcs_task_manager_), max_rpcs));
+    rpc_server_.RegisterService(std::make_unique<rpc::events::RayEventExportGrpcService>(
+        task_io,
+        MaybeGate(gated_ray_event_export_handler_, *gcs_task_manager_),
+        max_rpcs));
+  }
+
+  // ==========================================================================
+  // Intentionally NOT leader-gated.
+  //
+  // RaySyncer is an in-memory resource-view sync channel (a bidirectional stream,
+  // architecturally distinct from the request/response GcsService handlers above,
+  // so it does not fit the LeaderGated* proxy pattern). A passive GCS must keep
+  // receiving these updates to maintain a warm resource view; gating it would
+  // leave the passive GCS with a stale view and slow failover. It performs no
+  // shared-storage writes and has no leader-only side effects, so it is exempt by
+  // design.
+  // ==========================================================================
+  rpc_server_.RegisterService(std::make_unique<syncer::RaySyncerService>(
+      *ray_syncer_, ray::rpc::AuthenticationTokenLoader::instance().GetToken()));
 }
 
 void GcsServer::Stop() {
@@ -437,13 +547,11 @@ void GcsServer::InitGcsNodeManager(const GcsInitData &gcs_init_data) {
       *ray_event_recorder_,
       config_.session_name,
       observability_publisher_.get(),
-      clock_);
+      clock_,
+      [this]() { return IsLeader(); });
   // Initialize by gcs tables data.
   gcs_node_manager_->Initialize(gcs_init_data);
-  rpc_server_.RegisterService(std::make_unique<rpc::NodeInfoGrpcService>(
-      io_context_provider_.GetIOContext<GcsNodeManager>(),
-      *gcs_node_manager_,
-      RayConfig::instance().gcs_max_active_rpcs_per_handler()));
+  // Service registration is centralized in RegisterRpcServices().
 }
 
 void GcsServer::InitGcsHealthCheckManager(const GcsInitData &gcs_init_data) {
@@ -512,10 +620,7 @@ void GcsServer::InitGcsResourceManager(const GcsInitData &gcs_init_data) {
 
   // Initialize by gcs tables data.
   gcs_resource_manager_->Initialize(gcs_init_data);
-  rpc_server_.RegisterService(std::make_unique<rpc::NodeResourceInfoGrpcService>(
-      io_context_provider_.GetDefaultIOContext(),
-      *gcs_resource_manager_,
-      RayConfig::instance().gcs_max_active_rpcs_per_handler()));
+  // Service registration is centralized in RegisterRpcServices().
 }
 
 void GcsServer::InitGcsResourceLoadPuller() {
@@ -589,11 +694,7 @@ void GcsServer::InitGcsJobManager(
                                       job_duration_in_seconds_gauge,
                                       clock_);
   gcs_job_manager_->Initialize(gcs_init_data);
-
-  rpc_server_.RegisterService(std::make_unique<rpc::JobInfoGrpcService>(
-      io_context_provider_.GetDefaultIOContext(),
-      *gcs_job_manager_,
-      RayConfig::instance().gcs_max_active_rpcs_per_handler()));
+  // Service registration is centralized in RegisterRpcServices().
 }
 
 void GcsServer::InitGcsActorManager(
@@ -649,10 +750,7 @@ void GcsServer::InitGcsActorManager(
       clock_);
 
   gcs_actor_manager_->Initialize(gcs_init_data);
-  rpc_server_.RegisterService(std::make_unique<rpc::ActorInfoGrpcService>(
-      io_context_provider_.GetDefaultIOContext(),
-      *gcs_actor_manager_,
-      RayConfig::instance().gcs_max_active_rpcs_per_handler()));
+  // Service registration is centralized in RegisterRpcServices().
 }
 
 void GcsServer::InitGcsPlacementGroupManager(
@@ -685,10 +783,7 @@ void GcsServer::InitGcsPlacementGroupManager(
       clock_);
 
   gcs_placement_group_manager_->Initialize(gcs_init_data);
-  rpc_server_.RegisterService(std::make_unique<rpc::PlacementGroupInfoGrpcService>(
-      io_context_provider_.GetDefaultIOContext(),
-      *gcs_placement_group_manager_,
-      RayConfig::instance().gcs_max_active_rpcs_per_handler()));
+  // Service registration is centralized in RegisterRpcServices().
 }
 
 GcsServer::StorageType GcsServer::GetStorageType() const {
@@ -746,8 +841,7 @@ void GcsServer::InitRaySyncer(const GcsInitData &gcs_init_data) {
       syncer::MessageType::RESOURCE_VIEW, nullptr, gcs_resource_manager_.get());
   ray_syncer_->Register(
       syncer::MessageType::COMMANDS, nullptr, gcs_resource_manager_.get());
-  rpc_server_.RegisterService(std::make_unique<syncer::RaySyncerService>(
-      *ray_syncer_, ray::rpc::AuthenticationTokenLoader::instance().GetToken()));
+  // The RaySyncerService is constructed and registered in RegisterRpcServices().
 }
 
 void GcsServer::InitFunctionManager() {
@@ -824,12 +918,7 @@ void GcsServer::InitKVManager() {
 
 void GcsServer::InitKVService() {
   RAY_CHECK(kv_manager_);
-  rpc_server_.RegisterService(
-      std::make_unique<rpc::InternalKVGrpcService>(
-          io_context_provider_.GetIOContext<GcsInternalKVManager>(),
-          *kv_manager_,
-          /*max_active_rpcs_per_handler_=*/-1),
-      false /* token_auth */);
+  // Service registration is centralized in RegisterRpcServices().
 }
 
 void GcsServer::InitPubSubHandler() {
@@ -837,15 +926,10 @@ void GcsServer::InitPubSubHandler() {
   pubsub_handler_ =
       std::make_unique<ControlPlanePubSubHandler>(io_context, *gcs_publisher_);
 
-  // This service is used to handle long poll requests, so we don't limit active RPCs.
-  rpc_server_.RegisterService(std::make_unique<rpc::ControlPlanePubSubGrpcService>(
-      io_context, *pubsub_handler_, /*max_active_rpcs_per_handler_=*/-1));
-
   auto &obs_io = io_context_provider_.GetIOContext<pubsub::ObservabilityPublisher>();
   observability_pubsub_handler_ =
       std::make_unique<ObservabilityPubSubHandler>(obs_io, *observability_publisher_);
-  rpc_server_.RegisterService(std::make_unique<rpc::ObservabilityPubSubGrpcService>(
-      obs_io, *observability_pubsub_handler_, /*max_active_rpcs_per_handler_=*/-1));
+  // Service registration is centralized in RegisterRpcServices().
 }
 
 void GcsServer::InitRuntimeEnvManager() {
@@ -886,10 +970,7 @@ void GcsServer::InitRuntimeEnvManager() {
                              std::move(task),
                              std::chrono::milliseconds(delay_ms));
       });
-  rpc_server_.RegisterService(std::make_unique<rpc::RuntimeEnvGrpcService>(
-      io_context_provider_.GetDefaultIOContext(),
-      *runtime_env_handler_,
-      /*max_active_rpcs_per_handler=*/-1));
+  // Service registration is centralized in RegisterRpcServices().
 }
 
 void GcsServer::InitGcsWorkerManager(const GcsInitData &gcs_init_data) {
@@ -899,10 +980,7 @@ void GcsServer::InitGcsWorkerManager(const GcsInitData &gcs_init_data) {
                                          *gcs_publisher_,
                                          *ray_event_recorder_,
                                          config_.session_name);
-  rpc_server_.RegisterService(std::make_unique<rpc::WorkerInfoGrpcService>(
-      io_context_provider_.GetDefaultIOContext(),
-      *gcs_worker_manager_,
-      RayConfig::instance().gcs_max_active_rpcs_per_handler()));
+  // Service registration is centralized in RegisterRpcServices().
   // No-op unless dead worker entries survived a GCS restart (Redis FT).
   gcs_worker_manager_->RestoreDeadWorkerIdsQueue(gcs_init_data);
 }
@@ -952,11 +1030,7 @@ void GcsServer::InitGcsAutoscalerStateManager(const GcsInitData &gcs_init_data) 
       observability_publisher_.get(),
       clock_);
   gcs_autoscaler_state_manager_->Initialize(gcs_init_data);
-  rpc_server_.RegisterService(
-      std::make_unique<rpc::autoscaler::AutoscalerStateGrpcService>(
-          io_context_provider_.GetDefaultIOContext(),
-          *gcs_autoscaler_state_manager_,
-          RayConfig::instance().gcs_max_active_rpcs_per_handler()));
+  // Service registration is centralized in RegisterRpcServices().
 }
 
 void GcsServer::InitGcsTaskManager(
@@ -970,15 +1044,7 @@ void GcsServer::InitGcsTaskManager(
                                        task_events_reported_gauge,
                                        task_events_dropped_gauge,
                                        task_events_stored_gauge);
-  // Register service.
-  rpc_server_.RegisterService(std::make_unique<rpc::TaskInfoGrpcService>(
-      io_context,
-      *gcs_task_manager_,
-      RayConfig::instance().gcs_max_active_rpcs_per_handler()));
-  rpc_server_.RegisterService(std::make_unique<rpc::events::RayEventExportGrpcService>(
-      io_context,
-      *gcs_task_manager_,
-      RayConfig::instance().gcs_max_active_rpcs_per_handler()));
+  // Service registration is centralized in RegisterRpcServices().
 }
 
 void GcsServer::InstallEventListeners() {

--- a/src/ray/gcs/gcs_server.cc
+++ b/src/ray/gcs/gcs_server.cc
@@ -477,11 +477,14 @@ void GcsServer::RegisterRpcServices() {
         max_rpcs));
   }
 
-  // RaySyncer is an in-memory resource-view stream (not a request/response handler).
-  // It cannot follow the above pattern to be leader gated.
-  // It has no shared-storage writes or leader-only side effects, so it is exempt.
-  rpc_server_.RegisterService(std::make_unique<syncer::RaySyncerService>(
-      *ray_syncer_, ray::rpc::AuthenticationTokenLoader::instance().GetToken()));
+  // RaySyncer is registered through the same leader-gating proxy as the other
+  // services for consistency. Its sole method StartSync is *allowed* on a passive
+  // GCS (see LeaderGatedRaySyncerHandler): it is a side-effect-free stream already
+  // scoped upstream at node registration. The proxy exists so any future method
+  // added to the service must explicitly choose its own leader policy.
+  // ray_syncer_service_ (the real handler) is created in InitRaySyncer().
+  rpc_server_.RegisterService(std::make_unique<syncer::RaySyncerGrpcService>(
+      MaybeGate(gated_ray_syncer_handler_, *ray_syncer_service_)));
 }
 
 void GcsServer::Stop() {
@@ -825,7 +828,10 @@ void GcsServer::InitRaySyncer(const GcsInitData &gcs_init_data) {
       syncer::MessageType::RESOURCE_VIEW, nullptr, gcs_resource_manager_.get());
   ray_syncer_->Register(
       syncer::MessageType::COMMANDS, nullptr, gcs_resource_manager_.get());
-  // The RaySyncerService is constructed and registered in RegisterRpcServices().
+  // Create the stream handler here alongside the syncer; RegisterRpcServices()
+  // only wraps it in the leader-gating proxy and registers it.
+  ray_syncer_service_ = std::make_unique<syncer::RaySyncerService>(
+      *ray_syncer_, ray::rpc::AuthenticationTokenLoader::instance().GetToken());
 }
 
 void GcsServer::InitFunctionManager() {

--- a/src/ray/gcs/gcs_server.cc
+++ b/src/ray/gcs/gcs_server.cc
@@ -399,11 +399,11 @@ void GcsServer::DoStart(const GcsInitData &gcs_init_data) {
 void GcsServer::RegisterRpcServices() {
   const int64_t max_rpcs = RayConfig::instance().gcs_max_active_rpcs_per_handler();
 
-  // Leader-gated services: MaybeGate() wraps each handler so a passive GCS
-  // rejects mutating RPCs with Status::GcsPassive() while forwarding bootstrap/
-  // read RPCs. When leader election is off, IsLeader() is always true and every
-  // RPC is forwarded unchanged. Per-RPC gated/allowed status lives in
-  // gcs_leader_gated_handlers.h.
+  // Leader-gated services: MaybeGate() wraps each handler when leader election is
+  // enabled, so a passive GCS rejects mutating RPCs with Status::GcsPassive()
+  // while forwarding bootstrap/read RPCs. When leader election is off, MaybeGate()
+  // returns the real handler directly with zero overhead. Per-RPC gated/allowed
+  // status lives in gcs_leader_gated_handlers.h.
   rpc_server_.RegisterService(std::make_unique<rpc::NodeInfoGrpcService>(
       io_context_provider_.GetIOContext<GcsNodeManager>(),
       MaybeGate(gated_node_info_handler_,

--- a/src/ray/gcs/gcs_server.h
+++ b/src/ray/gcs/gcs_server.h
@@ -336,6 +336,7 @@ class GcsServer {
   std::unique_ptr<LeaderGatedObservabilityPubSubHandler>
       gated_observability_pubsub_handler_;
   std::unique_ptr<LeaderGatedRayEventExportHandler> gated_ray_event_export_handler_;
+  std::unique_ptr<LeaderGatedRaySyncerHandler> gated_ray_syncer_handler_;
 
   /// Ray Syncer related fields.
   std::unique_ptr<syncer::RaySyncer> ray_syncer_;

--- a/src/ray/gcs/gcs_server.h
+++ b/src/ray/gcs/gcs_server.h
@@ -154,24 +154,11 @@ class GcsServer {
   }
 
  protected:
-  // Wraps `real_handler` in the corresponding LeaderGated* proxy and returns a
-  // reference (typed as the wrapper's base handler interface `GatedT::HandlerType`,
-  // the exact type the GrpcService expects) suitable to pass to RegisterService.
-  // The wrapper is stored in `slot` to keep it alive for the lifetime of the
-  // GrpcService, which holds the handler by reference.
-  //
-  // The wrapper is always installed, regardless of whether leader election is
-  // enabled: when it is disabled, `IsLeader()` is always true so every RPC is
-  // forwarded to the real handler unchanged (identical behavior to registering the
-  // raw handler). This keeps the registration path uniform and avoids per-service
-  // branching on the feature flag.
-  //
-  // Typing the return as `GatedT::HandlerType` (rather than deducing it from the
-  // concrete manager) matters for managers that implement multiple handler
-  // interfaces (e.g. GcsTaskManager implements both TaskInfo and RayEventExport
-  // handlers): the interface must be selected by the wrapper. Any `extra` arguments
-  // are forwarded to the wrapper's constructor after the is-leader callback (e.g.
-  // the cache-local-node callback for NodeInfo).
+  // Builds the leader-gated handler to pass to a GrpcService's RegisterService.
+  // Given the real handler, returns a `GatedT` proxy that forwards each RPC only
+  // when IsLeader() is true and otherwise rejects it (see GatedT for per-RPC
+  // policy). With leader election off IsLeader() is always true, so this is a
+  // transparent pass-through.
   template <typename GatedT, typename RealHandlerT, typename... ExtraArgs>
   typename GatedT::HandlerType &MaybeGate(std::unique_ptr<GatedT> &slot,
                                           RealHandlerT &real_handler,
@@ -183,11 +170,8 @@ class GcsServer {
 
   void DoStart(const GcsInitData &gcs_init_data);
 
-  /// Register all GCS gRPC services on rpc_server_. This is the single, centralized
-  /// place where every service is registered, so whether a service is leader-gated
-  /// (via MaybeGate) or intentionally exempt is explicit and auditable in one spot.
-  /// Adding a new GCS service requires editing this method, which makes it hard to
-  /// forget to make a new mutating service leader-gated.
+  /// Register all GCS gRPC services on rpc_server_ in one place, so each service's
+  /// gated-vs-exempt status is explicit and a new service must be added here.
   void RegisterRpcServices();
 
   /// Initialize gcs node manager.

--- a/src/ray/gcs/gcs_server.h
+++ b/src/ray/gcs/gcs_server.h
@@ -28,6 +28,7 @@
 #include "ray/gcs/gcs_health_check_manager.h"
 #include "ray/gcs/gcs_init_data.h"
 #include "ray/gcs/gcs_kv_manager.h"
+#include "ray/gcs/gcs_leader_gated_handlers.h"
 #include "ray/gcs/gcs_resource_manager.h"
 #include "ray/gcs/gcs_server_io_context_policy.h"
 #include "ray/gcs/gcs_table_storage.h"
@@ -73,6 +74,10 @@ struct GcsServerConfig {
   // This includes the config list of raylet.
   std::string raylet_config_list;
   std::string session_name;
+  // Whether GCS active-passive leader election is enabled. When true, the GCS
+  // server boots as passive and its mutating RPCs are gated until it is promoted
+  // to the active leader. Defaults to false (single active GCS, legacy behavior).
+  bool ray_leader_elect_enabled = false;
 };
 
 class GcsNodeManager;
@@ -123,6 +128,9 @@ class GcsServer {
   /// Check if gcs server is stopped.
   bool IsStopped() const { return is_stopped_; }
 
+  /// Check if this GCS server instance is currently the active leader.
+  bool IsLeader() const { return is_leader_.load(); }
+
   /// Retrieve cluster ID
   const ClusterID &GetClusterId() const { return rpc_server_.GetClusterId(); }
 
@@ -146,7 +154,41 @@ class GcsServer {
   }
 
  protected:
+  // Wraps `real_handler` in the corresponding LeaderGated* proxy and returns a
+  // reference (typed as the wrapper's base handler interface `GatedT::HandlerType`,
+  // the exact type the GrpcService expects) suitable to pass to RegisterService.
+  // The wrapper is stored in `slot` to keep it alive for the lifetime of the
+  // GrpcService, which holds the handler by reference.
+  //
+  // The wrapper is always installed, regardless of whether leader election is
+  // enabled: when it is disabled, `IsLeader()` is always true so every RPC is
+  // forwarded to the real handler unchanged (identical behavior to registering the
+  // raw handler). This keeps the registration path uniform and avoids per-service
+  // branching on the feature flag.
+  //
+  // Typing the return as `GatedT::HandlerType` (rather than deducing it from the
+  // concrete manager) matters for managers that implement multiple handler
+  // interfaces (e.g. GcsTaskManager implements both TaskInfo and RayEventExport
+  // handlers): the interface must be selected by the wrapper. Any `extra` arguments
+  // are forwarded to the wrapper's constructor after the is-leader callback (e.g.
+  // the cache-local-node callback for NodeInfo).
+  template <typename GatedT, typename RealHandlerT, typename... ExtraArgs>
+  typename GatedT::HandlerType &MaybeGate(std::unique_ptr<GatedT> &slot,
+                                          RealHandlerT &real_handler,
+                                          ExtraArgs &&...extra) {
+    slot = std::make_unique<GatedT>(
+        real_handler, [this]() { return IsLeader(); }, std::forward<ExtraArgs>(extra)...);
+    return *slot;
+  }
+
   void DoStart(const GcsInitData &gcs_init_data);
+
+  /// Register all GCS gRPC services on rpc_server_. This is the single, centralized
+  /// place where every service is registered, so whether a service is leader-gated
+  /// (via MaybeGate) or intentionally exempt is explicit and auditable in one spot.
+  /// Adding a new GCS service requires editing this method, which makes it hard to
+  /// forget to make a new mutating service leader-gated.
+  void RegisterRpcServices();
 
   /// Initialize gcs node manager.
   void InitGcsNodeManager(const GcsInitData &gcs_init_data);
@@ -291,6 +333,26 @@ class GcsServer {
   std::unique_ptr<rpc::EventAggregatorClient> event_aggregator_client_;
   std::unique_ptr<observability::RayEventRecorder> ray_event_recorder_;
 
+  // Leader-gated proxy handlers. Each wraps the real service handler and, on a
+  // passive GCS, rejects that service's mutating RPCs. They are owned here so they
+  // outlive the GrpcServices that reference them. See RegisterRpcServices().
+  std::unique_ptr<LeaderGatedNodeInfoHandler> gated_node_info_handler_;
+  std::unique_ptr<LeaderGatedActorInfoHandler> gated_actor_info_handler_;
+  std::unique_ptr<LeaderGatedJobInfoHandler> gated_job_info_handler_;
+  std::unique_ptr<LeaderGatedPlacementGroupInfoHandler>
+      gated_placement_group_info_handler_;
+  std::unique_ptr<LeaderGatedAutoscalerStateHandler> gated_autoscaler_state_handler_;
+  std::unique_ptr<LeaderGatedInternalKVHandler> gated_internal_kv_handler_;
+  std::unique_ptr<LeaderGatedNodeResourceInfoHandler> gated_node_resource_info_handler_;
+  std::unique_ptr<LeaderGatedWorkerInfoHandler> gated_worker_info_handler_;
+  std::unique_ptr<LeaderGatedTaskInfoHandler> gated_task_info_handler_;
+  std::unique_ptr<LeaderGatedRuntimeEnvHandler> gated_runtime_env_handler_;
+  std::unique_ptr<LeaderGatedControlPlanePubSubHandler>
+      gated_control_plane_pubsub_handler_;
+  std::unique_ptr<LeaderGatedObservabilityPubSubHandler>
+      gated_observability_pubsub_handler_;
+  std::unique_ptr<LeaderGatedRayEventExportHandler> gated_ray_event_export_handler_;
+
   /// Ray Syncer related fields.
   std::unique_ptr<syncer::RaySyncer> ray_syncer_;
   std::unique_ptr<syncer::RaySyncerService> ray_syncer_service_;
@@ -317,6 +379,11 @@ class GcsServer {
   /// GCS service state flag, which is used for unit tests.
   std::atomic<bool> is_started_;
   std::atomic<bool> is_stopped_;
+  /// Whether this GCS is currently the active leader. Initialized from
+  /// config_.ray_leader_elect_enabled: leader election disabled => always leader
+  /// (legacy behavior); enabled => starts passive until promoted (promotion wired
+  /// up in a later PR).
+  std::atomic<bool> is_leader_;
   /// Flag to ensure InitMetricsExporter is only called once.
   std::atomic<bool> metrics_exporter_initialized_ = false;
   // Invoked when the RPC server has bound to a port.

--- a/src/ray/gcs/gcs_server.h
+++ b/src/ray/gcs/gcs_server.h
@@ -154,15 +154,20 @@ class GcsServer {
   }
 
  protected:
-  // Builds the leader-gated handler to pass to a GrpcService's RegisterService.
-  // Given the real handler, returns a `GatedT` proxy that forwards each RPC only
-  // when IsLeader() is true and otherwise rejects it (see GatedT for per-RPC
-  // policy). With leader election off IsLeader() is always true, so this is a
-  // transparent pass-through.
+  // Returns the handler to register for a GrpcService. When leader election is
+  // disabled the real handler is used directly (no wrapper, no per-RPC leader
+  // check), so non-HA clusters behave exactly as before with zero overhead.
+  // When enabled, the real handler is wrapped in a `GatedT` proxy (stored in `slot`
+  // to outlive the GrpcService, which holds it by reference) that rejects the
+  // service's mutating RPCs while passive. Any `extra` args are forwarded to
+  // the proxy constructor.
   template <typename GatedT, typename RealHandlerT, typename... ExtraArgs>
   typename GatedT::HandlerType &MaybeGate(std::unique_ptr<GatedT> &slot,
                                           RealHandlerT &real_handler,
                                           ExtraArgs &&...extra) {
+    if (!config_.ray_leader_elect_enabled) {
+      return real_handler;
+    }
     slot = std::make_unique<GatedT>(
         real_handler, [this]() { return IsLeader(); }, std::forward<ExtraArgs>(extra)...);
     return *slot;
@@ -318,8 +323,7 @@ class GcsServer {
   std::unique_ptr<observability::RayEventRecorder> ray_event_recorder_;
 
   // Leader-gated proxy handlers. Each wraps the real service handler and, on a
-  // passive GCS, rejects that service's mutating RPCs. They are owned here so they
-  // outlive the GrpcServices that reference them. See RegisterRpcServices().
+  // passive GCS, rejects that service's mutating RPCs.
   std::unique_ptr<LeaderGatedNodeInfoHandler> gated_node_info_handler_;
   std::unique_ptr<LeaderGatedActorInfoHandler> gated_actor_info_handler_;
   std::unique_ptr<LeaderGatedJobInfoHandler> gated_job_info_handler_;

--- a/src/ray/gcs/tests/BUILD.bazel
+++ b/src/ray/gcs/tests/BUILD.bazel
@@ -454,3 +454,15 @@ ray_cc_test(
         "//src/ray/gcs:gcs_ray_event_converter",
     ],
 )
+
+ray_cc_test(
+    name = "gcs_leader_gated_handlers_test",
+    size = "small",
+    srcs = ["gcs_leader_gated_handlers_test.cc"],
+    tags = ["team:core"],
+    visibility = ["//visibility:private"],
+    deps = [
+        "//src/ray/common:test_utils",
+        "//src/ray/gcs:gcs_server_lib",
+    ],
+)

--- a/src/ray/gcs/tests/gcs_leader_gated_handlers_test.cc
+++ b/src/ray/gcs/tests/gcs_leader_gated_handlers_test.cc
@@ -1,0 +1,1317 @@
+// Copyright 2025 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "ray/gcs/gcs_leader_gated_handlers.h"
+
+#include <memory>
+#include <string>
+
+#include "gtest/gtest.h"
+
+namespace ray {
+namespace gcs {
+
+// =========================================================================
+// 1. JobInfo Service Gating Tests
+// =========================================================================
+
+class MockJobInfoGcsServiceHandler : public rpc::JobInfoGcsServiceHandler {
+ public:
+  void HandleAddJob(rpc::AddJobRequest request,
+                    rpc::AddJobReply *reply,
+                    rpc::SendReplyCallback send_reply_callback) override {
+    called_ = true;
+    send_reply_callback(Status::OK(), nullptr, nullptr);
+  }
+
+  void HandleMarkJobFinished(rpc::MarkJobFinishedRequest request,
+                             rpc::MarkJobFinishedReply *reply,
+                             rpc::SendReplyCallback send_reply_callback) override {
+    called_ = true;
+    send_reply_callback(Status::OK(), nullptr, nullptr);
+  }
+
+  void HandleGetAllJobInfo(rpc::GetAllJobInfoRequest request,
+                           rpc::GetAllJobInfoReply *reply,
+                           rpc::SendReplyCallback send_reply_callback) override {
+    called_ = true;
+    send_reply_callback(Status::OK(), nullptr, nullptr);
+  }
+
+  void AddJobFinishedListener(JobFinishListenerCallback listener) override {}
+
+  void HandleGetNextJobID(rpc::GetNextJobIDRequest request,
+                          rpc::GetNextJobIDReply *reply,
+                          rpc::SendReplyCallback send_reply_callback) override {
+    called_ = true;
+    send_reply_callback(Status::OK(), nullptr, nullptr);
+  }
+
+  bool called_ = false;
+};
+
+TEST(GcsLeaderGatedHandlersTest, TestJobGating) {
+  MockJobInfoGcsServiceHandler underlying;
+  bool is_leader = false;
+  auto is_leader_fn = [&is_leader]() { return is_leader; };
+
+  LeaderGatedJobInfoHandler proxy(underlying, is_leader_fn);
+
+  // 1. Passive mode: unallowed mutating and read RPCs must be BLOCKED.
+  {
+    rpc::AddJobRequest request;
+    rpc::AddJobReply reply;
+    bool callback_called = false;
+    auto send_reply_callback = [&callback_called, &reply](Status status,
+                                                          std::function<void()> f1,
+                                                          std::function<void()> f2) {
+      EXPECT_TRUE(status.ok());
+      Status logical_status =
+          Status(StatusCode(reply.status().code()), reply.status().message());
+      EXPECT_TRUE(logical_status.IsGcsPassive());
+      callback_called = true;
+    };
+    proxy.HandleAddJob(request, &reply, send_reply_callback);
+    EXPECT_TRUE(callback_called);
+    EXPECT_FALSE(underlying.called_);
+  }
+  {
+    rpc::GetAllJobInfoRequest request;
+    rpc::GetAllJobInfoReply reply;
+    bool callback_called = false;
+    auto send_reply_callback = [&callback_called, &reply](Status status,
+                                                          std::function<void()> f1,
+                                                          std::function<void()> f2) {
+      EXPECT_TRUE(status.ok());
+      Status logical_status =
+          Status(StatusCode(reply.status().code()), reply.status().message());
+      EXPECT_TRUE(logical_status.IsGcsPassive());
+      callback_called = true;
+    };
+    proxy.HandleGetAllJobInfo(request, &reply, send_reply_callback);
+    EXPECT_TRUE(callback_called);
+    EXPECT_FALSE(underlying.called_);
+    underlying.called_ = false;
+  }
+
+  // 2. Passive mode: allowlisted RPCs (None for JobInfo service).
+
+  // 3. Leader mode: all RPCs work.
+  {
+    is_leader = true;
+    rpc::AddJobRequest request;
+    rpc::AddJobReply reply;
+    bool callback_called = false;
+    auto send_reply_callback = [&callback_called](Status status,
+                                                  std::function<void()> f1,
+                                                  std::function<void()> f2) {
+      EXPECT_TRUE(status.ok());
+      callback_called = true;
+    };
+    proxy.HandleAddJob(request, &reply, send_reply_callback);
+    EXPECT_TRUE(callback_called);
+    EXPECT_TRUE(underlying.called_);
+    underlying.called_ = false;
+  }
+  {
+    rpc::GetAllJobInfoRequest request;
+    rpc::GetAllJobInfoReply reply;
+    bool callback_called = false;
+    auto send_reply_callback = [&callback_called](Status status,
+                                                  std::function<void()> f1,
+                                                  std::function<void()> f2) {
+      EXPECT_TRUE(status.ok());
+      callback_called = true;
+    };
+    proxy.HandleGetAllJobInfo(request, &reply, send_reply_callback);
+    EXPECT_TRUE(callback_called);
+    EXPECT_TRUE(underlying.called_);
+  }
+}
+
+// =========================================================================
+// 2. InternalKV Service Gating Tests
+// =========================================================================
+
+class MockInternalKVGcsServiceHandler : public rpc::InternalKVGcsServiceHandler {
+ public:
+  void HandleInternalKVKeys(rpc::InternalKVKeysRequest request,
+                            rpc::InternalKVKeysReply *reply,
+                            rpc::SendReplyCallback send_reply_callback) override {
+    called_ = true;
+    send_reply_callback(Status::OK(), nullptr, nullptr);
+  }
+
+  void HandleInternalKVGet(rpc::InternalKVGetRequest request,
+                           rpc::InternalKVGetReply *reply,
+                           rpc::SendReplyCallback send_reply_callback) override {
+    called_ = true;
+    send_reply_callback(Status::OK(), nullptr, nullptr);
+  }
+
+  void HandleInternalKVMultiGet(rpc::InternalKVMultiGetRequest request,
+                                rpc::InternalKVMultiGetReply *reply,
+                                rpc::SendReplyCallback send_reply_callback) override {
+    called_ = true;
+    send_reply_callback(Status::OK(), nullptr, nullptr);
+  }
+
+  void HandleInternalKVPut(rpc::InternalKVPutRequest request,
+                           rpc::InternalKVPutReply *reply,
+                           rpc::SendReplyCallback send_reply_callback) override {
+    called_ = true;
+    send_reply_callback(Status::OK(), nullptr, nullptr);
+  }
+
+  void HandleInternalKVDel(rpc::InternalKVDelRequest request,
+                           rpc::InternalKVDelReply *reply,
+                           rpc::SendReplyCallback send_reply_callback) override {
+    called_ = true;
+    send_reply_callback(Status::OK(), nullptr, nullptr);
+  }
+
+  void HandleInternalKVExists(rpc::InternalKVExistsRequest request,
+                              rpc::InternalKVExistsReply *reply,
+                              rpc::SendReplyCallback send_reply_callback) override {
+    called_ = true;
+    send_reply_callback(Status::OK(), nullptr, nullptr);
+  }
+
+  void HandleGetInternalConfig(rpc::GetInternalConfigRequest request,
+                               rpc::GetInternalConfigReply *reply,
+                               rpc::SendReplyCallback send_reply_callback) override {
+    called_ = true;
+    send_reply_callback(Status::OK(), nullptr, nullptr);
+  }
+
+  bool called_ = false;
+};
+
+TEST(GcsLeaderGatedHandlersTest, TestKVGating) {
+  MockInternalKVGcsServiceHandler underlying;
+  bool is_leader = false;
+  auto is_leader_fn = [&is_leader]() { return is_leader; };
+
+  LeaderGatedInternalKVHandler proxy(underlying, is_leader_fn);
+
+  // 1. Passive mode: unallowed mutating KV Put must be BLOCKED.
+  {
+    rpc::InternalKVPutRequest request;
+    rpc::InternalKVPutReply reply;
+    bool callback_called = false;
+    auto send_reply_callback = [&callback_called, &reply](Status status,
+                                                          std::function<void()> f1,
+                                                          std::function<void()> f2) {
+      EXPECT_TRUE(status.ok());
+      Status logical_status =
+          Status(StatusCode(reply.status().code()), reply.status().message());
+      EXPECT_TRUE(logical_status.IsGcsPassive());
+      callback_called = true;
+    };
+    proxy.HandleInternalKVPut(request, &reply, send_reply_callback);
+    EXPECT_TRUE(callback_called);
+    EXPECT_FALSE(underlying.called_);
+  }
+
+  // 2. Passive mode: allowlisted KV Get must be FORWARDED.
+  {
+    rpc::InternalKVGetRequest request;
+    rpc::InternalKVGetReply reply;
+    bool callback_called = false;
+    auto send_reply_callback = [&callback_called](Status status,
+                                                  std::function<void()> f1,
+                                                  std::function<void()> f2) {
+      EXPECT_TRUE(status.ok());
+      callback_called = true;
+    };
+    proxy.HandleInternalKVGet(request, &reply, send_reply_callback);
+    EXPECT_TRUE(callback_called);
+    EXPECT_TRUE(underlying.called_);
+    underlying.called_ = false;
+  }
+
+  // 3. Leader mode: all RPCs work.
+  {
+    is_leader = true;
+    rpc::InternalKVPutRequest request;
+    rpc::InternalKVPutReply reply;
+    bool callback_called = false;
+    auto send_reply_callback = [&callback_called](Status status,
+                                                  std::function<void()> f1,
+                                                  std::function<void()> f2) {
+      EXPECT_TRUE(status.ok());
+      callback_called = true;
+    };
+    proxy.HandleInternalKVPut(request, &reply, send_reply_callback);
+    EXPECT_TRUE(callback_called);
+    EXPECT_TRUE(underlying.called_);
+    underlying.called_ = false;
+  }
+  {
+    rpc::InternalKVGetRequest request;
+    rpc::InternalKVGetReply reply;
+    bool callback_called = false;
+    auto send_reply_callback = [&callback_called](Status status,
+                                                  std::function<void()> f1,
+                                                  std::function<void()> f2) {
+      EXPECT_TRUE(status.ok());
+      callback_called = true;
+    };
+    proxy.HandleInternalKVGet(request, &reply, send_reply_callback);
+    EXPECT_TRUE(callback_called);
+    EXPECT_TRUE(underlying.called_);
+  }
+}
+
+// =========================================================================
+// 3. NodeInfo Service Gating Tests
+// =========================================================================
+
+class MockNodeInfoGcsServiceHandler : public rpc::NodeInfoGcsServiceHandler {
+ public:
+  void HandleGetClusterId(rpc::GetClusterIdRequest request,
+                          rpc::GetClusterIdReply *reply,
+                          rpc::SendReplyCallback send_reply_callback) override {
+    called_ = true;
+    send_reply_callback(Status::OK(), nullptr, nullptr);
+  }
+
+  void HandleRegisterNode(rpc::RegisterNodeRequest request,
+                          rpc::RegisterNodeReply *reply,
+                          rpc::SendReplyCallback send_reply_callback) override {
+    called_ = true;
+    send_reply_callback(Status::OK(), nullptr, nullptr);
+  }
+
+  void HandleUnregisterNode(rpc::UnregisterNodeRequest request,
+                            rpc::UnregisterNodeReply *reply,
+                            rpc::SendReplyCallback send_reply_callback,
+                            const std::string &grpc_peer) override {
+    called_ = true;
+    send_reply_callback(Status::OK(), nullptr, nullptr);
+  }
+
+  void HandleCheckAlive(rpc::CheckAliveRequest request,
+                        rpc::CheckAliveReply *reply,
+                        rpc::SendReplyCallback send_reply_callback) override {
+    called_ = true;
+    send_reply_callback(Status::OK(), nullptr, nullptr);
+  }
+
+  void HandleDrainNode(rpc::DrainNodeRequest request,
+                       rpc::DrainNodeReply *reply,
+                       rpc::SendReplyCallback send_reply_callback) override {
+    called_ = true;
+    send_reply_callback(Status::OK(), nullptr, nullptr);
+  }
+
+  void HandleGetAllNodeInfo(rpc::GetAllNodeInfoRequest request,
+                            rpc::GetAllNodeInfoReply *reply,
+                            rpc::SendReplyCallback send_reply_callback) override {
+    called_ = true;
+    send_reply_callback(Status::OK(), nullptr, nullptr);
+  }
+
+  void HandleGetAllNodeAddressAndLiveness(
+      rpc::GetAllNodeAddressAndLivenessRequest request,
+      rpc::GetAllNodeAddressAndLivenessReply *reply,
+      rpc::SendReplyCallback send_reply_callback) override {
+    called_ = true;
+    send_reply_callback(Status::OK(), nullptr, nullptr);
+  }
+
+  bool called_ = false;
+};
+
+TEST(GcsLeaderGatedHandlersTest, TestNodeRegistrationAndGating) {
+  MockNodeInfoGcsServiceHandler underlying;
+  bool is_leader = false;
+  auto is_leader_fn = [&is_leader]() { return is_leader; };
+
+  // Mock storage for passive node caching.
+  std::shared_ptr<rpc::GcsNodeInfo> cached_passive_node;
+  auto cache_local_node_fn = [&cached_passive_node](const rpc::GcsNodeInfo &node_info) {
+    cached_passive_node = std::make_shared<rpc::GcsNodeInfo>(node_info);
+  };
+
+  LeaderGatedNodeInfoHandler proxy(underlying, is_leader_fn, cache_local_node_fn);
+
+  // 1. Passive mode: unallowed worker node registration & unregister must be BLOCKED.
+  {
+    rpc::RegisterNodeRequest request;
+    request.mutable_node_info()->set_is_head_node(false);
+    rpc::RegisterNodeReply reply;
+    bool callback_called = false;
+    auto send_reply_callback = [&callback_called, &reply](Status status,
+                                                          std::function<void()> f1,
+                                                          std::function<void()> f2) {
+      EXPECT_TRUE(status.ok());
+      Status logical_status =
+          Status(StatusCode(reply.status().code()), reply.status().message());
+      EXPECT_TRUE(logical_status.IsGcsPassive());
+      callback_called = true;
+    };
+    proxy.HandleRegisterNode(request, &reply, send_reply_callback);
+    EXPECT_TRUE(callback_called);
+    EXPECT_FALSE(underlying.called_);
+  }
+  {
+    rpc::UnregisterNodeRequest request;
+    rpc::UnregisterNodeReply reply;
+    bool callback_called = false;
+    auto send_reply_callback = [&callback_called, &reply](Status status,
+                                                          std::function<void()> f1,
+                                                          std::function<void()> f2) {
+      EXPECT_TRUE(status.ok());
+      Status logical_status =
+          Status(StatusCode(reply.status().code()), reply.status().message());
+      EXPECT_TRUE(logical_status.IsGcsPassive());
+      callback_called = true;
+    };
+    proxy.HandleUnregisterNode(request, &reply, send_reply_callback, "peer");
+    EXPECT_TRUE(callback_called);
+    EXPECT_FALSE(underlying.called_);
+    underlying.called_ = false;
+  }
+
+  // 2. Passive mode: allowlisted local head node registration is HANDLED IN PROXY,
+  // CheckAlive is FORWARDED.
+  {
+    rpc::RegisterNodeRequest request;
+    request.mutable_node_info()->set_is_head_node(true);
+    rpc::RegisterNodeReply reply;
+    bool callback_called = false;
+    auto send_reply_callback = [&callback_called, &reply](Status status,
+                                                          std::function<void()> f1,
+                                                          std::function<void()> f2) {
+      EXPECT_TRUE(status.ok());
+      // Verify the reply status code is 0 (OK)
+      EXPECT_EQ(reply.status().code(), static_cast<int>(StatusCode::OK));
+      callback_called = true;
+    };
+    proxy.HandleRegisterNode(request, &reply, send_reply_callback);
+    EXPECT_TRUE(callback_called);
+    // Should NOT call underlying handler for head node in passive mode.
+    EXPECT_FALSE(underlying.called_);
+    // The head node should be cached in-memory via the cache callback.
+    ASSERT_NE(cached_passive_node, nullptr);
+    EXPECT_TRUE(cached_passive_node->is_head_node());
+    underlying.called_ = false;
+    cached_passive_node = nullptr;
+  }
+  {
+    rpc::CheckAliveRequest request;
+    rpc::CheckAliveReply reply;
+    bool callback_called = false;
+    auto send_reply_callback = [&callback_called](Status status,
+                                                  std::function<void()> f1,
+                                                  std::function<void()> f2) {
+      EXPECT_TRUE(status.ok());
+      callback_called = true;
+    };
+    proxy.HandleCheckAlive(request, &reply, send_reply_callback);
+    EXPECT_TRUE(callback_called);
+    EXPECT_TRUE(underlying.called_);
+    underlying.called_ = false;
+  }
+
+  // 3. Leader mode: all RPCs work.
+  {
+    is_leader = true;
+    rpc::RegisterNodeRequest request;
+    request.mutable_node_info()->set_is_head_node(false);
+    rpc::RegisterNodeReply reply;
+    bool callback_called = false;
+    auto send_reply_callback = [&callback_called](Status status,
+                                                  std::function<void()> f1,
+                                                  std::function<void()> f2) {
+      EXPECT_TRUE(status.ok());
+      callback_called = true;
+    };
+    proxy.HandleRegisterNode(request, &reply, send_reply_callback);
+    EXPECT_TRUE(callback_called);
+    EXPECT_TRUE(underlying.called_);
+    underlying.called_ = false;
+  }
+  {
+    rpc::UnregisterNodeRequest request;
+    rpc::UnregisterNodeReply reply;
+    bool callback_called = false;
+    auto send_reply_callback = [&callback_called](Status status,
+                                                  std::function<void()> f1,
+                                                  std::function<void()> f2) {
+      EXPECT_TRUE(status.ok());
+      callback_called = true;
+    };
+    proxy.HandleUnregisterNode(request, &reply, send_reply_callback, "peer");
+    EXPECT_TRUE(callback_called);
+    EXPECT_TRUE(underlying.called_);
+  }
+}
+
+// =========================================================================
+// 4. ActorInfo Service Gating Tests
+// =========================================================================
+
+class MockActorInfoGcsServiceHandler : public rpc::ActorInfoGcsServiceHandler {
+ public:
+  void HandleRegisterActor(rpc::RegisterActorRequest request,
+                           rpc::RegisterActorReply *reply,
+                           rpc::SendReplyCallback send_reply_callback) override {
+    called_ = true;
+    send_reply_callback(Status::OK(), nullptr, nullptr);
+  }
+  void HandleRestartActorForLineageReconstruction(
+      rpc::RestartActorForLineageReconstructionRequest request,
+      rpc::RestartActorForLineageReconstructionReply *reply,
+      rpc::SendReplyCallback send_reply_callback) override {
+    called_ = true;
+    send_reply_callback(Status::OK(), nullptr, nullptr);
+  }
+  void HandleCreateActor(rpc::CreateActorRequest request,
+                         rpc::CreateActorReply *reply,
+                         rpc::SendReplyCallback send_reply_callback) override {
+    called_ = true;
+    send_reply_callback(Status::OK(), nullptr, nullptr);
+  }
+  void HandleGetActorInfo(rpc::GetActorInfoRequest request,
+                          rpc::GetActorInfoReply *reply,
+                          rpc::SendReplyCallback send_reply_callback) override {
+    called_ = true;
+    send_reply_callback(Status::OK(), nullptr, nullptr);
+  }
+  void HandleGetNamedActorInfo(rpc::GetNamedActorInfoRequest request,
+                               rpc::GetNamedActorInfoReply *reply,
+                               rpc::SendReplyCallback send_reply_callback) override {
+    called_ = true;
+    send_reply_callback(Status::OK(), nullptr, nullptr);
+  }
+  void HandleListNamedActors(rpc::ListNamedActorsRequest request,
+                             rpc::ListNamedActorsReply *reply,
+                             rpc::SendReplyCallback send_reply_callback) override {
+    called_ = true;
+    send_reply_callback(Status::OK(), nullptr, nullptr);
+  }
+  void HandleGetAllActorInfo(rpc::GetAllActorInfoRequest request,
+                             rpc::GetAllActorInfoReply *reply,
+                             rpc::SendReplyCallback send_reply_callback) override {
+    called_ = true;
+    send_reply_callback(Status::OK(), nullptr, nullptr);
+  }
+  void HandleKillActorViaGcs(rpc::KillActorViaGcsRequest request,
+                             rpc::KillActorViaGcsReply *reply,
+                             rpc::SendReplyCallback send_reply_callback) override {
+    called_ = true;
+    send_reply_callback(Status::OK(), nullptr, nullptr);
+  }
+  void HandleReportActorOutOfScope(rpc::ReportActorOutOfScopeRequest request,
+                                   rpc::ReportActorOutOfScopeReply *reply,
+                                   rpc::SendReplyCallback send_reply_callback) override {
+    called_ = true;
+    send_reply_callback(Status::OK(), nullptr, nullptr);
+  }
+
+  bool called_ = false;
+};
+
+TEST(GcsLeaderGatedHandlersTest, TestActorGating) {
+  MockActorInfoGcsServiceHandler underlying;
+  bool is_leader = false;
+  auto is_leader_fn = [&is_leader]() { return is_leader; };
+
+  LeaderGatedActorInfoHandler proxy(underlying, is_leader_fn);
+
+  // 1. Passive mode: unallowed RPCs must be BLOCKED.
+  {
+    rpc::GetActorInfoRequest request;
+    rpc::GetActorInfoReply reply;
+    bool callback_called = false;
+    auto send_reply_callback = [&callback_called, &reply](Status status,
+                                                          std::function<void()> f1,
+                                                          std::function<void()> f2) {
+      EXPECT_TRUE(status.ok());
+      Status logical_status =
+          Status(StatusCode(reply.status().code()), reply.status().message());
+      EXPECT_TRUE(logical_status.IsGcsPassive());
+      callback_called = true;
+    };
+    proxy.HandleGetActorInfo(request, &reply, send_reply_callback);
+    EXPECT_TRUE(callback_called);
+    EXPECT_FALSE(underlying.called_);
+  }
+  {
+    rpc::CreateActorRequest request;
+    rpc::CreateActorReply reply;
+    bool callback_called = false;
+    auto send_reply_callback = [&callback_called, &reply](Status status,
+                                                          std::function<void()> f1,
+                                                          std::function<void()> f2) {
+      EXPECT_TRUE(status.ok());
+      Status logical_status =
+          Status(StatusCode(reply.status().code()), reply.status().message());
+      EXPECT_TRUE(logical_status.IsGcsPassive());
+      callback_called = true;
+    };
+    proxy.HandleCreateActor(request, &reply, send_reply_callback);
+    EXPECT_TRUE(callback_called);
+    EXPECT_FALSE(underlying.called_);
+    underlying.called_ = false;
+  }
+
+  // 2. Passive mode: allowlisted RPCs (None for ActorInfo service).
+
+  // 3. Leader mode: all RPCs work.
+  {
+    is_leader = true;
+    rpc::GetActorInfoRequest request;
+    rpc::GetActorInfoReply reply;
+    bool callback_called = false;
+    auto send_reply_callback = [&callback_called](Status status,
+                                                  std::function<void()> f1,
+                                                  std::function<void()> f2) {
+      EXPECT_TRUE(status.ok());
+      callback_called = true;
+    };
+    proxy.HandleGetActorInfo(request, &reply, send_reply_callback);
+    EXPECT_TRUE(callback_called);
+    EXPECT_TRUE(underlying.called_);
+    underlying.called_ = false;
+  }
+  {
+    rpc::CreateActorRequest request;
+    rpc::CreateActorReply reply;
+    bool callback_called = false;
+    auto send_reply_callback = [&callback_called](Status status,
+                                                  std::function<void()> f1,
+                                                  std::function<void()> f2) {
+      EXPECT_TRUE(status.ok());
+      callback_called = true;
+    };
+    proxy.HandleCreateActor(request, &reply, send_reply_callback);
+    EXPECT_TRUE(callback_called);
+    EXPECT_TRUE(underlying.called_);
+  }
+}
+
+// =========================================================================
+// 5. PlacementGroupInfo Service Gating Tests
+// =========================================================================
+
+class MockPlacementGroupInfoGcsServiceHandler
+    : public rpc::PlacementGroupInfoGcsServiceHandler {
+ public:
+  void HandleCreatePlacementGroup(rpc::CreatePlacementGroupRequest request,
+                                  rpc::CreatePlacementGroupReply *reply,
+                                  rpc::SendReplyCallback send_reply_callback) override {
+    called_ = true;
+    send_reply_callback(Status::OK(), nullptr, nullptr);
+  }
+  void HandleRemovePlacementGroup(rpc::RemovePlacementGroupRequest request,
+                                  rpc::RemovePlacementGroupReply *reply,
+                                  rpc::SendReplyCallback send_reply_callback) override {
+    called_ = true;
+    send_reply_callback(Status::OK(), nullptr, nullptr);
+  }
+  void HandleGetPlacementGroup(rpc::GetPlacementGroupRequest request,
+                               rpc::GetPlacementGroupReply *reply,
+                               rpc::SendReplyCallback send_reply_callback) override {
+    called_ = true;
+    send_reply_callback(Status::OK(), nullptr, nullptr);
+  }
+  void HandleGetAllPlacementGroup(rpc::GetAllPlacementGroupRequest request,
+                                  rpc::GetAllPlacementGroupReply *reply,
+                                  rpc::SendReplyCallback send_reply_callback) override {
+    called_ = true;
+    send_reply_callback(Status::OK(), nullptr, nullptr);
+  }
+  void HandleWaitPlacementGroupUntilReady(
+      rpc::WaitPlacementGroupUntilReadyRequest request,
+      rpc::WaitPlacementGroupUntilReadyReply *reply,
+      rpc::SendReplyCallback send_reply_callback) override {
+    called_ = true;
+    send_reply_callback(Status::OK(), nullptr, nullptr);
+  }
+  void HandleGetNamedPlacementGroup(rpc::GetNamedPlacementGroupRequest request,
+                                    rpc::GetNamedPlacementGroupReply *reply,
+                                    rpc::SendReplyCallback send_reply_callback) override {
+    called_ = true;
+    send_reply_callback(Status::OK(), nullptr, nullptr);
+  }
+
+  bool called_ = false;
+};
+
+TEST(GcsLeaderGatedHandlersTest, TestPlacementGroupGating) {
+  MockPlacementGroupInfoGcsServiceHandler underlying;
+  bool is_leader = false;
+  auto is_leader_fn = [&is_leader]() { return is_leader; };
+
+  LeaderGatedPlacementGroupInfoHandler proxy(underlying, is_leader_fn);
+
+  // 1. Passive mode: unallowed RPCs must be BLOCKED.
+  {
+    rpc::GetPlacementGroupRequest request;
+    rpc::GetPlacementGroupReply reply;
+    bool callback_called = false;
+    auto send_reply_callback = [&callback_called, &reply](Status status,
+                                                          std::function<void()> f1,
+                                                          std::function<void()> f2) {
+      EXPECT_TRUE(status.ok());
+      Status logical_status =
+          Status(StatusCode(reply.status().code()), reply.status().message());
+      EXPECT_TRUE(logical_status.IsGcsPassive());
+      callback_called = true;
+    };
+    proxy.HandleGetPlacementGroup(request, &reply, send_reply_callback);
+    EXPECT_TRUE(callback_called);
+    EXPECT_FALSE(underlying.called_);
+  }
+  {
+    rpc::CreatePlacementGroupRequest request;
+    rpc::CreatePlacementGroupReply reply;
+    bool callback_called = false;
+    auto send_reply_callback = [&callback_called, &reply](Status status,
+                                                          std::function<void()> f1,
+                                                          std::function<void()> f2) {
+      EXPECT_TRUE(status.ok());
+      Status logical_status =
+          Status(StatusCode(reply.status().code()), reply.status().message());
+      EXPECT_TRUE(logical_status.IsGcsPassive());
+      callback_called = true;
+    };
+    proxy.HandleCreatePlacementGroup(request, &reply, send_reply_callback);
+    EXPECT_TRUE(callback_called);
+    EXPECT_FALSE(underlying.called_);
+    underlying.called_ = false;
+  }
+
+  // 2. Passive mode: allowlisted RPCs (None for PlacementGroupInfo service).
+
+  // 3. Leader mode: all RPCs work.
+  {
+    is_leader = true;
+    rpc::GetPlacementGroupRequest request;
+    rpc::GetPlacementGroupReply reply;
+    bool callback_called = false;
+    auto send_reply_callback = [&callback_called](Status status,
+                                                  std::function<void()> f1,
+                                                  std::function<void()> f2) {
+      EXPECT_TRUE(status.ok());
+      callback_called = true;
+    };
+    proxy.HandleGetPlacementGroup(request, &reply, send_reply_callback);
+    EXPECT_TRUE(callback_called);
+    EXPECT_TRUE(underlying.called_);
+    underlying.called_ = false;
+  }
+  {
+    rpc::CreatePlacementGroupRequest request;
+    rpc::CreatePlacementGroupReply reply;
+    bool callback_called = false;
+    auto send_reply_callback = [&callback_called](Status status,
+                                                  std::function<void()> f1,
+                                                  std::function<void()> f2) {
+      EXPECT_TRUE(status.ok());
+      callback_called = true;
+    };
+    proxy.HandleCreatePlacementGroup(request, &reply, send_reply_callback);
+    EXPECT_TRUE(callback_called);
+    EXPECT_TRUE(underlying.called_);
+  }
+}
+
+// =========================================================================
+// 6. AutoscalerState Service Gating Tests
+// =========================================================================
+
+class MockAutoscalerStateServiceHandler
+    : public rpc::autoscaler::AutoscalerStateServiceHandler {
+ public:
+  void HandleGetClusterResourceState(
+      rpc::autoscaler::GetClusterResourceStateRequest request,
+      rpc::autoscaler::GetClusterResourceStateReply *reply,
+      rpc::SendReplyCallback send_reply_callback) override {
+    called_ = true;
+    send_reply_callback(Status::OK(), nullptr, nullptr);
+  }
+  void HandleReportAutoscalingState(
+      rpc::autoscaler::ReportAutoscalingStateRequest request,
+      rpc::autoscaler::ReportAutoscalingStateReply *reply,
+      rpc::SendReplyCallback send_reply_callback) override {
+    called_ = true;
+    send_reply_callback(Status::OK(), nullptr, nullptr);
+  }
+  void HandleRequestClusterResourceConstraint(
+      rpc::autoscaler::RequestClusterResourceConstraintRequest request,
+      rpc::autoscaler::RequestClusterResourceConstraintReply *reply,
+      rpc::SendReplyCallback send_reply_callback) override {
+    called_ = true;
+    send_reply_callback(Status::OK(), nullptr, nullptr);
+  }
+  void HandleGetClusterStatus(rpc::autoscaler::GetClusterStatusRequest request,
+                              rpc::autoscaler::GetClusterStatusReply *reply,
+                              rpc::SendReplyCallback send_reply_callback) override {
+    called_ = true;
+    send_reply_callback(Status::OK(), nullptr, nullptr);
+  }
+  void HandleDrainNode(rpc::autoscaler::DrainNodeRequest request,
+                       rpc::autoscaler::DrainNodeReply *reply,
+                       rpc::SendReplyCallback send_reply_callback,
+                       const std::string &grpc_peer) override {
+    called_ = true;
+    send_reply_callback(Status::OK(), nullptr, nullptr);
+  }
+  void HandleResizeRayletResourceInstances(
+      rpc::autoscaler::ResizeRayletResourceInstancesRequest request,
+      rpc::autoscaler::ResizeRayletResourceInstancesReply *reply,
+      rpc::SendReplyCallback send_reply_callback) override {
+    called_ = true;
+    send_reply_callback(Status::OK(), nullptr, nullptr);
+  }
+  void HandleReportClusterConfig(rpc::autoscaler::ReportClusterConfigRequest request,
+                                 rpc::autoscaler::ReportClusterConfigReply *reply,
+                                 rpc::SendReplyCallback send_reply_callback) override {
+    called_ = true;
+    send_reply_callback(Status::OK(), nullptr, nullptr);
+  }
+
+  bool called_ = false;
+};
+
+TEST(GcsLeaderGatedHandlersTest, TestAutoscalerGating) {
+  MockAutoscalerStateServiceHandler underlying;
+  bool is_leader = false;
+  auto is_leader_fn = [&is_leader]() { return is_leader; };
+
+  LeaderGatedAutoscalerStateHandler proxy(underlying, is_leader_fn);
+
+  // 1. Passive mode: unallowed RPCs must be BLOCKED (callback status is GcsPassive).
+  {
+    rpc::autoscaler::GetClusterStatusRequest request;
+    rpc::autoscaler::GetClusterStatusReply reply;
+    bool callback_called = false;
+    auto send_reply_callback = [&callback_called](Status status,
+                                                  std::function<void()> f1,
+                                                  std::function<void()> f2) {
+      EXPECT_TRUE(status.IsGcsPassive());
+      callback_called = true;
+    };
+    proxy.HandleGetClusterStatus(request, &reply, send_reply_callback);
+    EXPECT_TRUE(callback_called);
+    EXPECT_FALSE(underlying.called_);
+  }
+  {
+    rpc::autoscaler::ReportAutoscalingStateRequest request;
+    rpc::autoscaler::ReportAutoscalingStateReply reply;
+    bool callback_called = false;
+    auto send_reply_callback = [&callback_called](Status status,
+                                                  std::function<void()> f1,
+                                                  std::function<void()> f2) {
+      EXPECT_TRUE(status.IsGcsPassive());
+      callback_called = true;
+    };
+    proxy.HandleReportAutoscalingState(request, &reply, send_reply_callback);
+    EXPECT_TRUE(callback_called);
+    EXPECT_FALSE(underlying.called_);
+    underlying.called_ = false;
+  }
+
+  // 2. Passive mode: allowlisted RPCs (None for AutoscalerState service).
+
+  // 3. Leader mode: all RPCs work.
+  {
+    is_leader = true;
+    rpc::autoscaler::GetClusterStatusRequest request;
+    rpc::autoscaler::GetClusterStatusReply reply;
+    bool callback_called = false;
+    auto send_reply_callback = [&callback_called](Status status,
+                                                  std::function<void()> f1,
+                                                  std::function<void()> f2) {
+      EXPECT_TRUE(status.ok());
+      callback_called = true;
+    };
+    proxy.HandleGetClusterStatus(request, &reply, send_reply_callback);
+    EXPECT_TRUE(callback_called);
+    EXPECT_TRUE(underlying.called_);
+    underlying.called_ = false;
+  }
+  {
+    rpc::autoscaler::ReportAutoscalingStateRequest request;
+    rpc::autoscaler::ReportAutoscalingStateReply reply;
+    bool callback_called = false;
+    auto send_reply_callback = [&callback_called](Status status,
+                                                  std::function<void()> f1,
+                                                  std::function<void()> f2) {
+      EXPECT_TRUE(status.ok());
+      callback_called = true;
+    };
+    proxy.HandleReportAutoscalingState(request, &reply, send_reply_callback);
+    EXPECT_TRUE(callback_called);
+    EXPECT_TRUE(underlying.called_);
+  }
+}
+
+// =========================================================================
+// Helpers for body-reply gating assertions.
+// =========================================================================
+
+namespace {
+
+// Asserts that a gated RPC replied with Status::GcsPassive written into the reply
+// body, and that the underlying handler was NOT invoked.
+template <typename Reply>
+void ExpectGatedInBody(const Reply &reply, bool underlying_called) {
+  Status logical_status =
+      Status(StatusCode(reply.status().code()), reply.status().message());
+  EXPECT_TRUE(logical_status.IsGcsPassive());
+  EXPECT_FALSE(underlying_called);
+}
+
+}  // namespace
+
+// =========================================================================
+// NodeResourceInfo Service Gating Tests (all RPCs gated).
+// =========================================================================
+
+class MockNodeResourceInfoGcsServiceHandler
+    : public rpc::NodeResourceInfoGcsServiceHandler {
+ public:
+  void HandleGetAllAvailableResources(
+      rpc::GetAllAvailableResourcesRequest request,
+      rpc::GetAllAvailableResourcesReply *reply,
+      rpc::SendReplyCallback send_reply_callback) override {
+    called_ = true;
+    send_reply_callback(Status::OK(), nullptr, nullptr);
+  }
+
+  void HandleGetAllTotalResources(rpc::GetAllTotalResourcesRequest request,
+                                  rpc::GetAllTotalResourcesReply *reply,
+                                  rpc::SendReplyCallback send_reply_callback) override {
+    called_ = true;
+    send_reply_callback(Status::OK(), nullptr, nullptr);
+  }
+
+  void HandleGetDrainingNodes(rpc::GetDrainingNodesRequest request,
+                              rpc::GetDrainingNodesReply *reply,
+                              rpc::SendReplyCallback send_reply_callback) override {
+    called_ = true;
+    send_reply_callback(Status::OK(), nullptr, nullptr);
+  }
+
+  void HandleGetAllResourceUsage(rpc::GetAllResourceUsageRequest request,
+                                 rpc::GetAllResourceUsageReply *reply,
+                                 rpc::SendReplyCallback send_reply_callback) override {
+    called_ = true;
+    send_reply_callback(Status::OK(), nullptr, nullptr);
+  }
+
+  bool called_ = false;
+};
+
+TEST(GcsLeaderGatedHandlersTest, TestNodeResourceInfoGating) {
+  MockNodeResourceInfoGcsServiceHandler underlying;
+  bool is_leader = false;
+  LeaderGatedNodeResourceInfoHandler proxy(underlying,
+                                           [&is_leader]() { return is_leader; });
+
+  auto noop_cb = [](Status, std::function<void()>, std::function<void()>) {};
+
+  // Passive: every RPC is gated.
+  {
+    rpc::GetAllResourceUsageReply reply;
+    proxy.HandleGetAllResourceUsage({}, &reply, noop_cb);
+    ExpectGatedInBody(reply, underlying.called_);
+  }
+  {
+    rpc::GetAllAvailableResourcesReply reply;
+    proxy.HandleGetAllAvailableResources({}, &reply, noop_cb);
+    ExpectGatedInBody(reply, underlying.called_);
+  }
+
+  // Leader: forwarded to underlying handler.
+  is_leader = true;
+  {
+    rpc::GetAllResourceUsageReply reply;
+    proxy.HandleGetAllResourceUsage({}, &reply, noop_cb);
+    EXPECT_TRUE(underlying.called_);
+  }
+}
+
+// =========================================================================
+// WorkerInfo Service Gating Tests (all RPCs gated, incl. reads).
+// =========================================================================
+
+class MockWorkerInfoGcsServiceHandler : public rpc::WorkerInfoGcsServiceHandler {
+ public:
+  void HandleReportWorkerFailure(rpc::ReportWorkerFailureRequest request,
+                                 rpc::ReportWorkerFailureReply *reply,
+                                 rpc::SendReplyCallback send_reply_callback) override {
+    called_ = true;
+    send_reply_callback(Status::OK(), nullptr, nullptr);
+  }
+  void HandleGetWorkerInfo(rpc::GetWorkerInfoRequest request,
+                           rpc::GetWorkerInfoReply *reply,
+                           rpc::SendReplyCallback send_reply_callback) override {
+    called_ = true;
+    send_reply_callback(Status::OK(), nullptr, nullptr);
+  }
+  void HandleGetAllWorkerInfo(rpc::GetAllWorkerInfoRequest request,
+                              rpc::GetAllWorkerInfoReply *reply,
+                              rpc::SendReplyCallback send_reply_callback) override {
+    called_ = true;
+    send_reply_callback(Status::OK(), nullptr, nullptr);
+  }
+  void HandleAddWorkerInfo(rpc::AddWorkerInfoRequest request,
+                           rpc::AddWorkerInfoReply *reply,
+                           rpc::SendReplyCallback send_reply_callback) override {
+    called_ = true;
+    send_reply_callback(Status::OK(), nullptr, nullptr);
+  }
+  void HandleUpdateWorkerDebuggerPort(
+      rpc::UpdateWorkerDebuggerPortRequest request,
+      rpc::UpdateWorkerDebuggerPortReply *reply,
+      rpc::SendReplyCallback send_reply_callback) override {
+    called_ = true;
+    send_reply_callback(Status::OK(), nullptr, nullptr);
+  }
+  void HandleUpdateWorkerNumPausedThreads(
+      rpc::UpdateWorkerNumPausedThreadsRequest request,
+      rpc::UpdateWorkerNumPausedThreadsReply *reply,
+      rpc::SendReplyCallback send_reply_callback) override {
+    called_ = true;
+    send_reply_callback(Status::OK(), nullptr, nullptr);
+  }
+
+  bool called_ = false;
+};
+
+TEST(GcsLeaderGatedHandlersTest, TestWorkerInfoGating) {
+  MockWorkerInfoGcsServiceHandler underlying;
+  bool is_leader = false;
+  LeaderGatedWorkerInfoHandler proxy(underlying, [&is_leader]() { return is_leader; });
+
+  auto noop_cb = [](Status, std::function<void()>, std::function<void()>) {};
+
+  // Passive: writes are gated.
+  {
+    rpc::AddWorkerInfoReply reply;
+    proxy.HandleAddWorkerInfo({}, &reply, noop_cb);
+    ExpectGatedInBody(reply, underlying.called_);
+  }
+  // Passive: reads are also gated (no workers run on a passive head).
+  {
+    rpc::GetAllWorkerInfoReply reply;
+    proxy.HandleGetAllWorkerInfo({}, &reply, noop_cb);
+    ExpectGatedInBody(reply, underlying.called_);
+  }
+
+  // Leader: forwarded.
+  is_leader = true;
+  {
+    rpc::AddWorkerInfoReply reply;
+    proxy.HandleAddWorkerInfo({}, &reply, noop_cb);
+    EXPECT_TRUE(underlying.called_);
+  }
+}
+
+// =========================================================================
+// TaskInfo Service Gating Tests (all RPCs gated, incl. reads).
+// =========================================================================
+
+class MockTaskInfoGcsServiceHandler : public rpc::TaskInfoGcsServiceHandler {
+ public:
+  void HandleAddTaskEventData(rpc::AddTaskEventDataRequest request,
+                              rpc::AddTaskEventDataReply *reply,
+                              rpc::SendReplyCallback send_reply_callback) override {
+    called_ = true;
+    send_reply_callback(Status::OK(), nullptr, nullptr);
+  }
+  void HandleGetTaskEvents(rpc::GetTaskEventsRequest request,
+                           rpc::GetTaskEventsReply *reply,
+                           rpc::SendReplyCallback send_reply_callback) override {
+    called_ = true;
+    send_reply_callback(Status::OK(), nullptr, nullptr);
+  }
+
+  bool called_ = false;
+};
+
+TEST(GcsLeaderGatedHandlersTest, TestTaskInfoGating) {
+  MockTaskInfoGcsServiceHandler underlying;
+  bool is_leader = false;
+  LeaderGatedTaskInfoHandler proxy(underlying, [&is_leader]() { return is_leader; });
+
+  auto noop_cb = [](Status, std::function<void()>, std::function<void()>) {};
+
+  // Passive: write gated.
+  {
+    rpc::AddTaskEventDataReply reply;
+    proxy.HandleAddTaskEventData({}, &reply, noop_cb);
+    ExpectGatedInBody(reply, underlying.called_);
+  }
+  // Passive: read gated.
+  {
+    rpc::GetTaskEventsReply reply;
+    proxy.HandleGetTaskEvents({}, &reply, noop_cb);
+    ExpectGatedInBody(reply, underlying.called_);
+  }
+
+  // Leader: forwarded.
+  is_leader = true;
+  {
+    rpc::GetTaskEventsReply reply;
+    proxy.HandleGetTaskEvents({}, &reply, noop_cb);
+    EXPECT_TRUE(underlying.called_);
+  }
+}
+
+// =========================================================================
+// RuntimeEnv Service Gating Tests (single write RPC gated).
+// =========================================================================
+
+class MockRuntimeEnvGcsServiceHandler : public rpc::RuntimeEnvGcsServiceHandler {
+ public:
+  void HandlePinRuntimeEnvURI(rpc::PinRuntimeEnvURIRequest request,
+                              rpc::PinRuntimeEnvURIReply *reply,
+                              rpc::SendReplyCallback send_reply_callback) override {
+    called_ = true;
+    send_reply_callback(Status::OK(), nullptr, nullptr);
+  }
+
+  bool called_ = false;
+};
+
+TEST(GcsLeaderGatedHandlersTest, TestRuntimeEnvGating) {
+  MockRuntimeEnvGcsServiceHandler underlying;
+  bool is_leader = false;
+  LeaderGatedRuntimeEnvHandler proxy(underlying, [&is_leader]() { return is_leader; });
+
+  auto noop_cb = [](Status, std::function<void()>, std::function<void()>) {};
+
+  // Passive: gated.
+  {
+    rpc::PinRuntimeEnvURIReply reply;
+    proxy.HandlePinRuntimeEnvURI({}, &reply, noop_cb);
+    ExpectGatedInBody(reply, underlying.called_);
+  }
+
+  // Leader: forwarded.
+  is_leader = true;
+  {
+    rpc::PinRuntimeEnvURIReply reply;
+    proxy.HandlePinRuntimeEnvURI({}, &reply, noop_cb);
+    EXPECT_TRUE(underlying.called_);
+  }
+}
+
+// =========================================================================
+// ControlPlanePubSub Service Gating Tests (publish gated, subscribe allowed).
+// =========================================================================
+
+class MockControlPlanePubSubGcsServiceHandler
+    : public rpc::ControlPlanePubSubGcsServiceHandler {
+ public:
+  void HandleGcsPublish(rpc::GcsPublishRequest request,
+                        rpc::GcsPublishReply *reply,
+                        rpc::SendReplyCallback send_reply_callback) override {
+    publish_called_ = true;
+    send_reply_callback(Status::OK(), nullptr, nullptr);
+  }
+  void HandleGcsSubscriberPoll(rpc::GcsSubscriberPollRequest request,
+                               rpc::GcsSubscriberPollReply *reply,
+                               rpc::SendReplyCallback send_reply_callback) override {
+    poll_called_ = true;
+    send_reply_callback(Status::OK(), nullptr, nullptr);
+  }
+  void HandleGcsSubscriberCommandBatch(
+      rpc::GcsSubscriberCommandBatchRequest request,
+      rpc::GcsSubscriberCommandBatchReply *reply,
+      rpc::SendReplyCallback send_reply_callback) override {
+    command_batch_called_ = true;
+    send_reply_callback(Status::OK(), nullptr, nullptr);
+  }
+
+  bool publish_called_ = false;
+  bool poll_called_ = false;
+  bool command_batch_called_ = false;
+};
+
+TEST(GcsLeaderGatedHandlersTest, TestControlPlanePubSubGating) {
+  MockControlPlanePubSubGcsServiceHandler underlying;
+  bool is_leader = false;
+  LeaderGatedControlPlanePubSubHandler proxy(underlying,
+                                             [&is_leader]() { return is_leader; });
+
+  auto noop_cb = [](Status, std::function<void()>, std::function<void()>) {};
+
+  // Passive: publish is gated.
+  {
+    rpc::GcsPublishReply reply;
+    proxy.HandleGcsPublish({}, &reply, noop_cb);
+    ExpectGatedInBody(reply, underlying.publish_called_);
+  }
+
+  // Passive: subscribe poll and command batch are allowed (forwarded),
+  // required by the local raylet's node address/liveness subscription during
+  // startup.
+  {
+    rpc::GcsSubscriberPollReply reply;
+    proxy.HandleGcsSubscriberPoll({}, &reply, noop_cb);
+    EXPECT_TRUE(underlying.poll_called_);
+  }
+  {
+    rpc::GcsSubscriberCommandBatchReply reply;
+    proxy.HandleGcsSubscriberCommandBatch({}, &reply, noop_cb);
+    EXPECT_TRUE(underlying.command_batch_called_);
+  }
+
+  // Leader: publish is forwarded.
+  is_leader = true;
+  {
+    rpc::GcsPublishReply reply;
+    proxy.HandleGcsPublish({}, &reply, noop_cb);
+    EXPECT_TRUE(underlying.publish_called_);
+  }
+}
+
+// =========================================================================
+// ObservabilityPubSub Service Gating Tests
+// (publish + report-job-error gated, subscribe allowed).
+// =========================================================================
+
+class MockObservabilityPubSubServiceHandler
+    : public rpc::ObservabilityPubSubServiceHandler {
+ public:
+  void HandleGcsPublish(rpc::GcsPublishRequest request,
+                        rpc::GcsPublishReply *reply,
+                        rpc::SendReplyCallback send_reply_callback) override {
+    publish_called_ = true;
+    send_reply_callback(Status::OK(), nullptr, nullptr);
+  }
+  void HandleReportJobError(rpc::ReportJobErrorRequest request,
+                            rpc::ReportJobErrorReply *reply,
+                            rpc::SendReplyCallback send_reply_callback) override {
+    report_job_error_called_ = true;
+    send_reply_callback(Status::OK(), nullptr, nullptr);
+  }
+  void HandleGcsSubscriberPoll(rpc::GcsSubscriberPollRequest request,
+                               rpc::GcsSubscriberPollReply *reply,
+                               rpc::SendReplyCallback send_reply_callback) override {
+    poll_called_ = true;
+    send_reply_callback(Status::OK(), nullptr, nullptr);
+  }
+  void HandleGcsSubscriberCommandBatch(
+      rpc::GcsSubscriberCommandBatchRequest request,
+      rpc::GcsSubscriberCommandBatchReply *reply,
+      rpc::SendReplyCallback send_reply_callback) override {
+    command_batch_called_ = true;
+    send_reply_callback(Status::OK(), nullptr, nullptr);
+  }
+
+  bool publish_called_ = false;
+  bool report_job_error_called_ = false;
+  bool poll_called_ = false;
+  bool command_batch_called_ = false;
+};
+
+TEST(GcsLeaderGatedHandlersTest, TestObservabilityPubSubGating) {
+  MockObservabilityPubSubServiceHandler underlying;
+  bool is_leader = false;
+  LeaderGatedObservabilityPubSubHandler proxy(underlying,
+                                              [&is_leader]() { return is_leader; });
+
+  auto noop_cb = [](Status, std::function<void()>, std::function<void()>) {};
+
+  // Passive: publish and report-job-error are gated.
+  {
+    rpc::GcsPublishReply reply;
+    proxy.HandleGcsPublish({}, &reply, noop_cb);
+    ExpectGatedInBody(reply, underlying.publish_called_);
+  }
+  {
+    rpc::ReportJobErrorReply reply;
+    proxy.HandleReportJobError({}, &reply, noop_cb);
+    ExpectGatedInBody(reply, underlying.report_job_error_called_);
+  }
+
+  // Passive: subscribe poll and command batch are allowed (forwarded), mirroring
+  // the control-plane pubsub allowlist so local observability subscribers attach.
+  {
+    rpc::GcsSubscriberPollReply reply;
+    proxy.HandleGcsSubscriberPoll({}, &reply, noop_cb);
+    EXPECT_TRUE(underlying.poll_called_);
+  }
+  {
+    rpc::GcsSubscriberCommandBatchReply reply;
+    proxy.HandleGcsSubscriberCommandBatch({}, &reply, noop_cb);
+    EXPECT_TRUE(underlying.command_batch_called_);
+  }
+
+  // Leader: publish and report-job-error are forwarded.
+  is_leader = true;
+  {
+    rpc::GcsPublishReply reply;
+    proxy.HandleGcsPublish({}, &reply, noop_cb);
+    EXPECT_TRUE(underlying.publish_called_);
+  }
+  {
+    rpc::ReportJobErrorReply reply;
+    proxy.HandleReportJobError({}, &reply, noop_cb);
+    EXPECT_TRUE(underlying.report_job_error_called_);
+  }
+}
+
+// =========================================================================
+// RayEventExport Service Gating Tests (single ingest RPC gated).
+// =========================================================================
+
+class MockRayEventExportGcsServiceHandler
+    : public rpc::events::RayEventExportGcsServiceHandler {
+ public:
+  void HandleAddEvents(rpc::events::AddEventsRequest request,
+                       rpc::events::AddEventsReply *reply,
+                       rpc::SendReplyCallback send_reply_callback) override {
+    called_ = true;
+    send_reply_callback(Status::OK(), nullptr, nullptr);
+  }
+
+  bool called_ = false;
+};
+
+TEST(GcsLeaderGatedHandlersTest, TestRayEventExportGating) {
+  MockRayEventExportGcsServiceHandler underlying;
+  bool is_leader = false;
+  LeaderGatedRayEventExportHandler proxy(underlying,
+                                         [&is_leader]() { return is_leader; });
+
+  auto noop_cb = [](Status, std::function<void()>, std::function<void()>) {};
+
+  // Passive: event ingest is gated.
+  {
+    rpc::events::AddEventsReply reply;
+    proxy.HandleAddEvents({}, &reply, noop_cb);
+    ExpectGatedInBody(reply, underlying.called_);
+  }
+
+  // Leader: event ingest is forwarded.
+  is_leader = true;
+  {
+    rpc::events::AddEventsReply reply;
+    proxy.HandleAddEvents({}, &reply, noop_cb);
+    EXPECT_TRUE(underlying.called_);
+  }
+}
+
+}  // namespace gcs
+}  // namespace ray

--- a/src/ray/gcs/tests/gcs_leader_gated_handlers_test.cc
+++ b/src/ray/gcs/tests/gcs_leader_gated_handlers_test.cc
@@ -1316,8 +1316,7 @@ TEST(GcsLeaderGatedHandlersTest, TestRayEventExportGating) {
 // =========================================================================
 // RaySyncer Service Gating Tests (stream RPC ALLOWED even when passive).
 // Unlike every other gated handler, StartSync must be forwarded regardless of
-// leadership: it is a side-effect-free stream already scoped upstream at node
-// registration. This test guards that contract against a future change that
+// leadership. This test guards that contract against a future change that
 // wrongly gates it.
 // =========================================================================
 

--- a/src/ray/gcs/tests/gcs_leader_gated_handlers_test.cc
+++ b/src/ray/gcs/tests/gcs_leader_gated_handlers_test.cc
@@ -1313,5 +1313,40 @@ TEST(GcsLeaderGatedHandlersTest, TestRayEventExportGating) {
   }
 }
 
+// =========================================================================
+// RaySyncer Service Gating Tests (stream RPC ALLOWED even when passive).
+// Unlike every other gated handler, StartSync must be forwarded regardless of
+// leadership: it is a side-effect-free stream already scoped upstream at node
+// registration. This test guards that contract against a future change that
+// wrongly gates it.
+// =========================================================================
+
+class MockRaySyncerStreamHandler : public syncer::RaySyncerStreamHandler {
+ public:
+  syncer::SyncStreamReactor *StartSync(grpc::CallbackServerContext *context) override {
+    called_ = true;
+    return nullptr;
+  }
+
+  bool called_ = false;
+};
+
+TEST(GcsLeaderGatedHandlersTest, TestRaySyncerAllowedRegardlessOfLeadership) {
+  MockRaySyncerStreamHandler underlying;
+  bool is_leader = false;
+  LeaderGatedRaySyncerHandler proxy(underlying, [&is_leader]() { return is_leader; });
+
+  // Passive: StartSync is still forwarded (NOT gated, unlike other handlers).
+  underlying.called_ = false;
+  proxy.StartSync(/*context=*/nullptr);
+  EXPECT_TRUE(underlying.called_);
+
+  // Leader: also forwarded.
+  is_leader = true;
+  underlying.called_ = false;
+  proxy.StartSync(/*context=*/nullptr);
+  EXPECT_TRUE(underlying.called_);
+}
+
 }  // namespace gcs
 }  // namespace ray

--- a/src/ray/gcs/tests/gcs_node_manager_test.cc
+++ b/src/ray/gcs/tests/gcs_node_manager_test.cc
@@ -858,4 +858,354 @@ TEST_F(GcsNodeManagerTest, TestHandleGetAllNodeAddressAndLiveness) {
   }
 }
 
+TEST_F(GcsNodeManagerTest, TestHandleGetAllNodeAddressAndLivenessPassiveNode) {
+  gcs::GcsNodeManager node_manager(gcs_publisher_.get(),
+                                   gcs_table_storage_.get(),
+                                   *io_context_,
+                                   client_pool_.get(),
+                                   ClusterID::Nil(),
+                                   *fake_ray_event_recorder_,
+                                   "test_session_name",
+                                   observability_publisher_.get(),
+                                   clock_,
+                                   []() { return false; });  // Passive GCS
+
+  // Cache the local head node in-memory (passive mode). In production this is done
+  // by LeaderGatedNodeInfoHandler via the cache_local_node_fn callback.
+  auto head_node = GenNodeInfo();
+  head_node->set_is_head_node(true);
+  node_manager.CachePassiveLocalNode(*head_node);
+
+  // Test 1: Get all nodes without filter. Should return the passive local node.
+  {
+    absl::flat_hash_set<NodeID> node_ids;
+    std::vector<rpc::GcsNodeAddressAndLiveness> result;
+    node_manager.GetAllNodeAddressAndLiveness(
+        node_ids,
+        std::nullopt,
+        std::numeric_limits<int64_t>::max(),
+        [&result](rpc::GcsNodeAddressAndLiveness &&node) {
+          result.push_back(std::move(node));
+        });
+
+    EXPECT_EQ(result.size(), 1);
+    EXPECT_EQ(result[0].node_id(), head_node->node_id());
+    EXPECT_EQ(result[0].state(), rpc::GcsNodeInfo::ALIVE);
+  }
+
+  // Test 2: Filter by specific node ID
+  {
+    absl::flat_hash_set<NodeID> node_ids;
+    node_ids.insert(NodeID::FromBinary(head_node->node_id()));
+    std::vector<rpc::GcsNodeAddressAndLiveness> result;
+    node_manager.GetAllNodeAddressAndLiveness(
+        node_ids,
+        std::nullopt,
+        std::numeric_limits<int64_t>::max(),
+        [&result](rpc::GcsNodeAddressAndLiveness &&node) {
+          result.push_back(std::move(node));
+        });
+
+    EXPECT_EQ(result.size(), 1);
+    EXPECT_EQ(result[0].node_id(), head_node->node_id());
+  }
+
+  // Test 3: Filter by different node ID (should be empty)
+  {
+    absl::flat_hash_set<NodeID> node_ids;
+    node_ids.insert(NodeID::FromRandom());
+    std::vector<rpc::GcsNodeAddressAndLiveness> result;
+    node_manager.GetAllNodeAddressAndLiveness(
+        node_ids,
+        std::nullopt,
+        std::numeric_limits<int64_t>::max(),
+        [&result](rpc::GcsNodeAddressAndLiveness &&node) {
+          result.push_back(std::move(node));
+        });
+
+    EXPECT_EQ(result.size(), 0);
+  }
+
+  // Test 4: Get only alive nodes
+  {
+    absl::flat_hash_set<NodeID> node_ids;
+    std::vector<rpc::GcsNodeAddressAndLiveness> result;
+    node_manager.GetAllNodeAddressAndLiveness(
+        node_ids,
+        rpc::GcsNodeInfo::ALIVE,
+        std::numeric_limits<int64_t>::max(),
+        [&result](rpc::GcsNodeAddressAndLiveness &&node) {
+          result.push_back(std::move(node));
+        });
+
+    EXPECT_EQ(result.size(), 1);
+  }
+
+  // Test 5: Get only dead nodes (should be empty)
+  {
+    absl::flat_hash_set<NodeID> node_ids;
+    std::vector<rpc::GcsNodeAddressAndLiveness> result;
+    node_manager.GetAllNodeAddressAndLiveness(
+        node_ids,
+        rpc::GcsNodeInfo::DEAD,
+        std::numeric_limits<int64_t>::max(),
+        [&result](rpc::GcsNodeAddressAndLiveness &&node) {
+          result.push_back(std::move(node));
+        });
+
+    EXPECT_EQ(result.size(), 0);
+  }
+}
+
+TEST_F(GcsNodeManagerTest, TestCachePassiveLocalNodeSkipsWhenPromoted) {
+  // Race guard: leader election may promote this GCS between the handler's
+  // passive check and CachePassiveLocalNode. When already leader, the call must
+  // be a no-op (not crash and not cache), since the promotion path owns
+  // registration.
+  bool is_leader = true;
+  gcs::GcsNodeManager node_manager(gcs_publisher_.get(),
+                                   gcs_table_storage_.get(),
+                                   *io_context_,
+                                   client_pool_.get(),
+                                   ClusterID::Nil(),
+                                   *fake_ray_event_recorder_,
+                                   "test_session_name",
+                                   observability_publisher_.get(),
+                                   clock_,
+                                   [&is_leader]() { return is_leader; });
+
+  auto head_node = GenNodeInfo();
+  head_node->set_is_head_node(true);
+  NodeID node_id = NodeID::FromBinary(head_node->node_id());
+
+  // Already leader: cache is skipped, node is not visible.
+  node_manager.CachePassiveLocalNode(*head_node);
+  EXPECT_FALSE(node_manager.IsNodeAlive(node_id));
+
+  // Passive: cache takes effect, node becomes visible.
+  is_leader = false;
+  node_manager.CachePassiveLocalNode(*head_node);
+  EXPECT_TRUE(node_manager.IsNodeAlive(node_id));
+}
+
+TEST_F(GcsNodeManagerTest, TestCheckAliveLeadership) {
+  // 1. When constructed without is_leader_fn (or default), it must return is_leader =
+  // true.
+  {
+    gcs::GcsNodeManager node_manager(gcs_publisher_.get(),
+                                     gcs_table_storage_.get(),
+                                     *io_context_,
+                                     client_pool_.get(),
+                                     ClusterID::FromRandom(),
+                                     *fake_ray_event_recorder_,
+                                     "session_name",
+                                     observability_publisher_.get(),
+                                     clock_);
+
+    rpc::CheckAliveRequest request;
+    rpc::CheckAliveReply reply;
+    bool callback_called = false;
+    auto send_reply_callback = [&callback_called, &reply](Status status,
+                                                          std::function<void()> f1,
+                                                          std::function<void()> f2) {
+      EXPECT_TRUE(status.ok());
+      EXPECT_TRUE(reply.is_leader());
+      callback_called = true;
+    };
+    node_manager.HandleCheckAlive(request, &reply, send_reply_callback);
+    EXPECT_TRUE(callback_called);
+  }
+
+  // 2. When constructed with is_leader_fn returning false, it must return is_leader =
+  // false.
+  {
+    gcs::GcsNodeManager node_manager(gcs_publisher_.get(),
+                                     gcs_table_storage_.get(),
+                                     *io_context_,
+                                     client_pool_.get(),
+                                     ClusterID::FromRandom(),
+                                     *fake_ray_event_recorder_,
+                                     "session_name",
+                                     observability_publisher_.get(),
+                                     clock_,
+                                     []() { return false; });
+
+    rpc::CheckAliveRequest request;
+    rpc::CheckAliveReply reply;
+    bool callback_called = false;
+    auto send_reply_callback = [&callback_called, &reply](Status status,
+                                                          std::function<void()> f1,
+                                                          std::function<void()> f2) {
+      EXPECT_TRUE(status.ok());
+      EXPECT_FALSE(reply.is_leader());
+      callback_called = true;
+    };
+    node_manager.HandleCheckAlive(request, &reply, send_reply_callback);
+    EXPECT_TRUE(callback_called);
+  }
+}
+
+TEST_F(GcsNodeManagerTest, TestPassiveHandleGetAllNodeInfoAndCheckAlive) {
+  bool is_leader = false;
+  auto is_leader_fn = [&is_leader]() { return is_leader; };
+
+  gcs::GcsNodeManager node_manager(gcs_publisher_.get(),
+                                   gcs_table_storage_.get(),
+                                   *io_context_,
+                                   client_pool_.get(),
+                                   ClusterID::FromRandom(),
+                                   *fake_ray_event_recorder_,
+                                   "session_name",
+                                   observability_publisher_.get(),
+                                   clock_,
+                                   is_leader_fn);
+
+  auto wait_ready = [this](std::future<bool> future) {
+    while (future.wait_for(std::chrono::milliseconds(1)) != std::future_status::ready) {
+      io_context_->poll();
+      std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    return future.get();
+  };
+
+  // Cache a passive local head node (in production done by LeaderGatedNodeInfoHandler).
+  NodeID passive_node_id = NodeID::FromRandom();
+  auto node_info = GenNodeInfo(10, "127.0.0.1", "passive_node");
+  node_info->set_node_id(passive_node_id.Binary());
+  node_info->set_is_head_node(true);
+
+  node_manager.CachePassiveLocalNode(*node_info);
+
+  // CheckAlive: passive node reports alive, unknown node does not.
+  {
+    rpc::CheckAliveRequest check_request;
+    check_request.add_node_ids(passive_node_id.Binary());
+    NodeID random_node_id = NodeID::FromRandom();
+    check_request.add_node_ids(random_node_id.Binary());
+
+    rpc::CheckAliveReply check_reply;
+    std::promise<bool> check_promise;
+    auto send_check_reply_callback = [&check_promise](Status status,
+                                                      std::function<void()> f1,
+                                                      std::function<void()> f2) {
+      EXPECT_TRUE(status.ok());
+      check_promise.set_value(true);
+    };
+    node_manager.HandleCheckAlive(check_request, &check_reply, send_check_reply_callback);
+    EXPECT_TRUE(wait_ready(check_promise.get_future()));
+
+    EXPECT_FALSE(check_reply.is_leader());
+    ASSERT_EQ(check_reply.raylet_alive_size(), 2);
+    EXPECT_TRUE(check_reply.raylet_alive(0));   // passive node is alive
+    EXPECT_FALSE(check_reply.raylet_alive(1));  // random node is not alive
+  }
+
+  // GetAllNodeInfo: passive node is found by its id.
+  {
+    rpc::GetAllNodeInfoRequest get_request;
+    get_request.add_node_selectors()->set_node_id(passive_node_id.Binary());
+
+    rpc::GetAllNodeInfoReply get_reply;
+    std::promise<bool> get_promise;
+    auto cb = [&get_promise](
+                  Status status, std::function<void()>, std::function<void()>) {
+      EXPECT_TRUE(status.ok());
+      get_promise.set_value(true);
+    };
+    node_manager.HandleGetAllNodeInfo(get_request, &get_reply, cb);
+    EXPECT_TRUE(wait_ready(get_promise.get_future()));
+
+    ASSERT_EQ(get_reply.node_info_list_size(), 1);
+    EXPECT_EQ(NodeID::FromBinary(get_reply.node_info_list(0).node_id()), passive_node_id);
+  }
+
+  // GetAllNodeInfo: name selector matches the passive node.
+  {
+    rpc::GetAllNodeInfoRequest get_request;
+    get_request.add_node_selectors()->set_node_name("passive_node");
+
+    rpc::GetAllNodeInfoReply get_reply;
+    std::promise<bool> get_promise;
+    auto cb = [&get_promise](
+                  Status status, std::function<void()>, std::function<void()>) {
+      EXPECT_TRUE(status.ok());
+      get_promise.set_value(true);
+    };
+    node_manager.HandleGetAllNodeInfo(get_request, &get_reply, cb);
+    EXPECT_TRUE(wait_ready(get_promise.get_future()));
+
+    ASSERT_EQ(get_reply.node_info_list_size(), 1);
+    EXPECT_EQ(NodeID::FromBinary(get_reply.node_info_list(0).node_id()), passive_node_id);
+  }
+
+  // GetAllNodeInfo: DEAD filter must not return the (alive) passive node.
+  {
+    rpc::GetAllNodeInfoRequest get_request;
+    get_request.set_state_filter(rpc::GcsNodeInfo::DEAD);
+
+    rpc::GetAllNodeInfoReply get_reply;
+    std::promise<bool> get_promise;
+    auto cb = [&get_promise](
+                  Status status, std::function<void()>, std::function<void()>) {
+      EXPECT_TRUE(status.ok());
+      get_promise.set_value(true);
+    };
+    node_manager.HandleGetAllNodeInfo(get_request, &get_reply, cb);
+    EXPECT_TRUE(wait_ready(get_promise.get_future()));
+
+    EXPECT_EQ(get_reply.node_info_list_size(), 0);
+  }
+
+  // GetAllNodeInfo: Add a second (non-head) node to the cache and test filtering.
+  {
+    auto worker_info = GenNodeInfo(12, "127.0.0.3", "alive_worker");
+    NodeID worker_node_id = NodeID::FromRandom();
+    worker_info->set_node_id(worker_node_id.Binary());
+    worker_info->set_is_head_node(false);
+    node_manager.AddNode(worker_info);
+
+    // No filter: both nodes returned.
+    {
+      rpc::GetAllNodeInfoRequest get_request;
+      rpc::GetAllNodeInfoReply get_reply;
+      std::promise<bool> get_promise;
+      auto cb = [&get_promise](
+                    Status status, std::function<void()>, std::function<void()>) {
+        EXPECT_TRUE(status.ok());
+        get_promise.set_value(true);
+      };
+      node_manager.HandleGetAllNodeInfo(get_request, &get_reply, cb);
+      EXPECT_TRUE(wait_ready(get_promise.get_future()));
+
+      ASSERT_EQ(get_reply.node_info_list_size(), 2);
+      absl::flat_hash_set<NodeID> returned_ids;
+      for (const auto &node : get_reply.node_info_list()) {
+        returned_ids.insert(NodeID::FromBinary(node.node_id()));
+      }
+      EXPECT_TRUE(returned_ids.contains(passive_node_id));
+      EXPECT_TRUE(returned_ids.contains(worker_node_id));
+    }
+
+    // head-only query: only the passive head returned, no duplicate.
+    {
+      rpc::GetAllNodeInfoRequest get_request;
+      get_request.add_node_selectors()->set_is_head_node(true);
+      rpc::GetAllNodeInfoReply get_reply;
+      std::promise<bool> get_promise;
+      auto cb = [&get_promise](
+                    Status status, std::function<void()>, std::function<void()>) {
+        EXPECT_TRUE(status.ok());
+        get_promise.set_value(true);
+      };
+      node_manager.HandleGetAllNodeInfo(get_request, &get_reply, cb);
+      EXPECT_TRUE(wait_ready(get_promise.get_future()));
+
+      ASSERT_EQ(get_reply.node_info_list_size(), 1);
+      EXPECT_EQ(NodeID::FromBinary(get_reply.node_info_list(0).node_id()),
+                passive_node_id);
+      EXPECT_TRUE(get_reply.node_info_list(0).is_head_node());
+    }
+  }
+}
+
 }  // namespace ray

--- a/src/ray/gcs/tests/gcs_node_manager_test.cc
+++ b/src/ray/gcs/tests/gcs_node_manager_test.cc
@@ -962,7 +962,7 @@ TEST_F(GcsNodeManagerTest, TestCachePassiveLocalNodeSkipsWhenPromoted) {
   // passive check and CachePassiveLocalNode. When already leader, the call must
   // be a no-op (not crash and not cache), since the promotion path owns
   // registration.
-  bool is_leader = true;
+  bool is_leader = false;
   gcs::GcsNodeManager node_manager(gcs_publisher_.get(),
                                    gcs_table_storage_.get(),
                                    *io_context_,
@@ -978,14 +978,137 @@ TEST_F(GcsNodeManagerTest, TestCachePassiveLocalNodeSkipsWhenPromoted) {
   head_node->set_is_head_node(true);
   NodeID node_id = NodeID::FromBinary(head_node->node_id());
 
-  // Already leader: cache is skipped, node is not visible.
-  node_manager.CachePassiveLocalNode(*head_node);
-  EXPECT_FALSE(node_manager.IsNodeAlive(node_id));
+  // Query a node through the real visibility path (GetAllNodeInfo by node id) and
+  // return whether it is present in the reply.
+  auto node_visible = [&](const NodeID &id) {
+    rpc::GetAllNodeInfoRequest request;
+    request.add_node_selectors()->set_node_id(id.Binary());
+    rpc::GetAllNodeInfoReply reply;
+    node_manager.HandleGetAllNodeInfo(
+        request, &reply, [](Status, std::function<void()>, std::function<void()>) {});
+    return reply.node_info_list_size() == 1;
+  };
 
   // Passive: cache takes effect, node becomes visible.
-  is_leader = false;
   node_manager.CachePassiveLocalNode(*head_node);
-  EXPECT_TRUE(node_manager.IsNodeAlive(node_id));
+  EXPECT_TRUE(node_visible(node_id));
+
+  // Reset the cache so the next cases start clean and can reuse the same node id.
+  // TODO: update to real promotion path when implemented.
+  node_manager.ClearPassiveLocalNode();
+  EXPECT_FALSE(node_visible(node_id));
+
+  // Already leader: cache is skipped, node is not visible.
+  is_leader = true;
+  node_manager.CachePassiveLocalNode(*head_node);
+  EXPECT_FALSE(node_visible(node_id));
+
+  // Already leader: the normal registration path still works and makes the node
+  // visible (the leader owns registration).
+  rpc::RegisterNodeRequest register_request;
+  register_request.mutable_node_info()->CopyFrom(*head_node);
+  rpc::RegisterNodeReply register_reply;
+  node_manager.HandleRegisterNode(
+      register_request,
+      &register_reply,
+      [](Status, std::function<void()>, std::function<void()>) {});
+  while (io_context_->poll() > 0) {
+  }
+  EXPECT_TRUE(node_visible(node_id));
+}
+
+TEST_F(GcsNodeManagerTest, TestPassiveLocalNodeNotDoubleCounted) {
+  // Defensive de-dup: if the passive cache and alive_nodes_/dead_nodes_ both hold
+  // the same node id (e.g. a query racing with promotion before the cache is
+  // cleared), the visibility RPCs must surface it exactly once and never inflate
+  // the total.
+  bool is_leader = false;
+  gcs::GcsNodeManager node_manager(gcs_publisher_.get(),
+                                   gcs_table_storage_.get(),
+                                   *io_context_,
+                                   client_pool_.get(),
+                                   ClusterID::Nil(),
+                                   *fake_ray_event_recorder_,
+                                   "test_session_name",
+                                   observability_publisher_.get(),
+                                   clock_,
+                                   [&is_leader]() { return is_leader; });
+
+  auto head_node = GenNodeInfo();
+  head_node->set_is_head_node(true);
+  NodeID node_id = NodeID::FromBinary(head_node->node_id());
+
+  auto get_all = [&](std::optional<rpc::GcsNodeInfo::GcsNodeState> state_filter) {
+    rpc::GetAllNodeInfoRequest request;
+    if (state_filter.has_value()) {
+      request.set_state_filter(state_filter.value());
+    }
+    rpc::GetAllNodeInfoReply reply;
+    node_manager.HandleGetAllNodeInfo(
+        request, &reply, [](Status, std::function<void()>, std::function<void()>) {});
+    return reply;
+  };
+
+  auto count_node = [&](const rpc::GetAllNodeInfoReply &reply) {
+    int count = 0;
+    for (const auto &n : reply.node_info_list()) {
+      if (NodeID::FromBinary(n.node_id()) == node_id) {
+        ++count;
+      }
+    }
+    return count;
+  };
+
+  // Cache the passive head, then also add the same id to alive_nodes_ directly to
+  // simulate the cache not yet being cleared after promotion.
+  node_manager.CachePassiveLocalNode(*head_node);
+  node_manager.AddNode(std::make_shared<rpc::GcsNodeInfo>(*head_node));
+
+  // No filter: the node appears exactly once and total is not inflated.
+  {
+    auto reply = get_all(std::nullopt);
+    EXPECT_EQ(count_node(reply), 1);
+    EXPECT_EQ(reply.total(), 1);
+  }
+
+  // ALIVE filter: still exactly once (from alive_nodes_, not the cache).
+  {
+    auto reply = get_all(rpc::GcsNodeInfo::ALIVE);
+    EXPECT_EQ(count_node(reply), 1);
+  }
+}
+
+TEST_F(GcsNodeManagerTest, TestCachePassiveLocalNodeSkippedWhenAlreadyTracked) {
+  // Write-path de-dup: CachePassiveLocalNode must not cache a node that is already
+  // tracked in alive_nodes_ (or dead_nodes_).
+  bool is_leader = false;
+  gcs::GcsNodeManager node_manager(gcs_publisher_.get(),
+                                   gcs_table_storage_.get(),
+                                   *io_context_,
+                                   client_pool_.get(),
+                                   ClusterID::Nil(),
+                                   *fake_ray_event_recorder_,
+                                   "test_session_name",
+                                   observability_publisher_.get(),
+                                   clock_,
+                                   [&is_leader]() { return is_leader; });
+
+  auto head_node = GenNodeInfo();
+  head_node->set_is_head_node(true);
+  NodeID node_id = NodeID::FromBinary(head_node->node_id());
+
+  // Node is already alive; caching it as passive must be a no-op.
+  node_manager.AddNode(std::make_shared<rpc::GcsNodeInfo>(*head_node));
+  node_manager.CachePassiveLocalNode(*head_node);
+
+  rpc::GetAllNodeInfoRequest request;
+  request.add_node_selectors()->set_node_id(node_id.Binary());
+  rpc::GetAllNodeInfoReply reply;
+  node_manager.HandleGetAllNodeInfo(
+      request, &reply, [](Status, std::function<void()>, std::function<void()>) {});
+  // Exactly one entry (from alive_nodes_), and total counts it once.
+  EXPECT_EQ(reply.node_info_list_size(), 1);
+  EXPECT_EQ(reply.total(), 1);
 }
 
 TEST_F(GcsNodeManagerTest, TestCheckAliveLeadership) {

--- a/src/ray/gcs_rpc_client/tests/gcs_client_test.cc
+++ b/src/ray/gcs_rpc_client/tests/gcs_client_test.cc
@@ -576,6 +576,7 @@ TEST_P(GcsClientTest, TestGcsClientCheckAlive) {
     ASSERT_EQ(nodes_alive.size(), 2);
     ASSERT_FALSE(nodes_alive[0]);
     ASSERT_FALSE(nodes_alive[1]);
+    ASSERT_TRUE(gcs_client_->Nodes().IsGcsLeader());
   }
 
   ASSERT_TRUE(RegisterNode(*node_info1));
@@ -586,6 +587,7 @@ TEST_P(GcsClientTest, TestGcsClientCheckAlive) {
     ASSERT_EQ(nodes_alive.size(), 2);
     ASSERT_TRUE(nodes_alive[0]);
     ASSERT_FALSE(nodes_alive[1]);
+    ASSERT_TRUE(gcs_client_->Nodes().IsGcsLeader());
   }
 }
 

--- a/src/ray/ray_syncer/ray_syncer.cc
+++ b/src/ray/ray_syncer/ray_syncer.cc
@@ -224,7 +224,7 @@ void RaySyncer::BroadcastMessage(std::shared_ptr<const RaySyncMessage> message) 
       "RaySyncer.BroadcastMessage");
 }
 
-ServerBidiReactor *RaySyncerService::StartSync(grpc::CallbackServerContext *context) {
+SyncStreamReactor *RaySyncerService::StartSync(grpc::CallbackServerContext *context) {
   auto reactor = std::make_shared<RayServerBidiReactor>(
       context,
       syncer_.GetIOContext(),

--- a/src/ray/ray_syncer/ray_syncer.h
+++ b/src/ray/ray_syncer/ray_syncer.h
@@ -205,12 +205,26 @@ class RaySyncer {
   FRIEND_TEST(SyncerTest, Reconnect);
 };
 
+using SyncStreamReactor =
+    grpc::ServerBidiReactor<RaySyncMessageBatch, RaySyncMessageBatch>;
+
+/// Abstract handler for the RaySyncer stream RPCs. Lets the leader-gating proxy
+/// (LeaderGatedRaySyncerHandler) wrap the service without depending on the
+/// concrete gRPC-generated base. Any new stream RPC added here must also be
+/// implemented by the gated proxy, which forces an explicit leader-policy choice.
+class RaySyncerStreamHandler {
+ public:
+  virtual ~RaySyncerStreamHandler() = default;
+
+  virtual SyncStreamReactor *StartSync(grpc::CallbackServerContext *context) = 0;
+};
+
 /// RaySyncerService is a service to take care of resource synchronization
 /// related operations.
 /// Right now only raylet needs to setup this service. But in the future,
 /// we can use this to construct more complicated resource reporting algorithm,
 /// like tree-based one.
-class RaySyncerService : public ray::rpc::syncer::RaySyncer::CallbackService {
+class RaySyncerService : public RaySyncerStreamHandler {
  public:
   explicit RaySyncerService(
       RaySyncer &syncer,
@@ -221,8 +235,7 @@ class RaySyncerService : public ray::rpc::syncer::RaySyncer::CallbackService {
         auth_token_(std::move(auth_token)),
         auth_token_validator_(auth_token_validator) {}
 
-  grpc::ServerBidiReactor<RaySyncMessageBatch, RaySyncMessageBatch> *StartSync(
-      grpc::CallbackServerContext *context) override;
+  SyncStreamReactor *StartSync(grpc::CallbackServerContext *context) override;
 
  private:
   // The ray syncer this RPC wrappers of.
@@ -233,6 +246,21 @@ class RaySyncerService : public ray::rpc::syncer::RaySyncer::CallbackService {
 
   // Validator for authentication token
   ray::rpc::AuthenticationTokenValidator &auth_token_validator_;
+};
+
+/// gRPC-facing service. Thin adapter that forwards the generated CallbackService
+/// entry points to a RaySyncerStreamHandler (either the real RaySyncerService or
+/// the leader-gating proxy). Registered with the RPC server.
+class RaySyncerGrpcService : public ray::rpc::syncer::RaySyncer::CallbackService {
+ public:
+  explicit RaySyncerGrpcService(RaySyncerStreamHandler &handler) : handler_(handler) {}
+
+  SyncStreamReactor *StartSync(grpc::CallbackServerContext *context) override {
+    return handler_.StartSync(context);
+  }
+
+ private:
+  RaySyncerStreamHandler &handler_;
 };
 
 }  // namespace ray::syncer

--- a/src/ray/ray_syncer/tests/ray_syncer_test.cc
+++ b/src/ray/ray_syncer/tests/ray_syncer_test.cc
@@ -319,8 +319,9 @@ struct SyncerServerTest {
     auto server_address = BuildAddress("0.0.0.0", port);
     grpc::ServerBuilder builder;
     service = std::make_unique<RaySyncerService>(*syncer);
+    grpc_service = std::make_unique<RaySyncerGrpcService>(*service);
     builder.AddListeningPort(server_address, grpc::InsecureServerCredentials());
-    builder.RegisterService(service.get());
+    builder.RegisterService(grpc_service.get());
     server = builder.BuildAndStart();
 
     for (size_t cid = 0; cid < reporters.size(); ++cid) {
@@ -459,6 +460,7 @@ struct SyncerServerTest {
     return iter->second;
   }
   std::unique_ptr<RaySyncerService> service;
+  std::unique_ptr<RaySyncerGrpcService> grpc_service;
   std::unique_ptr<RaySyncer> syncer;
   std::unique_ptr<grpc::Server> server;
   std::unique_ptr<std::thread> thread;
@@ -1104,6 +1106,7 @@ class SyncerAuthenticationTest : public ::testing::Test {
     std::unique_ptr<std::thread> thread;
     std::unique_ptr<RaySyncer> syncer;
     std::unique_ptr<RaySyncerService> service;
+    std::unique_ptr<RaySyncerGrpcService> grpc_service;
     std::unique_ptr<grpc::Server> server;
 
     AuthenticatedSyncerServerTest(const std::string &port, const std::string &token)
@@ -1121,11 +1124,12 @@ class SyncerAuthenticationTest : public ::testing::Test {
           *syncer,
           token.empty() ? nullptr
                         : std::make_shared<const ray::rpc::AuthenticationToken>(token));
+      grpc_service = std::make_unique<RaySyncerGrpcService>(*service);
 
       auto server_address = BuildAddress("0.0.0.0", port);
       grpc::ServerBuilder builder;
       builder.AddListeningPort(server_address, grpc::InsecureServerCredentials());
-      builder.RegisterService(service.get());
+      builder.RegisterService(grpc_service.get());
       server = builder.BuildAndStart();
     }
 

--- a/src/ray/ray_syncer/tests/syncer_service_e2e_test.cc
+++ b/src/ray/ray_syncer/tests/syncer_service_e2e_test.cc
@@ -106,6 +106,7 @@ int main(int argc, char *argv[]) {
   // RPC related field
   grpc::ServerBuilder builder;
   std::unique_ptr<ray::syncer::RaySyncerService> service;
+  std::unique_ptr<ray::syncer::RaySyncerGrpcService> grpc_service;
   std::unique_ptr<grpc::Server> server;
   std::shared_ptr<grpc::Channel> channel;
   syncer.Register(
@@ -114,8 +115,9 @@ int main(int argc, char *argv[]) {
     RAY_LOG(INFO) << "Start server on port " << server_port;
     auto server_address = ray::BuildAddress("0.0.0.0", server_port);
     service = std::make_unique<ray::syncer::RaySyncerService>(syncer);
+    grpc_service = std::make_unique<ray::syncer::RaySyncerGrpcService>(*service);
     builder.AddListeningPort(server_address, grpc::InsecureServerCredentials());
-    builder.RegisterService(service.get());
+    builder.RegisterService(grpc_service.get());
     server = builder.BuildAndStart();
   }
   if (leader_port != ".") {

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -306,9 +306,11 @@ NodeManager::NodeManager(
   // Run the node manager rpc server.
   node_manager_server_.RegisterService(
       std::make_unique<rpc::NodeManagerGrpcService>(io_service, *this), false);
-  // Pass auth token from the RPC server to the syncer service
-  node_manager_server_.RegisterService(std::make_unique<syncer::RaySyncerService>(
-      ray_syncer_, ray::rpc::AuthenticationTokenLoader::instance().GetToken()));
+  // Pass auth token from the RPC server to the syncer service.
+  ray_syncer_service_ = std::make_unique<syncer::RaySyncerService>(
+      ray_syncer_, ray::rpc::AuthenticationTokenLoader::instance().GetToken());
+  node_manager_server_.RegisterService(
+      std::make_unique<syncer::RaySyncerGrpcService>(*ray_syncer_service_));
   node_manager_server_.Run();
   // GCS will check the health of the service named with the node id.
   // Fail to setup this will lead to the health check failure.

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -259,6 +259,7 @@ NodeManager::NodeManager(
                                                std::chrono::milliseconds(delay_ms)));
                     }),
       runtime_env_agent_port_(config.runtime_env_agent_port),
+      ray_syncer_(io_service_, periodical_runner, self_node_id_.Binary(), 1, 0),
       node_manager_server_("NodeManager",
                            config.node_manager_port,
                            IsLocalhost(config.node_manager_address)),
@@ -278,7 +279,6 @@ NodeManager::NodeManager(
       cluster_lease_manager_(cluster_lease_manager),
       record_metrics_period_ms_(config.record_metrics_period_ms),
       placement_group_resource_manager_(placement_group_resource_manager),
-      ray_syncer_(io_service_, periodical_runner, self_node_id_.Binary(), 1, 0),
       worker_killing_policy_(WorkerKillingPolicyFactory::Create(
           config.enable_resource_isolation, *cgroup_manager)),
       memory_monitors_(MemoryMonitorFactory::Create(CreateKillWorkersCallback(),

--- a/src/ray/raylet/node_manager.h
+++ b/src/ray/raylet/node_manager.h
@@ -1020,6 +1020,10 @@ class NodeManager : public rpc::NodeManagerServiceHandler,
   /// Ray syncer for synchronization
   syncer::RaySyncer ray_syncer_;
 
+  /// Owns the RaySyncer stream handler; the gRPC service registered below only holds a
+  /// reference to it, so it must outlive the RPC server.
+  std::unique_ptr<syncer::RaySyncerService> ray_syncer_service_;
+
   /// `version` for the RaySyncer COMMANDS channel. Monotonically incremented each time
   /// we issue a GC command so that none of the messages are dropped.
   int64_t gc_command_sync_version_ = 0;

--- a/src/ray/raylet/node_manager.h
+++ b/src/ray/raylet/node_manager.h
@@ -926,6 +926,13 @@ class NodeManager : public rpc::NodeManagerServiceHandler,
   int metrics_export_port_{0};
   int dashboard_agent_listen_port_{0};
 
+  /// Ray syncer for synchronization
+  syncer::RaySyncer ray_syncer_;
+
+  /// Owns the RaySyncer stream handler; must outlive node_manager_server_ which holds
+  /// a raw reference to it.
+  std::unique_ptr<syncer::RaySyncerService> ray_syncer_service_;
+
   /// The RPC server.
   rpc::GrpcServer node_manager_server_;
 
@@ -1016,13 +1023,6 @@ class NodeManager : public rpc::NodeManagerServiceHandler,
 
   /// Managers all bundle-related operations.
   PlacementGroupResourceManager &placement_group_resource_manager_;
-
-  /// Ray syncer for synchronization
-  syncer::RaySyncer ray_syncer_;
-
-  /// Owns the RaySyncer stream handler; the gRPC service registered below only holds a
-  /// reference to it, so it must outlive the RPC server.
-  std::unique_ptr<syncer::RaySyncerService> ray_syncer_service_;
 
   /// `version` for the RaySyncer COMMANDS channel. Monotonically incremented each time
   /// we issue a GC command so that none of the messages are dropped.


### PR DESCRIPTION

## Description

This is the C++ RPC-gating layer for the Active-Passive GCS feature (split from the larger #64422, following the interface PR #65132). It adds the server-side mechanism that, when a GCS is **not** the active leader, rejects mutating RPCs with `Status::GcsPassive()` while forwarding bootstrap/read RPCs. Everything is gated behind `LEADER_ELECT`, which **defaults to off**, so a normal single-GCS cluster behaves exactly as before. 

This PR intentionally contains **only the gating mechanism**. The deferred-loading / promotion lifecycle (which flips a GCS from passive to active, updates the `is_leader` and the clears the `passive_local_node_`) and the end-to-end passive-head startup are in a follow-up PR. Since the gcs hasn't connected with the leader election model, setting `LEADER_ELECT` will not have gcs leader election behavior.

AI assistance was used to prepare this change.

## Issue

https://github.com/ray-project/ray/issues/63643

## High-level changes

| Area | Change |
| :--- | :--- |
| **Leader-gated proxy handlers** | New gcs_leader_gated_handlers.h: a per-service proxy (`LeaderGated*Handler`) that wraps each real GCS service handler. `GCS_GATED_RPC` / `GCS_ALLOWED_RPC` macros make each RPC's gated-or-allowed status a single, auditable line; adding a new RPC to a service is a compile-time-enforced one-liner. |
| **GcsNodeManager leadership + passive cache** | Injects an `is_leader_fn` (defaults to `[]{return true;}`), reports it in `HandleCheckAlive` via `reply->set_is_leader(...)`, and adds an in-memory `passive_local_node_` cache (`CachePassiveLocalNode`) so the local head node is visible while passive and flushed through the normal RegisterNode path on promotion. |
| **Centralized service registration** | All 14 `rpc_server_.RegisterService(...)` calls are moved out of the individual `InitXxx()` methods into one `GcsServer::RegisterRpcServices()`, called from `DoStart` after all managers are constructed. Gated services go through `MaybeGate`; `RaySyncer` is registered in an explicit "intentionally NOT gated" section with a documented rationale. |

## Test plan

**Unit (C++)** — new
- `gcs_leader_gated_handlers_test.cc`
- `gcs_node_manager_test.cc` 
-  `gcs_client_test.cc`

**Integration / backward-compat (C++)** — existing
- `gcs_server_rpc_test` 

**Real-cluster smoke (default config, `LEADER_ELECT` off)**
- ensure backward compatibility