### PR TITLE
[tune] Fix dark mode readability for Tune status/progress tables

### DIFF
--- a/python/ray/tests/test_widgets.py
+++ b/python/ray/tests/test_widgets.py
@@ -6,6 +6,7 @@ from unittest import mock
 import pytest
 
 import ray
+from ray.widgets.render import Template
 from ray.widgets.util import _can_display_ipywidgets, repr_with_fallback
 
 
@@ -180,6 +181,27 @@ def test_can_display_ipywidgets(
 
     assert _can_display_ipywidgets(["somedep", "8"], message="") == can_display
     mock_get_ipython_shell_name.assert_called()
+
+
+@pytest.mark.parametrize(
+    "template_file,container_class",
+    [
+        ("tune_status.html.j2", "tuneStatus"),
+        ("trial_progress.html.j2", "trialProgress"),
+    ],
+)
+def test_tune_widget_templates_set_table_background(template_file, container_class):
+    """Table cells must set an explicit background so text stays legible when the
+    JupyterLab theme is switched to dark mode (see issue #52656)."""
+    rendered = Template(template_file).render(
+        status_table="",
+        sys_info_message="",
+        trial_progress="",
+        messages="",
+        table="",
+    )
+    assert f".{container_class} table" in rendered
+    assert "background-color: var(--jp-layout-color1)" in rendered
 
 
 if __name__ == "__main__":

--- a/python/ray/widgets/templates/trial_progress.html.j2
+++ b/python/ray/widgets/templates/trial_progress.html.j2
@@ -7,9 +7,20 @@
   display: flex;
   flex-direction: column;
   color: var(--jp-ui-font-color1);
+  background-color: var(--jp-layout-color1);
 }
 .trialProgress h3 {
   font-weight: bold;
+}
+.trialProgress table,
+.trialProgress th,
+.trialProgress td {
+  color: var(--jp-ui-font-color1);
+  background-color: var(--jp-layout-color1);
+  border-color: var(--jp-border-color0);
+}
+.trialProgress table {
+  border-collapse: collapse;
 }
 .trialProgress td {
   white-space: nowrap;

--- a/python/ray/widgets/templates/tune_status.html.j2
+++ b/python/ray/widgets/templates/tune_status.html.j2
@@ -20,10 +20,21 @@
 <style>
 .tuneStatus {
   color: var(--jp-ui-font-color1);
+  background-color: var(--jp-layout-color1);
 }
 .tuneStatus .systemInfo {
   display: flex;
   flex-direction: column;
+}
+.tuneStatus table,
+.tuneStatus th,
+.tuneStatus td {
+  color: var(--jp-ui-font-color1);
+  background-color: var(--jp-layout-color1);
+  border-color: var(--jp-border-color0);
+}
+.tuneStatus table {
+  border-collapse: collapse;
 }
 .tuneStatus td {
   white-space: nowrap;


### PR DESCRIPTION
## Description

The Tune status and trial progress Jupyter widgets set table text color via
JupyterLab's `--jp-ui-font-color1` variable but never set a matching
`background-color`, so in dark-themed notebooks the (now light-colored) text
renders against the default white background and becomes unreadable — see
the screenshot on the linked issue.

`scrollableTable.html.j2` already handles this correctly
(`background: var(--jp-layout-color1)`); this PR applies the same pattern to
`tune_status.html.j2` and `trial_progress.html.j2`, setting an explicit
`background-color` on the table/th/td elements (and the container, for
robustness) plus `border-collapse: collapse` for cleaner borders. Since
`--jp-layout-color1` and `--jp-ui-font-color1` are already redefined by
JupyterLab per-theme, no manual dark-mode media query/selector is needed.

Also adds a regression test (`test_tune_widget_templates_set_table_background`
in `test_widgets.py`) that renders both templates and asserts the
background-color rule is present, to guard against this regressing again.

## Related issues

Fixes #52656

## Additional information

Verified by rendering both templates with sample `Tuner.fit()`-shaped data
and viewing the output in a browser under both light and dark JupyterLab CSS
variable values — text is legible against the background in both. Ran
`pytest python/ray/tests/test_widgets.py -v` (10 passed) and `ruff
check`/`ruff format --check` on the changed Python file.

Two earlier attempts at this issue (#62364, #53969) proposed a similar fix
but went stale from inactivity rather than being rejected; this PR is a
fresh implementation informed by both, plus the automated review feedback
on #62364 to apply styling at the container/element level rather than
duplicating per-selector overrides.