### PR TITLE
[serve] Aggregate autoscaling metrics only at the controller

### DIFF
--- a/doc/source/serve/advanced-guides/advanced-autoscaling.md
+++ b/doc/source/serve/advanced-guides/advanced-autoscaling.md
@@ -125,33 +125,19 @@ Replicas and deployment handles continuously record autoscaling metrics:
 
 Periodically, replicas and handles push their metrics to the controller:
 - **Frequency**: Every 10s (configurable via `RAY_SERVE_REPLICA_AUTOSCALING_METRIC_PUSH_INTERVAL_S` and `RAY_SERVE_HANDLE_AUTOSCALING_METRIC_PUSH_INTERVAL_S`)
-- **Data sent**: Both raw timeseries data and pre-aggregated metrics
-  - **Raw timeseries**: Data points are clipped to the [`look_back_period_s`](../api/doc/ray.serve.config.AutoscalingConfig.rst) window before sending (only recent measurements within the window are sent)
-  - **Pre-aggregated metrics**: A simple average computed over the [`look_back_period_s`](../api/doc/ray.serve.config.AutoscalingConfig.rst) window at the replica/handle
-- **Controller usage**: The controller decides which data to use based on the `RAY_SERVE_AGGREGATE_METRICS_AT_CONTROLLER` setting (see Stage 3 below)
+- **Data sent**: Raw timeseries data. Data points are clipped to the [`look_back_period_s`](../api/doc/ray.serve.config.AutoscalingConfig.rst) window before sending (only recent measurements within the window are sent)
 
 #### Stage 3: Metric aggregation
 
-The controller aggregates metrics to compute total ongoing requests across all replicas. Ray Serve supports two aggregation modes (controlled by `RAY_SERVE_AGGREGATE_METRICS_AT_CONTROLLER`):
-
-**Simple mode (default - `RAY_SERVE_AGGREGATE_METRICS_AT_CONTROLLER=0`):**
-- **Input**: Pre-aggregated simple averages from replicas/handles (already clipped to [`look_back_period_s`](../api/doc/ray.serve.config.AutoscalingConfig.rst))
-- **Method**: Sums the pre-aggregated values from all sources. Each component computes a simple average (arithmetic mean) before sending.
-- **Output**: Single value representing total ongoing requests
-- **Characteristics**: Lightweight and works well for most workloads. However, because it uses simple averages rather than time-weighted averages, it can be less accurate when replicas have different metric reporting intervals or when metrics arrive at different times.
-
-**Aggregate mode (experimental - `RAY_SERVE_AGGREGATE_METRICS_AT_CONTROLLER=1`):**
+The controller aggregates the raw timeseries to compute total ongoing requests across all replicas:
 - **Input**: Raw timeseries data from replicas/handles (already clipped to [`look_back_period_s`](../api/doc/ray.serve.config.AutoscalingConfig.rst))
 - **Method**: Time-weighted aggregation using the [`aggregation_function`](../api/doc/ray.serve.config.AutoscalingConfig.rst) (mean, max, or min). Uses an instantaneous merge approach that treats metrics as right-continuous step functions.
 - **Output**: Single value representing total ongoing requests
-- **Characteristics**: Provides more mathematically accurate aggregation, especially when replicas report metrics at different intervals or you need precise time-weighted averages. The trade-off is increased controller overhead.
 
 :::{note}
-The [`aggregation_function`](../api/doc/ray.serve.config.AutoscalingConfig.rst) parameter only applies in aggregate mode. In simple mode, the aggregation is always a sum of the pre-computed simple averages.
-:::
-
-:::{note}
-The long-term plan is to deprecate simple mode in favor of aggregate mode. Aggregate mode provides more accurate metrics aggregation and will become the default in a future release. Consider testing aggregate mode(`RAY_SERVE_AGGREGATE_METRICS_AT_CONTROLLER=1`) in your deployments to prepare for this transition.
+Earlier releases also supported a "simple mode" that summed averages pre-computed at each replica and handle, selected by `RAY_SERVE_AGGREGATE_METRICS_AT_CONTROLLER`. That flag and that mode are removed: the controller now always aggregates raw timeseries. Two consequences if you are upgrading from a release that had the flag, where it defaulted to simple mode:
+- [`aggregation_function`](../api/doc/ray.serve.config.AutoscalingConfig.rst) now always applies. Under simple mode it was ignored, so a deployment that set `max` or `min` and never enabled the flag scaled on a mean and now scales on a peak or a trough.
+- Aggregating timeseries costs the controller more than summing pre-computed averages, and the cost grows with the number of replicas. Watch controller CPU on deployments with very high replica counts.
 :::
 
 #### Stage 4: Policy execution
@@ -200,10 +186,6 @@ Several environment variables control autoscaling behavior at a lower level. The
 * **`RAY_SERVE_RECORD_AUTOSCALING_STATS_TIMEOUT_S`** (default: 10.0s): Maximum time allowed for the `record_autoscaling_stats()` method to complete in custom metrics collection. If this timeout is exceeded, the metrics collection fails and a warning is logged.
 
 * **`RAY_SERVE_MIN_HANDLE_METRICS_TIMEOUT_S`** (default: 10.0s): Minimum timeout for handle metrics collection. The system uses the maximum of this value and `2 * `[`metrics_interval_s`](../api/doc/ray.serve.config.AutoscalingConfig.rst) to determine when to drop stale handle metrics.
-
-#### Advanced feature flags
-
-* **`RAY_SERVE_AGGREGATE_METRICS_AT_CONTROLLER`** (default: false): Enables an experimental metrics aggregation mode where the controller aggregates raw timeseries data instead of using pre-aggregated metrics. This mode provides more accurate time-weighted averages but may increase controller overhead. See Stage 3 in "How autoscaling metrics work" for details.
 
 
 ## Model composition example

--- a/doc/source/serve/advanced-guides/advanced-autoscaling.md
+++ b/doc/source/serve/advanced-guides/advanced-autoscaling.md
@@ -135,9 +135,9 @@ The controller aggregates the raw timeseries to compute total ongoing requests a
 - **Output**: Single value representing total ongoing requests
 
 :::{note}
-Earlier releases also supported a "simple mode" that summed averages pre-computed at each replica and handle, selected by `RAY_SERVE_AGGREGATE_METRICS_AT_CONTROLLER`. That flag and that mode are removed: the controller now always aggregates raw timeseries. Two consequences if you are upgrading from a release that had the flag, where it defaulted to simple mode:
+Earlier releases also supported a "simple mode" that summed averages pre-computed at each replica and handle, selected by `RAY_SERVE_AGGREGATE_METRICS_AT_CONTROLLER`. That flag and that mode are removed. The controller now always aggregates raw timeseries. Two consequences if you're upgrading from a release that had the flag, where it defaulted to simple mode:
 - [`aggregation_function`](../api/doc/ray.serve.config.AutoscalingConfig.rst) now always applies. Under simple mode it was ignored, so a deployment that set `max` or `min` and never enabled the flag scaled on a mean and now scales on a peak or a trough.
-- Aggregating timeseries costs the controller more than summing pre-computed averages, and the cost grows with the number of replicas. Watch controller CPU on deployments with very high replica counts.
+- Aggregating timeseries costs the controller more than summing pre-computed averages, and the cost grows with the number of replicas. Watch controller CPU on deployments with high replica counts.
 :::
 
 #### Stage 4: Policy execution

--- a/doc/source/serve/advanced-guides/advanced-autoscaling.md
+++ b/doc/source/serve/advanced-guides/advanced-autoscaling.md
@@ -88,8 +88,8 @@ This controls how often each replica and handle sends reports on current ongoing
 
 * **[`aggregation_function`](../api/doc/ray.serve.config.AutoscalingConfig.rst) [default_value="mean"]**: This controls how metrics are aggregated over the `look_back_period_s` time window. The aggregation function determines how Ray Serve combines multiple metric measurements into a single value for autoscaling decisions. Supported values:
   - `"mean"` (default): Uses time-weighted average of metrics. This provides smooth scaling behavior that responds to sustained traffic patterns.
-  - `"max"`: Uses the maximum metric value observed. This makes autoscaling more sensitive to spikes, scaling up quickly when any replica experiences high load.
-  - `"min"`: Uses the minimum metric value observed. This results in more conservative scaling behavior.
+  - `"max"`: Uses the highest value the deployment total reached during the window, not the highest value of any one replica. This makes autoscaling more sensitive to spikes.
+  - `"min"`: Uses the lowest value the deployment total reached during the window. This scales conservatively. Because an idle stretch inside the window pins the minimum to zero, a deployment that scaled to zero stays there until those samples age out.
 
 For most workloads, the default `"mean"` aggregation provides the best balance. Use `"max"` if you need to react quickly to traffic spikes, or `"min"` if you prefer conservative scaling that avoids rapid fluctuations.
 
@@ -135,8 +135,9 @@ The controller aggregates the raw timeseries to compute total ongoing requests a
 - **Output**: Single value representing total ongoing requests
 
 :::{note}
-Earlier releases also supported a "simple mode" that summed averages pre-computed at each replica and handle, selected by `RAY_SERVE_AGGREGATE_METRICS_AT_CONTROLLER`. That flag and that mode are removed. The controller now always aggregates raw timeseries. Two consequences if you're upgrading from a release that had the flag, where it defaulted to simple mode:
-- [`aggregation_function`](../api/doc/ray.serve.config.AutoscalingConfig.rst) now always applies. Under simple mode it was ignored, so a deployment that set `max` or `min` and never enabled the flag scaled on a mean and now scales on a peak or a trough.
+Earlier releases also supported a "simple mode" that summed averages pre-computed at each replica and handle, selected by `RAY_SERVE_AGGREGATE_METRICS_AT_CONTROLLER`. That flag and that mode are removed. The controller now always aggregates raw timeseries. Deployments already running with `RAY_SERVE_ENABLE_DIRECT_INGRESS`, which both `RAY_SERVE_THROUGHPUT_OPTIMIZED` and HAProxy turn on, aggregated at the controller regardless of the flag and see no change. If you're upgrading from a release where the flag defaulted to simple mode, expect three consequences:
+- [`aggregation_function`](../api/doc/ray.serve.config.AutoscalingConfig.rst) now always applies. Under simple mode it was ignored, so a deployment that set `max` or `min` scaled on a mean and now scales on a peak or a trough.
+- Under the default `"mean"`, steady-state values don't change, but transients do. Simple mode averaged each source's samples without regard to their spacing, whereas the controller weights them by time. Sources that report at different intervals diverge the most.
 - Aggregating timeseries costs the controller more than summing pre-computed averages, and the cost grows with the number of replicas. Watch controller CPU on deployments with high replica counts.
 :::
 

--- a/python/ray/serve/_private/autoscaling_state.py
+++ b/python/ray/serve/_private/autoscaling_state.py
@@ -652,7 +652,8 @@ class DeploymentAutoscalingState:
         """Calculate the total number of queued requests across all handles.
 
         Returns:
-            Sum of queued requests at all handles, aggregated from handle timeseries.
+            The merged instantaneous total of every handle's queued-requests
+            timeseries, aggregated over the window by `aggregation_function`.
         """
         return self._merge_and_aggregate_timeseries(
             self._collect_handle_queued_requests()

--- a/python/ray/serve/_private/autoscaling_state.py
+++ b/python/ray/serve/_private/autoscaling_state.py
@@ -300,24 +300,26 @@ class DeploymentAutoscalingState:
                 and handle_metric.actor_id not in alive_serve_actor_ids
             ):
                 del self._handle_requests[handle_id]
-                if handle_metric.total_requests > 0:
+                peak_requests = handle_metric.total_requests
+                if peak_requests > 0:
                     logger.debug(
                         f"Dropping metrics for handle '{handle_id}' because the Serve "
                         f"actor it was on ({handle_metric.actor_id}) is no longer "
-                        f"alive. It had {handle_metric.total_requests} ongoing requests"
+                        f"alive. Its peak ongoing requests was {peak_requests}."
                     )
             # Drop metrics for handles that haven't sent an update in a while.
             # This is expected behavior for handles that were on replicas or
             # proxies that have been shut down.
             elif time.time() - handle_metric.timestamp >= timeout_s:
                 del self._handle_requests[handle_id]
-                if handle_metric.total_requests > 0:
+                peak_requests = handle_metric.total_requests
+                if peak_requests > 0:
                     actor_id = handle_metric.actor_id
                     actor_info = f"on actor '{actor_id}' " if actor_id else ""
                     logger.info(
                         f"Dropping stale metrics for handle '{handle_id}' {actor_info}"
                         f"because no update was received for {timeout_s:.1f}s. "
-                        f"Ongoing requests was: {handle_metric.total_requests}."
+                        f"Peak ongoing requests was: {peak_requests}."
                     )
 
     def record_autoscaling_metrics(
@@ -545,65 +547,18 @@ class DeploymentAutoscalingState:
         return 0.0
 
     def get_total_num_requests(self) -> float:
-        """Get average total number of requests aggregated over the past
-        `look_back_period_s` number of seconds.
+        """Total ongoing requests, aggregated at the controller from raw timeseries.
 
-        Works with raw timeseries metrics data and performs aggregation at the
-        controller level. If there are 0 running replicas, then returns the total
-        number of requests queued at handles.
+        Replica and handle timeseries are merged into an instantaneous total and then
+        reduced by the deployment's `aggregation_function`, so the result is a window
+        mean, peak or trough rather than the current value. With no running replicas
+        this reduces to the handles' queued-requests series.
 
-        This code assumes that the metrics are either emmited on handles
-        or on replicas, but not both. Its the responsibility of the writer
-        to ensure enclusivity of the metrics.
-
-        Processing Steps:
-            1. Collect raw timeseries data (eg: running request) from replicas (if available)
-            2. Collect queued requests from handles (always tracked at handle level)
-            3. Collect raw timeseries data (eg: running request) from handles (if not available from replicas)
-            4. Merge timeseries using instantaneous approach for mathematically correct totals
-            5. Calculate time-weighted average running requests from the merged timeseries
-
-        Metrics Collection:
-            Running requests are collected with either replica-level or handle-level metrics.
-
-            Queued requests are always collected from handles regardless of where
-            running requests are collected.
-
-        Timeseries Aggregation:
-            Raw timeseries data from multiple sources is merged using an instantaneous
-            approach that treats gauges as right-continuous step functions. This provides
-            mathematically correct totals without arbitrary windowing bias.
-
-        Example with Numbers:
-            Assume metrics_interval_s = 0.5s, current time = 2.0s
-
-            Step 1: Collect raw timeseries from 2 replicas (r1, r2)
-            replica_metrics = [
-                {"running_requests": [(t=0.2, val=5), (t=0.8, val=7), (t=1.5, val=6)]},  # r1
-                {"running_requests": [(t=0.1, val=3), (t=0.9, val=4), (t=1.4, val=8)]}   # r2
-            ]
-
-            Step 2: Collect queued requests from handles
-            handle_queued = 2 + 3 = 5  # total from all handles
-
-            Step 3: No handle metrics needed (replica metrics available)
-            handle_metrics = []
-
-            Step 4: Merge timeseries using instantaneous approach
-            # Create delta events: r1 starts at 5 (t=0.2), changes to 7 (t=0.8), then 6 (t=1.5)
-            #                      r2 starts at 3 (t=0.1), changes to 4 (t=0.9), then 8 (t=1.4)
-            # Merged instantaneous total: [(t=0.1, val=3), (t=0.2, val=8), (t=0.8, val=10), (t=0.9, val=11), (t=1.4, val=15), (t=1.5, val=14)]
-            merged_timeseries = {"running_requests": [(0.1, 3), (0.2, 8), (0.8, 10), (0.9, 11), (1.4, 15), (1.5, 14)]}
-
-            Step 5: Calculate time-weighted average over full timeseries (t=0.1 to t=1.5+0.5=2.0)
-            # Time-weighted calculation: (3*0.1 + 8*0.6 + 10*0.1 + 11*0.5 + 15*0.1 + 14*0.5) / 2.0 = 10.05
-            avg_running = 10.05
-
-            Final result: total_requests = avg_running + queued = 10.05 + 5 = 15.05
+        Assumes running requests are emitted on handles or on replicas but not both;
+        the writer is responsible for keeping those exclusive.
 
         Returns:
-            Total number of requests (average running + queued) calculated from
-            timeseries data aggregation.
+            The aggregated total of running and queued requests.
         """
         # Collect replica-based running requests (returns List[TimeSeries])
         replica_timeseries = self._collect_replica_running_requests()

--- a/python/ray/serve/_private/autoscaling_state.py
+++ b/python/ray/serve/_private/autoscaling_state.py
@@ -17,8 +17,6 @@ from ray.serve._private.common import (
     TimeSeries,
 )
 from ray.serve._private.constants import (
-    RAY_SERVE_AGGREGATE_METRICS_AT_CONTROLLER,
-    RAY_SERVE_ENABLE_DIRECT_INGRESS,
     RAY_SERVE_MIN_HANDLE_METRICS_TIMEOUT_S,
     SERVE_LOGGER_NAME,
 )
@@ -549,8 +547,7 @@ class DeploymentAutoscalingState:
         """Calculate total requests using aggregate metrics mode with timeseries data.
 
         This method works with raw timeseries metrics data and performs aggregation
-        at the controller level, providing more accurate and stable metrics compared
-        to simple mode.
+        at the controller level.
 
         Processing Steps:
             1. Collect raw timeseries data (eg: running request) from replicas (if available)
@@ -640,87 +637,6 @@ class DeploymentAutoscalingState:
 
         return ongoing_requests
 
-    def _calculate_total_requests_simple_mode(self) -> float:
-        """Calculate total requests using simple aggregated metrics mode.
-
-        This method works with pre-aggregated metrics that are computed by averaging
-        (or other functions) over the past look_back_period_s seconds.
-
-        Metrics Collection:
-            Metrics can be collected at two levels:
-            1. Replica level: Each replica reports one aggregated metric value
-            2. Handle level: Each handle reports metrics for multiple replicas
-
-        Replica-Level Metrics Example:
-            For 3 replicas (r1, r2, r3), metrics might look like:
-            {
-                "r1": 10,
-                "r2": 20,
-                "r3": 30
-            }
-            Total requests = 10 + 20 + 30 = 60
-
-        Handle-Level Metrics Example:
-            For 3 handles (h1, h2, h3), each managing 2 replicas:
-            - h1 manages r1, r2
-            - h2 manages r2, r3
-            - h3 manages r3, r1
-
-            Metrics structure:
-            {
-                "h1": {"r1": 10, "r2": 20},
-                "h2": {"r2": 20, "r3": 30},
-                "h3": {"r3": 30, "r1": 10}
-            }
-
-            Total requests = 10 + 20 + 20 + 30 + 30 + 10 = 120
-
-            Note: We can safely sum all handle metrics because each unique request
-            is counted only once across all handles (no double-counting).
-
-        Queued Requests:
-            Queued request metrics are always tracked at the handle level, regardless
-            of whether running request metrics are collected at replicas or handles.
-
-        Returns:
-            Total number of requests (running + queued) across all replicas/handles.
-        """
-        total_requests: float = 0
-
-        # Iterate over _replica_metrics but only count running replicas. Stale metrics from
-        # stopped replicas can remain until on_replica_stopped runs; filtering avoids inflation.
-        for report in self._replica_metrics.values():
-            # TODO(abrar): Store replica_id as string in report to avoid this conversion.
-            if report.replica_id.to_full_id_str() in self._cached_running_replica_strs:
-                total_requests += report.aggregated_metrics.get(RUNNING_REQUESTS_KEY, 0)
-
-        metrics_collected_on_replicas = total_requests > 0
-
-        # Add handle metrics
-        for handle_metric in self._handle_requests.values():
-            total_requests += handle_metric.aggregated_queued_requests
-            # Add running requests from handles if not collected on replicas
-            if not metrics_collected_on_replicas:
-                running_reqs = handle_metric.aggregated_metrics.get(
-                    RUNNING_REQUESTS_KEY, {}
-                )
-                for replica_str, count in running_reqs.items():
-                    if replica_str in self._cached_running_replica_strs:
-                        total_requests += count
-        return total_requests
-
-    def _should_aggregate_metrics_at_controller(self) -> bool:
-        """
-        Determine if metrics should be aggregated at the controller.
-        If the Direct Ingress is enabled, then metrics should only be aggregated at the controller.
-
-        Returns:
-            True if metrics should be aggregated at the controller, False otherwise.
-        """
-        return (
-            RAY_SERVE_AGGREGATE_METRICS_AT_CONTROLLER or RAY_SERVE_ENABLE_DIRECT_INGRESS
-        )
-
     def get_total_num_requests(self) -> float:
         """Get average total number of requests aggregated over the past
         `look_back_period_s` number of seconds.
@@ -732,10 +648,7 @@ class DeploymentAutoscalingState:
         or on replicas, but not both. Its the responsibility of the writer
         to ensure enclusivity of the metrics.
         """
-        if self._should_aggregate_metrics_at_controller():
-            return self._calculate_total_requests_aggregate_mode()
-        else:
-            return self._calculate_total_requests_simple_mode()
+        return self._calculate_total_requests_aggregate_mode()
 
     def get_replica_metrics(self) -> Dict[str, List[TimeSeries]]:
         """Get the raw replica metrics dict."""
@@ -751,22 +664,13 @@ class DeploymentAutoscalingState:
         """Calculate the total number of queued requests across all handles.
 
         Returns:
-            Sum of queued requests at all handles. Uses aggregated values in simple mode,
-            or aggregates timeseries data in aggregate mode.
+            Sum of queued requests at all handles, aggregated from handle timeseries.
         """
-        if self._should_aggregate_metrics_at_controller():
-            # Aggregate mode: collect and aggregate timeseries
-            queued_timeseries = self._collect_handle_queued_requests()
-            if not queued_timeseries:
-                return 0.0
+        queued_timeseries = self._collect_handle_queued_requests()
+        if not queued_timeseries:
+            return 0.0
 
-            return self._merge_and_aggregate_timeseries(queued_timeseries)
-        else:
-            # Simple mode: sum pre-aggregated values
-            return sum(
-                handle_metric.aggregated_queued_requests
-                for handle_metric in self._handle_requests.values()
-            )
+        return self._merge_and_aggregate_timeseries(queued_timeseries)
 
     def _get_aggregated_custom_metrics(self) -> Dict[str, Dict[ReplicaID, float]]:
         """Aggregate custom metrics from replica metric reports.

--- a/python/ray/serve/_private/autoscaling_state.py
+++ b/python/ray/serve/_private/autoscaling_state.py
@@ -462,10 +462,11 @@ class DeploymentAutoscalingState:
 
         for handle_metric in self._handle_requests.values():
             running_reqs = handle_metric.metrics.get(RUNNING_REQUESTS_KEY, {})
-            for replica_str in self._cached_running_replica_strs:
-                if replica_str not in running_reqs:
-                    continue
-                timeseries_list.append(running_reqs[replica_str])
+            # Iterate the handle's own replicas, not every running replica: a handle
+            # usually routes to a subset, and the merge is order-independent.
+            for replica_str, timeseries in running_reqs.items():
+                if replica_str in self._cached_running_replica_strs:
+                    timeseries_list.append(timeseries)
 
         return timeseries_list
 
@@ -543,11 +544,17 @@ class DeploymentAutoscalingState:
 
         return 0.0
 
-    def _calculate_total_requests_aggregate_mode(self) -> float:
-        """Calculate total requests using aggregate metrics mode with timeseries data.
+    def get_total_num_requests(self) -> float:
+        """Get average total number of requests aggregated over the past
+        `look_back_period_s` number of seconds.
 
-        This method works with raw timeseries metrics data and performs aggregation
-        at the controller level.
+        Works with raw timeseries metrics data and performs aggregation at the
+        controller level. If there are 0 running replicas, then returns the total
+        number of requests queued at handles.
+
+        This code assumes that the metrics are either emmited on handles
+        or on replicas, but not both. Its the responsibility of the writer
+        to ensure enclusivity of the metrics.
 
         Processing Steps:
             1. Collect raw timeseries data (eg: running request) from replicas (if available)
@@ -555,12 +562,6 @@ class DeploymentAutoscalingState:
             3. Collect raw timeseries data (eg: running request) from handles (if not available from replicas)
             4. Merge timeseries using instantaneous approach for mathematically correct totals
             5. Calculate time-weighted average running requests from the merged timeseries
-
-        Key Differences from Simple Mode:
-            - Uses raw timeseries data instead of pre-aggregated metrics
-            - Performs instantaneous merging for exact gauge semantics
-            - Aggregates at the controller level rather than using pre-computed averages
-            - Uses time-weighted averaging over the look_back_period_s interval for accurate calculations
 
         Metrics Collection:
             Running requests are collected with either replica-level or handle-level metrics.
@@ -637,19 +638,6 @@ class DeploymentAutoscalingState:
 
         return ongoing_requests
 
-    def get_total_num_requests(self) -> float:
-        """Get average total number of requests aggregated over the past
-        `look_back_period_s` number of seconds.
-
-        If there are 0 running replicas, then returns the total number
-        of requests queued at handles
-
-        This code assumes that the metrics are either emmited on handles
-        or on replicas, but not both. Its the responsibility of the writer
-        to ensure enclusivity of the metrics.
-        """
-        return self._calculate_total_requests_aggregate_mode()
-
     def get_replica_metrics(self) -> Dict[str, List[TimeSeries]]:
         """Get the raw replica metrics dict."""
         metric_values: Dict[str, List[TimeSeries]] = defaultdict(list)
@@ -666,11 +654,9 @@ class DeploymentAutoscalingState:
         Returns:
             Sum of queued requests at all handles, aggregated from handle timeseries.
         """
-        queued_timeseries = self._collect_handle_queued_requests()
-        if not queued_timeseries:
-            return 0.0
-
-        return self._merge_and_aggregate_timeseries(queued_timeseries)
+        return self._merge_and_aggregate_timeseries(
+            self._collect_handle_queued_requests()
+        )
 
     def _get_aggregated_custom_metrics(self) -> Dict[str, Dict[ReplicaID, float]]:
         """Aggregate custom metrics from replica metric reports.

--- a/python/ray/serve/_private/autoscaling_state.py
+++ b/python/ray/serve/_private/autoscaling_state.py
@@ -549,13 +549,38 @@ class DeploymentAutoscalingState:
     def get_total_num_requests(self) -> float:
         """Total ongoing requests, aggregated at the controller from raw timeseries.
 
-        Replica and handle timeseries are merged into an instantaneous total and then
-        reduced by the deployment's `aggregation_function`, so the result is a window
-        mean, peak or trough rather than the current value. With no running replicas
-        this reduces to the handles' queued-requests series.
+        Running requests come from replicas or from handles, never both; the writer is
+        responsible for keeping those exclusive. Queued requests always come from
+        handles. Every series is merged as one set of sources, so the reduction sees
+        running and queued together rather than aggregating them separately.
 
-        Assumes running requests are emitted on handles or on replicas but not both;
-        the writer is responsible for keeping those exclusive.
+        Processing steps:
+            1. Collect running-request timeseries from replicas, if any reported.
+            2. Collect queued-request timeseries from handles (always).
+            3. Collect running-request timeseries from handles, only if step 1 was empty.
+            4. Merge every series into one instantaneous total: gauges are right-
+               continuous step functions, summed across sources at each change point,
+               which avoids the windowing bias of averaging each source first.
+            5. Reduce that step function with the deployment's `aggregation_function`,
+               so the result is a window mean, peak or trough, not the current value.
+
+        The window opens once every series has contributed a point, because a series is
+        implicitly 0 before its first sample and would otherwise drag the total down. It
+        closes `last_window_s` past the final point, that being how long the last sample
+        is assumed to hold.
+
+        Example (`aggregation_function` MEAN, now = 2.0s):
+            running r1  [(0.2, 5), (0.8, 7), (1.5, 6)]
+            running r2  [(0.1, 3), (0.9, 4), (1.4, 8)]
+            queued  h1  [(0.3, 2), (1.0, 3)]
+
+            merged      [(0.1, 3), (0.2, 8), (0.3, 10), (0.8, 12),
+                         (0.9, 13), (1.0, 14), (1.4, 18), (1.5, 17)]
+
+            window      opens at 0.3, the latest first point (h1); closes at 2.0,
+                        which is 1.5 plus a last_window_s of 0.5
+            result      (10*0.5 + 12*0.1 + 13*0.1 + 14*0.4 + 18*0.1 + 17*0.5) / 1.7
+                        = 23.4 / 1.7 = 13.76
 
         Returns:
             The aggregated total of running and queued requests.

--- a/python/ray/serve/_private/common.py
+++ b/python/ray/serve/_private/common.py
@@ -1010,9 +1010,9 @@ class HandleMetricReport:
 
     @property
     def total_requests(self) -> float:
-        """Upper bound on queued + running requests over this handle's reported window.
-        Diagnostic only (logged when a handle's metrics are dropped); peaks are summed
-        so a handle that was busy earlier in the window is not reported as idle."""
+        """Peak queued + running requests over this handle's reported window, summed
+        per series so it over-states any single instant. Diagnostic only: it gates and
+        labels the log line emitted when a handle's metrics are dropped."""
         running = self.metrics.get(RUNNING_REQUESTS_KEY, {}).values()
         series = [self.queued_requests, *running]
         return sum(max(point.value for point in s) for s in series if s)

--- a/python/ray/serve/_private/common.py
+++ b/python/ray/serve/_private/common.py
@@ -1010,17 +1010,12 @@ class HandleMetricReport:
 
     @property
     def total_requests(self) -> float:
-        """Most recently observed queued + running requests across this handle's
-        replicas. Diagnostic only (reported when a handle's metrics are dropped), so
-        the latest sample is enough and no windowing is applied."""
-
-        def latest(series: TimeSeries) -> float:
-            return series[-1].value if series else 0.0
-
-        return latest(self.queued_requests) + sum(
-            latest(series)
-            for series in self.metrics.get(RUNNING_REQUESTS_KEY, {}).values()
-        )
+        """Upper bound on queued + running requests over this handle's reported window.
+        Diagnostic only (logged when a handle's metrics are dropped); peaks are summed
+        so a handle that was busy earlier in the window is not reported as idle."""
+        running = self.metrics.get(RUNNING_REQUESTS_KEY, {}).values()
+        series = [self.queued_requests, *running]
+        return sum(max(point.value for point in s) for s in series if s)
 
     @property
     def is_serve_component_source(self) -> bool:

--- a/python/ray/serve/_private/common.py
+++ b/python/ray/serve/_private/common.py
@@ -989,14 +989,9 @@ class HandleMetricReport:
         handle_source: Describes what kind of entity holds this
             deployment handle: a Serve proxy, a Serve replica, or
             unknown.
-        aggregated_queued_requests: average number of queued requests at the
-            handle over the past look_back_period_s seconds.
         queued_requests: list of values of queued requests at the
             handle over the past look_back_period_s seconds. This is a list because
             we take multiple measurements over time.
-        aggregated_metrics: A map of metric name to the aggregated value over the past
-            look_back_period_s seconds at the handle for each replica. Replica keys
-            use ReplicaID.to_full_id_str() for efficient controller-side lookups.
         metrics: A map of metric name to the list of values running at that handle for each replica
             over the past look_back_period_s seconds. Replica keys use to_full_id_str().
             This is a list because we take multiple measurements over time.
@@ -1007,11 +1002,7 @@ class HandleMetricReport:
     handle_id: str
     actor_id: str
     handle_source: DeploymentHandleSource
-    aggregated_queued_requests: float
     queued_requests: TimeSeries
-    aggregated_metrics: Dict[
-        str, Dict[str, float]
-    ]  # replica key = ReplicaID.to_full_id_str()
     metrics: Dict[
         str, Dict[str, TimeSeries]
     ]  # replica key = ReplicaID.to_full_id_str()
@@ -1019,9 +1010,16 @@ class HandleMetricReport:
 
     @property
     def total_requests(self) -> float:
-        """Total number of queued and running requests."""
-        return self.aggregated_queued_requests + sum(
-            self.aggregated_metrics.get(RUNNING_REQUESTS_KEY, {}).values()
+        """Most recently observed queued + running requests across this handle's
+        replicas. Diagnostic only (reported when a handle's metrics are dropped), so
+        the latest sample is enough and no windowing is applied."""
+
+        def latest(series: TimeSeries) -> float:
+            return series[-1].value if series else 0.0
+
+        return latest(self.queued_requests) + sum(
+            latest(series)
+            for series in self.metrics.get(RUNNING_REQUESTS_KEY, {}).values()
         )
 
     @property
@@ -1045,8 +1043,6 @@ class ReplicaMetricReport:
 
     Args:
         replica_id: The replica ID of the replica.
-        aggregated_metrics: A map of metric name to the aggregated value over the past
-            look_back_period_s seconds at the replica.
         metrics: A map of metric name to the list of values running at that replica
             over the past look_back_period_s seconds. This is a list because
             we take multiple measurements over time.
@@ -1054,7 +1050,6 @@ class ReplicaMetricReport:
     """
 
     replica_id: ReplicaID
-    aggregated_metrics: Dict[str, float]
     metrics: Dict[str, TimeSeries]
     timestamp: float
 

--- a/python/ray/serve/_private/constants.py
+++ b/python/ray/serve/_private/constants.py
@@ -1118,10 +1118,6 @@ if RAY_SERVE_ENABLE_HA_PROXY:
 if RAY_SERVE_INGRESS_REQUEST_ROUTER_METRICS_ENABLED:
     RAY_SERVE_HAPROXY_METRICS_ENABLED = True
 
-# Feature flag to aggregate metrics at the controller instead of the replicas or handles.
-RAY_SERVE_AGGREGATE_METRICS_AT_CONTROLLER = get_env_bool(
-    "RAY_SERVE_AGGREGATE_METRICS_AT_CONTROLLER", "0"
-)
 
 # Feature flag to include high-cardinality source tags on Serve controller metrics.
 # Disable this to keep deployment/application tags while dropping source identifiers

--- a/python/ray/serve/_private/constants.py
+++ b/python/ray/serve/_private/constants.py
@@ -1118,7 +1118,6 @@ if RAY_SERVE_ENABLE_HA_PROXY:
 if RAY_SERVE_INGRESS_REQUEST_ROUTER_METRICS_ENABLED:
     RAY_SERVE_HAPROXY_METRICS_ENABLED = True
 
-
 # Feature flag to include high-cardinality source tags on Serve controller metrics.
 # Disable this to keep deployment/application tags while dropping source identifiers
 # like replica IDs from controller-emitted metrics.

--- a/python/ray/serve/_private/controller.py
+++ b/python/ray/serve/_private/controller.py
@@ -5,6 +5,7 @@ import pickle
 import time
 from typing import (
     Any,
+    Callable,
     Dict,
     Iterable,
     List,
@@ -385,6 +386,25 @@ class ServeController:
     def get_pid(self) -> int:
         return os.getpid()
 
+    def _record_metrics_delay(
+        self,
+        timestamp: float,
+        deployment_id: DeploymentID,
+        histogram: metrics.Histogram,
+        record_delay: Callable[[float], None],
+    ) -> None:
+        """Report ingest delay. A histogram lets Prometheus aggregate reports from all
+        sources of a deployment, so the per-source tag is omitted to bound cardinality."""
+        delay_ms = (time.time() - timestamp) * 1000
+        histogram.observe(
+            delay_ms,
+            tags={
+                "deployment": deployment_id.name,
+                "application": deployment_id.app_name,
+            },
+        )
+        record_delay(delay_ms)
+
     def record_autoscaling_metrics_from_replica(
         self, replica_metric_report: Union[ReplicaMetricReport, bytes]
     ):
@@ -392,23 +412,12 @@ class ServeController:
             replica_metric_report = decompress_metric_report(replica_metric_report)
         # Decompression (above) always yields a ReplicaMetricReport.
         replica_metric_report = cast(ReplicaMetricReport, replica_metric_report)
-        latency = time.time() - replica_metric_report.timestamp
-        latency_ms = latency * 1000
-        deployment = replica_metric_report.replica_id.deployment_id.name
-        application = replica_metric_report.replica_id.deployment_id.app_name
-
-        # Record the metrics delay for observability. A histogram lets Prometheus
-        # aggregate reports from all replicas of a deployment, so we omit the
-        # per-replica tag to keep cardinality bounded.
-        self.replica_metrics_delay_histogram.observe(
-            latency_ms,
-            tags={
-                "deployment": deployment,
-                "application": application,
-            },
+        self._record_metrics_delay(
+            replica_metric_report.timestamp,
+            replica_metric_report.replica_id.deployment_id,
+            self.replica_metrics_delay_histogram,
+            self._health_metrics_tracker.record_replica_metrics_delay,
         )
-        # Track in health metrics
-        self._health_metrics_tracker.record_replica_metrics_delay(latency_ms)
         self.autoscaling_state_manager.record_request_metrics_for_replica(
             replica_metric_report
         )
@@ -420,23 +429,12 @@ class ServeController:
             handle_metric_report = decompress_metric_report(handle_metric_report)
         # Decompression (above) always yields a HandleMetricReport.
         handle_metric_report = cast(HandleMetricReport, handle_metric_report)
-        latency = time.time() - handle_metric_report.timestamp
-        latency_ms = latency * 1000
-        deployment = handle_metric_report.deployment_id.name
-        application = handle_metric_report.deployment_id.app_name
-
-        # Record the metrics delay for observability. A histogram lets Prometheus
-        # aggregate reports from all handles of a deployment, so we omit the
-        # per-handle tag to keep cardinality bounded.
-        self.handle_metrics_delay_histogram.observe(
-            latency_ms,
-            tags={
-                "deployment": deployment,
-                "application": application,
-            },
+        self._record_metrics_delay(
+            handle_metric_report.timestamp,
+            handle_metric_report.deployment_id,
+            self.handle_metrics_delay_histogram,
+            self._health_metrics_tracker.record_handle_metrics_delay,
         )
-        # Track in health metrics
-        self._health_metrics_tracker.record_handle_metrics_delay(latency_ms)
         self.autoscaling_state_manager.record_request_metrics_for_handle(
             handle_metric_report
         )

--- a/python/ray/serve/_private/controller.py
+++ b/python/ray/serve/_private/controller.py
@@ -393,8 +393,8 @@ class ServeController:
         report_delay: Callable[..., None],
         record_delay: Optional[Callable[[float], None]] = None,
     ) -> None:
-        """Report ingest delay. Prometheus aggregates reports from all sources of a
-        deployment, so the per-source tag is omitted to bound cardinality."""
+        """Report ingest delay. Only deployment/application tags are set, so these
+        metrics stay bounded no matter how many sources report."""
         delay_ms = (time.time() - timestamp) * 1000
         report_delay(
             delay_ms,

--- a/python/ray/serve/_private/controller.py
+++ b/python/ray/serve/_private/controller.py
@@ -390,20 +390,21 @@ class ServeController:
         self,
         timestamp: float,
         deployment_id: DeploymentID,
-        histogram: metrics.Histogram,
-        record_delay: Callable[[float], None],
+        report_delay: Callable[..., None],
+        record_delay: Optional[Callable[[float], None]] = None,
     ) -> None:
-        """Report ingest delay. A histogram lets Prometheus aggregate reports from all
-        sources of a deployment, so the per-source tag is omitted to bound cardinality."""
+        """Report ingest delay. Prometheus aggregates reports from all sources of a
+        deployment, so the per-source tag is omitted to bound cardinality."""
         delay_ms = (time.time() - timestamp) * 1000
-        histogram.observe(
+        report_delay(
             delay_ms,
             tags={
                 "deployment": deployment_id.name,
                 "application": deployment_id.app_name,
             },
         )
-        record_delay(delay_ms)
+        if record_delay is not None:
+            record_delay(delay_ms)
 
     def record_autoscaling_metrics_from_replica(
         self, replica_metric_report: Union[ReplicaMetricReport, bytes]
@@ -415,7 +416,7 @@ class ServeController:
         self._record_metrics_delay(
             replica_metric_report.timestamp,
             replica_metric_report.replica_id.deployment_id,
-            self.replica_metrics_delay_histogram,
+            self.replica_metrics_delay_histogram.observe,
             self._health_metrics_tracker.record_replica_metrics_delay,
         )
         self.autoscaling_state_manager.record_request_metrics_for_replica(
@@ -432,7 +433,7 @@ class ServeController:
         self._record_metrics_delay(
             handle_metric_report.timestamp,
             handle_metric_report.deployment_id,
-            self.handle_metrics_delay_histogram,
+            self.handle_metrics_delay_histogram.observe,
             self._health_metrics_tracker.record_handle_metrics_delay,
         )
         self.autoscaling_state_manager.record_request_metrics_for_handle(
@@ -443,15 +444,10 @@ class ServeController:
         self, report: AsyncInferenceTaskQueueMetricReport
     ):
         """Record async inference task queue metrics pushed from QueueMonitor."""
-        latency = time.time() - report.timestamp_s
-        latency_ms = latency * 1000
-        # Record the metrics delay for observability
-        self.async_inference_task_queue_metrics_delay_gauge.set(
-            latency_ms,
-            tags={
-                "deployment": report.deployment_id.name,
-                "application": report.deployment_id.app_name,
-            },
+        self._record_metrics_delay(
+            report.timestamp_s,
+            report.deployment_id,
+            self.async_inference_task_queue_metrics_delay_gauge.set,
         )
         self.autoscaling_state_manager.record_async_inference_task_queue_metrics(report)
 

--- a/python/ray/serve/_private/metrics_utils.py
+++ b/python/ray/serve/_private/metrics_utils.py
@@ -1,10 +1,8 @@
 import asyncio
 import bisect
 import logging
-import statistics
 from collections import defaultdict
 from dataclasses import dataclass
-from itertools import chain
 from typing import (
     Any,
     Awaitable,
@@ -13,10 +11,8 @@ from typing import (
     DefaultDict,
     Dict,
     Hashable,
-    Iterable,
     List,
     Optional,
-    Tuple,
     Union,
 )
 
@@ -194,66 +190,6 @@ class InMemoryMetricsStore:
         )
         return datapoints[idx:]
 
-    def _aggregate_reduce(
-        self,
-        keys: Iterable[Hashable],
-        aggregate_fn: Callable[[Iterable[float]], float],
-    ) -> Tuple[Optional[float], int]:
-        """Reduce the entire set of timeseries values across the specified keys.
-
-        Args:
-            keys: Iterable of keys to aggregate across.
-            aggregate_fn: Function to apply across all float values, e.g., sum, max.
-
-        Returns:
-            A tuple of (float, int) where the first element is the aggregated value
-            and the second element is the number of valid keys used.
-            Returns (None, 0) if no valid keys have data.
-
-        Example:
-        Suppose the store contains:
-        >>> store = InMemoryMetricsStore()
-        >>> store.data.update({
-        ...     "a": [TimeStampedValue(0, 1.0), TimeStampedValue(1, 2.0)],
-        ...     "b": [],
-        ...     "c": [TimeStampedValue(0, 10.0)],
-        ... })
-
-        Using sum across keys:
-
-        >>> store._aggregate_reduce(keys=["a", "b", "c"], aggregate_fn=sum)
-        (13.0, 2)
-
-        Here:
-        - The aggregated value is 1.0 + 2.0 + 10.0 = 13.0
-        - Only keys "a" and "c" contribute values, so report_count = 2
-        """
-        valid_key_count = 0
-
-        def _values_generator():
-            """Generator that yields values from valid keys without storing them all in memory."""
-            nonlocal valid_key_count
-            for key in keys:
-                series = self.data.get(key, [])
-                if not series:
-                    continue
-
-                valid_key_count += 1
-                for timestamp_value in series:
-                    yield timestamp_value.value
-
-        # Create the generator and check if it has any values
-        values_gen = _values_generator()
-        try:
-            first_value = next(values_gen)
-        except StopIteration:
-            # No valid data found
-            return None, 0
-
-        # Apply aggregation to the generator (memory efficient)
-        aggregated_result = aggregate_fn(chain([first_value], values_gen))
-        return aggregated_result, valid_key_count
-
     def get_latest(
         self,
         key: Hashable,
@@ -262,47 +198,6 @@ class InMemoryMetricsStore:
         if not self.data.get(key, None):
             return None
         return self.data[key][-1].value
-
-    def aggregate_sum(
-        self,
-        keys: Iterable[Hashable],
-    ) -> Tuple[Optional[float], int]:
-        """Sum the entire set of timeseries values across the specified keys.
-        Args:
-            keys: Iterable of keys to aggregate across.
-        Returns:
-            A tuple of (float, int) where the first element is the sum across
-            all values found at `keys`, and the second is the number of valid
-            keys used to compute the sum.
-            Returns (None, 0) if no valid keys have data.
-        """
-        return self._aggregate_reduce(keys, sum)
-
-    def aggregate_avg(
-        self,
-        keys: Iterable[Hashable],
-    ) -> Tuple[Optional[float], int]:
-        """Average the entire set of timeseries values across the specified keys.
-
-        Args:
-            keys: Iterable of keys to aggregate across.
-        Returns:
-            A tuple of (float, int) where the first element is the mean across
-            all values found at `keys`, and the second is the number of valid
-            keys used to compute the mean.
-            Returns (None, 0) if no valid keys have data.
-        """
-        return self._aggregate_reduce(keys, statistics.mean)
-
-    def timeseries_count(
-        self,
-        key: Hashable,
-    ) -> int:
-        """Count the number of values across all timeseries values at the specified keys."""
-        series = self.data.get(key, [])
-        if not series:
-            return 0
-        return len(series)
 
 
 def time_weighted_average(

--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -962,21 +962,12 @@ class ReplicaMetricsManager:
         look_back_period = self._autoscaling_config.look_back_period_s
         self._metrics_store.prune_keys_and_compact_data(time.time() - look_back_period)
 
-        new_aggregated_metrics = {}
         # The store keys are `Hashable`; this replica only ever records `str` keys.
         new_metrics = cast(Dict[str, TimeSeries], {**self._metrics_store.data})
-
-        if self.should_collect_ongoing_requests():
-            # Keep the legacy window_avg ongoing requests in the merged metrics dict
-            window_avg = (
-                self._metrics_store.aggregate_avg([RUNNING_REQUESTS_KEY])[0] or 0.0
-            )
-            new_aggregated_metrics.update({RUNNING_REQUESTS_KEY: window_avg})
 
         replica_metric_report = ReplicaMetricReport(
             replica_id=self._replica_id,
             timestamp=time.time(),
-            aggregated_metrics=new_aggregated_metrics,
             metrics=new_metrics,
         )
         with self._metrics_push_lock:

--- a/python/ray/serve/_private/router.py
+++ b/python/ray/serve/_private/router.py
@@ -498,7 +498,7 @@ class RouterMetricsManager:
         queued_requests = self.metrics_store.data.get(
             QUEUED_REQUESTS_KEY, [TimeStampedValue(timestamp, self.num_queued_requests)]
         )
-        if RAY_SERVE_COLLECT_AUTOSCALING_METRICS_ON_HANDLE and self.autoscaling_config:
+        if RAY_SERVE_COLLECT_AUTOSCALING_METRICS_ON_HANDLE:
             for replica_id, num_requests in self.num_requests_sent_to_replicas.items():
                 running_requests[
                     replica_id.to_full_id_str()

--- a/python/ray/serve/_private/router.py
+++ b/python/ray/serve/_private/router.py
@@ -491,42 +491,18 @@ class RouterMetricsManager:
     def _get_metrics_report(self) -> HandleMetricReport:
         timestamp = time.time()
         running_requests = dict()
-        avg_running_requests = dict()
         autoscaling_config = self.autoscaling_config
         assert autoscaling_config is not None
         look_back_period = autoscaling_config.look_back_period_s
         self.metrics_store.prune_keys_and_compact_data(time.time() - look_back_period)
-        avg_queued_requests = self.metrics_store.aggregate_avg([QUEUED_REQUESTS_KEY])[0]
-        if avg_queued_requests is None:
-            # If the queued requests timeseries is empty, we set the
-            # average to the current number of queued requests.
-            avg_queued_requests = self.num_queued_requests
-        # If the queued requests timeseries is empty, we set the number of data points to 1.
-        # This is to avoid division by zero.
-        num_data_points = self.metrics_store.timeseries_count(QUEUED_REQUESTS_KEY) or 1
         queued_requests = self.metrics_store.data.get(
             QUEUED_REQUESTS_KEY, [TimeStampedValue(timestamp, self.num_queued_requests)]
         )
         if RAY_SERVE_COLLECT_AUTOSCALING_METRICS_ON_HANDLE and self.autoscaling_config:
             for replica_id, num_requests in self.num_requests_sent_to_replicas.items():
-                # Calculate avg running requests.
-                # NOTE (abrar): The number of data points from queued requests is often higher than
-                # those from running requests. This is because replica metrics are only collected
-                # once a replica is up, whereas queued request metrics are collected continuously
-                # as long as the handle is alive. To approximate the true average of ongoing requests,
-                # we should normalize by using the same number of data points for both queued and
-                # running request time series.
-                running_requests_sum = self.metrics_store.aggregate_sum([replica_id])[0]
-                if running_requests_sum is None:
-                    # If the running requests timeseries is empty, we set the sum
-                    # to the current number of requests.
-                    running_requests_sum = num_requests
-                replica_str = replica_id.to_full_id_str()
-                avg_running_requests[replica_str] = (
-                    running_requests_sum / num_data_points
-                )
-                # Get running requests data
-                running_requests[replica_str] = self.metrics_store.data.get(
+                running_requests[
+                    replica_id.to_full_id_str()
+                ] = self.metrics_store.data.get(
                     replica_id, [TimeStampedValue(timestamp, num_requests)]
                 )
         handle_metric_report = HandleMetricReport(
@@ -534,11 +510,7 @@ class RouterMetricsManager:
             handle_id=self._handle_id,
             actor_id=self._self_actor_id,
             handle_source=self._handle_source,
-            aggregated_queued_requests=avg_queued_requests,
             queued_requests=queued_requests,
-            aggregated_metrics={
-                RUNNING_REQUESTS_KEY: avg_running_requests,
-            },
             metrics={
                 RUNNING_REQUESTS_KEY: running_requests,
             },

--- a/python/ray/serve/config.py
+++ b/python/ray/serve/config.py
@@ -61,6 +61,10 @@ class AutoscalingContext:
     Note: The aggregated_metrics and raw_metrics fields support lazy evaluation.
     You can pass callables that will be evaluated only when accessed, with results
     cached for subsequent accesses.
+
+    Note: total_num_requests and total_queued_requests are both aggregated over
+    `look_back_period_s` using the deployment's `aggregation_function`, so under `min`
+    or `max` they report the window trough or peak rather than the current value.
     """
 
     def __init__(
@@ -112,10 +116,10 @@ class AutoscalingContext:
 
         # Built-in metrics
         self._total_num_requests_value = (
-            total_num_requests  #: Total number of requests across all replicas.
+            total_num_requests  #: Ongoing (running + queued) requests.
         )
         self._total_queued_requests_value = (
-            total_queued_requests  #: Number of requests currently queued.
+            total_queued_requests  #: Requests queued at handles.
         )
 
         # Custom metrics - store potentially lazy callables privately
@@ -172,8 +176,9 @@ class AutoscalingContext:
 
     @property
     def total_running_requests(self) -> float:
-        # NOTE: for non-additive aggregation functions, total_running_requests is not
-        # accurate, consider this is an approximation.
+        # Exact only because both sides share the deployment's `aggregation_function`;
+        # for non-additive ones (min/max) this difference is an approximation. Keep them
+        # on the same function -- aggregating either side differently breaks it outright.
         return self.total_num_requests - self.total_queued_requests
 
     @property

--- a/python/ray/serve/config.py
+++ b/python/ray/serve/config.py
@@ -176,10 +176,9 @@ class AutoscalingContext:
 
     @property
     def total_running_requests(self) -> float:
-        # Exact only because both sides share the deployment's `aggregation_function`;
-        # for non-additive ones (min/max) this difference is an approximation. Keep them
-        # on the same function -- aggregating either side differently breaks it outright.
-        return self.total_num_requests - self.total_queued_requests
+        # Approximate: the two operands are reduced over independently derived windows,
+        # so their difference can even go negative. Clamped until they share one window.
+        return max(0.0, self.total_num_requests - self.total_queued_requests)
 
     @property
     def total_pending_async_requests(self) -> int:

--- a/python/ray/serve/tests/BUILD.bazel
+++ b/python/ray/serve/tests/BUILD.bazel
@@ -36,21 +36,11 @@ py_test_module_list_with_env_variants(
     env_variants = {
         "metr_agg_at_controller": {
             "env": {
-                "RAY_SERVE_AGGREGATE_METRICS_AT_CONTROLLER": "1",
                 "RAY_SERVE_COLLECT_AUTOSCALING_METRICS_ON_HANDLE": "0",
                 "RAY_SERVE_AUTOSCALING_METRIC_RECORD_INTERVAL_FACTOR": "0.001",
                 "RAY_SERVE_RECORD_AUTOSCALING_STATS_TIMEOUT_S": "3",
             },
             "name_suffix": "_metr_agg_at_controller",
-        },
-        "metr_agg_at_replicas": {
-            "env": {
-                "RAY_SERVE_AGGREGATE_METRICS_AT_CONTROLLER": "0",
-                "RAY_SERVE_COLLECT_AUTOSCALING_METRICS_ON_HANDLE": "0",
-                "RAY_SERVE_AUTOSCALING_METRIC_RECORD_INTERVAL_FACTOR": "0.001",
-                "RAY_SERVE_RECORD_AUTOSCALING_STATS_TIMEOUT_S": "3",
-            },
-            "name_suffix": "_metr_agg_at_replicas",
         },
     },
     files = [
@@ -568,20 +558,10 @@ AUTOSCALING_METRIC_ENV_VARIANTS = {
     },
     "metr_agg_at_controller": {
         "env": {
-            "RAY_SERVE_AGGREGATE_METRICS_AT_CONTROLLER": "1",
             # Make sure queued metrics are cleared out quickly.
             "RAY_SERVE_HANDLE_AUTOSCALING_METRIC_PUSH_INTERVAL_S": "0.1",
         },
         "name_suffix": "_metr_agg_at_controller",
-    },
-    "metr_agg_at_controller_and_replicas": {
-        "env": {
-            "RAY_SERVE_AGGREGATE_METRICS_AT_CONTROLLER": "1",
-            "RAY_SERVE_COLLECT_AUTOSCALING_METRICS_ON_HANDLE": "0",
-            # Make sure queued metrics are cleared out quickly.
-            "RAY_SERVE_HANDLE_AUTOSCALING_METRIC_PUSH_INTERVAL_S": "0.1",
-        },
-        "name_suffix": "_metr_agg_at_controller_and_replicas",
     },
 }
 

--- a/python/ray/serve/tests/BUILD.bazel
+++ b/python/ray/serve/tests/BUILD.bazel
@@ -34,13 +34,13 @@ py_test_module_list(
 py_test_module_list_with_env_variants(
     size = "medium",
     env_variants = {
-        "metr_agg_at_controller": {
+        "metr_collect_on_replica": {
             "env": {
                 "RAY_SERVE_COLLECT_AUTOSCALING_METRICS_ON_HANDLE": "0",
                 "RAY_SERVE_AUTOSCALING_METRIC_RECORD_INTERVAL_FACTOR": "0.001",
                 "RAY_SERVE_RECORD_AUTOSCALING_STATS_TIMEOUT_S": "3",
             },
-            "name_suffix": "_metr_agg_at_controller",
+            "name_suffix": "_metr_collect_on_replica",
         },
     },
     files = [
@@ -556,12 +556,12 @@ AUTOSCALING_METRIC_ENV_VARIANTS = {
         },
         "name_suffix": "_metr_disab",
     },
-    "metr_agg_at_controller": {
+    "metr_collect_on_handle": {
         "env": {
             # Make sure queued metrics are cleared out quickly.
             "RAY_SERVE_HANDLE_AUTOSCALING_METRIC_PUSH_INTERVAL_S": "0.1",
         },
-        "name_suffix": "_metr_agg_at_controller",
+        "name_suffix": "_metr_collect_on_handle",
     },
 }
 

--- a/python/ray/serve/tests/BUILD.bazel
+++ b/python/ray/serve/tests/BUILD.bazel
@@ -373,6 +373,35 @@ py_test_module_list(
     ],
 )
 
+# Cover replica-side collection for `num_replicas="auto"`, whose looser upscaling
+# assertion is unreachable under the collect-on-handle default.
+py_test_module_list(
+    size = "medium",
+    args = [
+        "-k",
+        "test_num_replicas_auto_basic",
+    ],
+    data = glob(["test_config_files/**/*"]),
+    env = {
+        "RAY_SERVE_COLLECT_AUTOSCALING_METRICS_ON_HANDLE": "0",
+        "RAY_SERVE_ROUTER_QUEUE_LEN_GAUGE_THROTTLE_S": "0",
+    },
+    files = [
+        "test_deploy_app_2.py",
+    ],
+    name_suffix = "_metr_collect_on_replica",
+    tags = [
+        "exclusive",
+        "team:serve",
+        "use_all_core_windows",
+    ],
+    deps = [
+        ":common",
+        ":conftest",
+        "//python/ray/serve:serve_lib",
+    ],
+)
+
 # Run the controller metric high-cardinality opt-out test with the flag disabled.
 py_test_module_list(
     size = "medium",
@@ -548,16 +577,17 @@ py_test(
 
 # Test autoscaling with different metric collection configurations
 AUTOSCALING_METRIC_ENV_VARIANTS = {
-    "metr_disab": {
+    "metr_collect_on_replica": {
         "env": {
             "RAY_SERVE_COLLECT_AUTOSCALING_METRICS_ON_HANDLE": "0",
             # Make sure queued metrics are cleared out quickly.
             "RAY_SERVE_HANDLE_AUTOSCALING_METRIC_PUSH_INTERVAL_S": "0.1",
         },
-        "name_suffix": "_metr_disab",
+        "name_suffix": "_metr_collect_on_replica",
     },
     "metr_collect_on_handle": {
         "env": {
+            "RAY_SERVE_COLLECT_AUTOSCALING_METRICS_ON_HANDLE": "1",
             # Make sure queued metrics are cleared out quickly.
             "RAY_SERVE_HANDLE_AUTOSCALING_METRIC_PUSH_INTERVAL_S": "0.1",
         },

--- a/python/ray/serve/tests/test_deploy_app_2.py
+++ b/python/ray/serve/tests/test_deploy_app_2.py
@@ -15,7 +15,6 @@ from ray import serve
 from ray._common.test_utils import SignalActor, wait_for_condition
 from ray.serve._private.common import DeploymentID, ReplicaID
 from ray.serve._private.constants import (
-    RAY_SERVE_AGGREGATE_METRICS_AT_CONTROLLER,
     RAY_SERVE_COLLECT_AUTOSCALING_METRICS_ON_HANDLE,
     SERVE_DEFAULT_APP_NAME,
     SERVE_NAMESPACE,
@@ -680,10 +679,7 @@ def test_num_replicas_auto_basic(serve_instance):
 
         wait_for_condition(check_num_waiters, target=2 * (i + 1), timeout=30)
         print(time.time(), f"Number of waiters on signal reached {2*(i+1)}.")
-        if (
-            RAY_SERVE_COLLECT_AUTOSCALING_METRICS_ON_HANDLE is False
-            and RAY_SERVE_AGGREGATE_METRICS_AT_CONTROLLER is True
-        ):
+        if RAY_SERVE_COLLECT_AUTOSCALING_METRICS_ON_HANDLE is False:
             # When merging timeseries from replicas and handles with LOCF, the same request can appear in
             # both because they report at different times (e.g. replica: 4 running, handle: 2 queued).
             # That double-counts requests and inflates the total, biasing aggregations

--- a/python/ray/serve/tests/unit/BUILD.bazel
+++ b/python/ray/serve/tests/unit/BUILD.bazel
@@ -73,12 +73,12 @@ py_test_module_list(
 py_test_module_list_with_env_variants(
     size = "small",
     env_variants = {
-        "metr_disab": {
+        "metr_collect_on_replica": {
             "env": {
                 "RAY_SERVE_COLLECT_AUTOSCALING_METRICS_ON_HANDLE": "0",
                 "RAY_SERVE_FAIL_ON_RANK_ERROR": "1",
             },
-            "name_suffix": "_metr_disab",
+            "name_suffix": "_metr_collect_on_replica",
         },
         "metr_collect_on_handle": {
             "env": {

--- a/python/ray/serve/tests/unit/BUILD.bazel
+++ b/python/ray/serve/tests/unit/BUILD.bazel
@@ -80,12 +80,12 @@ py_test_module_list_with_env_variants(
             },
             "name_suffix": "_metr_disab",
         },
-        "metr_agg_at_controller": {
+        "metr_collect_on_handle": {
             "env": {
                 "RAY_SERVE_COLLECT_AUTOSCALING_METRICS_ON_HANDLE": "1",
                 "RAY_SERVE_FAIL_ON_RANK_ERROR": "1",
             },
-            "name_suffix": "_metr_agg_at_controller",
+            "name_suffix": "_metr_collect_on_handle",
         },
     },
     files = [

--- a/python/ray/serve/tests/unit/BUILD.bazel
+++ b/python/ray/serve/tests/unit/BUILD.bazel
@@ -82,19 +82,10 @@ py_test_module_list_with_env_variants(
         },
         "metr_agg_at_controller": {
             "env": {
-                "RAY_SERVE_AGGREGATE_METRICS_AT_CONTROLLER": "1",
                 "RAY_SERVE_COLLECT_AUTOSCALING_METRICS_ON_HANDLE": "1",
                 "RAY_SERVE_FAIL_ON_RANK_ERROR": "1",
             },
             "name_suffix": "_metr_agg_at_controller",
-        },
-        "metr_agg_at_controller_and_replicas": {
-            "env": {
-                "RAY_SERVE_AGGREGATE_METRICS_AT_CONTROLLER": "1",
-                "RAY_SERVE_COLLECT_AUTOSCALING_METRICS_ON_HANDLE": "0",
-                "RAY_SERVE_FAIL_ON_RANK_ERROR": "1",
-            },
-            "name_suffix": "_metr_agg_at_controller_and_replicas",
         },
     },
     files = [

--- a/python/ray/serve/tests/unit/test_application_state.py
+++ b/python/ray/serve/tests/unit/test_application_state.py
@@ -2725,13 +2725,6 @@ class TestAutoscale:
                 actor_id="actor_id",
                 handle_source=DeploymentHandleSource.UNKNOWN,
                 queued_requests=[TimeStampedValue(timestamp_offset, 0)],
-                aggregated_queued_requests=0,
-                aggregated_metrics={
-                    RUNNING_REQUESTS_KEY: {
-                        r1.to_full_id_str(): 3,
-                        r2.to_full_id_str(): 3,
-                    }
-                },
                 metrics={
                     RUNNING_REQUESTS_KEY: {
                         r1.to_full_id_str(): [TimeStampedValue(timestamp_offset, 3)],
@@ -2745,7 +2738,6 @@ class TestAutoscale:
             for i in [1, 2]:
                 replica_report = ReplicaMetricReport(
                     replica_id=ReplicaID(unique_id=f"replica_{i}", deployment_id=d1_id),
-                    aggregated_metrics={RUNNING_REQUESTS_KEY: 3},
                     metrics={
                         RUNNING_REQUESTS_KEY: [TimeStampedValue(timestamp_offset, 3)]
                     },
@@ -2872,7 +2864,6 @@ class TestAutoscale:
         for replica_id in app1_d1_replicas + app1_d2_replicas:
             replica_report = ReplicaMetricReport(
                 replica_id=replica_id,
-                aggregated_metrics={RUNNING_REQUESTS_KEY: 3},
                 metrics={RUNNING_REQUESTS_KEY: [TimeStampedValue(timestamp_offset, 3)]},
                 timestamp=time.time(),
             )
@@ -2882,7 +2873,6 @@ class TestAutoscale:
         for replica_id in app2_d1_replicas + app2_d2_replicas:
             replica_report = ReplicaMetricReport(
                 replica_id=replica_id,
-                aggregated_metrics={RUNNING_REQUESTS_KEY: 0},
                 metrics={RUNNING_REQUESTS_KEY: [TimeStampedValue(timestamp_offset, 0)]},
                 timestamp=time.time(),
             )
@@ -2946,7 +2936,6 @@ class TestAutoscale:
         for i in [1, 2]:
             replica_report = ReplicaMetricReport(
                 replica_id=ReplicaID(unique_id=f"d1_replica_{i}", deployment_id=d1_id),
-                aggregated_metrics={RUNNING_REQUESTS_KEY: 3},
                 metrics={RUNNING_REQUESTS_KEY: [TimeStampedValue(timestamp_offset, 3)]},
                 timestamp=time.time(),
             )
@@ -3027,7 +3016,6 @@ class TestAutoscale:
         for i in [1, 2]:
             replica_report = ReplicaMetricReport(
                 replica_id=ReplicaID(unique_id=f"replica_{i}", deployment_id=d1_id),
-                aggregated_metrics={RUNNING_REQUESTS_KEY: 4},
                 metrics={RUNNING_REQUESTS_KEY: [TimeStampedValue(timestamp_offset, 4)]},
                 timestamp=time.time(),
             )
@@ -3156,7 +3144,6 @@ class TestAutoscale:
             for replica in replicas:
                 replica_report = ReplicaMetricReport(
                     replica_id=replica,
-                    aggregated_metrics={RUNNING_REQUESTS_KEY: load},
                     metrics={
                         RUNNING_REQUESTS_KEY: [TimeStampedValue(timestamp_offset, load)]
                     },
@@ -3231,7 +3218,6 @@ class TestAutoscale:
         for i in range(3):
             replica_report = ReplicaMetricReport(
                 replica_id=ReplicaID(unique_id=f"replica_{i}", deployment_id=d1_id),
-                aggregated_metrics={RUNNING_REQUESTS_KEY: 10},
                 metrics={
                     RUNNING_REQUESTS_KEY: [TimeStampedValue(timestamp_offset, 10)]
                 },
@@ -3368,13 +3354,6 @@ class TestAutoscale:
             actor_id="actor_id",
             handle_source=DeploymentHandleSource.UNKNOWN,
             queued_requests=[TimeStampedValue(timestamp_offset, 0)],
-            aggregated_queued_requests=0,
-            aggregated_metrics={
-                RUNNING_REQUESTS_KEY: {
-                    d1_r1.to_full_id_str(): d1_load,
-                    d1_r2.to_full_id_str(): d1_load,
-                }
-            },
             metrics={
                 RUNNING_REQUESTS_KEY: {
                     d1_r1.to_full_id_str(): [
@@ -3398,13 +3377,6 @@ class TestAutoscale:
             actor_id="actor_id",
             handle_source=DeploymentHandleSource.UNKNOWN,
             queued_requests=[TimeStampedValue(timestamp_offset, 0)],
-            aggregated_queued_requests=0,
-            aggregated_metrics={
-                RUNNING_REQUESTS_KEY: {
-                    d2_r3.to_full_id_str(): d2_load,
-                    d2_r4.to_full_id_str(): d2_load,
-                }
-            },
             metrics={
                 RUNNING_REQUESTS_KEY: {
                     d2_r3.to_full_id_str(): [
@@ -3427,7 +3399,6 @@ class TestAutoscale:
         for i in [1, 2]:
             replica_report = ReplicaMetricReport(
                 replica_id=ReplicaID(unique_id=f"replica_{i}", deployment_id=d1_id),
-                aggregated_metrics={RUNNING_REQUESTS_KEY: d1_load},
                 metrics={
                     RUNNING_REQUESTS_KEY: [TimeStampedValue(timestamp_offset, d1_load)]
                 },
@@ -3439,7 +3410,6 @@ class TestAutoscale:
         for i in [3, 4]:
             replica_report = ReplicaMetricReport(
                 replica_id=ReplicaID(unique_id=f"replica_{i}", deployment_id=d2_id),
-                aggregated_metrics={RUNNING_REQUESTS_KEY: d2_load},
                 metrics={
                     RUNNING_REQUESTS_KEY: [TimeStampedValue(timestamp_offset, d2_load)]
                 },

--- a/python/ray/serve/tests/unit/test_common.py
+++ b/python/ray/serve/tests/unit/test_common.py
@@ -2,13 +2,17 @@ import pytest
 
 from ray.serve._private.common import (
     REPLICA_ID_FULL_ID_STR_PREFIX,
+    RUNNING_REQUESTS_KEY,
+    DeploymentHandleSource,
     DeploymentID,
     DeploymentStatus,
     DeploymentStatusInfo,
     DeploymentStatusInternalTrigger,
     DeploymentStatusTrigger,
+    HandleMetricReport,
     ReplicaID,
     RunningReplicaInfo,
+    TimeStampedValue,
 )
 from ray.serve._private.constants import SERVE_DEPLOYMENT_ACTOR_PREFIX
 from ray.serve._private.utils import get_deployment_actor_name, get_random_string
@@ -249,6 +253,31 @@ def test_running_replica_info():
     )
     assert replica6._hash != replica7._hash
     assert replica6._hash != replica8._hash
+
+
+def test_handle_metric_report_total_requests():
+    """Peaks are summed, so a handle that drained by its last sample still reports load."""
+    deployment_id = DeploymentID(name="D", app_name="app")
+    replica_str = ReplicaID("r1", deployment_id=deployment_id).to_full_id_str()
+
+    def report(queued, running):
+        return HandleMetricReport(
+            deployment_id=deployment_id,
+            handle_id="h1",
+            actor_id="a1",
+            handle_source=DeploymentHandleSource.UNKNOWN,
+            queued_requests=queued,
+            metrics={RUNNING_REQUESTS_KEY: running} if running else {},
+            timestamp=2,
+        )
+
+    drained = report(
+        [TimeStampedValue(1, 3), TimeStampedValue(2, 0)],
+        {replica_str: [TimeStampedValue(1, 5), TimeStampedValue(2, 0)]},
+    )
+    assert drained.total_requests == 8
+
+    assert report([], {}).total_requests == 0
 
 
 if __name__ == "__main__":

--- a/python/ray/serve/tests/unit/test_common.py
+++ b/python/ray/serve/tests/unit/test_common.py
@@ -256,9 +256,12 @@ def test_running_replica_info():
 
 
 def test_handle_metric_report_total_requests():
-    """Peaks are summed, so a handle that drained by its last sample still reports load."""
+    """Per-series peaks are summed, so the value survives a mid-window dip and counts
+    every replica. It deliberately over-states any single instant."""
     deployment_id = DeploymentID(name="D", app_name="app")
-    replica_str = ReplicaID("r1", deployment_id=deployment_id).to_full_id_str()
+    r1, r2 = (
+        ReplicaID(r, deployment_id=deployment_id).to_full_id_str() for r in ("r1", "r2")
+    )
 
     def report(queued, running):
         return HandleMetricReport(
@@ -271,12 +274,24 @@ def test_handle_metric_report_total_requests():
             timestamp=2,
         )
 
-    drained = report(
-        [TimeStampedValue(1, 3), TimeStampedValue(2, 0)],
-        {replica_str: [TimeStampedValue(1, 5), TimeStampedValue(2, 0)]},
+    # Peaks are 4 (queued), 6 (r1) and 3 (r2). Summing every point would give 18 and
+    # taking either endpoint would give 4, so this pins both the peak and the per-
+    # replica sum rather than passing on a coincidence.
+    peaky = report(
+        [TimeStampedValue(1, 1), TimeStampedValue(2, 4), TimeStampedValue(3, 2)],
+        {
+            r1: [
+                TimeStampedValue(1, 0),
+                TimeStampedValue(2, 6),
+                TimeStampedValue(3, 1),
+            ],
+            r2: [TimeStampedValue(1, 3), TimeStampedValue(2, 1)],
+        },
     )
-    assert drained.total_requests == 8
+    assert peaky.total_requests == 13
 
+    # An empty series contributes nothing rather than raising.
+    assert report([], {r1: []}).total_requests == 0
     assert report([], {}).total_requests == 0
 
 

--- a/python/ray/serve/tests/unit/test_deployment_state.py
+++ b/python/ray/serve/tests/unit/test_deployment_state.py
@@ -10631,5 +10631,34 @@ class TestRankConsistencyMembershipGate:
         assert ds._rank_manager.consistency_calls == 0
 
 
+@pytest.mark.parametrize("aggregation_function, expected", [("max", 8), ("min", 2)])
+def test_aggregation_function_reaches_builtin_metrics(aggregation_function, expected):
+    """`max`/`min` now reduce the built-in running-requests metric. The removed simple
+    mode ignored `aggregation_function` and always reported a mean."""
+    asm = AutoscalingStateManager()
+    info, _ = deployment_info(
+        autoscaling_config={
+            "target_ongoing_requests": 1,
+            "min_replicas": 1,
+            "max_replicas": 6,
+            "aggregation_function": aggregation_function,
+        }
+    )
+    asm.register_deployment(TEST_DEPLOYMENT_ID, info, 1)
+    replica_id = ReplicaID(unique_id="r1", deployment_id=TEST_DEPLOYMENT_ID)
+    asm.update_running_replica_ids(TEST_DEPLOYMENT_ID, [replica_id])
+    asm.record_request_metrics_for_replica(
+        ReplicaMetricReport(
+            replica_id=replica_id,
+            metrics={
+                RUNNING_REQUESTS_KEY: [TimeStampedValue(1, 8), TimeStampedValue(2, 2)]
+            },
+            timestamp=2,
+        )
+    )
+
+    assert asm.get_total_num_requests_for_deployment(TEST_DEPLOYMENT_ID) == expected
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main(["-v", "-s", __file__]))

--- a/python/ray/serve/tests/unit/test_deployment_state.py
+++ b/python/ray/serve/tests/unit/test_deployment_state.py
@@ -4799,13 +4799,6 @@ class TestAutoscaling:
                 actor_id="actor_id",
                 handle_source=DeploymentHandleSource.UNKNOWN,
                 queued_requests=[TimeStampedValue(timer.time() - 0.1, 0)],
-                aggregated_queued_requests=0,
-                aggregated_metrics={
-                    RUNNING_REQUESTS_KEY: {
-                        replica._actor.replica_id.to_full_id_str(): req_per_replica
-                        for replica in replicas
-                    }
-                },
                 metrics={
                     RUNNING_REQUESTS_KEY: {
                         replica._actor.replica_id.to_full_id_str(): [
@@ -4821,7 +4814,6 @@ class TestAutoscaling:
             for replica in replicas:
                 replica_metric_report = ReplicaMetricReport(
                     replica_id=replica._actor.replica_id,
-                    aggregated_metrics={RUNNING_REQUESTS_KEY: req_per_replica},
                     metrics={
                         RUNNING_REQUESTS_KEY: [
                             TimeStampedValue(timer.time() - 0.1, req_per_replica)
@@ -4993,13 +4985,6 @@ class TestAutoscaling:
                 actor_id="actor_id",
                 handle_source=DeploymentHandleSource.UNKNOWN,
                 queued_requests=[TimeStampedValue(timer.time() - 0.1, 0)],
-                aggregated_queued_requests=0,
-                aggregated_metrics={
-                    RUNNING_REQUESTS_KEY: {
-                        replica._actor.replica_id.to_full_id_str(): 2
-                        for replica in replicas
-                    }
-                },
                 metrics={
                     RUNNING_REQUESTS_KEY: {
                         replica._actor.replica_id.to_full_id_str(): [
@@ -5015,7 +5000,6 @@ class TestAutoscaling:
             for replica in replicas:
                 replica_metric_report = ReplicaMetricReport(
                     replica_id=replica._actor.replica_id,
-                    aggregated_metrics={RUNNING_REQUESTS_KEY: 2},
                     metrics={
                         RUNNING_REQUESTS_KEY: [TimeStampedValue(timer.time() - 0.1, 2)]
                     },
@@ -5092,13 +5076,6 @@ class TestAutoscaling:
                 actor_id="actor_id",
                 handle_source=DeploymentHandleSource.UNKNOWN,
                 queued_requests=[TimeStampedValue(timer.time() - 0.1, 0)],
-                aggregated_queued_requests=0,
-                aggregated_metrics={
-                    RUNNING_REQUESTS_KEY: {
-                        replica._actor.replica_id.to_full_id_str(): 1
-                        for replica in replicas
-                    }
-                },
                 metrics={
                     RUNNING_REQUESTS_KEY: {
                         replica._actor.replica_id.to_full_id_str(): [
@@ -5114,7 +5091,6 @@ class TestAutoscaling:
             for replica in replicas:
                 replica_metric_report = ReplicaMetricReport(
                     replica_id=replica._actor.replica_id,
-                    aggregated_metrics={RUNNING_REQUESTS_KEY: 1},
                     metrics={
                         RUNNING_REQUESTS_KEY: [TimeStampedValue(timer.time() - 0.1, 1)]
                     },
@@ -5204,13 +5180,6 @@ class TestAutoscaling:
                 actor_id="actor_id",
                 handle_source=DeploymentHandleSource.UNKNOWN,
                 queued_requests=[TimeStampedValue(timer.time() - 0.1, 0)],
-                aggregated_queued_requests=0,
-                aggregated_metrics={
-                    RUNNING_REQUESTS_KEY: {
-                        replica._actor.replica_id.to_full_id_str(): 1
-                        for replica in replicas
-                    }
-                },
                 metrics={
                     RUNNING_REQUESTS_KEY: {
                         replica._actor.replica_id.to_full_id_str(): [
@@ -5226,7 +5195,6 @@ class TestAutoscaling:
             for replica in replicas:
                 replica_metric_report = ReplicaMetricReport(
                     replica_id=replica._actor.replica_id,
-                    aggregated_metrics={RUNNING_REQUESTS_KEY: 1},
                     metrics={
                         RUNNING_REQUESTS_KEY: [TimeStampedValue(timer.time() - 0.1, 1)]
                     },
@@ -5325,8 +5293,6 @@ class TestAutoscaling:
             actor_id="actor_id",
             handle_source=DeploymentHandleSource.UNKNOWN,
             queued_requests=[TimeStampedValue(timer.time() - 0.1, 1)],
-            aggregated_queued_requests=1,
-            aggregated_metrics={},
             metrics={},
             timestamp=timer.time(),
         )
@@ -5445,8 +5411,6 @@ class TestAutoscaling:
             actor_id="actor_id",
             handle_source=DeploymentHandleSource.UNKNOWN,
             queued_requests=[TimeStampedValue(timer.time() - 0.1, 1)],
-            aggregated_queued_requests=1,
-            aggregated_metrics={},
             metrics={},
             timestamp=timer.time(),
         )
@@ -5522,12 +5486,6 @@ class TestAutoscaling:
             actor_id="actor_id",
             handle_source=DeploymentHandleSource.UNKNOWN,
             queued_requests=[TimeStampedValue(timer.time() - 0.1, 0)],
-            aggregated_queued_requests=0,
-            aggregated_metrics={
-                RUNNING_REQUESTS_KEY: {
-                    ds._replicas.get()[0]._actor.replica_id.to_full_id_str(): 2
-                }
-            },
             metrics={
                 RUNNING_REQUESTS_KEY: {
                     ds._replicas.get()[0]._actor.replica_id.to_full_id_str(): [
@@ -5637,12 +5595,6 @@ class TestAutoscaling:
             actor_id="d2_replica_actor_id",
             handle_source=DeploymentHandleSource.REPLICA,
             queued_requests=[TimeStampedValue(timer.time() - 0.1, 0)],
-            aggregated_queued_requests=0,
-            aggregated_metrics={
-                RUNNING_REQUESTS_KEY: {
-                    ds1._replicas.get()[0]._actor.replica_id.to_full_id_str(): 2
-                }
-            },
             metrics={
                 RUNNING_REQUESTS_KEY: {
                     ds1._replicas.get()[0]._actor.replica_id.to_full_id_str(): [
@@ -5768,13 +5720,6 @@ class TestAutoscaling:
                 actor_id="test_actor",
                 handle_source=DeploymentHandleSource.UNKNOWN,
                 queued_requests=[TimeStampedValue(timer.time() - 0.1, 0)],
-                aggregated_queued_requests=0,
-                aggregated_metrics={
-                    RUNNING_REQUESTS_KEY: {
-                        replica._actor.replica_id.to_full_id_str(): req_per_replica
-                        for replica in replicas
-                    }
-                },
                 metrics={
                     RUNNING_REQUESTS_KEY: {
                         replica._actor.replica_id.to_full_id_str(): [
@@ -5790,7 +5735,6 @@ class TestAutoscaling:
             for replica in replicas:
                 replica_metric_report = ReplicaMetricReport(
                     replica_id=replica._actor.replica_id,
-                    aggregated_metrics={RUNNING_REQUESTS_KEY: req_per_replica},
                     metrics={
                         RUNNING_REQUESTS_KEY: [
                             TimeStampedValue(timer.time() - 0.1, req_per_replica)
@@ -5834,13 +5778,6 @@ class TestAutoscaling:
                 actor_id="test_actor",
                 handle_source=DeploymentHandleSource.UNKNOWN,
                 queued_requests=[TimeStampedValue(timer.time() - 0.1, 0)],
-                aggregated_queued_requests=0,
-                aggregated_metrics={
-                    RUNNING_REQUESTS_KEY: {
-                        replica._actor.replica_id.to_full_id_str(): req_per_replica
-                        for replica in replicas
-                    }
-                },
                 metrics={
                     RUNNING_REQUESTS_KEY: {
                         replica._actor.replica_id.to_full_id_str(): [
@@ -5856,7 +5793,6 @@ class TestAutoscaling:
             for replica in replicas:
                 replica_metric_report = ReplicaMetricReport(
                     replica_id=replica._actor.replica_id,
-                    aggregated_metrics={RUNNING_REQUESTS_KEY: req_per_replica},
                     metrics={
                         RUNNING_REQUESTS_KEY: [
                             TimeStampedValue(timer.time() - 0.1, req_per_replica)

--- a/python/ray/serve/tests/unit/test_metrics_utils.py
+++ b/python/ray/serve/tests/unit/test_metrics_utils.py
@@ -163,7 +163,7 @@ class TestInMemoryMetricsStore:
         s = InMemoryMetricsStore()
         s.add_metrics_point({"m1": 1}, timestamp=1)
         s.add_metrics_point({"m1": 2}, timestamp=2)
-        assert s.aggregate_avg(["m1"]) == (1.5, 1)
+        assert [p.value for p in s.data["m1"]] == [1, 2]
         assert s.get_latest("m1") == 2
 
     def test_out_of_order_insert(self):
@@ -173,30 +173,23 @@ class TestInMemoryMetricsStore:
         s.add_metrics_point({"m1": 3}, timestamp=3)
         s.add_metrics_point({"m1": 2}, timestamp=2)
         s.add_metrics_point({"m1": 4}, timestamp=4)
-        assert s.aggregate_avg(["m1"]) == (3, 1)
+        assert [p.value for p in s.data["m1"]] == [1, 2, 3, 4, 5]
 
     def test_window_start_timestamp(self):
         s = InMemoryMetricsStore()
-        assert s.aggregate_avg(["m1"]) == (None, 0)
+        assert "m1" not in s.data
 
         s.add_metrics_point({"m1": 1}, timestamp=2)
-        assert s.aggregate_avg(["m1"]) == (1, 1)
+        assert [p.value for p in s.data["m1"]] == [1]
         s.prune_keys_and_compact_data(10)
-        assert s.aggregate_avg(["m1"]) == (None, 0)
+        assert "m1" not in s.data
 
     def test_multiple_metrics(self):
         s = InMemoryMetricsStore()
         s.add_metrics_point({"m1": 1, "m2": -1}, timestamp=1)
         s.add_metrics_point({"m1": 2, "m2": -2}, timestamp=2)
-        assert s.aggregate_avg(["m1"]) == (1.5, 1)
-        assert s.aggregate_avg(["m2"]) == (-1.5, 1)
-        assert s.aggregate_avg(["m1", "m2"]) == (0, 2)
-
-    def test_empty_key_mix(self):
-        s = InMemoryMetricsStore()
-        s.add_metrics_point({"m1": 1}, timestamp=1)
-        assert s.aggregate_avg(["m1", "m2"]) == (1, 1)
-        assert s.aggregate_avg(["m2"]) == (None, 0)
+        assert [p.value for p in s.data["m1"]] == [1, 2]
+        assert [p.value for p in s.data["m2"]] == [-1, -2]
 
     def test_prune_keys_and_compact_data(self):
         s = InMemoryMetricsStore()


### PR DESCRIPTION
Metrics could be aggregated either at the source (replicas/handles pre-computing a window average) or at the controller (merging raw timeseries), selected by RAY_SERVE_AGGREGATE_METRICS_AT_CONTROLLER. Source aggregation cannot be correct across sources, summing per-source window averages is not the time-weighted average of the instantaneous total, and it is wrong outright for MAX/MIN, and direct ingress already forced controller aggregation regardless of the flag.

Drop the flag and the simple-mode path so there is one aggregation model. Note the flag defaulted to "0", so this changes the default behavior.

Also extract the duplicated latency/histogram/tracker block shared by record_autoscaling_metrics_from_replica and _from_handle into one helper.

Test variants that differed from a sibling only by this flag would become duplicate targets, so they are removed rather than left as copies.
