### PR TITLE
[Data] Remove unused issue detector metrics

### DIFF
--- a/python/ray/data/_internal/execution/interfaces/op_runtime_metrics.py
+++ b/python/ray/data/_internal/execution/interfaces/op_runtime_metrics.py
@@ -45,7 +45,6 @@ class MetricsGroup(Enum):
     OUTPUTS = "outputs"
     TASKS = "tasks"
     OBJECT_STORE_MEMORY = "object_store_memory"
-    MISC = "misc"
     ACTORS = "actors"
 
 
@@ -542,9 +541,6 @@ class OpRuntimeMetrics(metaclass=OpRuntimesMetricsMeta):
         description="Byte size of used memory in object store.",
         metrics_group=MetricsGroup.OBJECT_STORE_MEMORY,
     )
-
-    # === Miscellaneous metrics ===
-    # Use "metrics_group: "misc" in the metadata for new metrics in this section.
 
     def __init__(self, op: "PhysicalOperator"):
         from ray.data._internal.execution.operators.map_operator import MapOperator

--- a/python/ray/data/_internal/execution/interfaces/op_runtime_metrics.py
+++ b/python/ray/data/_internal/execution/interfaces/op_runtime_metrics.py
@@ -566,9 +566,6 @@ class OpRuntimeMetrics(metaclass=OpRuntimesMetricsMeta):
         self._per_node_metrics: Dict[str, NodeMetrics] = defaultdict(NodeMetrics)
         self._per_node_metrics_enabled: bool = op.data_context.enable_per_node_metrics
 
-        self._issue_detector_hanging = 0
-        self._issue_detector_high_memory = 0
-
         # Initialize the histogram and distribution metrics
         self.task_completion_time = RuntimeMetricsHistogram(histogram_buckets_s)
         self.block_completion_time = RuntimeMetricsHistogram(histogram_buckets_s)
@@ -913,22 +910,6 @@ class OpRuntimeMetrics(metaclass=OpRuntimesMetricsMeta):
         if self.max_uss_bytes.num_samples == 0:
             return None
         return self.max_uss_bytes.mean
-
-    @metric_property(
-        description="Indicates if the operator is hanging.",
-        metrics_group=MetricsGroup.MISC,
-        internal_only=True,
-    )
-    def issue_detector_hanging(self) -> int:
-        return self._issue_detector_hanging
-
-    @metric_property(
-        description="Indicates if the operator is using high memory.",
-        metrics_group=MetricsGroup.MISC,
-        internal_only=True,
-    )
-    def issue_detector_high_memory(self) -> int:
-        return self._issue_detector_high_memory
 
     def on_input_received(self, input: RefBundle):
         """Callback when the operator receives a new input."""

--- a/python/ray/data/_internal/issue_detection/issue_detector_manager.py
+++ b/python/ray/data/_internal/issue_detection/issue_detector_manager.py
@@ -66,10 +66,6 @@ class IssueDetectorManager:
         for i, operator in enumerate(self.executor._topology.keys()):
             operators[operator.id] = operator
             op_to_id[operator] = self.executor._get_operator_id(operator, i)
-            # Reset issue detector metrics for each operator so that previous issues
-            # don't affect the current ones.
-            operator.metrics._issue_detector_hanging = 0
-            operator.metrics._issue_detector_high_memory = 0
 
         for issue in issues:
             logger.warning(issue.message)
@@ -96,11 +92,6 @@ class IssueDetectorManager:
                     message=issue.message,
                 )
                 self._operator_event_exporter.export_operator_event(operator_event)
-
-            if issue.issue_type == IssueType.HANGING:
-                operator.metrics._issue_detector_hanging += 1
-            if issue.issue_type == IssueType.HIGH_MEMORY:
-                operator.metrics._issue_detector_high_memory += 1
         if len(issues) > 0:
             logger.warning(
                 f"Found {len(issues)} issues. To disable issue detection, run DataContext.get_current().issue_detectors_config.detectors = []."

--- a/python/ray/data/_internal/stats.py
+++ b/python/ray/data/_internal/stats.py
@@ -482,14 +482,6 @@ class _StatsActor:
             )
         )
 
-        # Miscellaneous metrics
-        self.execution_metrics_misc = (
-            self._create_prometheus_metrics_for_execution_metrics(
-                metrics_group=MetricsGroup.MISC,
-                tag_keys=op_tags_keys,
-            )
-        )
-
         # Per Node metrics
         self.per_node_metrics = self._create_prometheus_metrics_for_per_node_metrics()
 
@@ -774,9 +766,6 @@ class _StatsActor:
                 _record(prom_metric, stats.get(field_name, 0), tags)
 
             for field_name, prom_metric in self.execution_metrics_actors.items():
-                _record(prom_metric, stats.get(field_name, 0), tags)
-
-            for field_name, prom_metric in self.execution_metrics_misc.items():
                 _record(prom_metric, stats.get(field_name, 0), tags)
 
         # Update per node metrics if they exist, the creation of these metrics is controlled

--- a/python/ray/data/tests/test_issue_detection_manager.py
+++ b/python/ray/data/tests/test_issue_detection_manager.py
@@ -74,10 +74,6 @@ def test_report_issues():
             ),
         ]
     )
-    assert input_operator.metrics.issue_detector_hanging == 1
-    assert input_operator.metrics.issue_detector_high_memory == 0
-    assert map_operator.metrics.issue_detector_hanging == 0
-    assert map_operator.metrics.issue_detector_high_memory == 1
 
     data = _get_exported_data()
     assert len(data) == 2


### PR DESCRIPTION
1. Remove the internal `issue_detector_hanging` and `issue_detector_high_memory` operator metrics and the corresponding reset/increment logic in `IssueDetectorManager`.

2. Because these were the only metrics in `MetricsGroup.MISC`, the now-empty group and its StatsActor creation/update paths are removed as well.

## Related issues

Closes #65715.

## Additional information

This cleanup was identified during review of #65512.
