### PR TITLE
[Serve] Drain timed-out queue-length probe tasks

### DIFF
--- a/python/ray/serve/_private/request_router/request_router.py
+++ b/python/ray/serve/_private/request_router/request_router.py
@@ -999,6 +999,12 @@ class RequestRouter(ABC):
                 "`RAY_SERVE_QUEUE_LENGTH_RESPONSE_DEADLINE_S` environment variable."
             )
 
+        # Cancellation is cooperative. Wait for every timed-out probe to finish
+        # before returning so a slow replica cannot keep running after its result
+        # has been discarded.
+        if pending:
+            await asyncio.gather(*pending, return_exceptions=True)
+
         for t in done:
             replica = task_to_replica[t]
             if t.exception() is not None:


### PR DESCRIPTION
## Summary

Fixes #65719.

The request router cancelled queue-length probe tasks that exceeded their response deadline but returned without awaiting cooperative cancellation. A timed-out replica probe could therefore continue running after its result had been discarded and overlap with subsequent routing work.

This change drains all cancelled probes with `asyncio.gather(..., return_exceptions=True)` before returning. The existing timeout behavior and unavailable-replica result are unchanged.

## Validation

- `python -m py_compile python/ray/serve/_private/request_router/request_router.py python/ray/serve/tests/unit/test_pow_2_request_router.py`
- `ruff check python/ray/serve/_private/request_router/request_router.py python/ray/serve/tests/unit/test_pow_2_request_router.py`
- `git diff --check`
- Focused pytest is currently blocked in this checkout because the compiled `ray._raylet` module is not installed.