### PR TITLE
[Serve] Clean up unary proxy result task on timeout or disconnect

### DIFF
--- a/python/ray/serve/_private/proxy_response_generator.py
+++ b/python/ray/serve/_private/proxy_response_generator.py
@@ -176,8 +176,12 @@ class ProxyResponseGenerator(_ProxyResponseGeneratorBase):
         if result_task in done:
             return result_task.result()
         elif self._disconnected_task in done:
+            result_task.cancel()
+            await asyncio.gather(result_task, return_exceptions=True)
             self._response.cancel()
             raise asyncio.CancelledError()
         else:
+            result_task.cancel()
+            await asyncio.gather(result_task, return_exceptions=True)
             self._response.cancel()
             raise TimeoutError()

--- a/python/ray/serve/tests/test_proxy_response_generator.py
+++ b/python/ray/serve/tests/test_proxy_response_generator.py
@@ -20,6 +20,39 @@ def disconnect_task_and_event() -> Tuple[asyncio.Event, asyncio.Task]:
 
 @pytest.mark.asyncio
 class TestUnary:
+    async def test_timeout_cleans_up_local_result_task(self):
+        active_waiters = 0
+        response_cancelled = False
+        response_finished = asyncio.Event()
+
+        class Response:
+            def cancelled(self):
+                return response_cancelled
+
+            def cancel(self):
+                nonlocal response_cancelled
+                response_cancelled = True
+
+            def __await__(self):
+                async def wait_for_response():
+                    nonlocal active_waiters
+                    active_waiters += 1
+                    try:
+                        await response_finished.wait()
+                    finally:
+                        active_waiters -= 1
+
+                return wait_for_response().__await__()
+
+        response = Response()
+        gen = ProxyResponseGenerator(response, timeout_s=0.001)
+
+        with pytest.raises(TimeoutError):
+            await gen.__anext__()
+
+        assert response_cancelled
+        assert active_waiters == 0
+
     async def test_basic(self, serve_instance):
         @serve.deployment
         class D:


### PR DESCRIPTION
## Summary

Fixes #65718.

When a unary Serve response timed out or the client disconnected, the proxy cancelled the underlying deployment response but left its local asyncio result task unmanaged. The streaming path already cancelled and drained its local task.

This change cancels and awaits the unary result task before propagating the timeout or cancellation. A focused regression test uses a pending awaitable and verifies that its local waiter has exited.

## Validation

- `python -m py_compile python/ray/serve/_private/proxy_response_generator.py python/ray/serve/tests/test_proxy_response_generator.py`
- `ruff check python/ray/serve/_private/proxy_response_generator.py python/ray/serve/tests/test_proxy_response_generator.py`
- `git diff --check`
- Focused pytest is currently blocked in this checkout because the compiled `ray._raylet` module is not installed.