### PR TITLE
[core][doc] Fix malformed Doxygen comments

### DIFF
--- a/cpp/include/ray/api.h
+++ b/cpp/include/ray/api.h
@@ -146,16 +146,16 @@ boost::optional<ActorHandle<T>> GetActor(const std::string &actor_name);
 /// The actor must have been created with name specified.
 ///
 /// \param[in] actor_name The name of the named actor.
-/// \param[in] namespace The namespace of the actor.
+/// \param[in] ray_namespace The namespace of the actor.
 /// \return An ActorHandle to the actor if the actor of specified name exists in
-/// specifiled namespace or an empty optional object.
+/// specified namespace or an empty optional object.
 template <typename T>
 boost::optional<ActorHandle<T>> GetActor(const std::string &actor_name,
                                          const std::string &ray_namespace);
 
 /// Intentionally exit the current actor.
 /// It is used to disconnect an actor and exit the worker.
-/// \Throws RayException if the current process is a driver or the current worker is not
+/// \throws RayException if the current process is a driver or the current worker is not
 /// an actor.
 void ExitActor();
 

--- a/cpp/include/ray/api/actor_handle.h
+++ b/cpp/include/ray/api/actor_handle.h
@@ -34,7 +34,7 @@ class ActorHandle {
   // Used to identify its type.
   static bool IsActorHandle() { return true; }
 
-  /// Get a untyped ID of the actor
+  /// Get an untyped ID of the actor
   const std::string &ID() const { return id_; }
 
   /// Include the `Call` methods for calling remote functions.

--- a/cpp/include/ray/api/object_ref.h
+++ b/cpp/include/ray/api/object_ref.h
@@ -94,7 +94,7 @@ class ObjectRef {
 
   bool operator==(const ObjectRef<T> &object) const;
 
-  /// Get a untyped ID of the object
+  /// Get an untyped ID of the object
   const std::string &ID() const;
 
   /// Get the object from the object store.
@@ -192,7 +192,7 @@ class ObjectRef<void> {
 
   bool operator==(const ObjectRef<void> &object) const { return id_ == object.id_; }
 
-  /// Get a untyped ID of the object
+  /// Get an untyped ID of the object
   const std::string &ID() const { return id_; }
 
   /// Get the object from the object store.
@@ -209,7 +209,6 @@ class ObjectRef<void> {
   ///
   /// \param timeout_ms The maximum amount of time in milliseconds to wait before
   /// returning.
-  ///  \return shared pointer of the result.
   void Get(const int &timeout_ms) const {
     auto packed_object = internal::GetRayRuntime()->Get(id_, timeout_ms);
     CheckResult(packed_object);

--- a/src/ray/asio/asio_util.h
+++ b/src/ray/asio/asio_util.h
@@ -108,7 +108,7 @@ class InstrumentedIOContextWithThread {
 /// It provides a method to retrieve the appropriate `io_context` for instances of
 /// different classes.
 ///
-/// @param Policy The policy class that defines which types require dedicated
+/// @tparam Policy The policy class that defines which types require dedicated
 /// `io_context` instances.
 ///
 /// ## The Policy

--- a/src/ray/asio/io_service_pool.h
+++ b/src/ray/asio/io_service_pool.h
@@ -44,8 +44,8 @@ class IOServicePool {
 
   /// Select io_service by hash.
   ///
-  /// \param hash Use this hash to pick a io_service.
-  /// The same hash will alway get the same io_service.
+  /// \param hash Use this hash to pick an io_service.
+  /// The same hash will always get the same io_service.
   /// \return io_service
   instrumented_io_context *Get(size_t hash);
 

--- a/src/ray/common/event_stats.cc
+++ b/src/ray/common/event_stats.cc
@@ -33,7 +33,7 @@ GlobalStats to_global_stats_view(std::shared_ptr<GuardedGlobalStats> stats) {
   return GlobalStats(stats->stats);
 }
 
-/// A helper for creating a snapshot view of the stats for a event.
+/// A helper for creating a snapshot view of the stats for an event.
 /// This acquires a lock on the provided guarded event stats, and creates a
 /// lockless copy of the stats.
 EventStats to_event_stats_view(std::shared_ptr<GuardedEventStats> stats) {

--- a/src/ray/common/event_stats.h
+++ b/src/ray/common/event_stats.h
@@ -115,12 +115,12 @@ class EventTracker {
   /// RecordExecution() or RecordEnd() call.
   ///
   /// \param name A human-readable name to which collected stats will be associated for
-  /// logging. \param expected_queueing_delay_ns How much to pad the observed queueing
-  /// start time,
-  ///  in nanoseconds.
-  ///  \param emit_metrics Emit the underlying stat as a service metric
-  ///  \param event_context_name A human-readable name to which collected stats will be
-  ///  associated for metrics.
+  /// logging.
+  /// \param expected_queueing_delay_ns How much to pad the observed queueing start time,
+  /// in nanoseconds.
+  /// \param emit_metrics Emit the underlying stat as a service metric.
+  /// \param event_context_name A human-readable name to which collected stats will be
+  /// associated for metrics.
   /// \return An opaque stats handle, to be given to RecordExecution() or RecordEnd().
   std::shared_ptr<StatsHandle> RecordStart(
       std::string name,

--- a/src/ray/common/ray_object.h
+++ b/src/ray/common/ray_object.h
@@ -66,7 +66,7 @@ class RayObject {
     }
   }
 
-  /// Create an Ray error object. It uses msgpack for the serialization format now.
+  /// Create a Ray error object. It uses msgpack for the serialization format now.
   /// Ray error objects consist of metadata that indicates the error code (see
   /// rpc::ErrorType) and the serialized message pack that contains serialized
   /// rpc::RayErrorInfo as a body.

--- a/src/ray/common/scheduling/resource_set.h
+++ b/src/ray/common/scheduling/resource_set.h
@@ -76,12 +76,12 @@ class ResourceSet {
   bool operator!=(const ResourceSet &other) const { return !(*this == other); }
 
   /// Check whether this set is a subset of another one.
-  /// If A <= B, it means for each resource, its value in A is less than or equqal to that
+  /// If A <= B, it means for each resource, its value in A is less than or equal to that
   /// in B.
   bool operator<=(const ResourceSet &other) const;
 
   /// Check whether this set is a super set of another one.
-  /// If A >= B, it means for each resource, its value in A is larger than or equqal to
+  /// If A >= B, it means for each resource, its value in A is larger than or equal to
   /// that in B.
   bool operator>=(const ResourceSet &other) const { return other <= *this; }
 
@@ -167,7 +167,7 @@ class NodeResourceSet {
   NodeResourceSet &operator-=(const ResourceSet &other);
 
   /// Check whether this set is a super set of other.
-  /// If A >= B, it means for each resource, its value in A is larger than or equqal to
+  /// If A >= B, it means for each resource, its value in A is larger than or equal to
   /// that in B.
   bool operator>=(const ResourceSet &other) const;
 

--- a/src/ray/common/task/task_spec.h
+++ b/src/ray/common/task/task_spec.h
@@ -39,7 +39,7 @@ extern "C" {
 namespace ray {
 
 /// ConcurrencyGroup is a group of actor methods that shares
-/// a executing thread pool.
+/// an executing thread pool.
 struct ConcurrencyGroup {
   // Name of this group.
   std::string name_;

--- a/src/ray/core_worker/core_worker.h
+++ b/src/ray/core_worker/core_worker.h
@@ -245,7 +245,7 @@ class CoreWorker : public std::enable_shared_from_this<CoreWorker> {
 
   /// Get the Plasma Store Usage.
   ///
-  /// \param output[out] memory usage from the plasma store
+  /// \param[out] output memory usage from the plasma store
   /// \return error status if unable to get response from the plasma store
   Status GetPlasmaUsage(std::string &output);
 
@@ -336,7 +336,7 @@ class CoreWorker : public std::enable_shared_from_this<CoreWorker> {
 
   NodeID GetCurrentNodeId() const { return NodeID::FromBinary(rpc_address_.node_id()); }
 
-  /// Read the next index of a ObjectRefStream of generator_id.
+  /// Read the next index of an ObjectRefStream of generator_id.
   /// This API always return immediately.
   ///
   /// \param[in] generator_id The object ref id of the streaming
@@ -369,11 +369,11 @@ class CoreWorker : public std::enable_shared_from_this<CoreWorker> {
   /// Return True if there's no more object to read. False otherwise.
   bool StreamingGeneratorIsFinished(const ObjectID &generator_id) const;
 
-  /// Read the next index of a ObjectRefStream of generator_id without
+  /// Read the next index of an ObjectRefStream of generator_id without
   /// consuming an index.
   /// \param[in] generator_id The object ref id of the streaming
   /// generator task.
-  /// \return A object reference of the next index and if the object is already ready
+  /// \return An object reference of the next index and if the object is already ready
   /// (meaning if the object's value if retrievable).
   /// It should not be nil.
   std::pair<rpc::ObjectReference, bool> PeekObjectRefStream(const ObjectID &generator_id);
@@ -1483,7 +1483,7 @@ class CoreWorker : public std::enable_shared_from_this<CoreWorker> {
 
   /// Add task log info for a task when it starts executing.
   ///
-  /// It's an no-op in local mode.
+  /// It's a no-op in local mode.
   ///
   /// \param stdout_path Path to stdout log file.
   /// \param stderr_path Path to stderr log file.
@@ -1498,7 +1498,7 @@ class CoreWorker : public std::enable_shared_from_this<CoreWorker> {
 
   /// Add task log info for a task when it finishes executing.
   ///
-  /// It's an no-op in local mode.
+  /// It's a no-op in local mode.
   ///
   /// \param stdout_end_offset End offset of the stdout for this task.
   /// \param stderr_end_offset End offset of the stderr for this task.
@@ -1672,22 +1672,24 @@ class CoreWorker : public std::enable_shared_from_this<CoreWorker> {
 
   /// Execute a task.
   ///
-  /// \param task_spec[in] Task specification.
-  /// \param resource_ids[in] Resource IDs of resources assigned to this
+  /// \param[in] task_spec Task specification.
+  /// \param[in] resource_ids Resource IDs of resources assigned to this
   /// worker. If nullopt, reuse the previously assigned resources.
-  /// \param return_objects[out] Result objects that should be returned
+  /// \param[out] return_objects Result objects that should be returned
   /// to the caller.
-  /// \param dynamic_return_objects[out]  Result objects whose ObjectRefs were dynamically
+  /// \param[out] dynamic_return_objects Result objects whose ObjectRefs were dynamically
   /// allocated during task execution by using a generator. The language-level ObjectRefs
   /// should be returned inside the statically allocated return_objects.
-  /// \param borrowed_refs[out]  Refs that this task (or a nested task) was or is still
+  /// \param[out] borrowed_refs Refs that this task (or a nested task) was or is still
   /// borrowing. This includes all objects whose IDs we passed to the task in its
   /// arguments and recursively, any object IDs that were contained in those objects.
-  /// \param is_retryable_error[out] Whether the task failed with a retryable
+  /// \param[out] is_retryable_error Whether the task failed with a retryable
   /// error.
-  /// \param actor_repr_name[out] The user-specified repr name for the actor in this
-  /// process if one has been set. \param application_error[out] The error message if the
-  /// task failed during execution or cancelled. \return Status.
+  /// \param[out] actor_repr_name The user-specified repr name for the actor in this
+  /// process if one has been set.
+  /// \param[out] application_error The error message if the task failed during execution
+  /// or was cancelled.
+  /// \return Status.
   Status ExecuteTask(
       const TaskSpecification &task_spec,
       std::optional<ResourceMappingType> resource_ids,
@@ -1730,16 +1732,16 @@ class CoreWorker : public std::enable_shared_from_this<CoreWorker> {
   /// being borrowed by this process. The IDs should be unpinned once the task
   /// completes.
   ///
-  /// \param spec[in] task Task specification.
-  /// \param args[out] args Argument data as RayObjects.
-  /// \param args[out] arg_reference_ids ObjectIDs corresponding to each by
+  /// \param[in] task Task specification.
+  /// \param[out] args Argument data as RayObjects.
+  /// \param[out] arg_refs ObjectIDs corresponding to each by
   ///                  reference argument. The length of this vector will be
   ///                  the same as args, and by value arguments will have
   ///                  ObjectID::Nil().
   ///                  // TODO(edoakes): this is a bit of a hack that's necessary because
   ///                  we have separate serialization paths for by-value and by-reference
   ///                  arguments in Python. This should ideally be handled better there.
-  /// \param args[out] pinned_ids ObjectIDs that should be unpinned once the
+  /// \param[out] pinned_ids ObjectIDs that should be unpinned once the
   ///                  task completes execution.  This vector will be populated
   ///                  with all argument IDs that were passed by reference and
   ///                  any ObjectIDs that were included in the task spec's

--- a/src/ray/core_worker/experimental_mutable_object_provider.h
+++ b/src/ray/core_worker/experimental_mutable_object_provider.h
@@ -46,7 +46,7 @@ class MutableObjectProviderInterface {
       const ObjectID &writer_object_id,
       const std::vector<NodeID> &remote_reader_node_ids) = 0;
 
-  /// Handles an RPC request from another note to register a mutable object on this node.
+  /// Handles an RPC request from another node to register a mutable object on this node.
   /// The remote node writes the object and this node reads the object. This node is
   /// notified of writes to the object via HandlePushMutableObject().
   /// \param[in] writer_object_id The ID of the object on the remote note.

--- a/src/ray/core_worker/store_provider/plasma_store_provider.h
+++ b/src/ray/core_worker/store_provider/plasma_store_provider.h
@@ -225,13 +225,17 @@ class CoreWorkerPlasmaStoreProvider {
   /// Successfully fetched objects will be removed from the input set of remaining IDs and
   /// added to the results map.
   ///
-  /// \param[in/out] remaining_object_id_to_idx map of object IDs to their indices left to
-  /// get. \param[in] ids IDs of the objects to get. \param[in] timeout_ms Timeout in
-  /// milliseconds. \param[out] results Map of objects to write results into. This method
-  /// will only add to this map, not clear or remove from it, so the caller can pass in a
-  /// non-empty map. \param[out] got_exception Set to true if any of the fetched objects
-  /// contained an exception. \return Status::IOError if there is an error in
-  /// communicating with the raylet or the plasma store. \return Status::OK if successful.
+  /// \param[in,out] remaining_object_id_to_idx map of object IDs to their indices left to
+  /// get.
+  /// \param[in] ids IDs of the objects to get.
+  /// \param[in] timeout_ms Timeout in milliseconds.
+  /// \param[out] results Map of objects to write results into. This method will only add
+  /// to this map, not clear or remove from it, so the caller can pass in a non-empty map.
+  /// \param[out] got_exception Set to true if any of the fetched objects contained an
+  /// exception.
+  /// \return Status::IOError if there is an error in communicating with the raylet or the
+  /// plasma store.
+  /// \return Status::OK if successful.
   Status GetObjectsFromPlasmaStore(
       absl::flat_hash_map<ObjectID, int64_t> &remaining_object_id_to_idx,
       const std::vector<ObjectID> &ids,

--- a/src/ray/core_worker/task_manager.h
+++ b/src/ray/core_worker/task_manager.h
@@ -1187,7 +1187,7 @@ class TaskManager : public TaskManagerInterface {
   /// Callback to free GPU object from the in-actor RDT store.
   FreeActorObjectCallback free_actor_object_callback_;
 
-  /// Callback to set the direct transport metadata for a object.
+  /// Callback to set the direct transport metadata for an object.
   SetDirectTransportMetadata set_direct_transport_metadata_;
 
   /// Callback to asynchronously free an object's copies on a set of nodes.

--- a/src/ray/core_worker/task_submission/normal_task_submitter.h
+++ b/src/ray/core_worker/task_submission/normal_task_submitter.h
@@ -135,7 +135,7 @@ class NormalTaskSubmitter {
   void CancelTask(TaskSpecification task_spec, bool force_kill, bool recursive);
 
   /// Request the owner of the object ID to cancel a request.
-  /// It is used when a object ID is not owned by the current process.
+  /// It is used when an object ID is not owned by the current process.
   /// We cannot cancel the task in this case because we don't have enough
   /// information to cancel a task.
   void RequestOwnerToCancelTask(const ObjectID &object_id,

--- a/src/ray/gcs/actor/gcs_actor_manager.h
+++ b/src/ray/gcs/actor/gcs_actor_manager.h
@@ -279,7 +279,7 @@ class GcsActorManager : public rpc::ActorInfoGcsServiceHandler,
   /// Get names of named actors.
   //
   /// \param[in] all_namespaces Whether to include actors from all Ray namespaces.
-  /// \param[in] namespace The namespace to filter to if all_namespaces is false.
+  /// \param[in] ray_namespace The namespace to filter to if all_namespaces is false.
   /// \returns List of <namespace, name> pairs.
   std::vector<std::pair<std::string, std::string>> ListNamedActors(
       bool all_namespaces, const std::string &ray_namespace) const;

--- a/src/ray/gcs/actor/gcs_actor_scheduler.h
+++ b/src/ray/gcs/actor/gcs_actor_scheduler.h
@@ -68,7 +68,7 @@ class GcsActorSchedulerInterface {
   /// \return ID list of actors associated with the specified node id.
   virtual std::vector<ActorID> CancelOnNode(const NodeID &node_id) = 0;
 
-  /// Cancel a outstanding leasing request to raylets.
+  /// Cancel an outstanding leasing request to raylets.
   ///
   /// \param node_id ID of the node where the actor leasing request has been sent.
   /// \param actor_id ID of an actor.
@@ -146,7 +146,7 @@ class GcsActorScheduler : public GcsActorSchedulerInterface {
   /// \return ID list of actors associated with the specified node id.
   std::vector<ActorID> CancelOnNode(const NodeID &node_id) override;
 
-  /// Cancel a outstanding leasing request to raylets.
+  /// Cancel an outstanding leasing request to raylets.
   ///
   /// NOTE: The current implementation does not actually send lease cancel request to
   /// raylet. This method must be only used to ignore incoming raylet lease request

--- a/src/ray/gcs/gcs_job_manager.cc
+++ b/src/ray/gcs/gcs_job_manager.cc
@@ -45,7 +45,7 @@ void GcsJobManager::Initialize(const GcsInitData &gcs_init_data) {
 
 void GcsJobManager::WriteDriverJobExportEvent(
     rpc::JobTableData job_data, rpc::events::DriverJobLifecycleEvent::State state) const {
-  /// Write job_data as a export driver job event if
+  /// Write job_data as an export driver job event if
   /// enable_export_api_write() is enabled and if this job is
   /// not in the _ray_internal_ namespace.
   if (absl::StartsWith(job_data.config().ray_namespace(), kRayInternalNamespacePrefix)) {

--- a/src/ray/gcs/gcs_placement_group_manager.h
+++ b/src/ray/gcs/gcs_placement_group_manager.h
@@ -129,7 +129,7 @@ class GcsPlacementGroupManager : public rpc::PlacementGroupInfoGcsServiceHandler
                                              const std::string &ray_namespace);
 
   /// Handle placement_group creation task failure. This should be called when scheduling
-  /// an placement_group creation task is infeasible.
+  /// a placement_group creation task is infeasible.
   ///
   /// \param placement_group The placement_group whose creation task is infeasible.
   /// \param is_feasible whether the scheduler can be retry or not currently.
@@ -314,7 +314,7 @@ class GcsPlacementGroupManager : public rpc::PlacementGroupInfoGcsServiceHandler
   /// The pending placement_groups which will not be scheduled until there's a
   /// resource change. The pending queue is represented as an ordered map, where
   /// the key is the time to schedule the pg and value if a pair containing the
-  /// actual placement group and a exp-backoff.
+  /// actual placement group and an exponential backoff.
   /// When error happens, we'll retry it later and this can be simply done by
   /// inserting an element into the queue with a bigger key. With this, we don't
   /// need to post retry job to io context. And when schedule pending placement

--- a/src/ray/gcs/gcs_task_manager.h
+++ b/src/ray/gcs/gcs_task_manager.h
@@ -103,7 +103,7 @@ class GcsTaskManager : public rpc::TaskInfoGcsServiceHandler,
                           ray::observability::MetricInterface &task_events_dropped_gauge,
                           ray::observability::MetricInterface &task_events_stored_gauge);
 
-  /// Handles a AddTaskEventData request.
+  /// Handles an AddTaskEventData request.
   ///
   /// \param request gRPC Request.
   /// \param reply gRPC Reply.
@@ -112,7 +112,7 @@ class GcsTaskManager : public rpc::TaskInfoGcsServiceHandler,
                               rpc::AddTaskEventDataReply *reply,
                               rpc::SendReplyCallback send_reply_callback) override;
 
-  /// Handles a AddEvents request.
+  /// Handles an AddEvents request.
   ///
   /// \param request gRPC Request.
   /// \param reply gRPC Reply.

--- a/src/ray/gcs/state_util.h
+++ b/src/ray/gcs/state_util.h
@@ -57,7 +57,7 @@ H AbslHashValue(H h, const ResourceDemandKey &key);
 /// Aggregate nodes' pending task info.
 ///
 /// \param resources_data A node's pending task info (by shape).
-/// \param aggregate_load[out] The aggregate pending task info (across the cluster).
+/// \param[out] aggregate_load The aggregate pending task info (across the cluster).
 void FillAggregateLoad(
     const rpc::ResourcesData &resources_data,
     absl::flat_hash_map<ResourceDemandKey, rpc::ResourceDemand> *aggregate_load);

--- a/src/ray/gcs_rpc_client/global_state_accessor.h
+++ b/src/ray/gcs_rpc_client/global_state_accessor.h
@@ -156,7 +156,8 @@ class GlobalStateAccessor {
   ///
   /// \param worker_id The ID of worker to update in the GCS Service.
   /// \param num_paused_threads_delta The delta of paused threads of worker to update in
-  /// the GCS Service. \return Is operation success.
+  /// the GCS Service.
+  /// \return Whether the operation succeeded.
   bool UpdateWorkerNumPausedThreads(const WorkerID &worker_id,
                                     const int num_paused_threads_delta);
 

--- a/src/ray/object_manager/plasma/get_request_queue.h
+++ b/src/ray/object_manager/plasma/get_request_queue.h
@@ -88,8 +88,9 @@ class GetRequestQueue {
   /// \param timeout_ms timeout in millisecond, -1 is used to indicate that no timer
   /// should be set.
   /// \param object_callback the callback function called once any object has been
-  /// satisfied. \param all_objects_callback the callback function called when all objects
-  /// has been satisfied.
+  /// satisfied.
+  /// \param all_objects_callback the callback function called when all objects have been
+  /// satisfied.
   void AddRequest(const std::shared_ptr<ClientInterface> &client,
                   const std::vector<ObjectID> &object_ids,
                   int64_t timeout_ms);

--- a/src/ray/object_manager/pull_manager.h
+++ b/src/ray/object_manager/pull_manager.h
@@ -63,7 +63,7 @@ class PullManager {
   /// \param cancel_pull_request A callback which should
   /// cancel pulling an object.
   /// \param restore_spilled_object A callback which should
-  /// retrieve an spilled object from the external store.
+  /// retrieve a spilled object from the external store.
   PullManager(
       NodeID self_node_id,
       std::function<bool(const ObjectID &)> object_is_local,

--- a/src/ray/pubsub/subscriber.h
+++ b/src/ray/pubsub/subscriber.h
@@ -136,8 +136,8 @@ class SubscriberChannel {
 
  protected:
   /// Invoke the publisher failure callback to the designated IO service for the given key
-  /// id. \return Return true if the given key id needs to be unsubscribed. False
-  /// otherwise.
+  /// id.
+  /// \return True if the given key id needs to be unsubscribed, and false otherwise.
   bool HandlePublisherFailureInternal(const rpc::Address &publisher_address,
                                       const std::string &key_id,
                                       const Status &status);

--- a/src/ray/raylet/node_manager.h
+++ b/src/ray/raylet/node_manager.h
@@ -847,14 +847,14 @@ class NodeManager : public rpc::NodeManagerServiceHandler,
   /// Garbage-collects CancelWorkerLease tombstones past their TTL.
   void GCCancelledLeaseTombstones();
 
-  /// Creates a AgentManager that creates and manages a dashboard agent.
+  /// Creates an AgentManager that creates and manages a dashboard agent.
   std::unique_ptr<AgentManager> CreateDashboardAgentManager(
       const NodeID &self_node_id, const NodeManagerConfig &config);
 
   std::tuple<int, int, int> WaitForDashboardAgentPorts(const NodeID &self_node_id,
                                                        const NodeManagerConfig &config);
 
-  /// Creates a AgentManager that creates and manages a runtime env agent.
+  /// Creates an AgentManager that creates and manages a runtime env agent.
   std::unique_ptr<AgentManager> CreateRuntimeEnvAgentManager(
       const NodeID &self_node_id, const NodeManagerConfig &config);
 

--- a/src/ray/raylet/runtime_env_agent_client.cc
+++ b/src/ray/raylet/runtime_env_agent_client.cc
@@ -316,24 +316,23 @@ class HttpRuntimeEnvAgentClient : public RuntimeEnvAgentClient {
     delay_executor_([]() { QuickExit(); }, /*ms*/ 10000);
   }
 
-  /// @brief Invokes `try_invoke_once`. If it fails with a network error, retries every
-  /// after `agent_manager_retry_interval_ms` up until `deadline` passed. After which,
-  /// fail_callback is called with the NotFound error from `try_invoke_once`.
+  /// @brief Invokes `try_invoke_once`. If it fails with a network error, retries after
+  /// every `agent_manager_retry_interval_ms` until `deadline_ms` passes. After that,
+  /// `fail_callback` is called with the NotFound error from `try_invoke_once`.
   ///
-  /// Note that retry only happens on network errors, i.e. NotFound and Disconnected, on
-  /// which cases we did not receive a well-formed HTTP response. Application errors
-  /// returned by the server are not retried.
+  /// Note that retries only happen for network errors, i.e., NotFound and Disconnected,
+  /// which indicate that we did not receive a well-formed HTTP response. Application
+  /// errors returned by the server are not retried.
   ///
-  /// If the retries took so long and exceeded deadline, Raylet exits immediately. Note
-  /// the check happens after `try_invoke_once` returns. This means if you have a
-  /// successful but very long connection (e.g. runtime env agent is busy downloading
-  /// from s3), you are safe.
+  /// If the retries exceed `deadline_ms`, the raylet exits immediately. The check happens
+  /// after `try_invoke_once` returns, so a successful but long connection is safe (for
+  /// example, while the runtime env agent downloads from S3).
   ///
   /// @tparam T the return type on success.
   /// @param try_invoke_once
   /// @param succ_callback
   /// @param fail_callback
-  /// @param deadline
+  /// @param deadline_ms
   template <typename T>
   void RetryInvokeOnNotFoundWithDeadline(TryInvokeOnce<T> try_invoke_once,
                                          SuccCallback<T> succ_callback,

--- a/src/ray/raylet/scheduling/cluster_resource_manager.h
+++ b/src/ray/raylet/scheduling/cluster_resource_manager.h
@@ -100,7 +100,7 @@ class ClusterResourceManager {
   bool SubtractNodeAvailableResources(scheduling::NodeID node_id,
                                       const ResourceRequest &resource_request);
 
-  /// Check if we have available resources to fullfill resource request for an given node.
+  /// Check if we have available resources to fulfill a resource request for a given node.
   ///
   /// \param node_id: the id of the node.
   /// \param resource_request: the request we want to check.

--- a/src/ray/raylet/scheduling/cluster_resource_scheduler.h
+++ b/src/ray/raylet/scheduling/cluster_resource_scheduler.h
@@ -97,7 +97,7 @@ class ClusterResourceScheduler {
   ///  prioritize_local_node if set to true.
   ///  \param requires_object_store_memory: take object store memory usage as part of
   ///  scheduling decision.
-  ///  \param is_infeasible[out]: It is set
+  ///  \param[out] is_infeasible: It is set
   ///  true if the task is not schedulable because it is infeasible.
   ///
   ///  \return empty string, if no node can schedule the current request; otherwise,
@@ -181,10 +181,10 @@ class ClusterResourceScheduler {
   ///  \param actor_creation: True if this is an actor creation task.
   ///  \param force_spillback: True if we want to avoid local node.
   ///  \param preferred_node_id: The node where the task is preferred to be placed.
-  ///  \param violations[out]: The number of soft constraint violations associated
+  ///  \param[out] violations: The number of soft constraint violations associated
   ///                     with the node returned by this function (assuming
   ///                     a node that can schedule resource_request is found).
-  ///  \param is_infeasible[out]: It is set true if the task is not schedulable because it
+  ///  \param[out] is_infeasible: It is set true if the task is not schedulable because it
   ///  is infeasible.
   ///
   ///  \return -1, if no node can schedule the current request; otherwise,

--- a/src/ray/raylet/worker_pool.h
+++ b/src/ray/raylet/worker_pool.h
@@ -170,10 +170,10 @@ class WorkerPoolInterface : public IOWorkerPoolInterface {
   /// Case 3: Worker process has been started, but the worker registered back to raylet
   /// timeout.
   //  Case 4: Any fails of runtime env creation.
-  /// Of course, the callback will also be executed when a valid worker found in following
+  /// The callback will also be executed when a valid worker is found in the following
   /// cases:
-  /// Case 1: An suitable worker was found in idle worker pool.
-  /// Case 2: An suitable worker registered to raylet.
+  /// Case 1: A suitable worker was found in idle worker pool.
+  /// Case 2: A suitable worker registered with the raylet.
   /// The corresponding PopWorkerStatus will be passed to the callback.
   virtual void PopWorker(const LeaseSpecification &lease_spec,
                          const PopWorkerCallback &callback) = 0;
@@ -441,7 +441,7 @@ class WorkerPool : public WorkerPoolInterface {
   void PushSpillWorker(const std::shared_ptr<WorkerInterface> &worker) override;
 
   /// Pop an idle spill I/O worker from the pool and trigger a callback when
-  /// an spill I/O worker is available.
+  /// a spill I/O worker is available.
   /// The caller is responsible for pushing the worker back onto the
   /// pool once the worker has completed its work.
   ///
@@ -455,7 +455,7 @@ class WorkerPool : public WorkerPoolInterface {
   void PushRestoreWorker(const std::shared_ptr<WorkerInterface> &worker) override;
 
   /// Pop an idle restore I/O worker from the pool and trigger a callback when
-  /// an restore I/O worker is available.
+  /// a restore I/O worker is available.
   /// The caller is responsible for pushing the worker back onto the
   /// pool once the worker has completed its work.
   ///

--- a/src/ray/raylet_ipc_client/client_connection.h
+++ b/src/ray/raylet_ipc_client/client_connection.h
@@ -44,8 +44,6 @@ Status ConnectSocketRetry(local_stream_socket &socket,
                           int num_retries = -1,
                           int64_t timeout_in_ms = -1);
 
-/// \typename ServerConnection
-///
 /// A generic type representing a client connection to a server. This typename
 /// can be used to write messages synchronously to the server.
 class ServerConnection : public std::enable_shared_from_this<ServerConnection> {
@@ -173,8 +171,6 @@ using MessageHandler = std::function<void(
 using ConnectionErrorHandler = std::function<void(std::shared_ptr<ClientConnection>,
                                                   const boost::system::error_code &)>;
 
-/// \typename ClientConnection
-///
 /// A generic type representing a client connection on a server. In addition to
 /// writing messages to the client, like in ServerConnection, this typename can
 /// also be used to process messages asynchronously from client.

--- a/src/ray/raylet_rpc_client/raylet_client_interface.h
+++ b/src/ray/raylet_rpc_client/raylet_client_interface.h
@@ -80,7 +80,7 @@ class RayletClientInterface {
   /// Notify raylets to release unused workers.
   /// \param workers_in_use Workers currently in use.
   /// \param callback Callback that will be called after raylet completes the release of
-  /// unused workers. \return ray::Status
+  /// unused workers.
   virtual void ReleaseUnusedActorWorkers(
       const std::vector<WorkerID> &workers_in_use,
       const rpc::ClientCallback<rpc::ReleaseUnusedActorWorkersReply> &callback) = 0;

--- a/src/ray/rpc/authentication/authentication_token_validator.h
+++ b/src/ray/rpc/authentication/authentication_token_validator.h
@@ -29,9 +29,10 @@ class AuthenticationTokenValidator {
   /// Validate the provided authentication metadata against the expected token.
   /// When auth_mode=token, uses constant-time comparison via CompareWithMetadata.
   /// When auth_mode=k8s, provided_metadata is parsed and validated against Kubernetes
-  /// API. \param expected_token The expected token (nullptr if auth disabled or K8S
-  /// mode). \param provided_metadata The authorization header value (e.g., "Bearer
-  /// <token>"). \return true if the token is valid, false otherwise.
+  /// API.
+  /// \param expected_token The expected token (nullptr if auth disabled or K8S mode).
+  /// \param provided_metadata The authorization header value (e.g., "Bearer <token>").
+  /// \return true if the token is valid, false otherwise.
   bool ValidateToken(const std::shared_ptr<const AuthenticationToken> &expected_token,
                      std::string_view provided_metadata);
 

--- a/src/ray/rpc/grpc_server.h
+++ b/src/ray/rpc/grpc_server.h
@@ -82,7 +82,7 @@ namespace rpc {
 
 class GrpcService;
 
-/// Class that represents an gRPC server.
+/// Class that represents a gRPC server.
 ///
 /// A `GrpcServer` listens on a specific port. It owns
 /// 1) a `ServerCompletionQueue` that is used for polling events from gRPC,
@@ -99,7 +99,8 @@ class GrpcServer {
   /// \param[in] port The port to bind this server to. If it's 0, a random available port
   ///  will be chosen.
   /// \param[in] listen_to_localhost_only If true, binds only on localhost, not other
-  /// interfaces. \param[in] num_threads Number of gRPC completion queue threads to use.
+  /// interfaces.
+  /// \param[in] num_threads Number of gRPC completion queue threads to use.
   /// \param[in] keepalive_time_ms Connection keepalive time (ms).
   /// \param[in] auth_token Authentication token that clients must present when making
   /// RPCs to the server. If nullptr, no authentication token is required.

--- a/src/ray/stats/stats.h
+++ b/src/ray/stats/stats.h
@@ -65,8 +65,8 @@ static inline bool should_enable_open_census() {
 /// - It is thread-safe.
 /// We recommend you to use this only once inside a main script and add Shutdown() method
 /// to any signal handler.
-/// \param global_tags[in] Tags that will be appended to all metrics in this process.
-/// \param worker_id[in] The worker ID of the current component.
+/// \param[in] global_tags Tags that will be appended to all metrics in this process.
+/// \param[in] worker_id The worker ID of the current component.
 static inline void Init(
     const TagsType &global_tags,
     const WorkerID &worker_id = WorkerID::Nil(),

--- a/src/ray/util/logging.h
+++ b/src/ray/util/logging.h
@@ -262,7 +262,7 @@ class RayLog {
 
   /// The init function of ray log for a program which should be called only once.
   ///
-  /// \parem appName The app name which starts the log.
+  /// \param app_name The app name which starts the log.
   /// \param severity_threshold Logging threshold for the program.
   /// \param log_filepath Logging output filepath. If empty, the log won't output to file,
   /// but to stdout.
@@ -315,7 +315,7 @@ class RayLog {
   /// to locate the object file containing debug symbols for ELF format executables. If
   /// this is left as nullptr, symbolization can fail in some cases. More details in:
   /// https://github.com/abseil/abseil-cpp/blob/master/absl/debugging/symbolize_elf.inc
-  /// \parem call_previous_handler Whether to call the previous signal handler. See
+  /// \param call_previous_handler Whether to call the previous signal handler. See
   /// important caveats:
   /// https://github.com/abseil/abseil-cpp/blob/7e446075d4aff4601c1e7627c7c0be2c4833a53a/absl/debugging/failure_signal_handler.h#L76-L88
   /// This is currently used to enable signal handler from both Python and C++ in Python

--- a/src/ray/util/sequencer.h
+++ b/src/ray/util/sequencer.h
@@ -22,7 +22,7 @@
 
 namespace ray {
 
-/// This callback is used to notify when a operation completes.
+/// This callback is used to notify when an operation completes.
 using SequencerDoneCallback = std::function<void()>;
 
 /// \class Sequencer
@@ -49,7 +49,7 @@ class Sequencer {
   }
 
  private:
-  /// This function is used when a operation completes.
+  /// This function is used when an operation completes.
   /// If the sequencer has operations with the same key, we will execute next operation.
   ///
   /// \param key The key of operation.


### PR DESCRIPTION
## Description

Fix invalid Doxygen commands, misplaced parameter directions, stale parameter names, and return descriptions on void functions. Move paragraph commands that follow prose to dedicated lines and correct nearby documentation typos.

## Related issues

This is simple enough not to create an issue.

