### PR TITLE
[ci][doc] Alert on confirmed-broken external doc links

### DIFF
--- a/.buildkite/doc.rayci.yml
+++ b/.buildkite/doc.rayci.yml
@@ -121,7 +121,16 @@ steps:
     key: doc_linkcheck
     instance_type: medium
     commands:
-      - make -C doc/ linkcheck_all
+      # `|| true` so a broken link doesn't stop the report step below. The step
+      # stays soft_fail, and the report script owns turning the output into a
+      # Slack alert. linkcheck_all writes _build/linkcheck/output.json.
+      - make -C doc/ linkcheck_all || true
+      # Re-checks reported-broken external links and posts the confirmed ones to
+      # Slack. It reads the webhook from DOCS_LINKCHECK_SLACK_WEBHOOK and, when
+      # that env var is unset, prints the confirmed list and skips the alert, so
+      # this is safe to land before the secret is provisioned. Wiring the secret
+      # (via ci/env/setup_credentials.py) is the remaining follow-up.
+      - python ci/ray_ci/doc/linkcheck_report.py doc/_build/linkcheck/output.json
     depends_on: docbuild
     job_env: docbuild-py3.11
     tags:

--- a/ci/ray_ci/doc/linkcheck_report.py
+++ b/ci/ray_ci/doc/linkcheck_report.py
@@ -13,9 +13,10 @@ crawl draws transient rejections from hosts that rate-limit or bot-filter by
 source IP, so each reported-broken link is re-checked once, serially, after a
 cooldown:
 
-* 2xx/3xx, or 403 (bot filtering, not a dead link): recovered, dropped.
+* 2xx, or 403 (bot filtering, not a dead link): recovered, dropped.
 * 429 (rate limited): inconclusive, reported but not counted as broken.
-* anything else: confirmed broken.
+* anything else, including a 3xx from a failed redirect chain: confirmed
+  broken.
 
 The script never fails the build; the Slack alert is the signal.
 """
@@ -60,22 +61,32 @@ def recheck(url: str) -> int:
 def load_broken(path: str) -> list:
     """Return the reported-broken external links from a linkcheck output file.
 
+    Sphinx 8.2 reports an unreachable host that hangs as ``timeout`` rather than
+    ``broken`` (``linkcheck_report_timeouts_as_broken`` defaults to False), so
+    both statuses are collected and left to the re-check to confirm.
+
     Args:
         path: Path to the Sphinx linkcheck ``output.json``.
 
     Returns:
-        The records whose status is ``broken`` and whose URI is external.
+        The records whose status is ``broken`` or ``timeout`` and whose URI is
+        external.
     """
     broken = []
-    with open(path) as handle:
-        for line in handle:
-            line = line.strip()
-            if not line:
-                continue
-            record = json.loads(line)
-            uri = record.get("uri", "")
-            if record.get("status") == "broken" and uri.startswith("http"):
-                broken.append(record)
+    try:
+        with open(path, encoding="utf-8") as handle:
+            for line in handle:
+                line = line.strip()
+                if not line:
+                    continue
+                record = json.loads(line)
+                uri = record.get("uri", "")
+                if record.get("status") in ("broken", "timeout") and uri.startswith(
+                    "http"
+                ):
+                    broken.append(record)
+    except FileNotFoundError:
+        print(f"::warning:: {path} not found; skipping report.")
     return broken
 
 
@@ -89,19 +100,27 @@ def confirm(broken: list) -> tuple:
         A ``(confirmed, inconclusive)`` pair of record lists.
     """
     confirmed, inconclusive = [], []
+    cache = {}
     for record in broken:
-        code = recheck(record["uri"])
-        if code == 429:
-            time.sleep(BACKOFF)
-            code = recheck(record["uri"])
-        if 200 <= code < 400 or code in ACCEPT_CODES:
+        uri = record["uri"]
+        if uri in cache:
+            code = cache[uri]
+        else:
+            code = recheck(uri)
+            if code == 429:
+                time.sleep(BACKOFF)
+                code = recheck(uri)
+            cache[uri] = code
+            time.sleep(1)
+        # urlopen follows redirects to a 2xx, so a 3xx that reaches here is a
+        # failed chain (redirect loop or too many hops) and stays broken.
+        if 200 <= code < 300 or code in ACCEPT_CODES:
             continue
         if code == 429:
             inconclusive.append(record)
         else:
             record["recheck_code"] = code
             confirmed.append(record)
-        time.sleep(1)
     return confirmed, inconclusive
 
 
@@ -148,9 +167,12 @@ def post_to_slack(text: str) -> None:
     request = urllib.request.Request(
         webhook, data=payload, headers={"Content-Type": "application/json"}
     )
-    with urllib.request.urlopen(request, timeout=30) as resp:
-        if resp.status != 200:
-            print(f"::warning:: Slack webhook returned HTTP {resp.status}.")
+    try:
+        with urllib.request.urlopen(request, timeout=30) as resp:
+            if resp.status != 200:
+                print(f"::warning:: Slack webhook returned HTTP {resp.status}.")
+    except Exception as err:
+        print(f"::warning:: Failed to post to Slack: {err}")
 
 
 def main(path: str) -> int:

--- a/ci/ray_ci/doc/linkcheck_report.py
+++ b/ci/ray_ci/doc/linkcheck_report.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+"""Post-process Sphinx linkcheck output and alert on confirmed-broken links.
+
+The nightly ``doc: linkcheck`` step runs ``make -C doc linkcheck_all``, which
+writes a machine-readable ``output.json`` (one JSON record per line). That step
+is ``soft_fail``, so a broken link never fails the build and, today, reaches no
+one. This script turns that output into an actionable signal: it filters the
+reported-broken external links down to the ones that are genuinely dead, then
+posts them to Slack.
+
+The filter mirrors the Anyscale docs external-link scan. A single concurrent
+crawl draws transient rejections from hosts that rate-limit or bot-filter by
+source IP, so each reported-broken link is re-checked once, serially, after a
+cooldown:
+
+* 2xx/3xx, or 403 (bot filtering, not a dead link): recovered, dropped.
+* 429 (rate limited): inconclusive, reported but not counted as broken.
+* anything else: confirmed broken.
+
+The script never fails the build; the Slack alert is the signal.
+"""
+
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.request
+
+# 403 is Cloudflare-style bot filtering, not a dead link.
+ACCEPT_CODES = {403}
+# Cooldowns are env-tunable so the re-check pass can be exercised quickly in
+# tests without waiting out the production cooldown.
+COOLDOWN = int(os.environ.get("LINKCHECK_RECHECK_COOLDOWN", "120"))
+BACKOFF = int(os.environ.get("LINKCHECK_RECHECK_BACKOFF", "30"))
+WEBHOOK_ENV = "DOCS_LINKCHECK_SLACK_WEBHOOK"
+MAX_SLACK_ROWS = 15
+
+
+def recheck(url: str) -> int:
+    """Return the HTTP status for ``url``, following redirects.
+
+    Args:
+        url: The link to re-check.
+
+    Returns:
+        The final HTTP status code, or 0 if the request could not complete
+        (DNS failure, timeout, connection error).
+    """
+    req = urllib.request.Request(url, headers={"User-Agent": "ray-linkcheck/1.0"})
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            return resp.status
+    except urllib.error.HTTPError as err:
+        return err.code
+    except Exception:
+        return 0
+
+
+def load_broken(path: str) -> list:
+    """Return the reported-broken external links from a linkcheck output file.
+
+    Args:
+        path: Path to the Sphinx linkcheck ``output.json``.
+
+    Returns:
+        The records whose status is ``broken`` and whose URI is external.
+    """
+    broken = []
+    with open(path) as handle:
+        for line in handle:
+            line = line.strip()
+            if not line:
+                continue
+            record = json.loads(line)
+            uri = record.get("uri", "")
+            if record.get("status") == "broken" and uri.startswith("http"):
+                broken.append(record)
+    return broken
+
+
+def confirm(broken: list) -> tuple:
+    """Re-check each broken link and split it into confirmed and inconclusive.
+
+    Args:
+        broken: Records from :func:`load_broken`.
+
+    Returns:
+        A ``(confirmed, inconclusive)`` pair of record lists.
+    """
+    confirmed, inconclusive = [], []
+    for record in broken:
+        code = recheck(record["uri"])
+        if code == 429:
+            time.sleep(BACKOFF)
+            code = recheck(record["uri"])
+        if 200 <= code < 400 or code in ACCEPT_CODES:
+            continue
+        if code == 429:
+            inconclusive.append(record)
+        else:
+            record["recheck_code"] = code
+            confirmed.append(record)
+        time.sleep(1)
+    return confirmed, inconclusive
+
+
+def format_message(confirmed: list, inconclusive: list) -> str:
+    """Return the Slack message body for a set of confirmed-broken links.
+
+    Args:
+        confirmed: Links that failed the re-check.
+        inconclusive: Links that stayed rate-limited (429) on re-check.
+
+    Returns:
+        The Slack message text.
+    """
+    rows = []
+    for record in confirmed[:MAX_SLACK_ROWS]:
+        code = record.get("recheck_code", record.get("code", "ERR"))
+        source = f"{record.get('filename', '?')}:{record.get('lineno', 0)}"
+        rows.append(f"• `{code}` {record['uri']}\n    ↳ {source}")
+    text = (
+        f":rotating_light: *Ray docs: {len(confirmed)} broken external link(s)*\n"
+        + "\n".join(rows)
+    )
+    if len(confirmed) > MAX_SLACK_ROWS:
+        text += f"\n_…and {len(confirmed) - MAX_SLACK_ROWS} more. See the build log._"
+    if inconclusive:
+        text += (
+            f"\n\n_{len(inconclusive)} link(s) stayed rate-limited (429) on "
+            "re-check and couldn't be verified; not counted as broken._"
+        )
+    return text
+
+
+def post_to_slack(text: str) -> None:
+    """Post ``text`` to the Slack webhook, if one is configured.
+
+    Args:
+        text: The message body to send.
+    """
+    webhook = os.environ.get(WEBHOOK_ENV)
+    if not webhook:
+        print(f"::warning:: {WEBHOOK_ENV} is not set; skipping Slack alert.")
+        return
+    payload = json.dumps({"text": text}).encode()
+    request = urllib.request.Request(
+        webhook, data=payload, headers={"Content-Type": "application/json"}
+    )
+    with urllib.request.urlopen(request, timeout=30) as resp:
+        if resp.status != 200:
+            print(f"::warning:: Slack webhook returned HTTP {resp.status}.")
+
+
+def main(path: str) -> int:
+    """Report confirmed-broken external links from a linkcheck output file.
+
+    Args:
+        path: Path to the Sphinx linkcheck ``output.json``.
+
+    Returns:
+        Always 0. The Slack alert is the signal; this never fails the build.
+    """
+    broken = load_broken(path)
+    if not broken:
+        print("linkcheck: no broken external links reported.")
+        return 0
+
+    print(f"Re-checking {len(broken)} reported-broken link(s) after {COOLDOWN}s.")
+    time.sleep(COOLDOWN)
+    confirmed, inconclusive = confirm(broken)
+    print(f"confirmed={len(confirmed)} inconclusive={len(inconclusive)}")
+
+    for record in confirmed:
+        code = record.get("recheck_code", "ERR")
+        print(f"broken\t{code}\t{record['uri']}\t{record.get('filename')}")
+
+    if confirmed:
+        post_to_slack(format_message(confirmed, inconclusive))
+    return 0
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print("usage: linkcheck_report.py <output.json>", file=sys.stderr)
+        sys.exit(2)
+    sys.exit(main(sys.argv[1]))


### PR DESCRIPTION
> **Draft / proposal.** Opening for maintainer feedback on the approach and the one open dependency (a Slack webhook secret). See "Open question" below.

## Why this change

Ray's docs already run external link checking, but it produces no actionable signal:

- The `doc: linkcheck` step is `skip-on-premerge`, so it never runs on PRs.
- On postmerge it runs only in the nightly full build (`RAYCI_SCHEDULE=nightly`).
- It's `soft_fail: true`, so a broken link never fails the build.
- The output lands in a CI log artifact nobody watches.

Concretely, the nightly build 19384 (2026-08-25) reported 148 broken / 323 redirect links — including several vLLM 404s that were live-broken in the docs — and none surfaced to anyone.

This wires the existing linkcheck output to a Slack alert, without adding any premerge gate (a flaky external-link signal shouldn't block PRs).

## What changed

- **`ci/ray_ci/doc/linkcheck_report.py`** (new): reads the Sphinx linkcheck `output.json`, re-checks each reported-broken external link once after a cooldown, and posts the confirmed-broken ones to Slack. The re-check filters the noise a single concurrent crawl produces:
  - 2xx/3xx or 403 (bot filtering) → recovered, dropped.
  - 429 (rate limited) → inconclusive, reported but not counted as broken.
  - anything else → confirmed broken.
- **`.buildkite/doc.rayci.yml`**: the `doc: linkcheck` step now runs the report script after `linkcheck_all`. The step stays `soft_fail`.

Stdlib-only (no new dependencies). The script always exits 0 — the alert is the signal, not a red build.

## Open question (the one thing blocking "done")

The alert needs a `DOCS_LINKCHECK_SLACK_WEBHOOK` env var. The script is written to no-op safely without it (it prints the confirmed list and skips the alert), so this PR is safe to land as-is and starts emitting a clean confirmed-broken list in the nightly log immediately. To turn on Slack delivery, the webhook needs provisioning through `ci/env/setup_credentials.py` (AWS Secrets Manager). I didn't add it there because a missing key in that secret would break every step that sources it. **Where should this secret live, and who can provision it?**

There's also a large pre-existing backlog (~148 entries) that should be triaged to a clean baseline before the alert is noisy-vs-useful; that cleanup is tracked separately on the Anyscale side.

## Testing

- Ran the report script against a sample `output.json` with a genuine 404, a transient (recovering) link, and a non-broken record: it correctly confirmed the 404, dropped the recovered link on re-check, ignored the non-broken record, and handled the missing webhook gracefully (`confirmed=1`, warn-and-skip).
- `pre-commit run --files ci/ray_ci/doc/linkcheck_report.py .buildkite/doc.rayci.yml` — passes (ruff, black, Ray docstyle, import order, semgrep).
- YAML validated.

## Not a duplicate

Checked open PRs (`gh pr list --search "linkcheck"`); no in-flight PR adds link-check alerting.

## AI assistance

Investigated and drafted with AI assistance (Claude Code); the approach and every changed line were reviewed by the submitter.
