### PR TITLE
[serve] Production defaults for HAProxy connect timeout and dead-replica detection

### DIFF
--- a/python/ray/serve/_private/constants.py
+++ b/python/ray/serve/_private/constants.py
@@ -801,8 +801,14 @@ RAY_SERVE_HAPROXY_CLOSE_SPREAD_TIME_S = get_env_int(
 # Minimum spacing between HAProxy reloads. Broadcasts arriving inside
 # the window are batched into one apply; without it, autoscaling churn
 # can fire reloads tens of ms apart.
+#
+# Every reload leaves the outgoing worker soft-stopping with a frozen copy of
+# the backend list, alive until hard-stop-after, so the number of workers
+# routing from a stale snapshot scales with the reload rate. The window trades
+# a bounded amount of propagation delay for a large reduction in that
+# population; it is additive with the reload itself, which dominates it.
 RAY_SERVE_HAPROXY_BROADCAST_COALESCE_S = get_env_float_non_negative(
-    "RAY_SERVE_HAPROXY_BROADCAST_COALESCE_S", 0.1
+    "RAY_SERVE_HAPROXY_BROADCAST_COALESCE_S", 1.0
 )
 
 # Histogram boundaries (seconds) for serve_haproxy_update_latency_s: the time
@@ -850,12 +856,12 @@ RAY_SERVE_HAPROXY_TIMEOUT_SERVER_S = (
     else None
 )
 
-RAY_SERVE_HAPROXY_TIMEOUT_CONNECT_S = (
-    # Guarded by the truthiness check below; the two get() calls can't be
-    # narrowed by mypy.
-    int(os.environ.get("RAY_SERVE_HAPROXY_TIMEOUT_CONNECT_S"))  # type: ignore[arg-type]
-    if os.environ.get("RAY_SERVE_HAPROXY_TIMEOUT_CONNECT_S")
-    else None
+# Connection timeout to a replica, in seconds. Replicas are in-cluster, so a
+# connect that takes seconds means the node is gone rather than busy; bounding
+# it lets `retry-on conn-failure` + `option redispatch` reach another replica
+# while the request still has budget.
+RAY_SERVE_HAPROXY_TIMEOUT_CONNECT_S = get_env_int_non_negative(
+    "RAY_SERVE_HAPROXY_TIMEOUT_CONNECT_S", 5
 )
 
 # When enabled, adds 'option http-no-delay' to the HAProxy config defaults,
@@ -908,7 +914,7 @@ RAY_SERVE_HAPROXY_HEALTH_CHECK_DOWNINTER = os.environ.get(
 # redispatch + the `backup` fallback take over. Health checks revive a false
 # positive in ~0.5s. Backup/fallback servers are never observed.
 RAY_SERVE_HAPROXY_OBSERVE_MARK_DOWN_ENABLED = get_env_bool(
-    "RAY_SERVE_HAPROXY_OBSERVE_MARK_DOWN_ENABLED", "0"
+    "RAY_SERVE_HAPROXY_OBSERVE_MARK_DOWN_ENABLED", "1"
 )
 
 # Consecutive observed layer4 errors before a server is marked DOWN. Only
@@ -918,9 +924,17 @@ RAY_SERVE_HAPROXY_OBSERVE_ERROR_LIMIT = get_env_int_positive(
     "RAY_SERVE_HAPROXY_OBSERVE_ERROR_LIMIT", 3
 )
 
-# The balancing algorithm to use in HAProxy backends. Default is leastconn.
+# The balancing algorithm to use in HAProxy backends.
+#
+# Every node runs its own HAProxy and they all receive the same fleet-wide
+# backend list, but each one only observes the connections it opened itself.
+# `leastconn` picks the minimum of that private view, so N proxies reading
+# near-identical state converge on the same replica and pile onto it.
+# `random(2)` (power-of-two-choices) samples two servers and takes the less
+# loaded one, which keeps the local signal useful without synchronizing the
+# proxies. Set to `leastconn` to restore the previous behavior.
 RAY_SERVE_HAPROXY_BALANCE_ALGORITHM = get_env_str(
-    "RAY_SERVE_HAPROXY_BALANCE_ALGORITHM", "leastconn"
+    "RAY_SERVE_HAPROXY_BALANCE_ALGORITHM", "random(2)"
 )
 
 # Timeout shared by the ingress-request-router Lua call and the frontend

--- a/python/ray/serve/_private/constants.py
+++ b/python/ray/serve/_private/constants.py
@@ -801,14 +801,8 @@ RAY_SERVE_HAPROXY_CLOSE_SPREAD_TIME_S = get_env_int(
 # Minimum spacing between HAProxy reloads. Broadcasts arriving inside
 # the window are batched into one apply; without it, autoscaling churn
 # can fire reloads tens of ms apart.
-#
-# Every reload leaves the outgoing worker soft-stopping with a frozen copy of
-# the backend list, alive until hard-stop-after, so the number of workers
-# routing from a stale snapshot scales with the reload rate. The window trades
-# a bounded amount of propagation delay for a large reduction in that
-# population; it is additive with the reload itself, which dominates it.
 RAY_SERVE_HAPROXY_BROADCAST_COALESCE_S = get_env_float_non_negative(
-    "RAY_SERVE_HAPROXY_BROADCAST_COALESCE_S", 1.0
+    "RAY_SERVE_HAPROXY_BROADCAST_COALESCE_S", 0.1
 )
 
 # Histogram boundaries (seconds) for serve_haproxy_update_latency_s: the time

--- a/python/ray/serve/_private/constants.py
+++ b/python/ray/serve/_private/constants.py
@@ -854,6 +854,10 @@ RAY_SERVE_HAPROXY_TIMEOUT_SERVER_S = (
 # connect that takes seconds means the node is gone rather than busy; bounding
 # it lets `retry-on conn-failure` + `option redispatch` reach another replica
 # while the request still has budget.
+#
+# Set to 0 to disable. HAProxy stores an unset timeout as 0, so `timeout
+# connect 0s` is indistinguishable from omitting the directive: an infinite
+# connect timeout, plus HAProxy's "missing timeouts" startup warning.
 RAY_SERVE_HAPROXY_TIMEOUT_CONNECT_S = get_env_int_non_negative(
     "RAY_SERVE_HAPROXY_TIMEOUT_CONNECT_S", 5
 )

--- a/python/ray/serve/_private/constants.py
+++ b/python/ray/serve/_private/constants.py
@@ -926,13 +926,14 @@ RAY_SERVE_HAPROXY_OBSERVE_ERROR_LIMIT = get_env_int_positive(
 
 # The balancing algorithm to use in HAProxy backends.
 #
-# Every node runs its own HAProxy and they all receive the same fleet-wide
-# backend list, but each one only observes the connections it opened itself.
-# `leastconn` picks the minimum of that private view, so N proxies reading
-# near-identical state converge on the same replica and pile onto it.
-# `random(2)` (power-of-two-choices) samples two servers and takes the less
-# loaded one, which keeps the local signal useful without synchronizing the
-# proxies. Set to `leastconn` to restore the previous behavior.
+# Each node's HAProxy renders the same fleet-wide backend list but counts only
+# its own connections, so a stable server set balances fine. Autoscaling keeps
+# it unstable: a replica that appears or returns from DOWN reads as zero
+# connections on every proxy at once, and `leastconn` deterministically prefers
+# it until local counts catch up. HAProxy's `slowstart` damps that herd; Serve
+# does not set it. `random(2)` ranks by the same counts across two sampled
+# servers, so identical observations stop producing identical choices.
+# Set `leastconn` to restore the previous behavior.
 RAY_SERVE_HAPROXY_BALANCE_ALGORITHM = get_env_str(
     "RAY_SERVE_HAPROXY_BALANCE_ALGORITHM", "random(2)"
 )

--- a/python/ray/serve/_private/constants.py
+++ b/python/ray/serve/_private/constants.py
@@ -924,18 +924,9 @@ RAY_SERVE_HAPROXY_OBSERVE_ERROR_LIMIT = get_env_int_positive(
     "RAY_SERVE_HAPROXY_OBSERVE_ERROR_LIMIT", 3
 )
 
-# The balancing algorithm to use in HAProxy backends.
-#
-# Each node's HAProxy renders the same fleet-wide backend list but counts only
-# its own connections, so a stable server set balances fine. Autoscaling keeps
-# it unstable: a replica that appears or returns from DOWN reads as zero
-# connections on every proxy at once, and `leastconn` deterministically prefers
-# it until local counts catch up. HAProxy's `slowstart` damps that herd; Serve
-# does not set it. `random(2)` ranks by the same counts across two sampled
-# servers, so identical observations stop producing identical choices.
-# Set `leastconn` to restore the previous behavior.
+# The balancing algorithm to use in HAProxy backends. Default is leastconn.
 RAY_SERVE_HAPROXY_BALANCE_ALGORITHM = get_env_str(
-    "RAY_SERVE_HAPROXY_BALANCE_ALGORITHM", "random(2)"
+    "RAY_SERVE_HAPROXY_BALANCE_ALGORITHM", "leastconn"
 )
 
 # Timeout shared by the ingress-request-router Lua call and the frontend

--- a/python/ray/serve/tests/test_haproxy_api.py
+++ b/python/ray/serve/tests/test_haproxy_api.py
@@ -944,7 +944,6 @@ def test_global_retry_knobs_render(haproxy_api_cleanup):
 # Overriding any of these is supported, and makes the shipped-default
 # assertions below meaningless rather than false, so the test opts out instead.
 _DEFAULT_TUNING_ENV_VARS = (
-    "RAY_SERVE_HAPROXY_BALANCE_ALGORITHM",
     "RAY_SERVE_HAPROXY_OBSERVE_MARK_DOWN_ENABLED",
     "RAY_SERVE_HAPROXY_OBSERVE_ERROR_LIMIT",
     "RAY_SERVE_HAPROXY_TIMEOUT_CONNECT_S",
@@ -957,9 +956,8 @@ _DEFAULT_TUNING_ENV_VARS = (
     reason=f"environment overrides one of {_DEFAULT_TUNING_ENV_VARS}",
 )
 def test_default_data_plane_tuning_renders(haproxy_api_cleanup):
-    """The shipped defaults balance with power-of-two-choices, bound connect
-    time, mark dead replicas down from live traffic, and leave `timeout server`
-    unset.
+    """The shipped defaults bound connect time, mark dead replicas down from
+    live traffic, and leave `timeout server` unset.
 
     Every other test in this file passes explicit overrides, so nothing else
     would catch a silent change to these; each one changes how every Serve
@@ -985,10 +983,6 @@ def test_default_data_plane_tuning_renders(haproxy_api_cleanup):
         api._generate_config_file_internal()
         with open(config_file_path) as f:
             cfg = f.read()
-
-    # Per-node proxies share a backend list but not connection counts, so a
-    # global-minimum rule such as leastconn makes them converge on one replica.
-    assert "\n    balance random(2)\n" in cfg
 
     # Replicas are in-cluster: a connect that takes seconds means the node is
     # gone, and failing fast lets redispatch reach another replica in time.

--- a/python/ray/serve/tests/test_haproxy_api.py
+++ b/python/ray/serve/tests/test_haproxy_api.py
@@ -982,11 +982,7 @@ def test_default_data_plane_tuning_renders(haproxy_api_cleanup):
             },
             config_file_path=config_file_path,
         )
-        with mock.patch(
-            "ray.serve._private.constants.RAY_SERVE_HAPROXY_CONFIG_FILE_LOC",
-            config_file_path,
-        ):
-            api._generate_config_file_internal()
+        api._generate_config_file_internal()
         with open(config_file_path) as f:
             cfg = f.read()
 

--- a/python/ray/serve/tests/test_haproxy_api.py
+++ b/python/ray/serve/tests/test_haproxy_api.py
@@ -397,8 +397,8 @@ backend api_backend
     http-check expect status 200
     default-server fastinter 250ms downinter 250ms fall 2 rise 3 inter 5s check
     # Servers in this backend
-    server api_server1 127.0.0.1:8001 check
-    server api_server2 127.0.0.1:8002 check
+    server api_server1 127.0.0.1:8001 check observe layer4 error-limit 3 on-error mark-down
+    server api_server2 127.0.0.1:8002 check observe layer4 error-limit 3 on-error mark-down
     # Fallback to head node's Serve proxy when no ingress replicas are available
     server api_fallback_server 127.0.0.1:8500 check backup
 backend web_backend
@@ -417,7 +417,7 @@ backend web_backend
     http-check expect status 200
     default-server fastinter 250ms downinter 250ms fall 3 rise 2 inter 2s check
     # Servers in this backend
-    server web_server1 127.0.0.1:8003 check
+    server web_server1 127.0.0.1:8003 check observe layer4 error-limit 3 on-error mark-down
 listen stats
   bind *:8080
   stats enable
@@ -939,6 +939,76 @@ def test_global_retry_knobs_render(haproxy_api_cleanup):
     overridden = render({"retry_on": "conn-failure junk-response", "retries": 2})
     assert "\n    retry-on conn-failure junk-response\n" in overridden
     assert "\n    retries 2\n" in overridden
+
+
+# Overriding any of these is supported, and makes the shipped-default
+# assertions below meaningless rather than false, so the test opts out instead.
+_DEFAULT_TUNING_ENV_VARS = (
+    "RAY_SERVE_HAPROXY_BALANCE_ALGORITHM",
+    "RAY_SERVE_HAPROXY_OBSERVE_MARK_DOWN_ENABLED",
+    "RAY_SERVE_HAPROXY_OBSERVE_ERROR_LIMIT",
+    "RAY_SERVE_HAPROXY_TIMEOUT_CONNECT_S",
+    "RAY_SERVE_HAPROXY_TIMEOUT_SERVER_S",
+)
+
+
+@pytest.mark.skipif(
+    any(v in os.environ for v in _DEFAULT_TUNING_ENV_VARS),
+    reason=f"environment overrides one of {_DEFAULT_TUNING_ENV_VARS}",
+)
+def test_default_data_plane_tuning_renders(haproxy_api_cleanup):
+    """The shipped defaults balance with power-of-two-choices, bound connect
+    time, mark dead replicas down from live traffic, and leave `timeout server`
+    unset.
+
+    Every other test in this file passes explicit overrides, so nothing else
+    would catch a silent change to these; each one changes how every Serve
+    cluster routes."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        config_file_path = os.path.join(temp_dir, "haproxy.cfg")
+        api = HAProxyApi(
+            cfg=HAProxyConfig(socket_path=os.path.join(temp_dir, "admin.sock")),
+            backend_configs={
+                "api": BackendConfig(
+                    name="api",
+                    path_prefix="/api",
+                    app_name="api",
+                    servers=[
+                        ServerConfig(
+                            name="s1", host="127.0.0.1", port=8001, replica_id="rid_1"
+                        )
+                    ],
+                )
+            },
+            config_file_path=config_file_path,
+        )
+        with mock.patch(
+            "ray.serve._private.constants.RAY_SERVE_HAPROXY_CONFIG_FILE_LOC",
+            config_file_path,
+        ):
+            api._generate_config_file_internal()
+        with open(config_file_path) as f:
+            cfg = f.read()
+
+    # Per-node proxies share a backend list but not connection counts, so a
+    # global-minimum rule such as leastconn makes them converge on one replica.
+    assert "\n    balance random(2)\n" in cfg
+
+    # Replicas are in-cluster: a connect that takes seconds means the node is
+    # gone, and failing fast lets redispatch reach another replica in time.
+    assert "\n    timeout connect 5s\n" in cfg
+
+    # No `timeout server`. It is a server-side inactivity limit applied to every
+    # connection on the live process, so any value caps request duration -- and
+    # Serve's own request_timeout_s defaults to no timeout. hard-stop-after
+    # bounds draining workers on a separate clock.
+    assert "\n    timeout server " not in cfg
+
+    # Live traffic marks a dead replica DOWN without waiting for a health check.
+    assert (
+        "server s1 127.0.0.1:8001 check observe layer4 "
+        "error-limit 3 on-error mark-down"
+    ) in cfg
 
 
 @pytest.mark.parametrize("forward_body", [True, False])


### PR DESCRIPTION
## Why this change

Two HAProxy defaults that are reasonable for a single-node dev cluster but poor once replicas come and go under autoscaling. Each is a default change only; both stay overridable through their existing environment variables.

| Constant | Before | After |
|---|---|---|
| `RAY_SERVE_HAPROXY_TIMEOUT_CONNECT_S` | unset | `5` |
| `RAY_SERVE_HAPROXY_OBSERVE_MARK_DOWN_ENABLED` | `0` | `1` |

### `timeout connect`: unset → `5s`

Replicas are in-cluster, so a connect that takes seconds means the node is gone rather than busy. Bounding it lets `retry-on conn-failure` + `option redispatch` reach another replica while the request still has budget. This is connection-establishment time only — it does not bound request duration.

`timeout server` is deliberately **not** set here; see *Deliberately not included*.

### `observe layer4 ... on-error mark-down`: off → on

Live traffic marks a dead replica DOWN without waiting for a health checker, and `redispatch` plus the `backup` fallback take over. A false positive revives in ~0.5s via the existing health check. Backup/fallback servers are never observed.

## Not a duplicate

Checked before opening, no overlapping work found:

```
gh pr list --repo ray-project/ray --state open --search "haproxy default"
```

The only open PR touching this area is #65698 (mine, direct-ingress listener close), which does not change any of these constants.

## Tests

Two environments. **(A)** nightly `ray-3.0.0.dev0` wheel with `python/ray/serve` and `python/ray/tests` symlinked in, `pytest==7.4.4` per `python/requirements/test-requirements.txt` — used for the rendering and unit runs. **(B)** the same, plus a real HAProxy binary (`brew` 3.4.4) via `RAY_SERVE_HAPROXY_BINARY_PATH`, running the CI job's env (`RAY_SERVE_ENABLE_HA_PROXY=1`, `RAY_SERVE_DIRECT_INGRESS_MIN_DRAINING_PERIOD_S=0.01`, `SERVE_SOCKET_REUSE_PORT_ENABLED=1`) — used for the integration runs.

**End-to-end with a real HAProxy (B)** — the tests premerge flagged on earlier revisions of this PR, re-run at this revision's defaults with no env overrides:

```
test_autoscaling_policy.py::test_e2e_preserve_prev_replicas_rest_api   => passed (x2)
test_streaming_response.py                                             => 23 passed
```

Both were failing on earlier revisions and pass here. Caveats on this environment: it is HAProxy **3.4.4**, while CI ships **2.8** via `ray-haproxy`; and macOS has no `splice(2)`, so `option splice-request` / `option splice-response` had to be dropped from the rendered config for HAProxy to start locally. Those options affect data forwarding, not routing or timing. CI remains the authority.

**HAProxy config rendering (A)**:

```
RAY_SERVE_ENABLE_HA_PROXY=1 pytest --pyargs ray.serve.tests.test_haproxy_api \
  -k "generate_config_file_internal or escapes_special_characters or close_spread_time
      or generate_backends_in_order or routers_and_targets or ingress_request_router_lua
      or router_servers_without_replica_ids or does_not_leak_into_other_backends
      or router_failure_503 or inherits_global_retry_policy or global_retry_knobs
      or default_data_plane_tuning"
=> 13 passed, 26 deselected
```

**New test** `test_default_data_plane_tuning_renders` pins the shipped values. Every other test in that file passes explicit overrides, so nothing previously caught a silent change to these defaults. It is `skipif`-guarded on the env vars it asserts about, so overriding any of them skips rather than fails:

```
RAY_SERVE_HAPROXY_OBSERVE_MARK_DOWN_ENABLED=0      => 1 skipped
RAY_SERVE_HAPROXY_TIMEOUT_SERVER_S=3600            => 1 skipped
RAY_SERVE_HAPROXY_TIMEOUT_CONNECT_S=9              => 1 skipped
```

The skip does not neuter it — changing a shipped default in *source* still fails the test.

**Serve unit suite (A)** — `pytest python/ray/serve/tests/unit`:

```
this branch:            195 failed, 4564 passed, 18 skipped, 2 errors
clean origin/master:    195 failed, 4564 passed, 18 skipped, 2 errors
```

Identical, so failure-neutral. The 195 are an artifact of running repo Serve code against a slightly older nightly core wheel on macOS; they are in `test_deployment_state.py` / `test_handle_options.py` and touch nothing this PR changes. Measured on the six-default revision of this PR; the diff has only shrunk since, so this is a ceiling rather than a current reading.

**Lint** at the versions pinned in `.pre-commit-config.yaml`, re-run at this revision:

```
ruff 0.8.4 check                => All checks passed
ruff 0.8.4 check --select I     => All checks passed
black 22.10.0 --check           => unchanged
```

`mypy 1.7.0` and `pyrefly 1.1.1` (both of which have `constants.py` on their allowlists) were clean on an earlier revision that already contained both remaining changes; they were not re-run at this exact commit, since everything removed since was a revert to master's own text.

One shape change worth calling out: `RAY_SERVE_HAPROXY_TIMEOUT_CONNECT_S` moves from the hand-rolled `int(os.environ.get(...)) if os.environ.get(...) else ...` conditional to the file's existing `get_env_int_non_negative` helper, which drops a `# type: ignore[arg-type]`. Its default is changing anyway, so the line is touched regardless, and the helper handles `=0` correctly — the truthiness form would silently turn an explicit `0` into the default. It does mean an empty-string value now raises instead of being ignored, matching every other `get_env_*` constant in the file. Say the word if you would rather keep the original shape and just swap the `else` branch.

## AI assistance

This change was drafted with AI assistance (Claude), including the code, the tests, and this description.

Opened as a **draft** on purpose: per `AGENTS.md` a human submitter has to review every changed line and run the relevant tests locally before review is requested. I have not finished that pass yet. Marking ready for review is the signal that it is done — please don't spend review time on it before then.

The binary-dependent HAProxy tests (26 deselected above) also still need a run on a machine that has `haproxy` installed.
