### PR TITLE
[cherry-pick][2.58.0][docs] Backport KubeRay v1.7 feature docs

### DIFF
--- a/doc/source/cluster/kubernetes/examples/argocd.md
+++ b/doc/source/cluster/kubernetes/examples/argocd.md
@@ -33,7 +33,7 @@ spec:
     namespace: ray-cluster
   source:
     repoURL: https://github.com/ray-project/kuberay
-    targetRevision: v1.6.0  # update this as necessary
+    targetRevision: v1.7.0  # update this as necessary
     path: helm-chart/kuberay-operator/crds
   syncPolicy:
     automated:
@@ -82,7 +82,7 @@ spec:
   project: default
   source:
     repoURL: https://github.com/ray-project/kuberay
-    targetRevision: v1.6.0  # update this as necessary
+    targetRevision: v1.7.0  # update this as necessary
     path: helm-chart/kuberay-operator
     helm:
       skipCrds: true   # CRDs are already installed in Step 1
@@ -156,7 +156,7 @@ spec:
   source:
     repoURL: https://ray-project.github.io/kuberay-helm/
     chart: ray-cluster
-    targetRevision: "1.6.0"
+    targetRevision: "1.7.0"
     helm:
       releaseName: raycluster
       valuesObject:
@@ -395,7 +395,7 @@ spec:
     namespace: ray-cluster
   source:
     repoURL: https://github.com/ray-project/kuberay
-    targetRevision: v1.6.0  # update this as necessary
+    targetRevision: v1.7.0  # update this as necessary
     path: helm-chart/kuberay-operator/crds
   syncPolicy:
     automated:
@@ -416,7 +416,7 @@ spec:
   project: default
   source:
     repoURL: https://github.com/ray-project/kuberay
-    targetRevision: v1.6.0  # update this as necessary
+    targetRevision: v1.7.0  # update this as necessary
     path: helm-chart/kuberay-operator
     helm:
       skipCrds: true   # CRDs are installed in the first Application
@@ -452,7 +452,7 @@ spec:
   source:
     repoURL: https://ray-project.github.io/kuberay-helm/
     chart: ray-cluster
-    targetRevision: "1.4.1"
+    targetRevision: "1.7.0"
     helm:
       releaseName: raycluster  # this affects the ignoreDifferences field
       valuesObject:

--- a/doc/source/cluster/kubernetes/examples/mobilenet-rayservice.md
+++ b/doc/source/cluster/kubernetes/examples/mobilenet-rayservice.md
@@ -18,7 +18,7 @@ Follow [this document](kuberay-operator-deploy) to install the latest stable Kub
 
 ```sh
 # Create a RayService
-kubectl apply -f https://raw.githubusercontent.com/ray-project/kuberay/v1.6.0/ray-operator/config/samples/ray-service.mobilenet.yaml
+kubectl apply -f https://raw.githubusercontent.com/ray-project/kuberay/v1.7.0/ray-operator/config/samples/ray-service.mobilenet.yaml
 ```
 
 * The [mobilenet.py](https://github.com/ray-project/serve_config_examples/blob/master/mobilenet/mobilenet.py) file needs `tensorflow` as a dependency. Hence, the YAML file uses `rayproject/ray-ml` image instead of `rayproject/ray` image.

--- a/doc/source/cluster/kubernetes/examples/rayjob-batch-inference-example.md
+++ b/doc/source/cluster/kubernetes/examples/rayjob-batch-inference-example.md
@@ -35,12 +35,12 @@ Follow [this document](kuberay-operator-deploy) to install the latest stable Kub
 
 ## Step 2: Submit the RayJob
 
-Create the RayJob custom resource with [ray-job.batch-inference.yaml](https://github.com/ray-project/kuberay/blob/v1.6.0/ray-operator/config/samples/ray-job.batch-inference.yaml).
+Create the RayJob custom resource with [ray-job.batch-inference.yaml](https://github.com/ray-project/kuberay/blob/v1.7.0/ray-operator/config/samples/ray-job.batch-inference.yaml).
 
 Download the file with `curl`:
 
 ```bash
-curl -LO https://raw.githubusercontent.com/ray-project/kuberay/v1.6.0/ray-operator/config/samples/ray-job.batch-inference.yaml
+curl -LO https://raw.githubusercontent.com/ray-project/kuberay/v1.7.0/ray-operator/config/samples/ray-job.batch-inference.yaml
 ```
 
 Note that the `RayJob` spec contains a spec for the `RayCluster`. This tutorial uses a single-node cluster with 4 GPUs. For production use cases, use a multi-node cluster where the head node doesn't have GPUs, so that Ray can automatically schedule GPU workloads on worker nodes which won't interfere with critical Ray processes on the head node.

--- a/doc/source/cluster/kubernetes/getting-started/kuberay-operator-installation.md
+++ b/doc/source/cluster/kubernetes/getting-started/kuberay-operator-installation.md
@@ -14,26 +14,29 @@ kind create cluster --image=kindest/node:v1.26.0
 
 ### Method 1: Helm (Recommended)
 
+Install the operator into a dedicated `ray-system` namespace rather than `default` to isolate the operator's service account from workload pods.
+
 ```sh
 helm repo add kuberay https://ray-project.github.io/kuberay-helm/
 helm repo update
-# Install both CRDs and KubeRay operator v1.6.0.
-helm install kuberay-operator kuberay/kuberay-operator --version 1.6.0
+kubectl create namespace ray-system
+helm install kuberay-operator kuberay/kuberay-operator --version 1.6.0 -n ray-system
 ```
 
 ### Method 2: Kustomize
 
 ```sh
-# Install CRD and KubeRay operator.
-kubectl create -k "github.com/ray-project/kuberay/ray-operator/config/default?ref=v1.6.0"
+# Install CRD and KubeRay operator into the ray-system namespace.
+kubectl create namespace ray-system
+kubectl create -k "github.com/ray-project/kuberay/ray-operator/config/default?ref=v1.6.0" -n ray-system
 ```
 
 ## Step 3: Validate Installation
 
-Confirm that the operator is running in the namespace `default`.
+Confirm that the operator is running. If you installed into `ray-system`, pass `-n ray-system`:
 
 ```sh
-kubectl get pods
+kubectl get pods -n ray-system
 ```
 
 ```text

--- a/doc/source/cluster/kubernetes/getting-started/kuberay-operator-installation.md
+++ b/doc/source/cluster/kubernetes/getting-started/kuberay-operator-installation.md
@@ -20,7 +20,7 @@ Install the operator into a dedicated `ray-system` namespace rather than `defaul
 helm repo add kuberay https://ray-project.github.io/kuberay-helm/
 helm repo update
 kubectl create namespace ray-system
-helm install kuberay-operator kuberay/kuberay-operator --version 1.6.0 -n ray-system
+helm install kuberay-operator kuberay/kuberay-operator --version 1.7.0 -n ray-system
 ```
 
 ### Method 2: Kustomize
@@ -28,7 +28,7 @@ helm install kuberay-operator kuberay/kuberay-operator --version 1.6.0 -n ray-sy
 ```sh
 # Install CRD and KubeRay operator into the ray-system namespace.
 kubectl create namespace ray-system
-kubectl create -k "github.com/ray-project/kuberay/ray-operator/config/default?ref=v1.6.0" -n ray-system
+kubectl create -k "github.com/ray-project/kuberay/ray-operator/config/default?ref=v1.7.0" -n ray-system
 ```
 
 ## Step 3: Validate Installation

--- a/doc/source/cluster/kubernetes/getting-started/raycluster-quick-start.md
+++ b/doc/source/cluster/kubernetes/getting-started/raycluster-quick-start.md
@@ -28,7 +28,7 @@ Once the KubeRay operator is running, you're ready to deploy a RayCluster. Creat
 
 ```sh
 # Deploy a sample RayCluster CR from the KubeRay Helm chart repo:
-helm install raycluster kuberay/ray-cluster --version 1.6.0
+helm install raycluster kuberay/ray-cluster --version 1.7.0
 ```
 
 

--- a/doc/source/cluster/kubernetes/getting-started/raycronjob-quick-start.md
+++ b/doc/source/cluster/kubernetes/getting-started/raycronjob-quick-start.md
@@ -62,9 +62,9 @@ Install the KubeRay operator, following [these instructions](https://docs.ray.io
 helm repo add kuberay https://ray-project.github.io/kuberay-helm/
 helm repo update
 
-# Install KubeRay operator v1.6.0 with the RayCronJob feature gate enabled
+# Install KubeRay operator v1.7.0 with the RayCronJob feature gate enabled
 helm install kuberay-operator kuberay/kuberay-operator \
-  --version 1.6.0 \
+  --version 1.7.0 \
   --set "featureGates[0].name=RayCronJob" \
   --set "featureGates[0].enabled=true"
 ```
@@ -72,7 +72,7 @@ helm install kuberay-operator kuberay/kuberay-operator \
 ### Step 3: Install a RayCronJob
 
 ```sh
-kubectl apply -f https://raw.githubusercontent.com/ray-project/kuberay/v1.6.0/ray-operator/config/samples/ray-cronjob.sample.yaml
+kubectl apply -f https://raw.githubusercontent.com/ray-project/kuberay/v1.7.0/ray-operator/config/samples/ray-cronjob.sample.yaml
 ```
 
 ### Step 4: Monitor the RayCronJob
@@ -130,7 +130,7 @@ To stop the recurring jobs and delete the resource, run:
 
 ```bash
 # Step 6.1: Delete the RayCronJob
-kubectl delete -f https://raw.githubusercontent.com/ray-project/kuberay/v1.6.0/ray-operator/config/samples/ray-cronjob.sample.yaml
+kubectl delete -f https://raw.githubusercontent.com/ray-project/kuberay/v1.7.0/ray-operator/config/samples/ray-cronjob.sample.yaml
 
 # Step 6.2: Delete the KubeRay operator
 helm uninstall kuberay-operator

--- a/doc/source/cluster/kubernetes/getting-started/rayjob-quick-start.md
+++ b/doc/source/cluster/kubernetes/getting-started/rayjob-quick-start.md
@@ -97,7 +97,7 @@ Follow the [KubeRay Operator Installation](kuberay-operator-deploy) to install t
 ## Step 3: Install a RayJob
 
 ```sh
-kubectl apply -f https://raw.githubusercontent.com/ray-project/kuberay/v1.6.0/ray-operator/config/samples/ray-job.sample.yaml
+kubectl apply -f https://raw.githubusercontent.com/ray-project/kuberay/v1.7.0/ray-operator/config/samples/ray-job.sample.yaml
 ```
 
 ## Step 4: Verify the Kubernetes cluster status
@@ -162,13 +162,13 @@ The Python script `sample_code.py` used by `entrypoint` is a simple Ray script t
 ## Step 6: Delete the RayJob
 
 ```sh
-kubectl delete -f https://raw.githubusercontent.com/ray-project/kuberay/v1.6.0/ray-operator/config/samples/ray-job.sample.yaml
+kubectl delete -f https://raw.githubusercontent.com/ray-project/kuberay/v1.7.0/ray-operator/config/samples/ray-job.sample.yaml
 ```
 
 ## Step 7: Create a RayJob with `shutdownAfterJobFinishes` set to true
 
 ```sh
-kubectl apply -f https://raw.githubusercontent.com/ray-project/kuberay/v1.6.0/ray-operator/config/samples/ray-job.shutdown.yaml
+kubectl apply -f https://raw.githubusercontent.com/ray-project/kuberay/v1.7.0/ray-operator/config/samples/ray-job.shutdown.yaml
 ```
 
 The `ray-job.shutdown.yaml` defines a RayJob custom resource with `shutdownAfterJobFinishes: true` and `ttlSecondsAfterFinished: 10`. Hence, the KubeRay operator deletes the RayCluster 10 seconds after the Ray job finishes. Note that the submitter job isn't deleted because it contains the ray job logs and doesn't use any cluster resources once completed. In addition, the RayJob cleans up the submitter job when the RayJob is eventually deleted due to its owner reference back to the RayJob.
@@ -193,7 +193,7 @@ kubectl get raycluster
 
 ```sh
 # Step 10.1: Delete the RayJob
-kubectl delete -f https://raw.githubusercontent.com/ray-project/kuberay/v1.6.0/ray-operator/config/samples/ray-job.shutdown.yaml
+kubectl delete -f https://raw.githubusercontent.com/ray-project/kuberay/v1.7.0/ray-operator/config/samples/ray-job.shutdown.yaml
 
 # Step 10.2: Delete the KubeRay operator
 helm uninstall kuberay-operator

--- a/doc/source/cluster/kubernetes/getting-started/rayjob-quick-start.md
+++ b/doc/source/cluster/kubernetes/getting-started/rayjob-quick-start.md
@@ -53,14 +53,15 @@ To understand the following content better, you should understand the difference
     * `K8sJobMode`: The KubeRay operator creates a submitter Kubernetes Job to submit the Ray job.
     * `HTTPMode`: The KubeRay operator sends a request to the RayCluster to create a Ray job.
     * `InteractiveMode`: The KubeRay operator waits for the user to submit a job to the RayCluster. This mode is currently in alpha and the [KubeRay kubectl plugin](kubectl-plugin) relies on it.
-    * `SidecarMode`: The KubeRay operator injects a container into the Ray head Pod to submit the Ray job. This mode does not support `clusterSelector`, `submitterPodTemplate`, and `submitterConfig`, and requires the head Pod's restart policy to be `Never`.
+    * `SidecarMode`: The KubeRay operator injects a container into the Ray head Pod to submit the Ray job. This mode does not support `clusterSelector` and `submitterPodTemplate`, and requires the head Pod's restart policy to be `Never`. When the `SidecarSubmitterRestart` feature gate is enabled **(requires KubeRay v1.7+, Ray v2.54.0+, and Kubernetes v1.35+)**, `submitterConfig.backoffLimit` is used to cap the submitter sidecar's restart count.
   * `submitterPodTemplate` (Optional): Defines the Pod template for the submitter Kubernetes Job. This field is only effective when `submissionMode` is "K8sJobMode".
     * `RAY_DASHBOARD_ADDRESS` - The KubeRay operator injects this environment variable to the submitter Pod. The value is `$HEAD_SERVICE:$DASHBOARD_PORT`.
     * `RAY_JOB_SUBMISSION_ID` - The KubeRay operator injects this environment variable to the submitter Pod. The value is the `RayJob.Status.JobId` of the RayJob.
     * Example: `ray job submit --address=http://$RAY_DASHBOARD_ADDRESS --submission-id=$RAY_JOB_SUBMISSION_ID ...`
     * See [ray-job.sample.yaml](https://github.com/ray-project/kuberay/blob/master/ray-operator/config/samples/ray-job.sample.yaml) for more details.
-  * `submitterConfig` (Optional): Additional configurations for the submitter Kubernetes Job.
-    * `backoffLimit` (Optional, added in version 1.2.0): The number of retries before marking the submitter Job as failed. The default value is 2.
+  * `submitterConfig` (Optional): Additional configurations for the submitter. Used in `K8sJobMode` (always). `SidecarMode` also honors `backoffLimit` internally when `SidecarSubmitterRestart` is enabled, but the field currently can't be set via the RayJob custom resource for `SidecarMode`. See {ref}`kuberay-rayjob-sidecar-submitter-restart`.
+    * `backoffLimit` (Optional, added in version 1.2.0): The number of retries before marking the submitter as failed. The default value is 2.
+  * `SidecarSubmitterRestart` (alpha in v1.7, disabled by default): Lets the submitter container restart in place on transient failures, independent of the head Pod's pod-level `restartPolicy: Never`. Requires Kubernetes v1.35+ and Ray v2.54.0+. See {ref}`kuberay-rayjob-sidecar-submitter-restart` for the full walkthrough, restart/reattach behavior, and version-skew caveats.
 * Automatic resource cleanup
   * `preRunningDeadlineSeconds` (Optional): If the RayJob doesn't transition the `JobDeploymentStatus` to `Running` within `preRunningDeadlineSeconds` seconds, the KubeRay operator transitions the `JobDeploymentStatus` to `Failed` with reason `PreRunningDeadlineExceeded`. The default value is 0 (no pre-running deadline is enforced).
   * `shutdownAfterJobFinishes` (Optional): Determines whether to recycle the RayCluster after the Ray job finishes. The default value is false.

--- a/doc/source/cluster/kubernetes/getting-started/rayservice-quick-start.md
+++ b/doc/source/cluster/kubernetes/getting-started/rayservice-quick-start.md
@@ -3,7 +3,7 @@
 
 ## Prerequisites
 
-This guide mainly focuses on the behavior of KubeRay v1.6.0 and Ray 2.46.0.
+This guide mainly focuses on the behavior of KubeRay v1.7.0 and Ray 2.46.0.
 
 ## What's a RayService?
 
@@ -34,7 +34,7 @@ Follow [this document](kuberay-operator-deploy) to install the latest stable Kub
 ## Step 3: Install a RayService
 
 ```sh
-kubectl apply -f https://raw.githubusercontent.com/ray-project/kuberay/v1.6.0/ray-operator/config/samples/ray-service.sample.yaml
+kubectl apply -f https://raw.githubusercontent.com/ray-project/kuberay/v1.7.0/ray-operator/config/samples/ray-service.sample.yaml
 ```
 
 ## Step 4: Verify the Kubernetes cluster status
@@ -126,7 +126,7 @@ curl -X POST -H 'Content-Type: application/json' rayservice-sample-serve-svc:800
 
 ```sh
 # Delete the RayService.
-kubectl delete -f https://raw.githubusercontent.com/ray-project/kuberay/v1.6.0/ray-operator/config/samples/ray-service.sample.yaml
+kubectl delete -f https://raw.githubusercontent.com/ray-project/kuberay/v1.7.0/ray-operator/config/samples/ray-service.sample.yaml
 
 # Uninstall the KubeRay operator.
 helm uninstall kuberay-operator

--- a/doc/source/cluster/kubernetes/k8s-ecosystem/ingress.md
+++ b/doc/source/cluster/kubernetes/k8s-ecosystem/ingress.md
@@ -4,6 +4,7 @@
 
 The following examples show how to use Ingress or Gateway to access your Ray clusters:
 
+  * [KubeRay built-in Ingress](kuberay-builtin-ingress)
   * [AWS Application Load Balancer (ALB) Ingress support on AWS EKS](kuberay-aws-alb)
   * [GKE Ingress support](kuberay-gke-ingress)
   * [GKE Gateway API support](kuberay-gke-gateway)
@@ -16,6 +17,53 @@ The following examples show how to use Ingress or Gateway to access your Ray clu
 **Only expose Ingresses or Gateways to authorized users.** The Ray Dashboard provides read and write access to the Ray Cluster. Anyone with access to this Ingress or Gateway can execute arbitrary code on the Ray Cluster.
 ```
 
+(kuberay-builtin-ingress)=
+## KubeRay built-in Ingress
+
+KubeRay 1.7.0 adds `ingressOptions`, which lets the operator generate and manage an Ingress for the Ray head service. You can configure the Ingress directly in the RayCluster using `ingressOptions`. The operator creates the corresponding Ingress, updates it when the configuration changes, and deletes it when the RayCluster is deleted.
+
+### Prerequisites
+
+- KubeRay operator v1.7 or later installed.
+
+- An Ingress controller running in your cluster. See the [Kubernetes Ingress Controllers documentation](https://kubernetes.io/docs/concepts/services-networking/ingress-controllers/) for more information.
+
+### Configure `ingressOptions`
+
+Set `enableIngress` to `true` and add `ingressOptions` to `headGroupSpec`:
+
+```yaml
+apiVersion: ray.io/v1
+kind: RayCluster
+metadata:
+  name: raycluster-ingress
+  annotations:
+    kubernetes.io/ingress.class: nginx
+spec:
+  headGroupSpec:
+    enableIngress: true
+    ingressOptions:
+      host: ray-dashboard.example.com
+      path: /
+      pathType: Prefix
+      tls:
+        - hosts:
+            - ray-dashboard.example.com
+          secretName: ray-dashboard-tls
+```
+
+The operator generates an Ingress named `<raycluster-name>-head-ingress` that routes to the head service on the dashboard port.
+
+Every field under `ingressOptions` is optional:
+
+| Field      | Description                                                                                                                                                                         | Default                         |
+| ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------- |
+| `host`     | Fully qualified domain name that routes external traffic to the Ray head dashboard.                                                                                                 | Unset, which matches any host.  |
+| `path`     | HTTP path that routes to the dashboard.                                                                                                                                             | `/`                             |
+| `pathType` | Path matching mode for `path`. One of `Exact`, `Prefix`, or `ImplementationSpecific`.                                                                                               | `Prefix`                        |
+| `tls`      | TLS termination for the generated Ingress, using the Kubernetes [IngressTLS](https://kubernetes.io/docs/reference/kubernetes-api/service-resources/ingress-v1/#IngressSpec) schema. | Unset, which serves plain HTTP. |
+
+If you set only `enableIngress: true`, KubeRay generates an Ingress that matches any host and routes `/` to the dashboard. If you update `ingressOptions` on an existing RayCluster, KubeRay updates the generated Ingress to match.
 
 (kuberay-aws-alb)=
 ## AWS Application Load Balancer (ALB) Ingress support on AWS EKS

--- a/doc/source/cluster/kubernetes/k8s-ecosystem/ingress.md
+++ b/doc/source/cluster/kubernetes/k8s-ecosystem/ingress.md
@@ -82,10 +82,10 @@ If you set only `enableIngress: true`, KubeRay generates an Ingress that matches
 # Step 1: Install KubeRay operator and CRD
 helm repo add kuberay https://ray-project.github.io/kuberay-helm/
 helm repo update
-helm install kuberay-operator kuberay/kuberay-operator --version 1.6.0
+helm install kuberay-operator kuberay/kuberay-operator --version 1.7.0
 
 # Step 2: Install a RayCluster
-helm install raycluster kuberay/ray-cluster --version 1.6.0
+helm install raycluster kuberay/ray-cluster --version 1.7.0
 
 # Step 3: Edit the `ray-operator/config/samples/ray-cluster-alb-ingress.yaml`
 #
@@ -172,10 +172,10 @@ Now run the following commands:
 # Step 1: Install KubeRay operator and CRD
 helm repo add kuberay https://ray-project.github.io/kuberay-helm/
 helm repo update
-helm install kuberay-operator kuberay/kuberay-operator --version 1.6.0
+helm install kuberay-operator kuberay/kuberay-operator --version 1.7.0
 
 # Step 2: Install a RayCluster. GKE Ingress requires the backend service to be of type NodePort.
-helm install raycluster kuberay/ray-cluster --version 1.6.0 --set service.type=NodePort
+helm install raycluster kuberay/ray-cluster --version 1.7.0 --set service.type=NodePort
 
 # Step 3: Edit ray-cluster-gclb-ingress.yaml to replace the service name with the name of the head service from the RayCluster. (Output of `kubectl get svc`)
 
@@ -252,10 +252,10 @@ Now run the following commands:
 # Step 1: Install KubeRay operator and CRD
 helm repo add kuberay https://ray-project.github.io/kuberay-helm/
 helm repo update
-helm install kuberay-operator kuberay/kuberay-operator --version 1.6.0
+helm install kuberay-operator kuberay/kuberay-operator --version 1.7.0
 
 # Step 2: Install a RayCluster
-helm install raycluster kuberay/ray-cluster --version 1.6.0
+helm install raycluster kuberay/ray-cluster --version 1.7.0
 
 # Step 3: Edit ray-cluster-gke-gateway.yaml to replace the service name with the name of the head service from the RayCluster. (Output of `kubectl get svc`)
 
@@ -320,12 +320,12 @@ kubectl wait --namespace ingress-nginx \
 # Step 3: Install KubeRay operator and CRD
 helm repo add kuberay https://ray-project.github.io/kuberay-helm/
 helm repo update
-helm install kuberay-operator kuberay/kuberay-operator --version 1.6.0
+helm install kuberay-operator kuberay/kuberay-operator --version 1.7.0
 
 # Step 4: Install RayCluster and create an ingress separately.
 # More information about change of setting was documented in https://github.com/ray-project/kuberay/pull/699
 # and `ray-operator/config/samples/ray-cluster.separate-ingress.yaml`
-curl -LO https://raw.githubusercontent.com/ray-project/kuberay/v1.6.0/ray-operator/config/samples/ray-cluster.separate-ingress.yaml
+curl -LO https://raw.githubusercontent.com/ray-project/kuberay/v1.7.0/ray-operator/config/samples/ray-cluster.separate-ingress.yaml
 kubectl apply -f ray-cluster.separate-ingress.yaml
 
 # Step 5: Check the ingress created in Step 4.
@@ -364,10 +364,10 @@ kubectl describe ingress raycluster-ingress-head-ingress
 # Step 1: Install KubeRay operator and CRD
 helm repo add kuberay https://ray-project.github.io/kuberay-helm/
 helm repo update
-helm install kuberay-operator kuberay/kuberay-operator --version 1.6.0
+helm install kuberay-operator kuberay/kuberay-operator --version 1.7.0
 
 # Step 2: Install a RayCluster
-helm install raycluster kuberay/ray-cluster --version 1.6.0
+helm install raycluster kuberay/ray-cluster --version 1.7.0
 
 # Step 3: Edit the `ray-operator/config/samples/ray-cluster-agc-gatewayapi.yaml`
 #

--- a/doc/source/cluster/kubernetes/k8s-ecosystem/istio.md
+++ b/doc/source/cluster/kubernetes/k8s-ecosystem/istio.md
@@ -66,7 +66,7 @@ In this mode, you _must_ disable the KubeRay init container injection by setting
 
 ```bash
 # Set ENABLE_INIT_CONTAINER_INJECTION=false on the KubeRay operator.
-helm upgrade kuberay-operator kuberay/kuberay-operator --version 1.6.0 \
+helm upgrade kuberay-operator kuberay/kuberay-operator --version 1.7.0 \
   --set env\[0\].name=ENABLE_INIT_CONTAINER_INJECTION \
   --set-string env\[0\].value=false
 

--- a/doc/source/cluster/kubernetes/k8s-ecosystem/prometheus-grafana.md
+++ b/doc/source/cluster/kubernetes/k8s-ecosystem/prometheus-grafana.md
@@ -55,10 +55,15 @@ kubectl get all -n prometheus-system
 * Set `metrics.serviceMonitor.enabled=true` when installing the KubeRay operator with Helm to create a ServiceMonitor that scrapes metrics exposed by the KubeRay operator's service.
   ```sh
   # Enable the ServiceMonitor and set the label `release: prometheus` to the ServiceMonitor so that Prometheus can discover it
-  helm install kuberay-operator kuberay/kuberay-operator --version 1.6.0 \
-    --set metrics.serviceMonitor.enabled=true \ 
-    --set metrics.serviceMonitor.selector.release=prometheus 
+  helm install kuberay-operator kuberay/kuberay-operator --version 1.7.0 \
+    --set metrics.serviceMonitor.enabled=true \
+    --set metrics.serviceMonitor.additionalLabels.release=prometheus
   ```
+
+  :::{warning}
+  KubeRay v1.7.0 renames the `metrics.serviceMonitor.selector` value to `metrics.serviceMonitor.additionalLabels`, because the value sets labels on the ServiceMonitor rather than a selector. On KubeRay v1.6.x or earlier, use `--set metrics.serviceMonitor.selector.release=prometheus` instead.
+  :::
+
   You can verify the ServiceMonitor creation with:
   ```sh
   kubectl get servicemonitor
@@ -103,7 +108,7 @@ curl localhost:8080
   * `# HELP`: Describe the meaning of this metric.
   * `# TYPE`: See [this document](https://prometheus.io/docs/concepts/metric_types/) for more details.
 
-* Three required environment variables are defined in [ray-cluster.embed-grafana.yaml](https://github.com/ray-project/kuberay/blob/v1.6.0/ray-operator/config/samples/ray-cluster.embed-grafana.yaml). See [Configuring and Managing Ray Dashboard](https://docs.ray.io/en/latest/cluster/configure-manage-dashboard.html) for more details about these environment variables.
+* Three required environment variables are defined in [ray-cluster.embed-grafana.yaml](https://github.com/ray-project/kuberay/blob/v1.7.0/ray-operator/config/samples/ray-cluster.embed-grafana.yaml). See [Configuring and Managing Ray Dashboard](https://docs.ray.io/en/latest/cluster/configure-manage-dashboard.html) for more details about these environment variables.
   ```yaml
   env:
     - name: RAY_GRAFANA_IFRAME_HOST

--- a/doc/source/cluster/kubernetes/k8s-ecosystem/scheduler-plugins.md
+++ b/doc/source/cluster/kubernetes/k8s-ecosystem/scheduler-plugins.md
@@ -28,7 +28,7 @@ KubeRay v1.4.0 only supports the *single scheduler mode*. You need to have the a
 KubeRay v1.4.0 and later versions support scheduler plugins.
 
 ```sh
-helm install kuberay-operator kuberay/kuberay-operator --version 1.6.0 --set batchScheduler.name=scheduler-plugins
+helm install kuberay-operator kuberay/kuberay-operator --version 1.7.0 --set batchScheduler.name=scheduler-plugins
 ```
 
 ## Step 4: Deploy a RayCluster with gang scheduling

--- a/doc/source/cluster/kubernetes/k8s-ecosystem/volcano.md
+++ b/doc/source/cluster/kubernetes/k8s-ecosystem/volcano.md
@@ -34,13 +34,13 @@ batchScheduler:
 * Pass the `--set batchScheduler.name=volcano` flag when running on the command line:
 ```shell
 # Install the Helm chart with the --batch-scheduler=volcano flag
-helm install kuberay-operator kuberay/kuberay-operator --version 1.6.0 --set batchScheduler.name=volcano
+helm install kuberay-operator kuberay/kuberay-operator --version 1.7.0 --set batchScheduler.name=volcano
 ```
 
 ### Step 4: Install a RayCluster with the Volcano scheduler
 ```shell
 # Path: kuberay/ray-operator/config/samples
-curl -LO https://raw.githubusercontent.com/ray-project/kuberay/v1.6.0/ray-operator/config/samples/ray-cluster.volcano-scheduler.yaml
+curl -LO https://raw.githubusercontent.com/ray-project/kuberay/v1.7.0/ray-operator/config/samples/ray-cluster.volcano-scheduler.yaml
 kubectl apply -f ray-cluster.volcano-scheduler.yaml
 
 # Check the RayCluster
@@ -120,7 +120,7 @@ Next, create a RayCluster with a head node (1 CPU + 2Gi of RAM) and two workers 
 ```shell
 # Path: kuberay/ray-operator/config/samples
 # Includes the `volcano.sh/queue-name: kuberay-test-queue` label in the metadata.labels
-curl -LO https://raw.githubusercontent.com/ray-project/kuberay/v1.6.0/ray-operator/config/samples/ray-cluster.volcano-scheduler-queue.yaml
+curl -LO https://raw.githubusercontent.com/ray-project/kuberay/v1.7.0/ray-operator/config/samples/ray-cluster.volcano-scheduler-queue.yaml
 kubectl apply -f ray-cluster.volcano-scheduler-queue.yaml
 ```
 
@@ -339,7 +339,7 @@ Starting with KubeRay 1.6.0, KubeRay supports gang scheduling for RayJob custom 
 First, create a queue with a capacity of 4 CPUs and 6Gi of RAM and RayJob a with a head node (1 CPU + 2Gi of RAM), two workers (1 CPU + 1Gi of RAM each) and a submitter pod (0.5 CPU + 200Mi of RAM), for a total of 3500m CPU and 4296Mi of RAM
 
 ```shell
-curl -LO https://raw.githubusercontent.com/ray-project/kuberay/v1.6.0/ray-operator/config/samples/ray-job.volcano-scheduler-queue.yaml
+curl -LO https://raw.githubusercontent.com/ray-project/kuberay/v1.7.0/ray-operator/config/samples/ray-job.volcano-scheduler-queue.yaml
 kubectl apply -f ray-job.volcano-scheduler-queue.yaml
 ```
 

--- a/doc/source/cluster/kubernetes/k8s-ecosystem/yunikorn.md
+++ b/doc/source/cluster/kubernetes/k8s-ecosystem/yunikorn.md
@@ -28,7 +28,7 @@ You need to successfully install Apache YuniKorn on your Kubernetes cluster befo
 When installing KubeRay operator using Helm, pass the `--set batchScheduler.name=yunikorn` flag at the command line:
 
 ```shell
-helm install kuberay-operator kuberay/kuberay-operator --version 1.6.0 --set batchScheduler.name=yunikorn
+helm install kuberay-operator kuberay/kuberay-operator --version 1.7.0 --set batchScheduler.name=yunikorn
 ```
 
 ## Step 4: Use Apache YuniKorn for gang scheduling

--- a/doc/source/cluster/kubernetes/user-guides.md
+++ b/doc/source/cluster/kubernetes/user-guides.md
@@ -29,6 +29,7 @@ user-guides/tpu
 user-guides/pod-command
 user-guides/helm-chart-rbac
 user-guides/tls
+user-guides/network-policy
 user-guides/k8s-autoscaler
 user-guides/kubectl-plugin
 user-guides/kuberay-auth
@@ -68,6 +69,7 @@ To learn the basics of Ray on Kubernetes, we recommend taking a look at the {ref
 * {ref}`kuberay-pod-command`
 * {ref}`kuberay-helm-chart-rbac`
 * {ref}`kuberay-tls`
+* {ref}`kuberay-network-policy`
 * {ref}`kuberay-gke-bucket`
 * {ref}`ray-k8s-autoscaler-comparison`
 * {ref}`kubectl-plugin`

--- a/doc/source/cluster/kubernetes/user-guides.md
+++ b/doc/source/cluster/kubernetes/user-guides.md
@@ -39,6 +39,7 @@ user-guides/kuberay-dashboard
 user-guides/resource-isolation-with-writable-cgroups
 user-guides/kuberay-history-server
 user-guides/k8s-events
+user-guides/rayjob-sidecar-submitter-restart
 ```
 
 
@@ -78,3 +79,4 @@ To learn the basics of Ray on Kubernetes, we recommend taking a look at the {ref
 * {ref}`resource-isolation-with-writable-cgroups`
 * {ref}`kuberay-history-server`
 * {ref}`kuberay-k8s-events`
+* {ref}`kuberay-rayjob-sidecar-submitter-restart`

--- a/doc/source/cluster/kubernetes/user-guides/configuring-autoscaling.md
+++ b/doc/source/cluster/kubernetes/user-guides/configuring-autoscaling.md
@@ -57,7 +57,7 @@ Follow [this document](kuberay-operator-deploy) to install the latest stable Kub
 ### Step 3: Create a RayCluster custom resource with autoscaling enabled
 
 ```bash
-kubectl apply -f https://raw.githubusercontent.com/ray-project/kuberay/v1.6.0/ray-operator/config/samples/ray-cluster.autoscaler.yaml
+kubectl apply -f https://raw.githubusercontent.com/ray-project/kuberay/v1.7.0/ray-operator/config/samples/ray-cluster.autoscaler.yaml
 ```
 
 ### Step 4: Verify the Kubernetes cluster status
@@ -79,7 +79,7 @@ kubectl get configmaps
 # ...
 ```
 
-The RayCluster has one head Pod and zero worker Pods. The head Pod has two containers: a Ray head container and a Ray Autoscaler sidecar container. Additionally, the [ray-cluster.autoscaler.yaml](https://github.com/ray-project/kuberay/blob/v1.6.0/ray-operator/config/samples/ray-cluster.autoscaler.yaml) includes a ConfigMap named `ray-example` that contains two Python scripts: `detached_actor.py` and `terminate_detached_actor.py`.
+The RayCluster has one head Pod and zero worker Pods. The head Pod has two containers: a Ray head container and a Ray Autoscaler sidecar container. Additionally, the [ray-cluster.autoscaler.yaml](https://github.com/ray-project/kuberay/blob/v1.7.0/ray-operator/config/samples/ray-cluster.autoscaler.yaml) includes a ConfigMap named `ray-example` that contains two Python scripts: `detached_actor.py` and `terminate_detached_actor.py`.
 
 * `detached_actor.py` is a Python script that creates a detached actor which requires 1 CPU.
   ```py
@@ -234,7 +234,7 @@ kubectl logs $HEAD_POD -c autoscaler | tail -n 20
 
 ```bash
 # Delete RayCluster and ConfigMap
-kubectl delete -f https://raw.githubusercontent.com/ray-project/kuberay/v1.6.0/ray-operator/config/samples/ray-cluster.autoscaler.yaml
+kubectl delete -f https://raw.githubusercontent.com/ray-project/kuberay/v1.7.0/ray-operator/config/samples/ray-cluster.autoscaler.yaml
 
 # Uninstall the KubeRay operator
 helm uninstall kuberay-operator
@@ -246,7 +246,7 @@ kind delete cluster
 (kuberay-autoscaling-config)=
 ## KubeRay Autoscaling Configurations
 
-The [ray-cluster.autoscaler.yaml](https://github.com/ray-project/kuberay/blob/v1.6.0/ray-operator/config/samples/ray-cluster.autoscaler.yaml) used in the quickstart example contains detailed comments about the configuration options. ***It's recommended to read this section in conjunction with the YAML file.***
+The [ray-cluster.autoscaler.yaml](https://github.com/ray-project/kuberay/blob/v1.7.0/ray-operator/config/samples/ray-cluster.autoscaler.yaml) used in the quickstart example contains detailed comments about the configuration options. ***It's recommended to read this section in conjunction with the YAML file.***
 
 ### 1. Enabling autoscaling
 
@@ -328,7 +328,7 @@ Earlier versions only support `rayStartParams` or resource limits, and don't rec
 If you omit `rayStartParams` and want to use autoscaling, the autoscaling image must have Ray 2.45.0 or later.
 ```
 
-The Ray Autoscaler reads the `rayStartParams` field or the Ray container's resource limits in the RayCluster custom resource specification to determine the Ray Pod's resource requirements. The information regarding the number of CPUs is essential for the Ray Autoscaler to scale the cluster. Therefore, without this information, the Ray Autoscaler reports an error and fails to start. Take [ray-cluster.autoscaler.yaml](https://github.com/ray-project/kuberay/blob/v1.6.0/ray-operator/config/samples/ray-cluster.autoscaler.yaml) as an example below:
+The Ray Autoscaler reads the `rayStartParams` field or the Ray container's resource limits in the RayCluster custom resource specification to determine the Ray Pod's resource requirements. The information regarding the number of CPUs is essential for the Ray Autoscaler to scale the cluster. Therefore, without this information, the Ray Autoscaler reports an error and fails to start. Take [ray-cluster.autoscaler.yaml](https://github.com/ray-project/kuberay/blob/v1.7.0/ray-operator/config/samples/ray-cluster.autoscaler.yaml) as an example below:
 
 * If users set `num-cpus` in `rayStartParams`, Ray Autoscaler would work regardless of the resource limits on the container.
 * If users don't set `rayStartParams`, the Ray container must have a specified CPU resource limit.
@@ -452,7 +452,7 @@ Node: 2d5fd3d4337ba5b5a8c3106c572492abb9a8de2dee9da7f6c24c1346
 
 2. **Stability** Autoscaler V2 makes significant improvements to idle node handling. The V1 autoscaler could stop nodes that became active during termination processing, potentially failing tasks or actors. V2 uses Ray's graceful draining mechanism, which safely stops idle nodes without disrupting ongoing work.
 
-[ray-cluster.autoscaler-v2.yaml](https://github.com/ray-project/kuberay/blob/v1.6.0/ray-operator/config/samples/ray-cluster.autoscaler-v2.yaml) is an example YAML file of a RayCluster with Autoscaler V2 enabled that works with the latest KubeRay version.
+[ray-cluster.autoscaler-v2.yaml](https://github.com/ray-project/kuberay/blob/v1.7.0/ray-operator/config/samples/ray-cluster.autoscaler-v2.yaml) is an example YAML file of a RayCluster with Autoscaler V2 enabled that works with the latest KubeRay version.
 
 If you're using KubeRay >= 1.4.0, enable V2 by setting `RayCluster.spec.autoscalerOptions.version: v2`.
 

--- a/doc/source/cluster/kubernetes/user-guides/gcp-gke-tpu-cluster.md
+++ b/doc/source/cluster/kubernetes/user-guides/gcp-gke-tpu-cluster.md
@@ -83,8 +83,8 @@ In a cluster without the Ray Operator Addon enabled, KubeRay can be manually ins
 ```sh
 helm repo add kuberay https://ray-project.github.io/kuberay-helm/
 
-# Install both CRDs and KubeRay operator v1.6.0.
-helm install kuberay-operator kuberay/kuberay-operator --version 1.6.0
+# Install both CRDs and KubeRay operator v1.7.0.
+helm install kuberay-operator kuberay/kuberay-operator --version 1.7.0
 ```
 
 GKE provides a [validating and mutating webhook](https://github.com/ai-on-gke/kuberay-tpu-webhook) to handle TPU Pod scheduling and bootstrap certain environment variables used for [JAX](https://github.com/google/jax) initialization. The Ray TPU webhook requires a KubeRay operator version of at least v1.1.0. GKE automatically installs the Ray TPU webhook through the [Ray Operator Addon](https://cloud.google.com/kubernetes-engine/docs/add-on/ray-on-gke/how-to/enable-ray-on-gke) with GKE versions 1.30.0-gke.1747000 or later.

--- a/doc/source/cluster/kubernetes/user-guides/gke-gcs-bucket.md
+++ b/doc/source/cluster/kubernetes/user-guides/gke-gcs-bucket.md
@@ -64,7 +64,7 @@ See [Authenticate to Google Cloud APIs from GKE workloads](https://docs.cloud.go
 You can download the RayCluster YAML manifest for this tutorial with `curl` as follows:
 
 ```bash
-curl -LO https://raw.githubusercontent.com/ray-project/kuberay/v1.6.0/ray-operator/config/samples/ray-cluster.gke-bucket.yaml
+curl -LO https://raw.githubusercontent.com/ray-project/kuberay/v1.7.0/ray-operator/config/samples/ray-cluster.gke-bucket.yaml
 ```
 
 The key parts are the following lines:

--- a/doc/source/cluster/kubernetes/user-guides/helm-chart-rbac.md
+++ b/doc/source/cluster/kubernetes/user-guides/helm-chart-rbac.md
@@ -65,9 +65,9 @@ kubectl get role
 #kuberay-operator-leader-election   2023-10-15T04:54:28Z
 
 # Install RayCluster in the `default`, `n1`, and `n2` namespaces.
-helm install raycluster kuberay/ray-cluster --version 1.6.0
-helm install raycluster kuberay/ray-cluster --version 1.6.0 -n n1
-helm install raycluster kuberay/ray-cluster --version 1.6.0 -n n2
+helm install raycluster kuberay/ray-cluster --version 1.7.0
+helm install raycluster kuberay/ray-cluster --version 1.7.0 -n n1
+helm install raycluster kuberay/ray-cluster --version 1.7.0 -n n2
 
 # You should create a RayCluster in these 3 namespaces.
 kubectl get raycluster -A
@@ -112,9 +112,9 @@ kubectl get role --all-namespaces | grep kuberay
 #default       kuberay-operator-leader-election                 2023-10-15T05:18:03Z
 
 # Install RayCluster in the `default`, `n1`, and `n2` namespaces.
-helm install raycluster kuberay/ray-cluster --version 1.6.0
-helm install raycluster kuberay/ray-cluster --version 1.6.0 -n n1
-helm install raycluster kuberay/ray-cluster --version 1.6.0 -n n2
+helm install raycluster kuberay/ray-cluster --version 1.7.0
+helm install raycluster kuberay/ray-cluster --version 1.7.0 -n n1
+helm install raycluster kuberay/ray-cluster --version 1.7.0 -n n2
 
 # KubeRay only creates a RayCluster in the `default` namespace.
 kubectl get raycluster -A
@@ -166,9 +166,9 @@ kubectl get role --all-namespaces | grep kuberay
 #n2            kuberay-operator                                 2023-10-15T05:34:27Z
 
 # Install RayCluster in the `default`, `n1`, and `n2` namespaces.
-helm install raycluster kuberay/ray-cluster --version 1.6.0
-helm install raycluster kuberay/ray-cluster --version 1.6.0 -n n1
-helm install raycluster kuberay/ray-cluster --version 1.6.0 -n n2
+helm install raycluster kuberay/ray-cluster --version 1.7.0
+helm install raycluster kuberay/ray-cluster --version 1.7.0 -n n1
+helm install raycluster kuberay/ray-cluster --version 1.7.0 -n n2
 
 # KubeRay creates a RayCluster only in the `n1` and `n2` namespaces.
 kubectl get raycluster -A

--- a/doc/source/cluster/kubernetes/user-guides/k8s-events.md
+++ b/doc/source/cluster/kubernetes/user-guides/k8s-events.md
@@ -13,7 +13,7 @@ This guide describes how to enable and use platform events in the Ray Dashboard 
 ## Prerequisites
 
 * **Ray version**: Ray 2.56.0 or later.
-* **Kubernetes Python client**: Install the `kubernetes` Python package in the Ray head pod's Python environment. The official `rayproject/ray` images include it. Add it to custom images.
+* **Kubernetes Python client**: Install the `kubernetes` Python package (`pip install kubernetes`) in the Ray head pod's Python environment. The official `rayproject/ray` images don't include it.
 * **Kubernetes cluster**: A Kubernetes cluster where you can deploy Ray workloads.
 
 ## Configure RBAC permissions

--- a/doc/source/cluster/kubernetes/user-guides/kubectl-plugin.md
+++ b/doc/source/cluster/kubernetes/user-guides/kubectl-plugin.md
@@ -29,11 +29,11 @@ Try to use the same plugin and KubeRay versions.
 
 Go to the [releases page](https://github.com/ray-project/kuberay/releases) and download the binary for your platform.
 
-For example, to install kubectl plugin version 1.6.0 on Linux amd64:
+For example, to install kubectl plugin version 1.7.0 on Linux amd64:
 
 ```bash
-curl -LO https://github.com/ray-project/kuberay/releases/download/v1.6.0/kubectl-ray_v1.6.0_linux_amd64.tar.gz
-tar -xvf kubectl-ray_v1.6.0_linux_amd64.tar.gz
+curl -LO https://github.com/ray-project/kuberay/releases/download/v1.7.0/kubectl-ray_v1.7.0_linux_amd64.tar.gz
+tar -xvf kubectl-ray_v1.7.0_linux_amd64.tar.gz
 cp kubectl-ray ~/.local/bin
 ```
 
@@ -93,12 +93,12 @@ Created Ray Cluster: raycluster-sample-2
 You can also override the default values with a config file. For example, the following config file sets the worker CPU to 3.
 
 ```text
-$ curl -LO https://raw.githubusercontent.com/ray-project/kuberay/refs/tags/v1.6.0/kubectl-plugin/config/samples/create-cluster.sample.yaml
+$ curl -LO https://raw.githubusercontent.com/ray-project/kuberay/refs/tags/v1.7.0/kubectl-plugin/config/samples/create-cluster.sample.yaml
 $ kubectl ray create cluster raycluster-sample-3 --file create-cluster.sample.yaml
 Created Ray Cluster: raycluster-sample-3
 ```
 
-See https://github.com/ray-project/kuberay/blob/v1.6.0/kubectl-plugin/config/samples/create-cluster.complete.yaml for the complete list of parameters that you can set in the config file.
+See https://github.com/ray-project/kuberay/blob/v1.7.0/kubectl-plugin/config/samples/create-cluster.complete.yaml for the complete list of parameters that you can set in the config file.
 
 By default it only creates one worker group. You can use `kubectl ray create workergroup` to add additional worker groups to existing RayClusters.
 

--- a/doc/source/cluster/kubernetes/user-guides/kuberay-auth-rbac.md
+++ b/doc/source/cluster/kubernetes/user-guides/kuberay-auth-rbac.md
@@ -43,7 +43,7 @@ When enabled, the KubeRay operator will:
 * Automatically set the `RAY_ENABLE_K8S_TOKEN_AUTH` environment variable to `true` on all Ray containers.
 * Automatically mount a projected service account token to the Ray containers, for intra-cluster Ray process authentication.
 
-If you are using a KubeRay version older than v1.6.0, you can enable RBAC authentication by setting the `RAY_AUTH_MODE` and `RAY_ENABLE_K8S_TOKEN_AUTH` environment variables and manually mounting the projected service account token to the Ray containers. See the following example:
+If you are using a KubeRay version older than v1.7.0, you can enable RBAC authentication by setting the `RAY_AUTH_MODE` and `RAY_ENABLE_K8S_TOKEN_AUTH` environment variables and manually mounting the projected service account token to the Ray containers. See the following example:
 
 ```bash
 kubectl apply -f https://raw.githubusercontent.com/ray-project/kuberay/refs/heads/master/ray-operator/config/samples/ray-cluster.kubernetes.auth-manual.yaml

--- a/doc/source/cluster/kubernetes/user-guides/kuberay-auth.md
+++ b/doc/source/cluster/kubernetes/user-guides/kuberay-auth.md
@@ -40,7 +40,7 @@ When enabled, the KubeRay operator will:
 * Create a Kubernetes Secret containing a randomly generated token.
 * Automatically set the `RAY_AUTH_TOKEN` and `RAY_AUTH_MODE` environment variables on all Ray containers.
 
-If you are using a KubeRay version older than v1.6.0, you can enable token authentication by creating a Kubernetes Secret containing your token and configuring the `RAY_AUTH_MODE` and `RAY_AUTH_TOKEN` environment variables.
+If you are using a KubeRay version older than v1.7.0, you can enable token authentication by creating a Kubernetes Secret containing your token and configuring the `RAY_AUTH_MODE` and `RAY_AUTH_TOKEN` environment variables.
 
 ```bash
 kubectl create secret generic ray-cluster-with-auth --from-literal=auth_token=$(openssl rand -base64 32)

--- a/doc/source/cluster/kubernetes/user-guides/kuberay-dashboard.md
+++ b/doc/source/cluster/kubernetes/user-guides/kuberay-dashboard.md
@@ -11,7 +11,7 @@ The KubeRay dashboard is a web-based UI that allows you to view and manage KubeR
 The KubeRay dashboard depends on the optional `kuberay-apiserver` that you need to install. For simplicity, this guide disables the security proxy and allows all origins for Cross-Origin Resource Sharing.
 
 ```bash
-helm install kuberay-apiserver kuberay/kuberay-apiserver --version v1.6.0 --set security= --set cors.allowOrigin='*'
+helm install kuberay-apiserver kuberay/kuberay-apiserver --version v1.7.0 --set security= --set cors.allowOrigin='*'
 ```
 
 And you need to port-forward the `kuberay-apiserver` service because the dashboard currently sends requests to `http://localhost:31888`:
@@ -23,7 +23,7 @@ kubectl port-forward svc/kuberay-apiserver-service 31888:8888
 Install the KubeRay dashboard:
 
 ```bash
-kubectl run kuberay-dashboard --image=quay.io/kuberay/dashboard:v1.6.0
+kubectl run kuberay-dashboard --image=quay.io/kuberay/dashboard:v1.7.0
 ```
 
 Port-forward the KubeRay dashboard:
@@ -35,7 +35,7 @@ kubectl port-forward kuberay-dashboard 3000:3000
 Go to `http://localhost:3000/ray/jobs` to see the list of Ray jobs. It's empty for now. You can create a RayJob custom resource to see how it works.
 
 ```bash
-kubectl apply -f https://raw.githubusercontent.com/ray-project/kuberay/v1.6.0/ray-operator/config/samples/ray-job.sample.yaml
+kubectl apply -f https://raw.githubusercontent.com/ray-project/kuberay/v1.7.0/ray-operator/config/samples/ray-job.sample.yaml
 ```
 
 The KubeRay dashboard only shows RayJob custom resources that the KubeRay API server creates. This guide simulates the API server by labeling the RayJob.

--- a/doc/source/cluster/kubernetes/user-guides/kuberay-gcs-ft.md
+++ b/doc/source/cluster/kubernetes/user-guides/kuberay-gcs-ft.md
@@ -51,7 +51,7 @@ Follow [this document](kuberay-operator-deploy) to install the latest stable Kub
 ### Step 3: Install a RayCluster with GCS FT enabled
 
 ```sh
-curl -LO https://raw.githubusercontent.com/ray-project/kuberay/v1.6.0/ray-operator/config/samples/ray-cluster.external-redis.yaml
+curl -LO https://raw.githubusercontent.com/ray-project/kuberay/v1.7.0/ray-operator/config/samples/ray-cluster.external-redis.yaml
 kubectl apply -f ray-cluster.external-redis.yaml
 ```
 

--- a/doc/source/cluster/kubernetes/user-guides/kuberay-gcs-rocksdb-ft.md
+++ b/doc/source/cluster/kubernetes/user-guides/kuberay-gcs-rocksdb-ft.md
@@ -30,11 +30,8 @@ For the officially supported, Redis-backed setup, see
 
 ## Prerequisites
 
-* A KubeRay version with embedded RocksDB support. This backend is only on KubeRay master
-  (nightly) at the time of writing; it isn't in a stable KubeRay release yet. Once a release
-  ships with it, use that version.
-* A Ray image that contains the embedded RocksDB backend. It isn't in a stable Ray release
-  yet, so the manifest below uses `rayproject/ray:nightly`.
+* KubeRay v1.7 or later, which is the first release that supports the embedded RocksDB backend.
+* Ray 2.57.0 or later, which is the first release that contains the embedded RocksDB backend.
 * Linux worker nodes (the RocksDB backend is Linux only).
 * A `StorageClass` that provisions a durable volume which can reattach to the node that runs
   the recovered head Pod.
@@ -114,7 +111,7 @@ spec:
       spec:
         containers:
         - name: ray-head
-          image: rayproject/ray:nightly
+          image: rayproject/ray:2.57.0
   workerGroupSpecs:
   - groupName: small-group
     replicas: 1
@@ -125,7 +122,7 @@ spec:
       spec:
         containers:
         - name: ray-worker
-          image: rayproject/ray:nightly
+          image: rayproject/ray:2.57.0
 ```
 
 ```{admonition} Storage options

--- a/doc/source/cluster/kubernetes/user-guides/network-policy.md
+++ b/doc/source/cluster/kubernetes/user-guides/network-policy.md
@@ -1,0 +1,296 @@
+(kuberay-network-policy)=
+
+# Configure RayCluster to use NetworkPolicies
+
+The KubeRay operator can generate Kubernetes `NetworkPolicy` resources for each `RayCluster`. When enabled, the operator creates separate policies for the head pod and worker pods, and removes them when the cluster is deleted.
+
+:::{warning}
+NetworkPolicy support is alpha and disabled by default. Enable the `RayClusterNetworkPolicy` feature gate before using `spec.networkPolicy`.
+:::
+
+## Prerequisites
+
+- KubeRay operator v1.7 or later installed.
+- `kubectl` installed and configured to interact with your cluster.
+
+## Install the KubeRay operator
+
+Install the KubeRay operator, following [these instructions](https://docs.ray.io/en/latest/cluster/kubernetes/getting-started/kuberay-operator-installation.html). The minimum version for this guide is v1.7.0. To use this feature, you must enable the `RayClusterNetworkPolicy` feature gate. To enable the feature gate when installing the KubeRay operator, run the following command:
+
+```sh
+helm repo add kuberay https://ray-project.github.io/kuberay-helm/
+helm repo update
+
+# Install KubeRay operator v1.7.0 with the RayClusterNetworkPolicy feature gate enabled
+helm install kuberay-operator kuberay/kuberay-operator \
+  --version 1.7.0 \
+  --set "featureGates[0].name=RayClusterNetworkPolicy" \
+  --set "featureGates[0].enabled=true"
+```
+
+## Enable NetworkPolicy
+
+Add a `networkPolicy` field to the `RayCluster` spec and choose a mode:
+
+```yaml
+apiVersion: ray.io/v1
+kind: RayCluster
+spec:
+  networkPolicy:
+    mode: DenyAll
+```
+
+Three modes are available:
+
+- **`DenyAll`**: deny all ingress and egress except intra-cluster pod traffic.
+- **`DenyAllIngress`**: deny inbound traffic only; outbound is unrestricted.
+- **`DenyAllEgress`**: deny outbound traffic only; inbound is unrestricted.
+
+In all modes, the operator always permits pod-to-pod traffic within the same `RayCluster` on all ports. For `DenyAll` and `DenyAllIngress`, the head pod policy also allows the submitter pod to reach the dashboard port when a `RayJob` running in `K8sJobMode` owns the cluster.
+
+## Apply a namespace default-deny policy first
+
+Ray cluster pods and their `NetworkPolicy` resources are created by different controllers asynchronously. A pod can start before its policy is applied, leaving a brief window where all traffic is permitted.
+
+To address this, pre-apply a namespace-level policy scoped to the directions your chosen mode manages. This closes the race window without interfering with the directions your mode leaves unrestricted.
+
+:::{note}
+This applies to every pod in the namespace, including pods that KubeRay doesn't manage. To scope it to Ray pods only, add a `podSelector` that matches the label KubeRay applies to head and worker pods:
+
+```yaml
+  podSelector:
+    matchLabels:
+      ray.io/is-ray-node: "yes"
+```
+
+Add this selector when you use the `DenyAll` or `DenyAllEgress` variant. The submitter pod for a `RayJob` doesn't carry the `ray.io/is-ray-node` label, so this selector excludes it from the deny rule. Without it, the submitter pod loses egress, and the `RayJob` fails unless you add an extra rule to allow submitter egress.
+:::
+
+**`DenyAll`** — deny both ingress and egress:
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-all
+  namespace: <your-ray-namespace>
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  - Egress
+```
+
+**`DenyAllIngress`** — deny inbound only:
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-ingress
+  namespace: <your-ray-namespace>
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+```
+
+**`DenyAllEgress`** — deny outbound only:
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-egress
+  namespace: <your-ray-namespace>
+spec:
+  podSelector: {}
+  policyTypes:
+  - Egress
+```
+
+The rules the operator generates are additive on top of whichever policy you apply. Kubernetes NetworkPolicy is allow-only — KubeRay's generated allow rules layer on top without needing to modify the namespace policy.
+
+:::{warning}
+Don't apply the `DenyAll` variant with `DenyAllIngress` or `DenyAllEgress` modes. It silently blocks the direction those modes intentionally leave unrestricted, because KubeRay's generated policies can't override a namespace-level deny.
+:::
+
+## Required rules under DenyAll and DenyAllEgress
+
+The operator doesn't add Domain Name System (DNS) or API server egress rules. Add both when using `DenyAll` or `DenyAllEgress`.
+
+### DNS egress
+
+Workers reach the head node through its service fully qualified domain name (FQDN). Without a DNS egress rule, workers can't resolve the head address and the cluster won't start. The operator doesn't add this rule by default because DNS deployments vary across clusters. Adjust the selector to match your cluster's DNS provider before applying. Add the rule to both `head.egressRules` and `worker.egressRules`:
+
+```yaml
+spec:
+  networkPolicy:
+    mode: DenyAll
+    head:
+      egressRules:
+      - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+        ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+    worker:
+      egressRules:
+      - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+        ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+```
+
+### API server egress
+
+When `enableInTreeAutoscaling: true`, the Ray autoscaler on the head pod must reach the Kubernetes API server to scale the cluster. The operator doesn't add this rule because the correct form depends on the Container Network Interface (CNI) plugin:
+
+| CNI | Required form |
+|---|---|
+| kindnet | No rule needed — kindnet allows egress to the API server by default |
+| Calico, Cilium (with `kube-proxy-replacement`) | `ipBlock` with the endpoint IP (after Destination NAT); a ClusterIP rule blocks autoscaling |
+| EKS (Amazon VPC CNI) | `ipBlock` with the `kubernetes` Service ClusterIP; an endpoint IP rule blocks autoscaling |
+
+These results come from testing in [KubeRay #4638](https://github.com/ray-project/kuberay/pull/4638#issuecomment-4660571594). Other CNI configurations may behave differently.
+
+Calico and Cilium also require `policyCIDRMatchMode: Node` set on the CNI (see [this issue](https://github.com/hcloud-k8s/terraform-hcloud-kubernetes/issues/285)) for the endpoint-IP `ipBlock` rule below to match. Without it, the rule may not take effect.
+
+Find the endpoint IP with:
+
+```bash
+kubectl get endpointslices -n default -l kubernetes.io/service-name=kubernetes
+```
+
+For Calico and Cilium (with `kube-proxy-replacement`), add this rule to `head.egressRules`:
+
+```yaml
+- to:
+  - ipBlock:
+      cidr: <endpoint-ip>/32
+  ports:
+  - port: 6443
+    protocol: TCP
+```
+
+For EKS, replace `<endpoint-ip>` with the ClusterIP from `kubectl get svc kubernetes`. As a [suggested alternative for Cilium in KubeRay #4638](https://github.com/ray-project/kuberay/pull/4638#discussion_r3336164401), you can instead use a `CiliumNetworkPolicy` with `toEntities: [kube-apiserver]` to target the API server by identity instead of IP. See Cilium's [Layer 3 policy docs](https://docs.cilium.io/en/stable/security/policy/layer3/) for details.
+
+## RayJob patterns
+
+### RayJob-owned clusters
+
+When a `RayJob` in `K8sJobMode` creates and owns the `RayCluster`, the operator automatically injects an ingress rule allowing the submitter pod to reach the head dashboard port. No additional configuration is needed.
+
+For `HTTPMode` and `SidecarMode`, there is no standalone submitter pod, so no additional ingress rule is required.
+
+### Standalone clusters with clusterSelector
+
+When a `RayJob` targets a pre-existing cluster with `clusterSelector`, the cluster has no `RayJob` owner reference. The operator can't automatically add a submitter ingress rule. To allow the submitter pod to reach the head dashboard port, add an opt-in label to both the `RayCluster` ingress rule and the `RayJob` submitter pod template.
+
+On the `RayCluster`, add an ingress rule under `networkIsolation` that matches the opt-in label:
+
+```yaml
+spec:
+  networkIsolation:
+    mode: DenyAll
+    ingressRules:
+    - from:
+      - podSelector:
+          matchLabels:
+            ray.io/allow-head-access: "true"
+      ports: [ { protocol: TCP, port: 8265 } ]
+```
+
+On the `RayJob`, set the same label on the submitter pod via `submitterPodTemplate`:
+
+```yaml
+spec:
+  submitterPodTemplate:
+    metadata:
+      labels:
+        ray.io/allow-head-access: "true"
+```
+
+## Custom rules
+
+Add rules under `head`, `worker`, or `workerGroups` to target specific policies. The operator appends `head` rules only to the head pod's policy, and `worker` rules to all worker pods' policies by default. To override rules for a specific worker group, use `workerGroups`.
+
+### Allow Prometheus to scrape metrics
+
+```yaml
+spec:
+  networkPolicy:
+    mode: DenyAll
+    head:
+      ingressRules:
+      - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: <prometheus-namespace>
+        ports:
+        - port: 8080
+          protocol: TCP
+```
+
+### Allow worker egress to external services
+
+To allow workers to pull packages or reach external APIs, add an egress rule:
+
+```yaml
+spec:
+  networkPolicy:
+    mode: DenyAll
+    worker:
+      egressRules:
+      - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+        ports:
+        - port: 443
+          protocol: TCP
+```
+
+### Per-worker-group rules
+
+Each worker group defaults to the rules defined in `worker`. To override rules for a specific group, add an entry under `workerGroups`. This replaces the `worker` rules entirely for that group.
+```yaml
+spec:
+  networkPolicy:
+    mode: DenyAll
+    worker:
+      egressRules:
+      - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+        ports:
+        - port: 443
+          protocol: TCP
+    workerGroups:
+    - groupName: gpu-group
+      egressRules:
+      - to:
+        - ipBlock:
+            cidr: 10.0.0.0/8
+        ports:
+        - port: 8080
+          protocol: TCP
+```
+
+## Full example
+
+See [`ray-cluster.network-policy-deny-all.yaml`](https://raw.githubusercontent.com/ray-project/kuberay/refs/heads/master/ray-operator/config/samples/ray-cluster.network-policy-deny-all.yaml) for a complete annotated example covering `DenyAll` mode, DNS egress, API server egress (commented out with per-CNI notes), Prometheus scraping, and the clusterSelector `RayJob` pattern.

--- a/doc/source/cluster/kubernetes/user-guides/network-policy.md
+++ b/doc/source/cluster/kubernetes/user-guides/network-policy.md
@@ -202,18 +202,21 @@ For `HTTPMode` and `SidecarMode`, there is no standalone submitter pod, so no ad
 
 When a `RayJob` targets a pre-existing cluster with `clusterSelector`, the cluster has no `RayJob` owner reference. The operator can't automatically add a submitter ingress rule. To allow the submitter pod to reach the head dashboard port, add an opt-in label to both the `RayCluster` ingress rule and the `RayJob` submitter pod template.
 
-On the `RayCluster`, add an ingress rule under `networkIsolation` that matches the opt-in label:
+On the `RayCluster`, add an ingress rule under `head.ingressRules` that matches the opt-in label:
 
 ```yaml
 spec:
-  networkIsolation:
+  networkPolicy:
     mode: DenyAll
-    ingressRules:
-    - from:
-      - podSelector:
-          matchLabels:
-            ray.io/allow-head-access: "true"
-      ports: [ { protocol: TCP, port: 8265 } ]
+    head:
+      ingressRules:
+      - from:
+        - podSelector:
+            matchLabels:
+              ray.io/allow-head-access: "true"
+        ports:
+        - port: 8265
+          protocol: TCP
 ```
 
 On the `RayJob`, set the same label on the submitter pod via `submitterPodTemplate`:

--- a/doc/source/cluster/kubernetes/user-guides/rayjob-sidecar-submitter-restart.md
+++ b/doc/source/cluster/kubernetes/user-guides/rayjob-sidecar-submitter-restart.md
@@ -1,0 +1,156 @@
+(kuberay-rayjob-sidecar-submitter-restart)=
+# RayJob SidecarSubmitterRestart
+
+`SidecarMode` runs the RayJob submitter as a container inside the Ray head Pod. Unlike `K8sJobMode`, `SidecarMode` does not require pulling a duplicated Ray image and avoids the need for inter-pod communication as the submitter container reaches the head container through localhost. Keeping everything in one Pod also makes it easier for batch schedulers to reason about, and lets KubeRay check the submitter's status from the Pod's container status, which it already watches via its informer cache, instead of polling the Ray dashboard on every reconciliation. Compared to `HTTPMode`, users can also see logs directly in STDOUT/STDERR. Despite these benefits, it couples the submitter's lifecycle to the head Pod's. This guide walks through enabling the `SidecarSubmitterRestart` feature gate, which softens that coupling by letting the submitter container recover from transient failures without failing the RayJob. If you are unfamiliar with RayJob and KubeRay, see the {ref}`RayJob Quickstart <kuberay-rayjob-quickstart>` first.
+
+## Prerequisites
+
+* This feature requires Kubernetes v1.35+.
+* KubeRay v1.7.0 or higher.
+* Ray v2.54.0 or higher.
+
+## Behavior and caveats
+
+* The submitter container's `restartPolicy` is set to `OnFailure` at the container level, independent of the head Pod's pod-level `restartPolicy: Never`. A non-zero exit code restarts only the submitter container in place without restarting the `ray-head` container. A failure in the Ray job's own code doesn't make the submitter exit non-zero, so it won't trigger a restart by itself.
+* On restart, the submitter checks the Ray job status first. If the Ray job is still running, the submitter reattaches to the log stream instead of resubmitting, so a dropped log-follow connection doesn't force-kill a running job.
+* The KubeRay operator only validates the API server version. Per the Kubernetes version skew policy, worker node kubelets can be up to 3 minor versions older, so the node running the Ray head Pod must also be on v1.35+. If that kubelet doesn't support `ContainerRestartRules`, the per-container restart policy is silently ignored, and the operator's default 30-second submitter-finished timeout can mark the RayJob `Failed` even though the Ray job is still running.
+* Exceeding `submitterConfig.backoffLimit` still marks the RayJob as failed even if the Ray job itself is still running. The default is 2, and it currently can't be overridden for `SidecarMode` as the KubeRay validating webhook rejects any `submitterConfig` when `submissionMode` is `SidecarMode`.
+
+## Verifying SidecarSubmitterRestart on kind
+
+### Step 1: Create a Kubernetes v1.35+ cluster on kind
+
+```sh
+kind create cluster --name rayjob-test --image kindest/node:v1.35.0
+```
+
+### Step 2: Install the KubeRay operator with `SidecarSubmitterRestart` enabled
+
+```sh
+helm upgrade --install kuberay-operator kuberay/kuberay-operator --version 1.7.0 \
+  --set "featureGates[0].name=SidecarSubmitterRestart" \
+  --set "featureGates[0].enabled=true"
+```
+
+### Step 3: Create a long-running RayJob in `SidecarMode`
+
+The job runs for ~5 minutes so there is time to simulate a crash mid-run.
+
+```sh
+kubectl apply -f - <<'EOF'
+apiVersion: ray.io/v1
+kind: RayJob
+metadata:
+  name: rayjob-sidecar-restart
+spec:
+  submissionMode: SidecarMode
+  entrypoint: python /home/ray/samples/sample_code.py
+  rayClusterSpec:
+    rayVersion: '2.56.0'
+    headGroupSpec:
+      rayStartParams: {}
+      template:
+        spec:
+          containers:
+          - name: ray-head
+            image: rayproject/ray:2.56.0
+            resources:
+              limits:
+                cpu: "1"
+                memory: "5Gi"
+            volumeMounts:
+            - mountPath: /home/ray/samples
+              name: code-sample
+          volumes:
+          - name: code-sample
+            configMap:
+              name: ray-job-code-sample
+    workerGroupSpecs:
+    - replicas: 1
+      groupName: small-group
+      rayStartParams: {}
+      template:
+        spec:
+          containers:
+          - name: ray-worker
+            image: rayproject/ray:2.56.0
+            resources:
+              limits:
+                cpu: "1"
+                memory: "1Gi"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ray-job-code-sample
+data:
+  sample_code.py: |
+    import ray, time
+    ray.init()
+
+    @ray.remote
+    class Counter:
+        def __init__(self):
+            self.count = 0
+        def inc(self):
+            self.count += 1
+        def get(self):
+            return self.count
+
+    c = Counter.remote()
+    for _ in range(5):
+        ray.get(c.inc.remote())
+        print(f"count={ray.get(c.get.remote())}")
+
+    print("Entering long-running phase...")
+    for i in range(300):
+        ray.get(c.inc.remote())
+        if i % 30 == 0:
+            print(f"tick={i}")
+        time.sleep(1)
+    print("Done.")
+EOF
+```
+
+### Step 4: Simulate a submitter crash
+
+Wait until `jobDeploymentStatus` is `Running`, then force-stop the submitter container to mimic a transient failure:
+
+```sh
+JOB_ID=$(kubectl get rayjob rayjob-sidecar-restart -o jsonpath='{.status.jobId}')
+CLUSTER=$(kubectl get rayjob rayjob-sidecar-restart -o jsonpath='{.status.rayClusterName}')
+HEAD_POD=$(kubectl get pods -l ray.io/cluster=$CLUSTER,ray.io/node-type=head -o jsonpath='{.items[0].metadata.name}')
+CONTAINER_ID=$(kubectl get pod $HEAD_POD \
+  -o jsonpath='{.status.containerStatuses[?(@.name=="ray-job-submitter")].containerID}' \
+  | sed 's|containerd://||')
+
+docker exec rayjob-test-control-plane crictl stop $CONTAINER_ID
+```
+
+### Step 5: Verify recovery
+
+The submitter container should restart and reattach to the log stream. The RayJob should remain `Running`:
+
+```sh
+# restartCount for ray-job-submitter should increment to 1 while ray-head should remain 0
+kubectl get pod $HEAD_POD \
+  -o jsonpath='{range .status.containerStatuses[*]}{.name}{" restartCount="}{.restartCount}{"\n"}{end}'
+# ray-head restartCount=0
+# ray-job-submitter restartCount=1
+
+# RayJob deployment status should still be Running
+kubectl get rayjob rayjob-sidecar-restart -o jsonpath='{.status.jobDeploymentStatus}'
+
+# Ray job should still be RUNNING with the same job ID
+kubectl exec $HEAD_POD -c ray-head -- \
+  ray job status --address=http://127.0.0.1:8265 "$JOB_ID"
+```
+
+### Step 6: Clean up
+
+```sh
+kubectl delete rayjob rayjob-sidecar-restart
+kubectl delete configmap ray-job-code-sample
+helm uninstall kuberay-operator
+kind delete cluster --name rayjob-test
+```

--- a/doc/source/cluster/kubernetes/user-guides/rayservice-incremental-upgrade.md
+++ b/doc/source/cluster/kubernetes/user-guides/rayservice-incremental-upgrade.md
@@ -314,7 +314,7 @@ status:
 
 ## How to upgrade safely?
 
-Since this feature is alpha and rollback is not yet supported, we recommend conservative parameter settings to minimize risk during upgrades.
+Since this feature is beta and remains open to adjustments based on feedback, we recommend conservative parameter settings to minimize risk during upgrades.
 
 ### Recommended Parameters
 
@@ -374,6 +374,59 @@ upgradeStrategy:
   intervalSeconds: 60  # Wait 1 minute between steps
 ```
 
+## Rollback
+
+RayService incremental upgrades support rollback, which is triggered when you update the `RayService` spec during an ongoing upgrade. Rollback requires KubeRay v1.7.0 or later.
+
+### Rollback Behavior
+
+The KubeRay controller tracks three `RayCluster` specs at any given time:
+
+- Original `RayCluster` spec `A`: the spec of the active cluster that served traffic before the upgrade started.
+- Upgraded `RayCluster` spec `B`: the spec of the pending cluster that the in-progress upgrade migrates to.
+- Desired `RayCluster` spec `C`: the latest spec in the `RayService` CR.
+
+When you modify `rayClusterConfig` in the `RayService` spec during an upgrade, the rollback behavior depends on how the desired spec `C` relates to the original spec `A` and the upgraded spec `B`:
+
+**Case 1: `C == A` (reverting to the original spec)**
+
+The controller cancels the upgrade and gradually shifts traffic back to the original cluster, moving `stepSizePercent` of traffic every `intervalSeconds`. In step with the traffic shift, it scales the original cluster's `targetCapacity` back up to 100% and the pending cluster's down to 0%, `maxSurgePercent` at a time, then deletes the pending cluster.
+
+Pipeline: `A -> B -> A`
+
+**Case 2: `C == B` (canceling the rollback and resuming the upgrade)**
+
+If a rollback is in progress, the controller cancels it and resumes migrating traffic toward `B` from the current traffic split. If no rollback has started, the upgrade is on track and continues unchanged.
+
+Pipeline: `A -> B -> A -> B`, where the trailing `A -> B` is the resumed upgrade.
+
+**Case 3: `C != A` and `C != B` (submitting a new spec)**
+
+The controller first completes the rollback to `A` as defined in **Case 1**, then begins a fresh upgrade toward `C`.
+
+Pipeline: `A -> B -> A -> C`
+
+As the KubeRay controller adopts a safe rollback-first approach, a known-good cluster serves 100% of traffic before the controller provisions a cluster for `C`. This approach keeps the resource ceiling at 100% plus `maxSurgePercent` and never runs two pending clusters at once, at the cost of a longer end-to-end migration.
+
+While the `RollbackInProgress` condition is `True`, KubeRay also:
+
+- Doesn't promote the pending cluster to active, even if the pending cluster reaches 100% `targetCapacity` and `trafficRoutedPercent`.
+- Doesn't submit an updated `serveConfigV2` to the pending cluster, because that cluster only drains its traffic before deletion. KubeRay applies `serveConfigV2` updates to the active cluster instead.
+- Doesn't create a new pending cluster until the rollback completes.
+
+## What triggers an upgrade or rollback?
+
+There are two types of changes in the `RayService` spec:
+
+| Change | Trigger | Behavior |
+|--------|---------|-----------|
+| `rayClusterConfig` (for example, `image` or `resources`) | Upgrade or rollback | Creates a new pending cluster and gradually migrates traffic (upgrade), or switches traffic back to the original cluster (rollback) |
+| `serveConfigV2` | In-place update | Updates the running deployment directly without creating a new cluster or shifting traffic |
+
+:::{note}
+If both `rayClusterConfig` and `serveConfigV2` change simultaneously, the `rayClusterConfig` change takes precedence. Therefore, KubeRay creates a new pending cluster and applies the updated `serveConfigV2` to it.
+:::
+
 ## API Overview (Reference)
 
 This section details the new and updated fields in the `RayService` CRD.
@@ -405,6 +458,15 @@ Three new fields are added to both the `activeServiceStatus` and `pendingService
 | `targetCapacity` | `int32` | The target percentage of Serve replicas this cluster is *configured* to handle (from 0 to 100). This is controlled by KubeRay based on `maxSurgePercent`. |
 | `trafficRoutedPercent` | `int32` | The *actual* percentage of traffic (from 0 to 100) currently being routed to this cluster's endpoint. This is controlled by KubeRay during an upgrade based on `stepSizePercent` and `intervalSeconds`. |
 | `lastTrafficMigratedTime` | `metav1.Time` | A timestamp indicating the last time `trafficRoutedPercent` was updated. |
+
+### `RayService.status.conditions`
+
+These conditions track the state machine that drives an incremental upgrade and its rollback.
+
+| Condition | Description |
+| :--- | :--- |
+| `UpgradeInProgress` | `True` while both an active and a pending `RayCluster` exist for the `RayService`. KubeRay sets this condition to `False` with reason `NoPendingCluster` after it promotes the pending cluster, or after a rollback finishes and it deletes the pending cluster. |
+| `RollbackInProgress` | `True` while KubeRay is rolling an in-progress incremental upgrade back to the original active cluster, with reason `DesiredClusterSpecChanged`. KubeRay removes this condition when the rollback completes, that is, when the active cluster is back at 100% `trafficRoutedPercent` and KubeRay has deleted the pending cluster, or when you revert the spec back to the pending cluster's spec to cancel the rollback. |
 
 #### Next steps:
 * See [Deploy on Kubernetes](https://docs.ray.io/en/latest/serve/production-guide/kubernetes.html) for more information about deploying Ray Serve with KubeRay.

--- a/doc/source/cluster/kubernetes/user-guides/rayservice-incremental-upgrade.md
+++ b/doc/source/cluster/kubernetes/user-guides/rayservice-incremental-upgrade.md
@@ -103,7 +103,7 @@ spec:
 
 6. Install the KubeRay operator, following [these instructions](https://docs.ray.io/en/latest/cluster/kubernetes/getting-started/kuberay-operator-installation.html). The minimum version for this guide is v1.5.1. To use this feature, the `RayServiceIncrementalUpgrade` feature gate must be enabled. To enable the feature gate when installing the kuberay operator, run the following command:
 ```bash
-helm install kuberay-operator kuberay/kuberay-operator --version v1.6.0 \
+helm install kuberay-operator kuberay/kuberay-operator --version v1.7.0 \
   --set featureGates\[0\].name=RayServiceIncrementalUpgrade \
   --set featureGates\[0\].enabled=true
 ```

--- a/doc/source/cluster/kubernetes/user-guides/rayservice.md
+++ b/doc/source/cluster/kubernetes/user-guides/rayservice.md
@@ -4,7 +4,7 @@
 
 ## Prerequisites
 
-This guide mainly focuses on the behavior of KubeRay v1.4.0 and Ray 2.46.0.
+This guide mainly focuses on the behavior of KubeRay v1.7.0 and Ray 2.46.0.
 
 ## What's a RayService?
 
@@ -35,7 +35,7 @@ Follow [this document](kuberay-operator-deploy) to install the latest stable Kub
 ## Step 3: Install a RayService
 
 ```sh
-curl -O https://raw.githubusercontent.com/ray-project/kuberay/v1.6.0/ray-operator/config/samples/ray-service.sample.yaml
+curl -O https://raw.githubusercontent.com/ray-project/kuberay/v1.7.0/ray-operator/config/samples/ray-service.sample.yaml
 kubectl apply -f ray-service.sample.yaml
 ```
 
@@ -196,7 +196,7 @@ curl -X POST -H 'Content-Type: application/json' rayservice-sample-serve-svc:800
 
 You can update the configurations for the applications by modifying `serveConfigV2` in the RayService configuration file. Reapplying the modified configuration with `kubectl apply` reapplies the new configurations to the existing RayCluster instead of creating a new RayCluster.
 
-Update the price of Mango from `3` to `4` for the fruit stand app in [ray-service.sample.yaml](https://github.com/ray-project/kuberay/blob/v1.6.0/ray-operator/config/samples/ray-service.sample.yaml). This change reconfigures the existing MangoStand deployment, and future requests are going to use the updated mango price.
+Update the price of Mango from `3` to `4` for the fruit stand app in [ray-service.sample.yaml](https://github.com/ray-project/kuberay/blob/v1.7.0/ray-operator/config/samples/ray-service.sample.yaml). This change reconfigures the existing MangoStand deployment, and future requests are going to use the updated mango price.
 
 ```sh
 # Step 7.1: Update the price of mangos from 3 to 4.

--- a/doc/source/cluster/kubernetes/user-guides/tls.md
+++ b/doc/source/cluster/kubernetes/user-guides/tls.md
@@ -32,7 +32,7 @@ your CA private key in a Kubernetes Secret in your production environment.
 # `ray-cluster.tls.yaml` will cover from Step 1 to Step 3
 
 # Download `ray-cluster.tls.yaml`
-curl -LO https://raw.githubusercontent.com/ray-project/kuberay/v1.6.0/ray-operator/config/samples/ray-cluster.tls.yaml
+curl -LO https://raw.githubusercontent.com/ray-project/kuberay/v1.7.0/ray-operator/config/samples/ray-cluster.tls.yaml
 
 # Create a RayCluster
 kubectl apply -f ray-cluster.tls.yaml
@@ -76,11 +76,11 @@ kubectl create secret generic ca-tls --from-file=ca.key --from-file=ca.crt
 * `ca.key`: CA's private key
 * `ca.crt`: CA's self-signed certificate
 
-This step is optional because the `ca.key` and `ca.crt` files have already been included in the Kubernetes Secret specified in [ray-cluster.tls.yaml](https://github.com/ray-project/kuberay/blob/v1.6.0/ray-operator/config/samples/ray-cluster.tls.yaml).
+This step is optional because the `ca.key` and `ca.crt` files have already been included in the Kubernetes Secret specified in [ray-cluster.tls.yaml](https://github.com/ray-project/kuberay/blob/v1.7.0/ray-operator/config/samples/ray-cluster.tls.yaml).
 
 # Step 2: Create separate private key and self-signed certificate for Ray Pods
 
-In [ray-cluster.tls.yaml](https://github.com/ray-project/kuberay/blob/v1.6.0/ray-operator/config/samples/ray-cluster.tls.yaml), each Ray Pod (both head and workers) generates its own private key file (`tls.key`) and self-signed certificate file (`tls.crt`) in its init container. We generate separate files for each Pod because worker Pods do not have deterministic DNS names, and we cannot use the same certificate across different Pods.
+In [ray-cluster.tls.yaml](https://github.com/ray-project/kuberay/blob/v1.7.0/ray-operator/config/samples/ray-cluster.tls.yaml), each Ray Pod (both head and workers) generates its own private key file (`tls.key`) and self-signed certificate file (`tls.crt`) in its init container. We generate separate files for each Pod because worker Pods do not have deterministic DNS names, and we cannot use the same certificate across different Pods.
 
 In the YAML file, you'll find a ConfigMap named `tls` that contains two shell scripts: `gencert_head.sh` and `gencert_worker.sh`. These scripts are used to generate the private key and self-signed certificate files (`tls.key` and `tls.crt`) for the Ray head and worker Pods. An alternative approach for users is to prebake the shell scripts directly into the docker image that's utilized by the init containers, rather than relying on a ConfigMap.
 

--- a/doc/source/cluster/kubernetes/user-guides/upgrade-guide.md
+++ b/doc/source/cluster/kubernetes/user-guides/upgrade-guide.md
@@ -39,16 +39,16 @@ To upgrade the KubeRay version, follow these steps in order:
 2. Upgrade the kuberay-operator image to the new version.
 3. Verify the success of the upgrade.
 
-The following is an example of upgrading KubeRay from v1.3.X to v1.4.0:
+The following is an example of upgrading KubeRay to v1.7.0:
 ```
-# Upgrade the CRD to v1.6.0.
+# Upgrade the CRD to v1.7.0.
 # Note: This example uses kubectl because Helm doesn't support lifecycle management of CRDs.
 # See the Helm documentation for more details: https://helm.sh/docs/chart_best_practices/custom_resource_definitions/#some-caveats-and-explanations
-$ kubectl replace -k "github.com/ray-project/kuberay/ray-operator/config/crd?ref=v1.6.0"
+$ kubectl replace -k "github.com/ray-project/kuberay/ray-operator/config/crd?ref=v1.7.0"
 
-# Upgrade kuberay-operator to v1.6.0. This step doesn't upgrade the CRDs.
-$ helm upgrade kuberay-operator kuberay/kuberay-operator --version v1.6.0
+# Upgrade kuberay-operator to v1.7.0. This step doesn't upgrade the CRDs.
+$ helm upgrade kuberay-operator kuberay/kuberay-operator --version v1.7.0
 
-# Install a RayCluster using the v1.6.0 helm chart to verify the success of the upgrade.
-$ helm install raycluster kuberay/ray-cluster --version 1.6.0
+# Install a RayCluster using the v1.7.0 helm chart to verify the success of the upgrade.
+$ helm install raycluster kuberay/ray-cluster --version 1.7.0
 ```

--- a/python/ray/autoscaler/kuberay/init-config.sh
+++ b/python/ray/autoscaler/kuberay/init-config.sh
@@ -4,8 +4,8 @@ set -euo pipefail
 
 # Clone pinned KubeRay commit to temporary directory, copy the CRD definitions
 # into the autoscaler folder.
-KUBERAY_BRANCH="v1.6.0"
-OPERATOR_TAG="v1.6.0"
+KUBERAY_BRANCH="v1.7.0"
+OPERATOR_TAG="v1.7.0"
 
 # Requires Kustomize
 if ! command -v kustomize &> /dev/null

--- a/release/k8s_tests/run_gcs_ft_on_k8s.py
+++ b/release/k8s_tests/run_gcs_ft_on_k8s.py
@@ -51,7 +51,7 @@ def generate_cluster_variable():
 
 def check_kuberay_installed():
     # Make sure the ray namespace exists
-    KUBERAY_VERSION = "v1.6.0"
+    KUBERAY_VERSION = "v1.7.0"
     uri = (
         "github.com/ray-project/kuberay/manifests"
         f"/base?ref={KUBERAY_VERSION}&timeout=90s"


### PR DESCRIPTION
## Why

The [KubeRay v1.7 blog](https://www.anyscale.com/blog/kuberay-v1-7) highlights several features whose docs currently live only on `master`. The corresponding pages are missing (404) or incomplete on the `latest` (2.58.0) docs build, and several blog links point at `/master` as a result. This backports the doc pages so the 2.58.0 `latest` docs cover the released KubeRay v1.7 surface.

## What (cherry-picks onto `releases/2.58.0`)

| Commit | Blog feature | Gap on `latest` |
|---|---|---|
| #64303 | RayJob `SidecarMode` retry | new page was missing |
| #65249 | RayService incremental upgrade rollback (beta) | `#rollback` section missing |
| #65074 | NetworkPolicy support (alpha) | new page was missing |
| #65429 | Embedded RocksDB GCS backend | example version pin missing |
| #65513 | Fix docs for KubeRay v1.7 | wrong NetworkPolicy field names + incorrect `kubernetes` pip guidance |
| #65483 | Customizable Ingress options | `ingressOptions` undocumented |

Each commit is applied with `cherry-pick -x` (provenance preserved) and DCO sign-off.

## Not duplicating

- No open PR cherry-picks these into `releases/2.58.0` (checked by PR number and by `--base releases/2.58.0`).
- The two History Server refinements (#65441, #65505) are intentionally **excluded** — they already landed on `releases/2.58.0` (`c6061c10b97`, `d8277b53b0d`) and that page is already identical to `master`.
- Broad, non-feature changes touching these files on `master` (llms.txt page descriptions #65115, the "Ray Pod" terminology rename #65423, the vendored CRD API reference #65428) are deliberately left out to keep this a tight, low-risk release-branch backport.

## Testing

- Verified every new/changed page's `{ref}`/`{doc}` cross-reference target resolves on this branch (`fail_on_warning: true` build safety).
- Verified both new toctree entries (`network-policy`, `rayjob-sidecar-submitter-restart`) point at files that exist on the branch.
- Confirmed each touched file matches `master` except for the intentionally-excluded frontmatter/rename hunks above.
- A full local Sphinx docs build is recommended before marking ready for review.

AI assistance (Claude Code) was used to prepare this backport.
