### PR TITLE
[tune] Make the quantized integer upper bound reachable

### DIFF
--- a/python/ray/tune/search/sample.py
+++ b/python/ray/tune/search/sample.py
@@ -576,6 +576,15 @@ class Quantized(Sampler):
         quantized_domain = copy(domain)
         quantized_domain.lower = np.ceil(domain.lower / self.q) * self.q
         quantized_domain.upper = np.floor(domain.upper / self.q) * self.q
+        if isinstance(domain, Integer):
+            # `Integer` sampling is upper-exclusive, but the bounds above are grid
+            # points and quantization documents the upper one as inclusive, so pass
+            # the exclusive equivalent. Without it the draw stops one short of the
+            # top grid point, which is then only reachable by rounding up, and
+            # `np.round` (half to even) rounds the other way for some (upper, q):
+            # `qrandint(2, 10, 2)` never returns 10. A grid with a single point has
+            # nothing left to draw at all and raises `ValueError: low >= high`.
+            quantized_domain.upper = quantized_domain.upper + 1
         values = self.sampler.sample(
             quantized_domain, config, size, random_state=random_state
         )

--- a/python/ray/tune/tests/test_sample.py
+++ b/python/ray/tune/tests/test_sample.py
@@ -437,6 +437,40 @@ class SearchSpaceTest(unittest.TestCase):
         samples = ray.tune.search.sample.Float(0, 33).quantized(3).sample(size=1000)
         self.assertTrue(all(0 <= s <= 33 for s in samples))
 
+    def testQuantizedIntegerBounds(self):
+        # qrandint/qlograndint document the upper bound as inclusive, so the top grid
+        # point has to be drawable, and a grid with a single point has to sample at all.
+        random_state = np.random.RandomState(1000)
+
+        for lower, upper, q in [
+            (2, 10, 2),
+            (1, 11, 2),
+            (1, 9, 5),
+            (3, 11, 8),
+            (2, 20, 2),
+        ]:
+            top = (upper // q) * q
+            for name, domain in [
+                ("qrandint", tune.qrandint(lower, upper, q)),
+                ("qlograndint", tune.qlograndint(lower, upper, q)),
+            ]:
+                where = f"{name}({lower}, {upper}, {q})"
+                sampled = {
+                    domain.sample(size=1, random_state=random_state)
+                    for _ in range(2000)
+                }
+                self.assertIn(
+                    top, sampled, msg=f"{where} never sampled its upper bound {top}"
+                )
+                self.assertTrue(
+                    all(lower <= s <= upper for s in sampled),
+                    msg=f"{where} sampled out of bounds",
+                )
+                self.assertTrue(
+                    all(s % q == 0 for s in sampled),
+                    msg=f"{where} sampled off the grid",
+                )
+
     def testCategoricalDtype(self):
         dist = tune.choice([1.0, "str"])
 


### PR DESCRIPTION
## Why this is not a duplicate

I searched the tracker and open PRs for `qrandint`, `qlograndint`, `Quantized`, and `low >= high` and found no issue or PR covering either symptom below.

The one nearby PR is my own #65535, which removes the `if self.q == 1` short circuit in the same method. It is a different defect (quantization not being applied at all when `q == 1`) on different lines, and the two changes are independent. There is one interaction worth flagging: on `master` a `q == 1` integer domain returns from the short circuit before reaching this code, so nothing changes today; if #65535 lands, `tune.qrandint(lower, upper, 1)` would then also become upper-inclusive. That is what its docstring and the searcher converters already say it should be, but it is a behaviour change, so I would rather have it decided explicitly than arrive as a side effect. Happy to rebase whichever of the two lands second.

## The bug

`Quantized.sample()` narrows the domain to the grid it is about to round onto:

```python
quantized_domain.lower = np.ceil(domain.lower / self.q) * self.q
quantized_domain.upper = np.floor(domain.upper / self.q) * self.q
```

Both bounds are grid points, and `qrandint` / `qlograndint` document the upper one as inclusive:

> `lower` is inclusive, `upper` is also inclusive (!). [...] Quantization makes the upper bound inclusive.

`Integer` sampling is upper-exclusive, so the draw stops one short of the top grid point, which is then reachable only by rounding up. `np.round` rounds half to even, and for some `(upper, q)` that sends the last drawable integer the other way.

**1. The upper bound is never sampled.**

```python
>>> rs = np.random.RandomState(0)
>>> collections.Counter(tune.qrandint(2, 10, 2).sample(size=1, random_state=rs) for _ in range(30000))
{2: 3729, 4: 11298, 6: 3778, 8: 11195}          # 10 never appears
```

**2. A grid with a single point raises.**

```python
>>> tune.qrandint(1, 9, 5).sample()             # grid is {5}
ValueError: low >= high
```

Sweeping `q` in 2..8 over `lower` in 1..3 and `upper` in {9, 10, 11, 12, 16, 20, 24}: 36 `qrandint` combinations raise `ValueError`, and 12 combinations (`qrandint` and `qlograndint`, `q = 2`, `upper` in {10, 11}) silently drop their upper bound.

## Why the inclusive reading is the intended one

`test_sample.py` already asserts it for three of its four quantized integer spaces, e.g.

```python
elif k == "qrandint":                    # tune.qrandint(-21, 12, 3)
    for i in range(-21, 13, 3):          # includes 12
        self.assertIn(i, v, msg=f"qrandint failed for i={i}")
```

Those pass only because their `(upper, q)` happen to fall on the parity where the rounding goes the right way.

The searcher converters do it explicitly. From `optuna_search.py`:

```python
# Upper bound should be inclusive for quantization and
# exclusive otherwise
return ot.distributions.IntDistribution(
    domain.lower,
    domain.upper - int(bool(not quantize)),
    step=quantize or 1,
)
```

So today the same `qrandint(2, 10, 2)` space samples `{2, 4, 6, 8, 10}` under `OptunaSearch` and `{2, 4, 6, 8}` under the default `BasicVariantGenerator`.

## The change

Pass the exclusive equivalent of the inclusive bound for integer domains. Float domains are untouched: rounding a continuous draw in `[lower, upper]` already reaches the top grid point.

After the fix, `qrandint(2, 10, 2)` yields `{2: 11%, 4: 33%, 6: 11%, 8: 33%, 10: 11%}` and `qrandint(2, 10, 5)` becomes an even `{5: 50%, 10: 50%}`. The remaining 3:1 spread on `q = 2` is `np.round`'s half-to-even, i.e. sample-then-round behaving as the docstring describes ("rounded to an integer increment of `q`"); flattening it would mean changing the rounding rule, which moves every quantized sample rather than just the endpoint, so I left it alone. `qlograndint` keeps its shape exactly, with only the top point's share changing (`qlograndint(1, 128, 8)`: 128 goes from 336/30000 draws to 434, every other bucket within noise).

## Testing

Added `SearchSpaceTest::testQuantizedIntegerBounds`, which checks that the top grid point is sampled, that nothing lands outside `[lower, upper]`, and that nothing lands off the grid, for five `(lower, upper, q)` triples covering both symptoms and two working controls.

```
$ python -m pytest test_sample.py -k "Quantized or BoundedInt or BoundedFloat or Categorical"

# before
E  AssertionError: 10 not found in {8, 2, 4, 6} : qrandint(2, 10, 2) never sampled its upper bound 10
1 failed, 7 passed, 40 deselected in 18.95s

# after
8 passed, 40 deselected in 17.32s
```

Controls, run before and after so the change is a no-op for them:

```
$ python -m pytest test_sample.py -k "SampleBoundsRandom or Reproducibility"
3 passed, 45 deselected      # before
3 passed, 45 deselected      # after
```

Separately, a sweep of 294 `(lower, upper, q)` combinations of `qrandint` / `qlograndint` with the patch applied: no exceptions, the top grid point reachable in every one, and no sample outside `[lower, upper]` or off the grid.

The searcher-specific `testConvert*` / `testSampleBounds*` cases need optional searcher packages that are not installed here, so I did not run them; they do not touch `Quantized.sample`.

## Note on tooling

AI assistance was used in preparing this change.
