### PR TITLE
[ci] Correct the docs-go scope guard for release backports and repo-root agent files

### DIFF
--- a/.buildkite/always.rules.test.txt
+++ b/.buildkite/always.rules.test.txt
@@ -21,8 +21,12 @@ doc/README.md: always
 doc/source/images/ray-logo.png: always
 doc/source/data/images/dataset-arch.svg: always
 
-# Claude Code skills and agent files participate in no build.
+# Claude Code skills and agent files participate in no build. This holds for
+# both the doc subtree and the repo-root .claude/, which is Markdown plus a
+# settings JSON with no target of its own.
 doc/.claude/skills/sphinx-fix/SKILL.md: always
+.claude/skills/backport-docs/SKILL.md: always
+.claude/settings.json: always
 
 # Executable and config assets under doc/ are deliberately NOT exempt: they can
 # carry code that the code-oriented checks lint. pre_commit is the only

--- a/.buildkite/always.rules.txt
+++ b/.buildkite/always.rules.txt
@@ -50,10 +50,13 @@
 # at all.
 #
 # The path set matches the prose skip rule in test.rules.txt so the two files
-# agree on what prose is. Keep them in sync when either changes. doc/.claude/
-# holds Claude Code skills and agent files, which participate in no build and
-# define no targets.
+# agree on what prose is. Keep them in sync when either changes. Both cover the
+# doc subtree (doc/.claude/) and the repo-root .claude/, which is Markdown plus
+# a settings JSON: Claude Code skills and agent files that participate in no
+# build and define no targets, so they carry `always` without `lint` just like
+# the prose below.
 doc/.claude/
+.claude/
 doc/*.md
 doc/*.rst
 doc/*.png

--- a/.buildkite/test.rules.test.txt
+++ b/.buildkite/test.rules.test.txt
@@ -112,8 +112,11 @@ doc/source/ray-core/examples/highly_parallel.ipynb: doc
 doc/external/test_hashes.py: ml_doc
 doc/external/pytorch_tutorials_hyperparameter_tuning_tutorial.py: ml_doc
 # Claude Code skills and agent files trigger nothing, matching the RtD guard.
+# This holds for both the doc subtree and the repo-root .claude/.
 doc/.claude/skills/sphinx-fix/sphinx_fix.py:
 doc/.claude/agents/reviewer.md:
+.claude/skills/backport-docs/SKILL.md:
+.claude/settings.json:
 doc/source/llm/doc_code/example.py: llm
 # Unowned doc dirs and doc-root executables fall to the core docs example step.
 doc/source/cluster/example.py: core_doc

--- a/.buildkite/test.rules.txt
+++ b/.buildkite/test.rules.txt
@@ -80,11 +80,15 @@ doc/source/ray-observability/reference/
 # library's docs example step. Config assets that examples consume (.yaml, .sh)
 # are deliberately absent: they can change what a test does, so they keep
 # routing to the owning library below.
-# Claude Code skills and agent files under doc/.claude/ never participate in
-# the Sphinx build and define no test targets, so they trigger nothing. This
-# matches the RtD build guard, which excludes the same path for the same reason
-# (see the `:!doc/.claude/` exclude in .readthedocs.yaml).
+# Claude Code skills and agent files never participate in the Sphinx build and
+# define no test targets, so they trigger nothing. This covers both the doc
+# subtree (doc/.claude/, which also matches the `:!doc/.claude/` exclude in
+# .readthedocs.yaml) and the repo-root .claude/, which is Markdown plus a
+# settings JSON with no target of its own. Routing them here, ahead of the
+# catch-all, keeps an agent-file edit from fanning out to the full test suite
+# and lets the docs-go scope guard treat them as content.
 doc/.claude/
+.claude/
 doc/*.md
 doc/*.rst
 doc/*.png

--- a/ci/lint/validate_docs_go_scope.sh
+++ b/ci/lint/validate_docs_go_scope.sh
@@ -7,8 +7,9 @@
 # content-only change they must still cover.) Skipping is only safe when the PR
 # really is documentation content. This guard runs whenever the label is present
 # and fails the build unless every changed file is documentation content:
-# anything under doc/, the Vale prose-lint configuration at the repo root, or
-# the API-consistency checker's own source under ci/ray_ci/doc/ -- in every case
+# anything under doc/, the Claude Code agent files at the repo root under
+# .claude/, the Vale prose-lint configuration at the repo root, or the
+# API-consistency checker's own source under ci/ray_ci/doc/ -- in every case
 # excluding BUILD files (which define test targets and must not be changed under
 # a test-skipping label). It cannot tell an editorial edit from a code edit
 # inside a doc file; that judgment stays with the author and is backstopped by
@@ -36,6 +37,15 @@
 # `doc_api` API checks, and the `tools` job that runs the six ci_unit py_test
 # targets declared here. Editing the checker therefore still runs the checker
 # and its own unit tests, with or without the label.
+#
+# Why the repo-root .claude/ counts, on the same argument as doc/.claude/. These
+# are Claude Code skills and agent files: Markdown plus a settings JSON, no bazel
+# target and no executable Ray code, so nothing the label skips can be affected
+# by them. test.rules.txt routes the repo-root .claude/ to no tags at all,
+# alongside doc/.claude/ and ahead of the catch-all, so a change confined to it
+# selects no step in the first place and the label can only subtract from an
+# empty set. This keeps a doc PR that also updates an agent skill on the fast
+# path instead of forcing a split, matching how doc/.claude/ is already treated.
 #
 # This list is deliberately narrow. For Vale it covers the prose rules
 # themselves, not the CI wiring that runs them: ci/lint/check-documentation-style.sh
@@ -67,10 +77,10 @@ if [[ -z "${changed}" ]]; then
   exit 1
 fi
 
-# Paths that count as documentation content: everything under doc/, the Vale
-# prose-lint configuration at the repo root, and the API-consistency checker's
-# own source.
-in_scope_re='^doc/|^\.vale\.ini$|^\.vale/|^ci/ray_ci/doc/'
+# Paths that count as documentation content: everything under doc/, the
+# repo-root Claude Code agent files under .claude/, the Vale prose-lint
+# configuration at the repo root, and the API-consistency checker's own source.
+in_scope_re='^doc/|^\.claude/|^\.vale\.ini$|^\.vale/|^ci/ray_ci/doc/'
 
 # Anything outside that set is out of scope for a content-only PR.
 out_of_scope="$(printf '%s\n' "${changed}" | grep -vE "${in_scope_re}" || true)"
@@ -79,7 +89,7 @@ out_of_scope="$(printf '%s\n' "${changed}" | grep -vE "${in_scope_re}" || true)"
 build_edits="$(printf '%s\n' "${changed}" | grep -E '(^|/)BUILD(\.bazel)?$' | grep -E "${in_scope_re}" || true)"
 
 if [[ -n "${out_of_scope}" || -n "${build_edits}" ]]; then
-  echo "The 'docs-go' label is only valid on content-only PRs: changes under doc/, to the Vale configuration (.vale.ini, .vale/), or to the API-consistency checker (ci/ray_ci/doc/), excluding BUILD files."
+  echo "The 'docs-go' label is only valid on content-only PRs: changes under doc/, to the repo-root Claude Code agent files (.claude/), to the Vale configuration (.vale.ini, .vale/), or to the API-consistency checker (ci/ray_ci/doc/), excluding BUILD files."
   echo
   if [[ -n "${out_of_scope}" ]]; then
     echo "Out-of-scope files (not documentation content):"
@@ -99,5 +109,5 @@ if [[ -n "${out_of_scope}" || -n "${build_edits}" ]]; then
   exit 1
 fi
 
-echo "docs-go scope OK: all changed files are documentation content (under doc/, Vale configuration, or ci/ray_ci/doc/, excluding BUILD files)."
+echo "docs-go scope OK: all changed files are documentation content (under doc/, repo-root .claude/ agent files, Vale configuration, or ci/ray_ci/doc/, excluding BUILD files)."
 printf '%s\n' "${changed}" | sed 's/^/  /'

--- a/ci/lint/validate_docs_go_scope.sh
+++ b/ci/lint/validate_docs_go_scope.sh
@@ -55,7 +55,7 @@ set -uo pipefail
 # ci/pipeline/determine_tests_to_run.py.
 base_branch="${BUILDKITE_PULL_REQUEST_BASE_BRANCH:-master}"
 
-git fetch --depth=500 origin "${base_branch}" >/dev/null 2>&1 || true
+git fetch -q --depth=500 origin "${base_branch}" || true
 if ! base="$(git merge-base "origin/${base_branch}" HEAD 2>/dev/null)"; then
   echo "docs-go scope guard: could not determine merge-base with origin/${base_branch}; failing closed."
   exit 1

--- a/ci/lint/validate_docs_go_scope.sh
+++ b/ci/lint/validate_docs_go_scope.sh
@@ -46,9 +46,18 @@
 
 set -uo pipefail
 
-git fetch --depth=500 origin master >/dev/null 2>&1 || true
-if ! base="$(git merge-base origin/master HEAD 2>/dev/null)"; then
-  echo "docs-go scope guard: could not determine merge-base with origin/master; failing closed."
+# Diff against the PR's actual base branch, not a hardcoded master. On a
+# release-branch backport the merge-base with master is where the release
+# branch diverged, so diffing against master attributes every release-only
+# change to the PR and the guard fails a genuinely content-only backport.
+# BUILDKITE_PULL_REQUEST_BASE_BRANCH is the base the PR targets; fall back to
+# master for local runs, matching ci/lint/lint.sh and
+# ci/pipeline/determine_tests_to_run.py.
+base_branch="${BUILDKITE_PULL_REQUEST_BASE_BRANCH:-master}"
+
+git fetch --depth=500 origin "${base_branch}" >/dev/null 2>&1 || true
+if ! base="$(git merge-base "origin/${base_branch}" HEAD 2>/dev/null)"; then
+  echo "docs-go scope guard: could not determine merge-base with origin/${base_branch}; failing closed."
   exit 1
 fi
 


### PR DESCRIPTION
Two related corrections that keep the `docs-go` scope guard from false-failing genuinely content-only PRs.

## 1. Diff against the PR base branch, not a hardcoded master

`ci/lint/validate_docs_go_scope.sh` computed its diff base as the merge-base with a hardcoded `origin/master`. On a release-branch backport (base `releases/X.Y`), that merge-base is where the release branch diverged from master, so the diff includes every change that landed on the release branch but not on master. A genuinely content-only doc backport then gets flagged with the release branch's non-doc changes and the guard fails a valid PR.

Concretely, a doc-only backport onto `releases/2.58.0` that changed 9 files under `doc/` was flagged with 181 out-of-scope C++/CI/Java files — all release-branch changes, none in the PR.

Diff against `${BUILDKITE_PULL_REQUEST_BASE_BRANCH:-master}` instead, matching `ci/lint/lint.sh` and `ci/pipeline/determine_tests_to_run.py`. On a normal PR the base is `master`, so behavior is unchanged; on a backport it scopes to the files the PR actually adds.

## 2. Treat repo-root `.claude/` agent files as content

A PR that updates a Claude Code skill or agent file at the repo root (`.claude/`) alongside a doc change was also failing the guard, because `.claude/` is outside `doc/`.

Repo-root `.claude/` is Markdown plus a settings JSON: no bazel target, no executable Ray code, nothing a doc or example test runs. It gets the same treatment `doc/.claude/` already has:

- `test.rules.txt` routes repo-root `.claude/` to no tags, ahead of the catch-all, so an agent-file edit stops fanning out to the full test suite.
- The scope guard accepts `.claude/` as content, so a doc-plus-agent-file PR keeps the fast path instead of being forced to split.

Fixture cases added in `test.rules.test.txt` for a repo-root skill file and `settings.json`.

## Verification

- Base-branch fix: simulated against the `releases/2.58.0` backport — with the release base the guard sees exactly the 9 doc files and passes, versus 209 files / 181 non-doc under the old master-based diff.
- `.claude/` scope: the guard passes for the exact file set of a doc-plus-skill PR (`.claude/skills/.../SKILL.md` + three `doc/` files); the rules parser confirms repo-root `.claude/` files match and emit no tags, while a `src/ray/*.cc` control still fans out to the full suite.
- Also switched the base fetch to `git fetch -q ... || true` so a real fetch failure surfaces instead of the generic downstream error (reviewer feedback).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
