### PR TITLE
[cherry-pick][2.58.0][docs] Style pass on the Ray Sandboxes networking section (#65627)

### DIFF
--- a/doc/source/ray-core/sandboxes.md
+++ b/doc/source/ray-core/sandboxes.md
@@ -184,7 +184,7 @@ ray.get(pool.close.remote())
 
 ### Pass custom OCI configurations to gVisor
 
-For advanced workloads, you might need to configure low-level runtime options such as custom host mounts, Linux capabilities, or custom network and DNS settings. Use the `_oci_spec_transform_fn` parameter to inspect and modify the generated [OCI runtime specification](https://github.com/opencontainers/runtime-spec) dictionary before Ray passes it to gVisor (`runsc`).
+For advanced workloads, you might need to configure low-level runtime options such as custom host mounts, Linux capabilities, or custom network and DNS settings. Use the `_oci_spec_transform_fn` parameter to inspect and modify the generated [Open Container Initiative (OCI) runtime specification](https://github.com/opencontainers/runtime-spec) dictionary before Ray passes it to gVisor (`runsc`).
 
 :::{note}
 `_oci_spec_transform_fn` is an experimental hook for advanced use cases. The Ray project is designing first-class configuration APIs for Ray Sandboxes, such as higher-level volume mount and capability abstractions, and this hook is likely to change once those land. To help shape them, open an issue describing your use case.
@@ -195,7 +195,7 @@ The `_oci_spec_transform_fn` callable receives the fully generated OCI specifica
 * **Host mounts**: Mount host directories, read-only datasets, or model weights into the sandbox container.
 * **Namespace and mount details**: Configure namespace or mount behavior that the first-class options don't cover.
 
-Internet access, DNS, and Linux capabilities each have a first-class option: `network=`, `dns=`, and `capabilities=`. Pass `capabilities=[]` to run with no capabilities at all. Reserve the hook for network or capability configurations those options don't reach. See [Networking and DNS](#networking-and-dns).
+Internet access, DNS, and Linux capabilities each have a first-class option: `network`, `dns`, and `capabilities`. Pass `capabilities=[]` to run with no capabilities at all. Reserve the hook for network or capability configurations those options don't reach. See [Networking and DNS](#networking-and-dns).
 
 ```python
 import ray
@@ -245,7 +245,7 @@ Sandboxes support four network modes. The default is `none`, which follows the s
 | --- | --- | --- | --- |
 | `none` *(default)* | None | untouched | No egress. |
 | `public` | Host egress | Generated from `dns` (default `8.8.8.8`, `1.1.1.1`), mounted read-only | Egress works, but the sandbox inherits nothing from the host's resolver configuration. No internal search domains, resolver addresses, or `ndots` options leak in, and the sandbox config stays portable across clusters. |
-| `host` | Full host network identity | Host's own file, mounted read-only (`dns=` overrides it) | Strictly more permissive than `public`. The sandbox can reach anything the node can reach, including internal networks and node-local services. Use `public` for untrusted code. |
+| `host` | Full host network identity | Host's own file, mounted read-only (`dns` overrides it) | Strictly more permissive than `public`. The sandbox can reach anything the node can reach, including internal networks and node-local services. Use `public` for untrusted code. |
 | `sandbox` | gVisor netstack | untouched | Requires `rootless=False`. runsc doesn't support the sandbox netstack in rootless mode. |
 
 To give a sandbox internet access, use `network="public"`. Pair it with `DOCKER_DEFAULT_CAPABILITIES` so standard images behave the way they do under Docker, because `apt-get`, `tar` ownership restore, and similar operations all need those capabilities:
@@ -264,7 +264,7 @@ sb = sandbox.create(
 
 ### DNS in locked-down networks
 
-Some VPCs block outbound port 53 to public resolvers, where the `public` defaults can't resolve. Pass your internal resolver instead with `network="public", dns=["10.0.0.2"]`. If that isn't an option, fall back to `network="host"`, which uses the host's `/etc/resolv.conf`, at the cost of full host network identity. Configure anything beyond that through the OCI spec. See [Pass custom OCI configurations to gVisor](#pass-custom-oci-configurations-to-gvisor).
+Some virtual private clouds (VPCs) block outbound port 53 to public resolvers, so the default `public` DNS settings can't resolve queries. Pass your internal resolver instead with `network="public", dns=["10.0.0.2"]`. If that isn't an option, fall back to `network="host"`, which uses the host's `/etc/resolv.conf`, at the cost of full host network identity. Configure anything beyond that through the OCI spec. See [Pass custom OCI configurations to gVisor](#pass-custom-oci-configurations-to-gvisor).
 
 ## Architecture
 

--- a/doc/source/ray-core/sandboxes.md
+++ b/doc/source/ray-core/sandboxes.md
@@ -193,7 +193,9 @@ For advanced workloads, you might need to configure low-level runtime options su
 The `_oci_spec_transform_fn` callable receives the fully generated OCI specification dictionary. It can mutate the dictionary in place or return a modified one. Common use cases include the following:
 
 * **Host mounts**: Mount host directories, read-only datasets, or model weights into the sandbox container.
-* **Namespace or mount details** that the first-class options don't cover. Internet access, DNS, and Linux capabilities no longer need this hook — use `network=`, `dns=`, and `capabilities=` (including `capabilities=[]` to run with none at all; see [Networking and DNS](#networking-and-dns)). The hook remains for advanced network or capability configurations beyond those options.
+* **Namespace and mount details**: Configure namespace or mount behavior that the first-class options don't cover.
+
+Internet access, DNS, and Linux capabilities each have a first-class option: `network=`, `dns=`, and `capabilities=`. Pass `capabilities=[]` to run with no capabilities at all. Reserve the hook for network or capability configurations those options don't reach. See [Networking and DNS](#networking-and-dns).
 
 ```python
 import ray
@@ -237,20 +239,16 @@ ray.get(sb.delete.remote())
 
 ## Networking and DNS
 
-Sandboxes support four network modes. `none` is the default, following the
-safe-defaults principle; `public` is the recommended mode when a sandbox
-needs internet access.
+Sandboxes support four network modes. The default is `none`, which follows the safe-defaults principle. Use `public` when a sandbox needs internet access.
 
 | Mode | Network access | `/etc/resolv.conf` | Security property |
 | --- | --- | --- | --- |
 | `none` *(default)* | None | untouched | No egress. |
-| `public` — **recommended for internet access** | Host egress | Generated from `dns` (default `8.8.8.8`, `1.1.1.1`), mounted read-only | Egress works, but the sandbox inherits *nothing* from the host's resolver configuration — no internal search domains, resolver addresses, or `ndots` options leak in, and the sandbox config stays portable across clusters. |
-| `host` | Full host network identity | Host's own file, mounted read-only (`dns=` overrides it) | Strictly more permissive than `public`: the sandbox can reach anything the node can reach, including internal networks and node-local services. Prefer `public` for untrusted code. |
-| `sandbox` | gVisor netstack | untouched | Requires `rootless=False`; runsc doesn't support the sandbox netstack in rootless mode. |
+| `public` | Host egress | Generated from `dns` (default `8.8.8.8`, `1.1.1.1`), mounted read-only | Egress works, but the sandbox inherits nothing from the host's resolver configuration. No internal search domains, resolver addresses, or `ndots` options leak in, and the sandbox config stays portable across clusters. |
+| `host` | Full host network identity | Host's own file, mounted read-only (`dns=` overrides it) | Strictly more permissive than `public`. The sandbox can reach anything the node can reach, including internal networks and node-local services. Use `public` for untrusted code. |
+| `sandbox` | gVisor netstack | untouched | Requires `rootless=False`. runsc doesn't support the sandbox netstack in rootless mode. |
 
-The recommended way to give a sandbox internet access — together with
-Docker-parity capabilities so standard images behave the way they do under
-Docker (`apt-get`, `tar` ownership restore, and similar all need them):
+To give a sandbox internet access, use `network="public"`. Pair it with `DOCKER_DEFAULT_CAPABILITIES` so standard images behave the way they do under Docker, because `apt-get`, `tar` ownership restore, and similar operations all need those capabilities:
 
 ```python
 from ray.experimental import sandbox
@@ -264,12 +262,9 @@ sb = sandbox.create(
 )
 ```
 
-**DNS in locked-down networks.** Some VPCs block outbound port 53 to public
-resolvers, where the `public` defaults can't resolve. Pass your internal
-resolver instead — `network="public", dns=["10.0.0.2"]` — or fall back to
-`network="host"` (which uses the host's resolv.conf) at the cost of full host
-network identity. Anything beyond that can be configured through the OCI spec
-(see [Pass custom OCI configurations to gVisor](#pass-custom-oci-configurations-to-gvisor)).
+### DNS in locked-down networks
+
+Some VPCs block outbound port 53 to public resolvers, where the `public` defaults can't resolve. Pass your internal resolver instead with `network="public", dns=["10.0.0.2"]`. If that isn't an option, fall back to `network="host"`, which uses the host's `/etc/resolv.conf`, at the cost of full host network identity. Configure anything beyond that through the OCI spec. See [Pass custom OCI configurations to gVisor](#pass-custom-oci-configurations-to-gvisor).
 
 ## Architecture
 


### PR DESCRIPTION
Cherry-picks the Ray Sandboxes networking-section style pass onto `releases/2.58.0`.

Ray Sandboxing (gVisor) ships in 2.58.0 (#64964, #65570, and the initial docs #65503, all already on the release branch). This editorial pass on the networking and DNS section landed on master after the branch cut, so the versioned 2.58.0 docs are missing it. The change is prose-only: it tightens the network-mode table, splits the DNS guidance into its own subsection, and removes recommendation hedging. No behavior or API content changes.

Cherry-pick of #65627.
