### PR TITLE
[train] Remove usage of wandb's removed RunDisabled class

### DIFF
--- a/python/ray/air/integrations/wandb.py
+++ b/python/ray/air/integrations/wandb.py
@@ -5,7 +5,7 @@ import urllib
 import warnings
 from numbers import Number
 from types import ModuleType
-from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
+from typing import Any, Dict, List, Optional, Sequence, Tuple
 
 import numpy as np
 import pyarrow.fs
@@ -29,11 +29,10 @@ try:
     from wandb.sdk.data_types.base_types.wb_value import WBValue
     from wandb.sdk.data_types.image import Image
     from wandb.sdk.data_types.video import Video
-    from wandb.sdk.lib.disabled import RunDisabled
     from wandb.util import json_dumps_safer
     from wandb.wandb_run import Run
 except ImportError:
-    wandb = json_dumps_safer = Run = RunDisabled = WBValue = None
+    wandb = json_dumps_safer = Run = WBValue = None
 
 
 WANDB_ENV_VAR = "WANDB_API_KEY"
@@ -66,7 +65,7 @@ def setup_wandb(
     api_key_file: Optional[str] = None,
     rank_zero_only: bool = True,
     **kwargs,
-) -> Union[Run, RunDisabled]:
+) -> Run:
     """Set up a Weights & Biases session.
 
     This function can be used to initialize a Weights & Biases session in a
@@ -132,7 +131,9 @@ def setup_wandb(
     if rank_zero_only:
         # Check if we are in a train session and if we are not the rank 0 worker
         if session and session.world_rank is not None and session.world_rank != 0:
-            return RunDisabled()
+            # Return a disabled, no-op run for non-rank-zero workers.
+            _wandb = kwargs.get("_wandb") or wandb
+            return _wandb.init(mode="disabled")
 
     if session:
         default_trial_id = session.trial_id
@@ -161,7 +162,7 @@ def _setup_wandb(
     api_key_file: Optional[str] = None,
     _wandb: Optional[ModuleType] = None,
     **kwargs,
-) -> Union[Run, RunDisabled]:
+) -> Run:
     _config = config.copy() if config else {}
 
     # If key file is specified, set

--- a/python/ray/air/tests/test_integration_wandb.py
+++ b/python/ray/air/tests/test_integration_wandb.py
@@ -50,7 +50,6 @@ from ray.air.integrations.wandb import (
     WANDB_POPULATE_RUN_LOCATION_HOOK,
     WANDB_PROJECT_ENV_VAR,
     WANDB_SETUP_API_KEY_HOOK,
-    RunDisabled,
     WandbLoggerCallback,
     _QueueItem,
     _WandbLoggingActor,
@@ -562,25 +561,29 @@ def test_wandb_logger_rank_zero_only(trial, monkeypatch):
     # Test case 1: rank_zero_only=True, rank 0
     mock_session.world_rank = 0
     with patch("ray.air.integrations.wandb.get_session", return_value=mock_session):
-        run = setup_wandb(project="test_project", rank_zero_only=True, _wandb=Mock())
-        assert not isinstance(run, RunDisabled)
+        mock_wandb = Mock()
+        setup_wandb(project="test_project", rank_zero_only=True, _wandb=mock_wandb)
+        assert mock_wandb.init.call_args.kwargs.get("mode") != "disabled"
 
     # Test case 2: rank_zero_only=True, non-rank-0
     mock_session.world_rank = 1
     with patch("ray.air.integrations.wandb.get_session", return_value=mock_session):
-        run = setup_wandb(project="test_project", rank_zero_only=True, _wandb=Mock())
-        assert isinstance(run, RunDisabled)
+        mock_wandb = Mock()
+        setup_wandb(project="test_project", rank_zero_only=True, _wandb=mock_wandb)
+        assert mock_wandb.init.call_args.kwargs.get("mode") == "disabled"
 
     # Test case 3: rank_zero_only=False, any rank
     mock_session.world_rank = 1
     with patch("ray.air.integrations.wandb.get_session", return_value=mock_session):
-        run = setup_wandb(project="test_project", rank_zero_only=False, _wandb=Mock())
-        assert not isinstance(run, RunDisabled)
+        mock_wandb = Mock()
+        setup_wandb(project="test_project", rank_zero_only=False, _wandb=mock_wandb)
+        assert mock_wandb.init.call_args.kwargs.get("mode") != "disabled"
 
     # Test case 4: rank_zero_only=True, no session
     with patch("ray.air.integrations.wandb.get_session", return_value=None):
-        run = setup_wandb(project="test_project", rank_zero_only=True, _wandb=Mock())
-        assert not isinstance(run, RunDisabled)
+        mock_wandb = Mock()
+        setup_wandb(project="test_project", rank_zero_only=True, _wandb=mock_wandb)
+        assert mock_wandb.init.call_args.kwargs.get("mode") != "disabled"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
wandb deprecated `RunDisabled` in v0.17.6 (wandb/wandb#8064): since then, `wandb.init(mode="disabled")` returns a regular no-op `wandb.Run`, and `RunDisabled` has been an empty compatibility shim that emits a deprecation warning on attribute access. The shim is being removed in an upcoming wandb release (wandb/wandb#12586), after which importing it raises `ImportError`.

This PR drops the remaining references so the integration keeps working with upcoming wandb releases, while remaining compatible with older ones.

Details:
- The `RunDisabled` import sits in the `try/except ImportError` block at the top of `ray/air/integrations/wandb.py`, so after the upcoming wandb release Ray would silently treat wandb as *not installed*.
- `setup_wandb(rank_zero_only=True)` returns `RunDisabled()` for non-rank-zero workers. On wandb >= 0.17.6 calling any method on that object (e.g. `run.log(...)`) raises `TypeError: 'NoneType' object is not callable`, because the shim's `__getattr__` returns `None`. This PR returns `wandb.init(mode="disabled")` instead — a fully functional no-op `Run` on all wandb versions Ray supports.
- Note for reviewers: `RunDisabled` was importable from `ray.air.integrations.wandb` (Ray's own tests imported it from there); this PR removes that name from the module.
- Tests updated to assert on the `mode="disabled"` init kwarg instead of the class.
