### PR TITLE
[Serve][LLM] Export SGLangServer from a public module

### DIFF
--- a/doc/source/llm/doc_code/serve/sglang/sglang_multinode_example.py
+++ b/doc/source/llm/doc_code/serve/sglang/sglang_multinode_example.py
@@ -1,8 +1,6 @@
 # __sglang_multinode_start__
-from ray.llm._internal.serve.engines.sglang import SGLangServer
-
 from ray import serve
-from ray.serve.llm import LLMConfig, build_openai_app
+from ray.serve.llm import LLMConfig, SGLangServer, build_openai_app
 
 llm_config = LLMConfig(
     model_loading_config={

--- a/doc/source/llm/doc_code/serve/sglang/sglang_serving_example.py
+++ b/doc/source/llm/doc_code/serve/sglang/sglang_serving_example.py
@@ -1,8 +1,6 @@
 # __sglang_single_node_start__
-from ray.llm._internal.serve.engines.sglang import SGLangServer
-
 from ray import serve
-from ray.serve.llm import LLMConfig, build_openai_app
+from ray.serve.llm import LLMConfig, SGLangServer, build_openai_app
 
 llm_config = LLMConfig(
     model_loading_config={

--- a/doc/source/serve/api/index.md
+++ b/doc/source/serve/api/index.md
@@ -531,6 +531,7 @@ Content-Type: application/json
    :toctree: doc/
 
    serve.llm.LLMServer
+   serve.llm.SGLangServer
    serve.llm.deployment.PDDecodeServer
    serve.llm.deployment.PDPrefillServer
    serve.llm.deployment.DPServer

--- a/python/ray/llm/tests/serve/cpu/test_public_imports.py
+++ b/python/ray/llm/tests/serve/cpu/test_public_imports.py
@@ -1,0 +1,18 @@
+import sys
+
+import pytest
+
+
+def test_sglang_server_public_export():
+    from ray.llm._internal.serve.engines.sglang import (
+        SGLangServer as InternalSGLangServer,
+    )
+    from ray.serve.llm import SGLangServer
+    from ray.serve.llm.deployment import SGLangServer as DeploymentSGLangServer
+
+    assert SGLangServer is DeploymentSGLangServer
+    assert issubclass(SGLangServer, InternalSGLangServer)
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-v", __file__]))

--- a/python/ray/serve/llm/__init__.py
+++ b/python/ray/serve/llm/__init__.py
@@ -9,7 +9,7 @@ from ray.llm._internal.serve.core.configs.llm_config import (
 from ray.llm._internal.serve.core.ingress.builder import (
     LLMServingArgs as _LLMServingArgs,
 )
-from ray.serve.llm.deployment import LLMServer
+from ray.serve.llm.deployment import LLMServer, SGLangServer
 from ray.util.annotations import PublicAPI
 
 if TYPE_CHECKING:
@@ -406,4 +406,5 @@ __all__ = [
     "build_dp_deployment",
     "build_dp_openai_app",
     "LLMServer",
+    "SGLangServer",
 ]

--- a/python/ray/serve/llm/deployment.py
+++ b/python/ray/serve/llm/deployment.py
@@ -1,6 +1,9 @@
 from ray.llm._internal.serve.core.server.llm_server import (
     LLMServer as InternalLLMServer,
 )
+from ray.llm._internal.serve.engines.sglang.sglang_engine import (
+    SGLangServer as _SGLangServer,
+)
 from ray.llm._internal.serve.serving_patterns.data_parallel.dp_server import (
     DPServer as _DPServer,
 )
@@ -65,6 +68,16 @@ class LLMServer(InternalLLMServer):
             )
             response = ray.get(model_handle.chat(request))
             print(response)
+    """
+
+    pass
+
+
+@PublicAPI(stability="alpha")
+class SGLangServer(_SGLangServer):
+    """SGLang engine deployment for Ray Serve LLM.
+
+    Pass this class to ``LLMConfig.server_cls`` to serve a model with SGLang.
     """
 
     pass
@@ -142,6 +155,7 @@ class DPServer(_DPServer):
 
 __all__ = [
     "LLMServer",
+    "SGLangServer",
     "PDDecodeServer",
     "PDPrefillServer",
     "DPServer",


### PR DESCRIPTION
## Description

`SGLangServer` had no public import path, even though `LLMConfig.server_cls` — a field on a `@PublicAPI(stability="stable")` config — names it explicitly as a supported value. Both SGLang examples in the user guide therefore opened with `from ray.llm._internal.serve.engines.sglang import SGLangServer`, and that line is inside the rendered `literalinclude` region, so it's the first thing readers copy.

This follows the pattern already in `python/ray/serve/llm/deployment.py`, which wraps internal server classes as thin annotated subclasses:

```python
@PublicAPI(stability="alpha")
class SGLangServer(_SGLangServer):
    """SGLang engine deployment for Ray Serve LLM.

    Pass this class to ``LLMConfig.server_cls`` to serve a model with SGLang.
    """

    pass
```

`SGLangServer` is exported from both `ray.serve.llm.deployment` and `ray.serve.llm`, the two doc examples now import it from the public path, and it's listed in the Serve API reference.

I used `stability="alpha"` rather than `"stable"` for the reason raised in the issue: SGLang support is still evolving (#62480, #63901, #63020), and unlike the four classes already in `deployment.py`, `SGLangServer` doesn't subclass `LLMServer` — it's a standalone, duck-typed server class. Happy to change it to `"stable"` if maintainers prefer.

No implementation code moved; this is purely an export plus documentation.

## Related issues

Closes #65386

## Additional information

**Checks run locally** (macOS, from the repo root):

```
ruff check <changed .py files>          # All checks passed
ruff check --select I <changed .py files>  # All checks passed
ruff format --check <changed .py files>    # 5 files already formatted
python -m py_compile <changed .py files>   # OK
```

ruff pinned to `v0.8.4` per `.pre-commit-config.yaml`.

**Not run locally:** `python/ray/llm/tests/serve/cpu/test_public_imports.py`. Importing `ray.serve.llm` pulls in an engine backend (vLLM or SGLang), and both are Linux/CUDA-only, so the test cannot execute on macOS. It is left to CI. The test asserts only that the public symbol resolves to the internal class:

```python
assert SGLangServer is DeploymentSGLangServer
assert issubclass(SGLangServer, InternalSGLangServer)
```

If it belongs in a different target than `python/ray/llm/tests/serve/cpu/`, let me know and I'll move it.
