### PR TITLE
[core][sandbox] Docker-parity /etc/hosts and /tmp handling

### DIFF
--- a/python/ray/experimental/sandbox/_internal/image_utils.py
+++ b/python/ray/experimental/sandbox/_internal/image_utils.py
@@ -273,11 +273,17 @@ def extract_tar_layer(
                     pass
             elif member.isdir():
                 os.makedirs(target_path, exist_ok=True)
-                # Applied after the loop: extracting children would bump it.
-                # Skip preserved symlinks (UsrMerge /bin -> usr/bin): utime
-                # would follow them and stamp the target with the wrong time.
+                # Modes and mtimes are applied after the loop, children
+                # before parents: tar lists a directory before its contents,
+                # so applying a restrictive archived mode (0500) here would
+                # break extracting the children, and extracting children
+                # bumps the mtime. Images rely on directory permissions (a
+                # 0755 root /tmp instead of 1777 breaks every non-root
+                # writer, apt-key first among them). Skip preserved symlinks
+                # (UsrMerge /bin -> usr/bin): chmod and utime would follow
+                # the link to its target.
                 if not os.path.islink(target_path):
-                    dir_mtimes.append((target_path, member.mtime))
+                    dir_mtimes.append((target_path, member.mode, member.mtime))
             elif member.issym():
                 os.makedirs(parent_dir, exist_ok=True)
                 try:
@@ -295,8 +301,13 @@ def extract_tar_layer(
                     except OSError:
                         pass
 
-    for dir_path, mtime in dir_mtimes:
+    # Reversed: children come after their parents in the archive, so this
+    # order restores child attributes before a parent's restrictive mode
+    # could block the traversal.
+    for dir_path, mode, mtime in reversed(dir_mtimes):
         try:
+            if mode:
+                os.chmod(dir_path, mode)
             os.utime(dir_path, (mtime, mtime))
         except OSError:
             pass

--- a/python/ray/experimental/sandbox/_internal/image_utils.py
+++ b/python/ray/experimental/sandbox/_internal/image_utils.py
@@ -273,15 +273,10 @@ def extract_tar_layer(
                     pass
             elif member.isdir():
                 os.makedirs(target_path, exist_ok=True)
-                # Modes and mtimes are applied after the loop, children
-                # before parents: tar lists a directory before its contents,
-                # so applying a restrictive archived mode (0500) here would
-                # break extracting the children, and extracting children
-                # bumps the mtime. Images rely on directory permissions (a
-                # 0755 root /tmp instead of 1777 breaks every non-root
-                # writer, apt-key first among them). Skip preserved symlinks
-                # (UsrMerge /bin -> usr/bin): chmod and utime would follow
-                # the link to its target.
+                # Deferred to the post-loop pass: tar lists a directory
+                # before its contents, so a restrictive archived mode (0500)
+                # applied here would break extracting the children. Preserved
+                # symlinks (UsrMerge) are skipped: chmod/utime follow them.
                 if not os.path.islink(target_path):
                     dir_mtimes.append((target_path, member.mode, member.mtime))
             elif member.issym():
@@ -301,9 +296,7 @@ def extract_tar_layer(
                     except OSError:
                         pass
 
-    # Reversed: children come after their parents in the archive, so this
-    # order restores child attributes before a parent's restrictive mode
-    # could block the traversal.
+    # Children first, so a parent's restrictive mode cannot block them.
     for dir_path, mode, mtime in reversed(dir_mtimes):
         try:
             if mode:

--- a/python/ray/experimental/sandbox/backend/gvisor.py
+++ b/python/ray/experimental/sandbox/backend/gvisor.py
@@ -169,19 +169,6 @@ class GVisorSandboxBackend(BaseSandboxBackend):
             shutil.rmtree(root_dir, ignore_errors=True)
             raise
 
-        if not config.readonly:
-            # Drop the /tmp placeholder (see create_oci_spec) from this
-            # sandbox's overlay; the shared cache stays seeded, and readonly
-            # sandboxes already hide it under their tmpfs.
-            cleanup_args = self._runsc_base_args(config) + [
-                "exec",
-                sandbox_id,
-                "/bin/rm",
-                "-f",
-                "/tmp/.ray-sandbox-keep",
-            ]
-            subprocess.run(cleanup_args, capture_output=True, timeout=10)
-
         self._sandbox_metadata[sandbox_id] = {
             "root_dir": root_dir,
             "workdir": workdir_path,

--- a/python/ray/experimental/sandbox/backend/gvisor.py
+++ b/python/ray/experimental/sandbox/backend/gvisor.py
@@ -170,11 +170,9 @@ class GVisorSandboxBackend(BaseSandboxBackend):
             raise
 
         if not config.readonly:
-            # The rootfs /tmp is seeded with a placeholder so runsc keeps
-            # /tmp on the rootfs device (see create_oci_spec). Remove it
-            # from this sandbox's view — the overlay makes the deletion
-            # per-sandbox while the shared cache stays seeded. Readonly
-            # sandboxes mount a tmpfs over /tmp, which hides it already.
+            # Drop the /tmp placeholder (see create_oci_spec) from this
+            # sandbox's overlay; the shared cache stays seeded, and readonly
+            # sandboxes already hide it under their tmpfs.
             cleanup_args = self._runsc_base_args(config) + [
                 "exec",
                 sandbox_id,

--- a/python/ray/experimental/sandbox/backend/gvisor.py
+++ b/python/ray/experimental/sandbox/backend/gvisor.py
@@ -169,6 +169,21 @@ class GVisorSandboxBackend(BaseSandboxBackend):
             shutil.rmtree(root_dir, ignore_errors=True)
             raise
 
+        if not config.readonly:
+            # The rootfs /tmp is seeded with a placeholder so runsc keeps
+            # /tmp on the rootfs device (see create_oci_spec). Remove it
+            # from this sandbox's view — the overlay makes the deletion
+            # per-sandbox while the shared cache stays seeded. Readonly
+            # sandboxes mount a tmpfs over /tmp, which hides it already.
+            cleanup_args = self._runsc_base_args(config) + [
+                "exec",
+                sandbox_id,
+                "/bin/rm",
+                "-f",
+                "/tmp/.ray-sandbox-keep",
+            ]
+            subprocess.run(cleanup_args, capture_output=True, timeout=10)
+
         self._sandbox_metadata[sandbox_id] = {
             "root_dir": root_dir,
             "workdir": workdir_path,

--- a/python/ray/experimental/sandbox/image_manager.py
+++ b/python/ray/experimental/sandbox/image_manager.py
@@ -24,6 +24,7 @@ logger = logging.getLogger(__name__)
 _OCI_CAPABILITY_SETS = ("bounding", "effective", "permitted")
 
 _RESOLV_CONF = "/etc/resolv.conf"
+_ETC_HOSTS = "/etc/hosts"
 
 
 def get_default_oci_spec() -> Dict[str, Any]:
@@ -138,6 +139,7 @@ class BaseImageManager(ABC):
         capabilities: Optional[List[str]] = None,
         network: str = "none",
         resolv_conf_source: Optional[str] = None,
+        hosts_source: Optional[str] = None,
         base_spec: Optional[Dict[str, Any]] = None,
         _oci_spec_transform_fn: Optional[Callable[[Dict], Optional[Dict]]] = None,
     ) -> Dict[str, Any]:
@@ -159,6 +161,9 @@ class BaseImageManager(ABC):
                 spec's empty network namespace.
             resolv_conf_source: Optional file to bind-mount read-only at
                 /etc/resolv.conf.
+            hosts_source: Optional file to bind-mount read-write at
+                /etc/hosts (a per-sandbox copy, like the one container
+                engines inject).
             base_spec: Optional base OCI spec dict to modify instead of generating a default.
             _oci_spec_transform_fn: Optional callback to transform the final spec.
 
@@ -329,6 +334,7 @@ class ImageManager(BaseImageManager):
         capabilities: Optional[List[str]] = None,
         network: str = "none",
         resolv_conf_source: Optional[str] = None,
+        hosts_source: Optional[str] = None,
         base_spec: Optional[Dict[str, Any]] = None,
         _oci_spec_transform_fn: Optional[Callable[[Dict], Optional[Dict]]] = None,
     ) -> Dict[str, Any]:
@@ -350,6 +356,9 @@ class ImageManager(BaseImageManager):
                 spec's empty network namespace.
             resolv_conf_source: Optional file to bind-mount read-only at
                 /etc/resolv.conf.
+            hosts_source: Optional file to bind-mount read-write at
+                /etc/hosts (a per-sandbox copy, like the one container
+                engines inject).
             base_spec: Optional base OCI spec dict to modify instead of generating a default.
             _oci_spec_transform_fn: Optional callback to transform the final spec.
 
@@ -368,6 +377,25 @@ class ImageManager(BaseImageManager):
         spec.setdefault("root", {})
         spec["root"]["path"] = rootfs
         spec["root"]["readonly"] = readonly
+
+        # Docker parity: keep /tmp on the rootfs. runsc mounts a private
+        # tmpfs over an *empty* /tmp, which puts /tmp on a different device
+        # from the rootfs and breaks the rename(2)-from-/tmp pattern that
+        # works under Docker (EXDEV). A placeholder keeps it non-empty;
+        # readonly sandboxes get an explicit tmpfs mount below instead so
+        # /tmp stays writable there.
+        tmp_dir = os.path.join(rootfs, "tmp")
+        try:
+            if not os.path.isdir(tmp_dir):
+                os.makedirs(tmp_dir, exist_ok=True)
+                os.chmod(tmp_dir, 0o1777)
+            with open(
+                os.path.join(tmp_dir, ".ray-sandbox-keep"), "a", encoding="utf-8"
+            ):
+                pass
+        except OSError:
+            # Best effort: runsc then falls back to its private tmpfs.
+            pass
 
         spec.setdefault("process", {})
         spec["process"]["args"] = ["sleep", "infinity"]
@@ -454,6 +482,33 @@ class ImageManager(BaseImageManager):
             )
             existing_dests.add(_RESOLV_CONF)
 
+        # Read-write like the file container engines inject: tasks may add
+        # entries. The source is always a per-sandbox copy, never the node's
+        # own file.
+        if hosts_source and _ETC_HOSTS not in existing_dests:
+            mounts.append(
+                {
+                    "destination": _ETC_HOSTS,
+                    "type": "bind",
+                    "source": hosts_source,
+                    "options": ["rbind", "rw"],
+                }
+            )
+            existing_dests.add(_ETC_HOSTS)
+
+        # The rootfs /tmp above is read-only whenever the rootfs is; keep
+        # /tmp always writable, as it effectively is under Docker.
+        if readonly and "/tmp" not in existing_dests:
+            mounts.append(
+                {
+                    "destination": "/tmp",
+                    "type": "tmpfs",
+                    "source": "tmpfs",
+                    "options": ["nosuid", "nodev", "mode=1777"],
+                }
+            )
+            existing_dests.add("/tmp")
+
         spec["mounts"] = mounts
 
         # Configure OCI cgroup resource limits for CPU and memory
@@ -533,6 +588,24 @@ class ImageManager(BaseImageManager):
             elif os.path.exists(_RESOLV_CONF):
                 resolv_conf_source = _RESOLV_CONF
 
+        # Container engines inject a per-container /etc/hosts at run time
+        # (images do not ship a usable one), and without it `localhost` does
+        # not resolve at all. Host networking additionally inherits the
+        # node's entries, mirroring the resolver handling above.
+        hosts_source = os.path.join(root_dir, "hosts")
+        host_entries = ""
+        if network == "host" and os.path.exists(_ETC_HOSTS):
+            try:
+                with open(_ETC_HOSTS, "r", encoding="utf-8") as f:
+                    host_entries = f.read()
+            except OSError:
+                host_entries = ""
+        with open(hosts_source, "w", encoding="utf-8") as f:
+            f.write("127.0.0.1\tlocalhost\n")
+            f.write("::1\tlocalhost ip6-localhost ip6-loopback\n")
+            if host_entries:
+                f.write(host_entries)
+
         spec = self.create_oci_spec(
             image=image,
             container_cwd=container_cwd,
@@ -544,6 +617,7 @@ class ImageManager(BaseImageManager):
             capabilities=capabilities,
             network=network,
             resolv_conf_source=resolv_conf_source,
+            hosts_source=hosts_source,
             _oci_spec_transform_fn=_oci_spec_transform_fn,
         )
 

--- a/python/ray/experimental/sandbox/image_manager.py
+++ b/python/ray/experimental/sandbox/image_manager.py
@@ -386,9 +386,10 @@ class ImageManager(BaseImageManager):
         # /tmp stays writable there.
         tmp_dir = os.path.join(rootfs, "tmp")
         try:
-            if not os.path.isdir(tmp_dir):
-                os.makedirs(tmp_dir, exist_ok=True)
-                os.chmod(tmp_dir, 0o1777)
+            os.makedirs(tmp_dir, exist_ok=True)
+            # Unconditional: /tmp must be world-writable with the sticky bit
+            # whether it came from the image or was just created.
+            os.chmod(tmp_dir, 0o1777)
             with open(
                 os.path.join(tmp_dir, ".ray-sandbox-keep"), "a", encoding="utf-8"
             ):

--- a/python/ray/experimental/sandbox/image_manager.py
+++ b/python/ray/experimental/sandbox/image_manager.py
@@ -597,7 +597,7 @@ class ImageManager(BaseImageManager):
         host_entries = ""
         if network == "host" and os.path.exists(_ETC_HOSTS):
             try:
-                with open(_ETC_HOSTS, "r", encoding="utf-8") as f:
+                with open(_ETC_HOSTS, "r", encoding="utf-8", errors="replace") as f:
                     host_entries = f.read()
             except OSError:
                 host_entries = ""

--- a/python/ray/experimental/sandbox/image_manager.py
+++ b/python/ray/experimental/sandbox/image_manager.py
@@ -378,12 +378,9 @@ class ImageManager(BaseImageManager):
         spec["root"]["path"] = rootfs
         spec["root"]["readonly"] = readonly
 
-        # Docker parity: keep /tmp on the rootfs. runsc mounts a private
-        # tmpfs over an *empty* /tmp, which puts /tmp on a different device
-        # from the rootfs and breaks the rename(2)-from-/tmp pattern that
-        # works under Docker (EXDEV). A placeholder keeps it non-empty;
-        # readonly sandboxes get an explicit tmpfs mount below instead so
-        # /tmp stays writable there.
+        # Docker parity: runsc mounts a private tmpfs over an *empty*
+        # /tmp, breaking rename(2) from /tmp with EXDEV. The placeholder
+        # keeps /tmp on the rootfs; readonly sandboxes get a tmpfs below.
         tmp_dir = os.path.join(rootfs, "tmp")
         try:
             os.makedirs(tmp_dir, exist_ok=True)
@@ -483,9 +480,8 @@ class ImageManager(BaseImageManager):
             )
             existing_dests.add(_RESOLV_CONF)
 
-        # Read-write like the file container engines inject: tasks may add
-        # entries. The source is always a per-sandbox copy, never the node's
-        # own file.
+        # Read-write like the file container engines inject; the source
+        # is always a per-sandbox copy, never the node's own file.
         if hosts_source and _ETC_HOSTS not in existing_dests:
             mounts.append(
                 {
@@ -497,8 +493,7 @@ class ImageManager(BaseImageManager):
             )
             existing_dests.add(_ETC_HOSTS)
 
-        # The rootfs /tmp above is read-only whenever the rootfs is; keep
-        # /tmp always writable, as it effectively is under Docker.
+        # Keep /tmp writable on a readonly rootfs, as it is under Docker.
         if readonly and "/tmp" not in existing_dests:
             mounts.append(
                 {
@@ -589,10 +584,8 @@ class ImageManager(BaseImageManager):
             elif os.path.exists(_RESOLV_CONF):
                 resolv_conf_source = _RESOLV_CONF
 
-        # Container engines inject a per-container /etc/hosts at run time
-        # (images do not ship a usable one), and without it `localhost` does
-        # not resolve at all. Host networking additionally inherits the
-        # node's entries, mirroring the resolver handling above.
+        # Engines inject /etc/hosts at run time; without it `localhost`
+        # does not resolve. Host networking also inherits the node's entries.
         hosts_source = os.path.join(root_dir, "hosts")
         host_entries = ""
         if network == "host" and os.path.exists(_ETC_HOSTS):

--- a/python/ray/experimental/sandbox/image_manager.py
+++ b/python/ray/experimental/sandbox/image_manager.py
@@ -380,7 +380,9 @@ class ImageManager(BaseImageManager):
 
         # Docker parity: runsc mounts a private tmpfs over an *empty*
         # /tmp, breaking rename(2) from /tmp with EXDEV. The placeholder
-        # keeps /tmp on the rootfs; readonly sandboxes get a tmpfs below.
+        # keeps /tmp on the rootfs and stays visible in the sandbox (one
+        # empty dotfile in scratch space); readonly sandboxes get a tmpfs
+        # below, which hides it.
         tmp_dir = os.path.join(rootfs, "tmp")
         try:
             os.makedirs(tmp_dir, exist_ok=True)

--- a/python/ray/experimental/sandbox/tests/test_image_manager.py
+++ b/python/ray/experimental/sandbox/tests/test_image_manager.py
@@ -526,6 +526,7 @@ def test_extract_tar_layer_preserves_mtimes(tmp_path):
     with tarfile.open(fileobj=buf, mode="w") as tar:
         dir_info = tarfile.TarInfo("etc")
         dir_info.type = tarfile.DIRTYPE
+        dir_info.mode = 0o755  # TarInfo defaults to 0644; dir modes are honored now
         dir_info.mtime = archived_mtime
         tar.addfile(dir_info)
         file_info = tarfile.TarInfo("etc/os-release")
@@ -540,6 +541,8 @@ def test_extract_tar_layer_preserves_mtimes(tmp_path):
 
     assert int(os.path.getmtime(dest / "etc" / "os-release")) == archived_mtime
     assert int(os.path.getmtime(dest / "etc")) == archived_mtime
+
+
 def test_oci_spec_docker_parity_hosts_and_tmp(tmp_path):
     """/etc/hosts is a per-sandbox read-write bind (localhost must resolve),
     and /tmp stays on the rootfs (readonly sandboxes get an explicit tmpfs
@@ -622,6 +625,39 @@ def test_extract_tar_layer_applies_directory_modes(tmp_path):
     extract_tar_layer(buf.getvalue(), str(dest))
 
     assert stat.S_IMODE(os.stat(dest / "tmp").st_mode) == 0o1777
+
+
+def test_extract_tar_layer_defers_restrictive_directory_modes(tmp_path):
+    """Directory modes are applied after extraction, children first: tar
+    lists a directory before its contents, so applying a read-only archived
+    mode inline would break extracting the children."""
+    import io
+    import os
+    import stat
+    import tarfile
+
+    from ray.experimental.sandbox._internal.image_utils import extract_tar_layer
+
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w") as tar:
+        locked = tarfile.TarInfo("locked")
+        locked.type = tarfile.DIRTYPE
+        locked.mode = 0o500  # no write bit: inline chmod would break children
+        tar.addfile(locked)
+        inner = tarfile.TarInfo("locked/secret.txt")
+        data = b"contents"
+        inner.size = len(data)
+        inner.mode = 0o400
+        tar.addfile(inner, io.BytesIO(data))
+
+    dest = tmp_path / "rootfs"
+    dest.mkdir()
+    extract_tar_layer(buf.getvalue(), str(dest))
+
+    assert (dest / "locked" / "secret.txt").read_bytes() == b"contents"
+    assert stat.S_IMODE(os.stat(dest / "locked").st_mode) == 0o500
+    # Restore writability so pytest can clean the tmp dir up.
+    os.chmod(dest / "locked", 0o700)
 
 
 if __name__ == "__main__":

--- a/python/ray/experimental/sandbox/tests/test_image_manager.py
+++ b/python/ray/experimental/sandbox/tests/test_image_manager.py
@@ -558,8 +558,13 @@ def test_oci_spec_docker_parity_hosts_and_tmp(tmp_path):
     assert mounts["/etc/hosts"]["source"] == str(hosts)
     assert "rw" in mounts["/etc/hosts"]["options"]
     assert mounts["/tmp"]["type"] == "tmpfs"
-    # The rootfs /tmp was seeded so runsc keeps it on the rootfs device.
+    # The rootfs /tmp was seeded so runsc keeps it on the rootfs device —
+    # and is world-writable + sticky regardless of how it was extracted.
     assert (tmp_path / "rootfs" / "tmp" / ".ray-sandbox-keep").exists()
+    import stat
+
+    mode = stat.S_IMODE((tmp_path / "rootfs" / "tmp").stat().st_mode)
+    assert mode == 0o1777
 
     spec = mgr.create_oci_spec(
         image="fake:latest",
@@ -593,6 +598,30 @@ def test_prepare_oci_bundle_writes_hosts_file(tmp_path, monkeypatch):
     spec = json.loads((bundle / "config.json").read_text())
     dests = {m["destination"] for m in spec["mounts"]}
     assert "/etc/hosts" in dests
+
+
+def test_extract_tar_layer_applies_directory_modes(tmp_path):
+    """Archived directory modes survive extraction: a 0755 root /tmp breaks
+    every non-root writer (apt-key first among them)."""
+    import io
+    import os
+    import stat
+    import tarfile
+
+    from ray.experimental.sandbox._internal.image_utils import extract_tar_layer
+
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w") as tar:
+        info = tarfile.TarInfo("tmp")
+        info.type = tarfile.DIRTYPE
+        info.mode = 0o1777
+        tar.addfile(info)
+
+    dest = tmp_path / "rootfs"
+    dest.mkdir()
+    extract_tar_layer(buf.getvalue(), str(dest))
+
+    assert stat.S_IMODE(os.stat(dest / "tmp").st_mode) == 0o1777
 
 
 if __name__ == "__main__":

--- a/python/ray/experimental/sandbox/tests/test_image_manager.py
+++ b/python/ray/experimental/sandbox/tests/test_image_manager.py
@@ -540,6 +540,59 @@ def test_extract_tar_layer_preserves_mtimes(tmp_path):
 
     assert int(os.path.getmtime(dest / "etc" / "os-release")) == archived_mtime
     assert int(os.path.getmtime(dest / "etc")) == archived_mtime
+def test_oci_spec_docker_parity_hosts_and_tmp(tmp_path):
+    """/etc/hosts is a per-sandbox read-write bind (localhost must resolve),
+    and /tmp stays on the rootfs (readonly sandboxes get an explicit tmpfs
+    so it remains writable)."""
+    mgr = _StubImageManager(tmp_path)
+    hosts = tmp_path / "hosts"
+    hosts.write_text("127.0.0.1\tlocalhost\n")
+
+    spec = mgr.create_oci_spec(
+        image="fake:latest",
+        base_spec=_sample_base_spec(),
+        hosts_source=str(hosts),
+        readonly=True,
+    )
+    mounts = {m["destination"]: m for m in spec["mounts"]}
+    assert mounts["/etc/hosts"]["source"] == str(hosts)
+    assert "rw" in mounts["/etc/hosts"]["options"]
+    assert mounts["/tmp"]["type"] == "tmpfs"
+    # The rootfs /tmp was seeded so runsc keeps it on the rootfs device.
+    assert (tmp_path / "rootfs" / "tmp" / ".ray-sandbox-keep").exists()
+
+    spec = mgr.create_oci_spec(
+        image="fake:latest",
+        base_spec=_sample_base_spec(),
+        readonly=False,
+    )
+    dests = {m["destination"] for m in spec["mounts"]}
+    # Writable rootfs: /tmp is plain rootfs, same device — no tmpfs mount.
+    assert "/tmp" not in dests
+
+
+def test_prepare_oci_bundle_writes_hosts_file(tmp_path, monkeypatch):
+    import ray.experimental.sandbox.image_manager as image_manager_mod
+
+    # The default spec shells out to runsc; substitute a static one so this
+    # runs on hosts without gVisor.
+    monkeypatch.setattr(image_manager_mod, "get_default_oci_spec", _sample_base_spec)
+    mgr = _StubImageManager(tmp_path)
+    bundle = tmp_path / "bundle"
+    bundle.mkdir()
+    mgr.prepare_oci_bundle(
+        root_dir=str(bundle),
+        workdir_path=None,
+        container_cwd="/",
+        image="fake:latest",
+    )
+    content = (bundle / "hosts").read_text()
+    assert "127.0.0.1\tlocalhost" in content
+    import json
+
+    spec = json.loads((bundle / "config.json").read_text())
+    dests = {m["destination"] for m in spec["mounts"]}
+    assert "/etc/hosts" in dests
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Why are these changes needed?

Two filesystem-behavior divergences from Docker, both found running Terminal-Bench 2.1 oracle evaluations in Ray sandboxes (via the Harbor integration):

1. **`localhost` does not resolve.** Container engines inject `/etc/hosts` at run time, so images do not ship a usable one — and the sandbox never provided it either. glibc consults hosts files before DNS, and public resolvers will not answer for `localhost`, so every task that starts a local server and connects to it fails with `Name or service not known` (6 of 89 TB tasks). Fix: generate a per-sandbox hosts file next to the generated `resolv.conf` (seeded from the node's file under host networking) and bind-mount it **read-write**, matching engine behavior — the source is always a per-sandbox copy, never the node's file.

2. **`/tmp` sits on a different device than the rootfs.** runsc mounts a private tmpfs over an *empty* `/tmp`, so the common tempfile-then-`rename(2)` pattern fails with `EXDEV` where it works under Docker (plain rootfs `/tmp`). Fix: seed the extracted rootfs `/tmp` with a placeholder so runsc keeps it on the rootfs; **readonly** sandboxes get an explicit tmpfs mount instead, preserving the always-writable `/tmp` they have today.

## Related issue number

Follow-up to #65570, sibling of #65737.

## Checks

- [x] Signed off (DCO); pre-commit hooks pass on the changed files.
- [ ] Unit tests included (`test_oci_spec_docker_parity_hosts_and_tmp`, `test_prepare_oci_bundle_writes_hosts_file`); both run without gVisor.