### PR TITLE
[tune] Round instead of truncate when PBT perturbs an integer

### DIFF
--- a/python/ray/tune/schedulers/pbt.py
+++ b/python/ray/tune/schedulers/pbt.py
@@ -142,18 +142,12 @@ def _explore(
                 new_config[key] = config[key] * perturbation_factor
                 operations[key] = f"* {perturbation_factor}"
             if isinstance(config[key], bool):
-                # `bool` is a subclass of `int`, so the branch below would turn a
-                # `tune.choice([True, False])` flag into 1 or 0. Multiplying a flag by
-                # a perturbation factor is meaningless anyway, so keep it a bool and
-                # let `resample_probability` be the only thing that flips it.
+                # Keep as bool, let `resample_probability` flip it and ignore
+                # `perturbation_factor`
                 new_config[key] = bool(new_config[key])
             elif isinstance(config[key], int):
-                # If this hyperparameter started out as an integer (ex: `batch_size`),
-                # convert the new value back. Round rather than truncate: int() drops
-                # the fraction toward zero, so with the default factors `* 1.2` was a
-                # no-op for every value below 5 while `* 0.8` always landed lower. An
-                # integer hyperparameter could therefore only ratchet down, and 0
-                # absorbed it because every factor leaves 0 unchanged.
+                # If this parameter started out as an integer (e.g. `batch_size`),
+                # round before converting the new value back.
                 new_config[key] = int(round(new_config[key]))
         else:
             raise ValueError(

--- a/python/ray/tune/schedulers/pbt.py
+++ b/python/ray/tune/schedulers/pbt.py
@@ -141,7 +141,13 @@ def _explore(
                 perturbation_factor = random.choice(perturbation_factors)
                 new_config[key] = config[key] * perturbation_factor
                 operations[key] = f"* {perturbation_factor}"
-            if isinstance(config[key], int):
+            if isinstance(config[key], bool):
+                # `bool` is a subclass of `int`, so the branch below would turn a
+                # `tune.choice([True, False])` flag into 1 or 0. Multiplying a flag by
+                # a perturbation factor is meaningless anyway, so keep it a bool and
+                # let `resample_probability` be the only thing that flips it.
+                new_config[key] = bool(new_config[key])
+            elif isinstance(config[key], int):
                 # If this hyperparameter started out as an integer (ex: `batch_size`),
                 # convert the new value back. Round rather than truncate: int() drops
                 # the fraction toward zero, so with the default factors `* 1.2` was a

--- a/python/ray/tune/schedulers/pbt.py
+++ b/python/ray/tune/schedulers/pbt.py
@@ -143,8 +143,12 @@ def _explore(
                 operations[key] = f"* {perturbation_factor}"
             if isinstance(config[key], int):
                 # If this hyperparameter started out as an integer (ex: `batch_size`),
-                # convert the new value back
-                new_config[key] = int(new_config[key])
+                # convert the new value back. Round rather than truncate: int() drops
+                # the fraction toward zero, so with the default factors `* 1.2` was a
+                # no-op for every value below 5 while `* 0.8` always landed lower. An
+                # integer hyperparameter could therefore only ratchet down, and 0
+                # absorbed it because every factor leaves 0 unchanged.
+                new_config[key] = int(round(new_config[key]))
         else:
             raise ValueError(
                 f"Unsupported hyperparameter distribution type: {type(distribution)}"

--- a/python/ray/tune/tests/test_trial_scheduler.py
+++ b/python/ray/tune/tests/test_trial_scheduler.py
@@ -1398,6 +1398,38 @@ class PopulationBasedTestingSuite(unittest.TestCase):
             # least half a step, rather than rounding straight back down.
             self.assertGreater(perturb(value, 1.2), value)
 
+    def testBooleanPerturbationKeepsItsType(self):
+        """`bool` is a subclass of `int`, so the integer branch would eat a flag.
+
+        Truncation also made the flag one-directional: `True * 0.8` is `0.8`, which
+        `int()` floors to `0`, while `False * anything` is `0`, so a boolean could
+        ratchet from True to False and never back. Multiplying a flag by a
+        perturbation factor means nothing, so perturbation leaves it alone and
+        `resample_probability` is the only thing that flips it.
+        """
+
+        def perturb(value, factor, resample_probability=0.0):
+            new_config, _ = _explore(
+                {"v": value},
+                {"v": tune.choice([True, False])},
+                resample_probability,
+                perturbation_factors=(factor, factor),
+                custom_explore_fn=None,
+            )
+            return new_config["v"]
+
+        for value in (True, False):
+            for factor in (0.8, 1.2):
+                perturbed = perturb(value, factor)
+                self.assertIsInstance(perturbed, bool)
+                self.assertEqual(perturbed, value)
+
+        # Resampling still hands back a real bool, and is the path that can flip it.
+        random.seed(0)
+        resampled = [perturb(True, 0.8, resample_probability=1.0) for _ in range(20)]
+        self.assertTrue(all(isinstance(v, bool) for v in resampled))
+        self.assertIn(False, resampled)
+
     def testPerturbationValues(self):
         def assertProduces(fn, values):
             random.seed(0)

--- a/python/ray/tune/tests/test_trial_scheduler.py
+++ b/python/ray/tune/tests/test_trial_scheduler.py
@@ -1368,6 +1368,36 @@ class PopulationBasedTestingSuite(unittest.TestCase):
                 hyperparam_mutations={"float_factor": tune.sample_from(lambda: 100.0)}
             )
 
+    def testIntegerPerturbationDirection(self):
+        """An integer hyperparameter has to be able to grow, and must not reach zero.
+
+        `int()` truncates toward zero, so with the default factors `* 1.2` was thrown
+        away for every value below 5 while `* 0.8` always landed lower: the parameter
+        could only ratchet down, and 0 absorbed it because every factor leaves 0 alone.
+        """
+
+        def perturb(value, factor):
+            new_config, _ = _explore(
+                {"v": value},
+                {"v": lambda: value},
+                0.0,  # never resample, always apply a perturbation factor
+                perturbation_factors=(factor, factor),
+                custom_explore_fn=None,
+            )
+            return new_config["v"]
+
+        for value in range(1, 9):
+            # A factor above one never shrinks, a factor below one never grows.
+            self.assertGreaterEqual(perturb(value, 1.2), value)
+            self.assertLessEqual(perturb(value, 0.8), value)
+            # Shrinking a positive integer must not land on the absorbing zero.
+            self.assertGreater(perturb(value, 0.8), 0)
+
+        for value in range(3, 9):
+            # Growing has to reach a larger value once the factor moves it by at
+            # least half a step, rather than rounding straight back down.
+            self.assertGreater(perturb(value, 1.2), value)
+
     def testPerturbationValues(self):
         def assertProduces(fn, values):
             random.seed(0)


### PR DESCRIPTION
## Description

`_explore` perturbs a continuous hyperparameter by multiplying it by one of `perturbation_factors`, then converts the result back to an `int` if the parameter started out as one:

```python
perturbation_factor = random.choice(perturbation_factors)
new_config[key] = config[key] * perturbation_factor
...
if isinstance(config[key], int):
    new_config[key] = int(new_config[key])
```

`int()` truncates toward zero, so with the default factors `(1.2, 0.8)` the two directions are not symmetric:

| value | `* 1.2` | `int()` | `* 0.8` | `int()` |
| --- | --- | --- | --- | --- |
| 1 | 1.2 | **1** | 0.8 | **0** |
| 2 | 2.4 | **2** | 1.6 | 1 |
| 3 | 3.6 | **3** | 2.4 | 2 |
| 4 | 4.8 | **4** | 3.2 | 3 |
| 5 | 6.0 | 6 | 4.0 | 4 |

The upward factor is discarded for every value below 5, while the downward factor always lands lower. So an integer hyperparameter can only ratchet down, and 0 is absorbing because every factor leaves 0 unchanged. `operations[key]` still records `"* 1.2"` for a step that did nothing.

Simulating 50 perturbations from a starting value of 32, over 500 seeds:

| conversion | median final value | fraction ending at 0 |
| --- | --- | --- |
| `int()` (today) | 0 | **61%** |
| `round()` | 11.5 | 0% |

So a `tune.randint`-style hyperparameter such as `batch_size` or `num_layers` tends toward 0 over a PBT run rather than being explored in both directions.

## Fix

Round to nearest instead of truncating. Values large enough that truncation was already harmless are unchanged (`100 -> 120 / 80` either way), and the perturbation stops being one-directional for small ones.

Values of 1 and 2 become fixed points under both default factors, since ±20% of them is less than half a step. That is a symmetric no-op rather than a one-way ratchet, and it is what a ±20% multiplicative operator on a small integer means; forcing a minimum step of one instead reintroduces the collapse to 0 (8.2% of runs in the same simulation), so this keeps the simpler rounding. A value of 0 remains a fixed point of any multiplicative perturbation, which is unchanged by this PR.

## Related issues

None. This was found by reading `_explore`, not from an issue.

## Additional information

**Not a duplicate.** Checked before starting:

```
gh search prs --repo ray-project/ray "pbt _explore"                        -> 3 hits, all merged 2019-2025, unrelated (MLflow callback, docs notebook, config logging)
gh search prs --repo ray-project/ray "PopulationBasedTraining integer"     -> 0 hits
gh search issues --repo ray-project/ray "pbt integer hyperparameter perturbation" -> 0 hits
gh search prs --author vineethsaivs --repo ray-project/ray                 -> 9, none touching pbt.py
```

No open PR touches `python/ray/tune/schedulers/pbt.py`.

**Tests run and their results.** New test `PopulationBasedTestingSuite::testIntegerPerturbationDirection` in `python/ray/tune/tests/test_trial_scheduler.py`, checking that a factor above one grows and one below one shrinks without reaching zero. Run against the unpatched scheduler first to confirm it fails:

```
$ pytest test_trial_scheduler.py -k "PopulationBasedTestingSuite"     # before
FAILED PopulationBasedTestingSuite::testIntegerPerturbationDirection
   AssertionError: 0 not greater than 0
1 failed, 24 passed, 2 skipped

$ pytest test_trial_scheduler.py -k "PopulationBasedTestingSuite"     # after
25 passed, 2 skipped
```

The existing `testPerturbationValues` passes unchanged: it asserts `{"v": 100}` produces `{80, 120}`, which rounding preserves exactly.

Lint: `ruff check --select E,F,I,B,Q,C4,W --ignore <pyproject list>` on both files reports no findings; `black --check` leaves the test file unchanged and reports only a pre-existing hunk in `pbt.py` unrelated to this change.

AI assistance was used in preparing this change.
