### PR TITLE
[core] Preserve existing signal handlers after Ray shutdown

### DIFF
--- a/src/ray/util/logging.cc
+++ b/src/ray/util/logging.cc
@@ -435,6 +435,7 @@ namespace {
 constexpr std::array<int, 5> kInstalledSignals = {
     SIGSEGV, SIGILL, SIGFPE, SIGABRT, SIGTERM};
 #else
+// Ray pins Abseil 20230802.1, whose failure-signal table is defined here:
 // https://github.com/abseil/abseil-cpp/blob/fb3621f4f897824c0dbe0615fa94543df6192f30/absl/debugging/failure_signal_handler.cc#L94-L104
 constexpr std::array<int, 7> kInstalledSignals = {
     SIGSEGV, SIGILL, SIGFPE, SIGABRT, SIGTERM, SIGBUS, SIGTRAP};

--- a/src/ray/util/logging.cc
+++ b/src/ray/util/logging.cc
@@ -429,25 +429,60 @@ void RayLog::InitLogFormat() {
   initialized_ = true;
 }
 
+namespace {
+
+// Signals whose disposition absl::InstallFailureSignalHandler() replaces.
+constexpr std::array<int, 5> kInstalledSignals = {
+    SIGSEGV, SIGILL, SIGFPE, SIGABRT, SIGTERM};
+
+#ifdef _WIN32  // Do NOT use WIN32 (without the underscore); we want _WIN32 here
+using SignalDisposition = void (*)(int);
+#else
+using SignalDisposition = struct sigaction;
+#endif
+
+// Saved on install so uninstall can put back what the embedding process had. Resetting to
+// SIG_DFL instead silently disables a handler installed before Ray, such as an embedded
+// JVM's or an application's own crash reporter.
+//
+// Zero initialization is SIG_DFL, so a restore without a prior save degrades to the
+// historical behavior rather than to an invalid disposition.
+std::array<SignalDisposition, kInstalledSignals.size()>
+    previous_signal_dispositions;  // NOLINT
+
+void SavePreviousSignalDispositions() {
+  for (size_t i = 0; i < kInstalledSignals.size(); ++i) {
+#ifdef _WIN32  // Do NOT use WIN32 (without the underscore); we want _WIN32 here
+    // Windows has no query-only form of signal(), so read the current disposition by
+    // setting it and immediately putting it back.
+    SignalDisposition previous = signal(kInstalledSignals[i], SIG_DFL);
+    RAY_CHECK(previous != SIG_ERR);
+    RAY_CHECK(signal(kInstalledSignals[i], previous) != SIG_ERR);
+    previous_signal_dispositions[i] = previous;
+#else
+    RAY_CHECK(sigaction(kInstalledSignals[i],
+                        /*act=*/nullptr,
+                        &previous_signal_dispositions[i]) == 0);
+#endif
+  }
+}
+
+}  // namespace
+
 void RayLog::UninstallSignalAction() {
   if (!is_failure_signal_handler_installed_) {
     return;
   }
   RAY_LOG(DEBUG) << "Uninstall signal handlers.";
-  std::vector<int> installed_signals({SIGSEGV, SIGILL, SIGFPE, SIGABRT, SIGTERM});
+  for (size_t i = 0; i < kInstalledSignals.size(); ++i) {
 #ifdef _WIN32  // Do NOT use WIN32 (without the underscore); we want _WIN32 here
-  for (int signal_num : installed_signals) {
-    RAY_CHECK(signal(signal_num, SIG_DFL) != SIG_ERR);
-  }
+    RAY_CHECK(signal(kInstalledSignals[i], previous_signal_dispositions[i]) != SIG_ERR);
 #else
-  struct sigaction sig_action;
-  memset(&sig_action, 0, sizeof(sig_action));
-  sigemptyset(&sig_action.sa_mask);
-  sig_action.sa_handler = SIG_DFL;
-  for (int signal_num : installed_signals) {
-    RAY_CHECK(sigaction(signal_num, &sig_action, NULL) == 0);
-  }
+    RAY_CHECK(sigaction(kInstalledSignals[i],
+                        &previous_signal_dispositions[i],
+                        /*oldact=*/nullptr) == 0);
 #endif
+  }
   is_failure_signal_handler_installed_ = false;
 }
 
@@ -496,6 +531,7 @@ void RayLog::InstallFailureSignalHandler(const char *argv0, bool call_previous_h
   if (is_failure_signal_handler_installed_) {
     return;
   }
+  SavePreviousSignalDispositions();
 #ifndef _WIN32
   // InitializeSymbolizer cannot be called twice on windows, (causes a
   // crash)and is called in other libraries like pytorchaudio. It does not seem

--- a/src/ray/util/logging.cc
+++ b/src/ray/util/logging.cc
@@ -431,9 +431,14 @@ void RayLog::InitLogFormat() {
 
 namespace {
 
-// Signals whose disposition absl::InstallFailureSignalHandler() replaces.
+#ifdef _WIN32
 constexpr std::array<int, 5> kInstalledSignals = {
     SIGSEGV, SIGILL, SIGFPE, SIGABRT, SIGTERM};
+#else
+// https://github.com/abseil/abseil-cpp/blob/fb3621f4f897824c0dbe0615fa94543df6192f30/absl/debugging/failure_signal_handler.cc#L94-L104
+constexpr std::array<int, 7> kInstalledSignals = {
+    SIGSEGV, SIGILL, SIGFPE, SIGABRT, SIGTERM, SIGBUS, SIGTRAP};
+#endif
 
 #ifdef _WIN32  // Do NOT use WIN32 (without the underscore); we want _WIN32 here
 using SignalDisposition = void (*)(int);

--- a/src/ray/util/tests/logging_test.cc
+++ b/src/ray/util/tests/logging_test.cc
@@ -16,6 +16,7 @@
 
 #include <signal.h>
 
+#include <array>
 #include <chrono>
 #include <cstdlib>
 #include <fstream>
@@ -385,9 +386,7 @@ TEST(PrintLogTest, TestFailureSignalHandler) {
 // Never raised; installed only so its address is observable as a signal disposition.
 void ObservableSignalHandler(int /*signum*/) {}
 
-// One of the signals RayLog installs on, and the only one of those never raised
-// spontaneously by a healthy test process.
-constexpr int kSignalUnderTest = SIGTERM;
+constexpr std::array<int, 3> kSignalsUnderTest = {SIGTERM, SIGBUS, SIGTRAP};
 
 struct sigaction GetSignalAction(int signum) {
   struct sigaction current {};
@@ -404,30 +403,41 @@ void SetSignalHandler(int signum, void (*handler)(int)) {
 
 // Ray installs first, so the disposition it has to restore is the default one.
 TEST(PrintLogTest, TestUninstallSignalActionRestoresDefault) {
-  // Earlier tests in this binary may have left a handler installed.
   ray::RayLog::UninstallSignalAction();
-  SetSignalHandler(kSignalUnderTest, SIG_DFL);
+  for (const int signal : kSignalsUnderTest) {
+    SetSignalHandler(signal, SIG_DFL);
+  }
 
   ray::RayLog::InstallFailureSignalHandler(nullptr);
-  EXPECT_NE(GetSignalAction(kSignalUnderTest).sa_handler, SIG_DFL);
+  for (const int signal : kSignalsUnderTest) {
+    EXPECT_NE(GetSignalAction(signal).sa_handler, SIG_DFL);
+  }
 
   ray::RayLog::UninstallSignalAction();
-  EXPECT_EQ(GetSignalAction(kSignalUnderTest).sa_handler, SIG_DFL);
+  for (const int signal : kSignalsUnderTest) {
+    EXPECT_EQ(GetSignalAction(signal).sa_handler, SIG_DFL);
+  }
 }
 
-// A handler installed before Ray, as an embedded JVM or an application's own crash
-// reporter would be, has to survive Ray's shutdown.
 TEST(PrintLogTest, TestUninstallSignalActionRestoresPreexistingHandler) {
   ray::RayLog::UninstallSignalAction();
-  SetSignalHandler(kSignalUnderTest, ObservableSignalHandler);
+  for (const int signal : kSignalsUnderTest) {
+    SetSignalHandler(signal, ObservableSignalHandler);
+  }
 
   ray::RayLog::InstallFailureSignalHandler(nullptr);
-  EXPECT_NE(GetSignalAction(kSignalUnderTest).sa_handler, &ObservableSignalHandler);
+  for (const int signal : kSignalsUnderTest) {
+    EXPECT_NE(GetSignalAction(signal).sa_handler, &ObservableSignalHandler);
+  }
 
   ray::RayLog::UninstallSignalAction();
-  EXPECT_EQ(GetSignalAction(kSignalUnderTest).sa_handler, &ObservableSignalHandler);
+  for (const int signal : kSignalsUnderTest) {
+    EXPECT_EQ(GetSignalAction(signal).sa_handler, &ObservableSignalHandler);
+  }
 
-  SetSignalHandler(kSignalUnderTest, SIG_DFL);
+  for (const int signal : kSignalsUnderTest) {
+    SetSignalHandler(signal, SIG_DFL);
+  }
 }
 #endif
 

--- a/src/ray/util/tests/logging_test.cc
+++ b/src/ray/util/tests/logging_test.cc
@@ -14,6 +14,8 @@
 
 #include "ray/util/logging.h"
 
+#include <signal.h>
+
 #include <chrono>
 #include <cstdlib>
 #include <fstream>
@@ -378,5 +380,55 @@ TEST(PrintLogTest, TestFailureSignalHandler) {
   ray::RayLog::InstallFailureSignalHandler(nullptr);
   ASSERT_DEATH(abort(), ".*SIGABRT received.*");
 }
+
+#ifndef _WIN32
+// Never raised; installed only so its address is observable as a signal disposition.
+void ObservableSignalHandler(int /*signum*/) {}
+
+// One of the signals RayLog installs on, and the only one of those never raised
+// spontaneously by a healthy test process.
+constexpr int kSignalUnderTest = SIGTERM;
+
+struct sigaction GetSignalAction(int signum) {
+  struct sigaction current {};
+  EXPECT_EQ(sigaction(signum, /*act=*/nullptr, &current), 0);
+  return current;
+}
+
+void SetSignalHandler(int signum, void (*handler)(int)) {
+  struct sigaction action {};
+  sigemptyset(&action.sa_mask);
+  action.sa_handler = handler;
+  ASSERT_EQ(sigaction(signum, &action, /*oldact=*/nullptr), 0);
+}
+
+// Ray installs first, so the disposition it has to restore is the default one.
+TEST(PrintLogTest, TestUninstallSignalActionRestoresDefault) {
+  // Earlier tests in this binary may have left a handler installed.
+  ray::RayLog::UninstallSignalAction();
+  SetSignalHandler(kSignalUnderTest, SIG_DFL);
+
+  ray::RayLog::InstallFailureSignalHandler(nullptr);
+  EXPECT_NE(GetSignalAction(kSignalUnderTest).sa_handler, SIG_DFL);
+
+  ray::RayLog::UninstallSignalAction();
+  EXPECT_EQ(GetSignalAction(kSignalUnderTest).sa_handler, SIG_DFL);
+}
+
+// A handler installed before Ray, as an embedded JVM or an application's own crash
+// reporter would be, has to survive Ray's shutdown.
+TEST(PrintLogTest, TestUninstallSignalActionRestoresPreexistingHandler) {
+  ray::RayLog::UninstallSignalAction();
+  SetSignalHandler(kSignalUnderTest, ObservableSignalHandler);
+
+  ray::RayLog::InstallFailureSignalHandler(nullptr);
+  EXPECT_NE(GetSignalAction(kSignalUnderTest).sa_handler, &ObservableSignalHandler);
+
+  ray::RayLog::UninstallSignalAction();
+  EXPECT_EQ(GetSignalAction(kSignalUnderTest).sa_handler, &ObservableSignalHandler);
+
+  SetSignalHandler(kSignalUnderTest, SIG_DFL);
+}
+#endif
 
 }  // namespace ray


### PR DESCRIPTION
## Description

After a Ray shutdown, a crash that an embedded runtime should have caught kills the process instead, and the runtime that owns the handler never gets to print its traceback.

This affects any process where something else installed signal handlers before Ray started. The case that surfaced it is a Java virtual machine loaded inside a Python process for filesystem access, where the machine's own fault handlers are what turn a segfault into a readable stack trace. An application's own crash reporter has the same shape.

Before this change, shutting Ray down in such a process left the fault and termination signals pointing at the default disposition, so a later fault produced a bare signal death with no diagnostic. After it, the handlers that were in place before Ray started are the ones that run again.

The cause is that the uninstall path reset those signals to the default rather than restoring what was installed beforehand, so shutting down silently took the other runtime's handlers away.

The fix saves each signal disposition before Abseil replaces it, including `SIGBUS` and `SIGTRAP` on POSIX, and restores it on uninstall. The existing guard prevents a second install from overwriting the saved originals, and an uninstall with no prior install still returns early.

## Related issues

None. Found by reading the logging utility source.

## Additional information

The new cases install a recognisable handler, run the install and uninstall cycle, and assert that the original handler is what the operating system reports afterwards.

```
bazel test //src/ray/util/tests:logging_test --test_output=summary
```

With only the production file reverted:

```
git checkout HEAD~1 -- src/ray/util/logging.cc
```

```
  Which is: NULL
  &ObservableSignalHandler
    Which is: 0x102a662d8
[  FAILED  ] PrintLogTest.TestUninstallSignalActionRestoresPreexistingHandler (0 ms)
[  PASSED  ] 13 tests.
Executed 1 out of 1 test: 1 fails locally.
```

Restoring the file:

```
git checkout HEAD -- src/ray/util/logging.cc
bazel test //src/ray/util/tests:logging_test --test_output=summary
```

```
//src/ray/util/tests:logging_test                                        PASSED in 0.7s
Executed 1 out of 1 test: 1 test passes.
```
