### PR TITLE
[Core] Allow zero-increment leases over pinned argument limit

### DIFF
--- a/src/ray/raylet/scheduling/local_lease_manager.cc
+++ b/src/ray/raylet/scheduling/local_lease_manager.cc
@@ -809,7 +809,10 @@ bool LocalLeaseManager::PinLeaseArgsIfMemoryAvailable(
   }
   RAY_LOG(DEBUG) << "RayLease " << lease_spec.LeaseId() << " has args of size "
                  << lease_arg_bytes;
+  const size_t pinned_bytes_before = pinned_lease_arguments_bytes_;
   PinLeaseArgs(lease_spec, std::move(args));
+  RAY_CHECK_GE(pinned_lease_arguments_bytes_, pinned_bytes_before);
+  const size_t newly_pinned_bytes = pinned_lease_arguments_bytes_ - pinned_bytes_before;
   RAY_LOG(DEBUG) << "Size of pinned task args is now " << pinned_lease_arguments_bytes_;
   if (max_pinned_lease_arguments_bytes_ == 0) {
     // Max threshold for pinned args is not set.
@@ -822,7 +825,8 @@ bool LocalLeaseManager::PinLeaseArgsIfMemoryAvailable(
         << lease_arg_bytes
         << ", but the max memory allowed for arguments of granted leases is only "
         << max_pinned_lease_arguments_bytes_;
-  } else if (pinned_lease_arguments_bytes_ > max_pinned_lease_arguments_bytes_) {
+  } else if (newly_pinned_bytes > 0 &&
+             pinned_lease_arguments_bytes_ > max_pinned_lease_arguments_bytes_) {
     ReleaseLeaseArgs(lease_spec.LeaseId());
     RAY_LOG(DEBUG) << "Cannot grant lease " << lease_spec.LeaseId()
                    << " with arguments of size " << lease_arg_bytes

--- a/src/ray/raylet/scheduling/tests/cluster_lease_manager_test.cc
+++ b/src/ray/raylet/scheduling/tests/cluster_lease_manager_test.cc
@@ -2685,12 +2685,16 @@ TEST_F(ClusterLeaseManagerTest, PinnedArgsMemoryTest) {
 
 TEST_F(ClusterLeaseManagerTest, PinnedArgsSameMemoryTest) {
   /*
-   * Two leases that depend on the same object can run concurrently.
+   * Two leases that depend on the same object can run concurrently even if another
+   * granted lease has pushed the total pinned argument bytes over the threshold.
    */
   std::shared_ptr<MockWorker> worker =
       std::make_shared<MockWorker>(WorkerID::FromRandom(), 1234, clock_);
   std::shared_ptr<MockWorker> worker2 =
       std::make_shared<MockWorker>(WorkerID::FromRandom(), 12345, clock_);
+  std::shared_ptr<MockWorker> worker3 =
+      std::make_shared<MockWorker>(WorkerID::FromRandom(), 123456, clock_);
+  pool_.PushWorker(std::static_pointer_cast<WorkerInterface>(worker3));
   pool_.PushWorker(std::static_pointer_cast<WorkerInterface>(worker2));
   pool_.PushWorker(std::static_pointer_cast<WorkerInterface>(worker));
 
@@ -2713,13 +2717,76 @@ TEST_F(ClusterLeaseManagerTest, PinnedArgsSameMemoryTest) {
   pool_.TriggerCallbacks();
   ASSERT_EQ(num_callbacks, 1);
   ASSERT_EQ(leased_workers_.size(), 1);
-  ASSERT_EQ(pool_.workers.size(), 1);
+  ASSERT_EQ(pool_.workers.size(), 2);
   AssertPinnedLeaseArgumentsPresent(lease);
 
-  // This lease can run because it depends on the same object as the first lease.
-  auto lease2 = CreateLease({{ray::kCPU_ResourceLabel, 1}},
+  // This oversized lease can run to avoid starvation and pushes the total pinned
+  // argument bytes over the threshold.
+  default_arg_size_ = 2000;
+  auto lease2 = CreateLease({{ray::kCPU_ResourceLabel, 1}}, 1);
+  lease_manager_.QueueAndScheduleLease(
+      lease2,
+      false,
+      false,
+      std::vector<internal::ReplyCallback>{internal::ReplyCallback(callback, &reply)});
+  pool_.TriggerCallbacks();
+  ASSERT_EQ(num_callbacks, 2);
+  ASSERT_EQ(leased_workers_.size(), 2);
+  ASSERT_EQ(pool_.workers.size(), 1);
+
+  // This lease can still run because it depends on the same object as the first lease
+  // and therefore adds no new pinned bytes.
+  default_arg_size_ = 600;
+  auto lease3 = CreateLease({{ray::kCPU_ResourceLabel, 1}},
                             1,
                             lease.GetLeaseSpecification().GetDependencyIds());
+  lease_manager_.QueueAndScheduleLease(
+      lease3,
+      false,
+      false,
+      std::vector<internal::ReplyCallback>{internal::ReplyCallback(callback, &reply)});
+  pool_.TriggerCallbacks();
+  ASSERT_EQ(num_callbacks, 3);
+  ASSERT_EQ(leased_workers_.size(), 3);
+  ASSERT_EQ(pool_.workers.size(), 0);
+
+  for (auto &cur_worker : leased_workers_) {
+    local_lease_manager_->CleanupLease(cur_worker.second);
+  }
+  AssertNoLeaks();
+}
+
+TEST_F(ClusterLeaseManagerTest, LargeArgsNoStarvationTest) {
+  std::shared_ptr<MockWorker> worker =
+      std::make_shared<MockWorker>(WorkerID::FromRandom(), 1234, clock_);
+  std::shared_ptr<MockWorker> worker2 =
+      std::make_shared<MockWorker>(WorkerID::FromRandom(), 12345, clock_);
+  pool_.PushWorker(std::static_pointer_cast<WorkerInterface>(worker2));
+  pool_.PushWorker(std::static_pointer_cast<WorkerInterface>(worker));
+
+  rpc::RequestWorkerLeaseReply reply;
+  int num_callbacks = 0;
+  int *num_callbacks_ptr = &num_callbacks;
+  auto callback = [num_callbacks_ptr](
+                      Status, std::function<void()>, std::function<void()>) {
+    (*num_callbacks_ptr) = *num_callbacks_ptr + 1;
+  };
+
+  default_arg_size_ = 2000;
+  auto lease = CreateLease({{ray::kCPU_ResourceLabel, 1}}, 1);
+  lease_manager_.QueueAndScheduleLease(
+      lease,
+      false,
+      false,
+      std::vector<internal::ReplyCallback>{internal::ReplyCallback(callback, &reply)});
+  pool_.TriggerCallbacks();
+  ASSERT_EQ(num_callbacks, 1);
+  ASSERT_EQ(leased_workers_.size(), 1);
+  AssertPinnedLeaseArgumentsPresent(lease);
+
+  // A lease with no dependencies can still run while the oversized lease keeps the
+  // node over the pinned argument threshold because it adds no pinned bytes.
+  auto lease2 = CreateLease({{ray::kCPU_ResourceLabel, 1}});
   lease_manager_.QueueAndScheduleLease(
       lease2,
       false,
@@ -2733,36 +2800,6 @@ TEST_F(ClusterLeaseManagerTest, PinnedArgsSameMemoryTest) {
   for (auto &cur_worker : leased_workers_) {
     local_lease_manager_->CleanupLease(cur_worker.second);
   }
-  AssertNoLeaks();
-}
-
-TEST_F(ClusterLeaseManagerTest, LargeArgsNoStarvationTest) {
-  std::shared_ptr<MockWorker> worker =
-      std::make_shared<MockWorker>(WorkerID::FromRandom(), 1234, clock_);
-  pool_.PushWorker(std::static_pointer_cast<WorkerInterface>(worker));
-
-  rpc::RequestWorkerLeaseReply reply;
-  int num_callbacks = 0;
-  int *num_callbacks_ptr = &num_callbacks;
-  auto callback = [num_callbacks_ptr](
-                      Status, std::function<void()>, std::function<void()>) {
-    (*num_callbacks_ptr) = *num_callbacks_ptr + 1;
-  };
-
-  default_arg_size_ = 2000;
-  auto lease = CreateLease({{ray::kCPU_ResourceLabel, 1}}, 1);
-  pool_.PushWorker(std::static_pointer_cast<WorkerInterface>(worker));
-  lease_manager_.QueueAndScheduleLease(
-      lease,
-      false,
-      false,
-      std::vector<internal::ReplyCallback>{internal::ReplyCallback(callback, &reply)});
-  pool_.TriggerCallbacks();
-  ASSERT_EQ(num_callbacks, 1);
-  ASSERT_EQ(leased_workers_.size(), 1);
-  AssertPinnedLeaseArgumentsPresent(lease);
-
-  local_lease_manager_->CleanupLease(leased_workers_.begin()->second);
   AssertNoLeaks();
 }
 


### PR DESCRIPTION
## Description

When a node is already over the pinned lease-argument limit, admission currently rejects every normal-sized lease after pinning, even if that lease adds no new pinned bytes. This can block leases with no object dependencies and leases that only reuse objects already pinned by granted leases.

This change measures the incremental pinned bytes added by the current lease and applies the over-limit rejection only when that increment is positive. The existing unlimited configuration and oversized-single-lease anti-starvation behavior remain unchanged.

The regression coverage exercises both zero-increment cases while the node is already over the limit:

- a lease with no dependencies;
- a lease whose dependencies are already pinned by another granted lease.

## Related issues

Closes #65752

## Additional information

- Changed files: `local_lease_manager.cc` and `cluster_lease_manager_test.cc` only.
- Duplicate check: no open PR references #65752. #62185 changes owner-death cleanup and does not address zero-increment lease admission.
- AI assistance was used to analyze the issue and prepare the implementation. The final two-file diff was presented for review and explicitly approved before submission.

## Testing

- `clang-format 12.0.1` on both changed files: passed.
- `git diff --check`: passed.
- Bazel tests were not run to completion; submission was requested without waiting for further test execution.
