### PR TITLE
[ci][docker] Install google-cloud-cli in base-extra

### DIFF
--- a/docker/base-extra/Dockerfile
+++ b/docker/base-extra/Dockerfile
@@ -48,7 +48,7 @@ wget -O - https://packages.cloud.google.com/apt/doc/apt-key.gpg \
 # Add gdb since ray dashboard uses `memray attach`, which requires gdb.
 
 APT_PKGS=(
-    google-cloud-sdk
+    google-cloud-cli
     supervisor
     vim
     zsh


### PR DESCRIPTION
## What

`docker/base-extra/Dockerfile` installs the apt package `google-cloud-sdk`, which no longer exists. Renames it to `google-cloud-cli`. One word, one line.

## Why

Any `base-extra` build that misses the layer cache fails outright:

```
Package google-cloud-sdk is not available, but is referred to by another package.
However the following packages replace it:
  google-cloud-cli
E: Package 'google-cloud-sdk' has no installation candidate
=> ERROR: process "/bin/bash -c /dev/pipes/EOF" ... exit code: 100
```

The package name is simply gone from Google's repo — confirmed against the live index, in every suite it serves:

```
$ curl -s https://packages.cloud.google.com/apt/dists/cloud-sdk/main/binary-amd64/Packages \
    | awk '/^Package: /{print $2}' | sort -u
google-cloud-cli
google-cloud-cli-anthos-auth
... (28 more google-cloud-cli-* components)
kubectl

# google-cloud-sdk stanzas per suite (amd64 / arm64):
cloud-sdk           0    cloud-sdk-jammy  0    cloud-sdk-bullseye  0
# google-cloud-cli stanzas: 49 in each
```

The rename happened at 467.0.0 — `google-cloud-cli` still carries `Replaces: google-cloud-sdk (<< 467.0.0-0)`, which is the metadata apt is reading when it suggests the replacement. A `Replaces` relationship is not an installation candidate, so the install fails anyway. The old name kept resolving only while some version providing it remained in the repo's retention window; the oldest version now retained is `536.0.1-0`, so that window has rolled past.

## Why this surfaced now, not at the rename

The layer is normally an ECR cache hit, so the apt step never executes. It only runs on a cache miss:

```
cache image miss: GET .../rayproject/citemp/manifests/z-ac0c9dae...: MANIFEST_UNKNOWN: Requested image not found
```

The same commit and the same Dockerfile therefore built green on 2026-08-24 (`cache hit: sha256:09ec1be3...`) and failed on 2026-08-27. A green older build is not evidence the Dockerfile still builds — every image layering on `base-extra` (ray, ray-ml, ray-torch, all Python versions) hits this once its cache entry is gone.

## Precedent

`ci/docker/forge.Dockerfile:64` already installs `google-cloud-cli` from the same repo, same key, same apt source line. This only brings `base-extra` in line with it; the source list and key handling are unchanged.

## Testing

Reproduced the CI failure and verified the fix in `ubuntu:22.04` (the image's base), using the same apt source and key as the Dockerfile:

```
--- OLD NAME (expected to fail) ---
However the following packages replace it:
  google-cloud-cli
E: Package 'google-cloud-sdk' has no installation candidate

--- NEW NAME (expected to resolve) ---
Inst google-cloud-cli (582.0.0-0 cloud-sdk:cloud-sdk [amd64])
Conf google-cloud-cli (582.0.0-0 cloud-sdk:cloud-sdk [amd64])
Google Cloud SDK 582.0.0
```

No loss of tooling — the CLI entry points are all still provided:

```
gcloud   -> /usr/bin/gcloud
gsutil   -> /usr/bin/gsutil      (gsutil version: 5.37)
bq       -> /usr/bin/bq
```

Both architectures the image builds are covered: `google-cloud-cli` has 49 versions in the `binary-amd64` index and 49 in `binary-arm64`.

Real verification is CI building `base-extra` on this PR.

## Not a duplicate

`gh pr list --state open --search "google-cloud-cli"` returns nothing, and no open PR touches `docker/base-extra/Dockerfile`. Its last three commits (#61497, #60878, #60687) are unrelated.

## AI assistance

AI assistance was used: diagnosing the failing Buildkite job, confirming the package's absence against the live apt index, and running the container reproduction above. Every changed line was reviewed and every command shown was run and its output confirmed before requesting review.