### PR TITLE
[dashboard] Clarify unaccounted task hint

### DIFF
--- a/python/ray/dashboard/client/src/components/ProgressBar/ProgressBar.component.test.tsx
+++ b/python/ray/dashboard/client/src/components/ProgressBar/ProgressBar.component.test.tsx
@@ -54,7 +54,7 @@ describe("ProgressBar", () => {
     await screen.findByText("Unaccounted: 1");
     expect(
       screen.getByLabelText(
-        "Unaccounted tasks are excluded from the current view, such as finished tasks when Hide finished is selected.",
+        "Unaccounted tasks are excluded from the current view, such as finished tasks when 'Hide finished' is selected.",
       ),
     ).toBeInTheDocument();
   });

--- a/python/ray/dashboard/client/src/components/ProgressBar/ProgressBar.component.test.tsx
+++ b/python/ray/dashboard/client/src/components/ProgressBar/ProgressBar.component.test.tsx
@@ -35,4 +35,27 @@ describe("ProgressBar", () => {
     const segments = screen.getAllByTestId("progress-bar-segment");
     expect(segments).toHaveLength(3);
   });
+
+  it("explains unaccounted tasks as excluded from the current view", async () => {
+    render(
+      <ProgressBar
+        progress={[
+          {
+            color: "green",
+            label: "Finished",
+            value: 2,
+          },
+        ]}
+        total={3}
+      />,
+      { wrapper: TEST_APP_WRAPPER },
+    );
+
+    await screen.findByText("Unaccounted: 1");
+    expect(
+      screen.getByLabelText(
+        "Unaccounted tasks are excluded from the current view, such as finished tasks when Hide finished is selected.",
+      ),
+    ).toBeInTheDocument();
+  });
 });

--- a/python/ray/dashboard/client/src/components/ProgressBar/ProgressBar.tsx
+++ b/python/ray/dashboard/client/src/components/ProgressBar/ProgressBar.tsx
@@ -93,7 +93,7 @@ export const ProgressBar = ({
           {
             value: finalTotal - segmentTotal,
             label: unaccountedLabel ?? "Unaccounted",
-            hint: "Unaccounted tasks are excluded from the current view, such as finished tasks when Hide finished is selected.",
+            hint: "Unaccounted tasks are excluded from the current view, such as finished tasks when 'Hide finished' is selected.",
             color:
               theme.palette.mode === "dark"
                 ? theme.palette.grey[700]

--- a/python/ray/dashboard/client/src/components/ProgressBar/ProgressBar.tsx
+++ b/python/ray/dashboard/client/src/components/ProgressBar/ProgressBar.tsx
@@ -93,7 +93,7 @@ export const ProgressBar = ({
           {
             value: finalTotal - segmentTotal,
             label: unaccountedLabel ?? "Unaccounted",
-            hint: "Unaccounted tasks can happen when there are too many tasks. Ray drops older tasks to conserve memory.",
+            hint: "Unaccounted tasks are excluded from the current view, such as finished tasks when Hide finished is selected.",
             color:
               theme.palette.mode === "dark"
                 ? theme.palette.grey[700]


### PR DESCRIPTION
## Description

Clarifies the dashboard’s unaccounted-task hint: tasks can be excluded from the current view, including when the **Hide finished** control is selected; the hint no longer suggests that Ray drops those tasks.

Adds a component regression test for the accessible hint text.

## Related issues

Fixes #65755

## Duplicate check

Checked open Ray PRs for `65755` and `unaccounted task`; no duplicate was open when this PR was created.

## Testing

Working directory: `python/ray/dashboard/client`

- `CI=true npm test -- --runInBand src/components/ProgressBar/ProgressBar.component.test.tsx`  passed (2 tests)
- `./node_modules/.bin/prettier -c src/components/ProgressBar/ProgressBar.tsx src/components/ProgressBar/ProgressBar.component.test.tsx`  passed
- `./node_modules/.bin/eslint src/components/ProgressBar/ProgressBar.tsx src/components/ProgressBar/ProgressBar.component.test.tsx`  passed
- `CI=true npm run build`  passed

## AI assistance

AI assistance was used for implementation. I have reviewed every changed line.