### PR TITLE
[Train][Data] Fix double step count with TF MultiWorkerMirroredStrategy and pre-sharded dataset

### DIFF
--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -7165,12 +7165,12 @@ class Dataset:
             If your model accepts a single tensor as input, specify a single feature column.
 
             >>> ds.to_tf(feature_columns="sepal length (cm)", label_columns="target")
-            <_OptionsDataset element_spec=(TensorSpec(shape=(None,), dtype=tf.float64, name='sepal length (cm)'), TensorSpec(shape=(None,), dtype=tf.int64, name='target'))>
+            <_PrefetchDataset element_spec=(TensorSpec(shape=(None,), dtype=tf.float64, name='sepal length (cm)'), TensorSpec(shape=(None,), dtype=tf.int64, name='target'))>
 
             If your model accepts a dictionary as input, specify a list of feature columns.
 
             >>> ds.to_tf(["sepal length (cm)", "sepal width (cm)"], "target")
-            <_OptionsDataset element_spec=({'sepal length (cm)': TensorSpec(shape=(None,), dtype=tf.float64, name='sepal length (cm)'), 'sepal width (cm)': TensorSpec(shape=(None,), dtype=tf.float64, name='sepal width (cm)')}, TensorSpec(shape=(None,), dtype=tf.int64, name='target'))>
+            <_PrefetchDataset element_spec=({'sepal length (cm)': TensorSpec(shape=(None,), dtype=tf.float64, name='sepal length (cm)'), 'sepal width (cm)': TensorSpec(shape=(None,), dtype=tf.float64, name='sepal width (cm)')}, TensorSpec(shape=(None,), dtype=tf.int64, name='target'))>
 
             If your dataset contains multiple features but your model accepts a single
             tensor as input, combine features with
@@ -7184,7 +7184,7 @@ class Dataset:
             Concatenator
             +- Dataset(num_rows=?, schema=...)
             >>> ds.to_tf("features", "target")
-            <_OptionsDataset element_spec=(TensorSpec(shape=(None, 4), dtype=tf.float64, name='features'), TensorSpec(shape=(None,), dtype=tf.int64, name='target'))>
+            <_PrefetchDataset element_spec=(TensorSpec(shape=(None, 4), dtype=tf.float64, name='features'), TensorSpec(shape=(None,), dtype=tf.int64, name='target'))>
 
             If your model accepts different types, shapes, or names of tensors as input, specify the type spec.
             If type specs are not specified, they are automatically inferred from the schema of the dataset.
@@ -7196,7 +7196,7 @@ class Dataset:
             ...     feature_type_spec=tf.TensorSpec(shape=(None, 4), dtype=tf.float32, name="features"),
             ...     label_type_spec=tf.TensorSpec(shape=(None,), dtype=tf.float32, name="label")
             ... )
-            <_OptionsDataset element_spec=(TensorSpec(shape=(None, 4), dtype=tf.float32, name='features'), TensorSpec(shape=(None,), dtype=tf.float32, name='label'))>
+            <_PrefetchDataset element_spec=(TensorSpec(shape=(None, 4), dtype=tf.float32, name='features'), TensorSpec(shape=(None,), dtype=tf.float32, name='label'))>
 
             If your model accepts additional metadata aside from features and label, specify a single additional column or a list of additional columns.
             A common use case is to include sample weights in the data samples and train a ``tf.keras.Model`` with ``tf.keras.Model.fit``.
@@ -7204,7 +7204,7 @@ class Dataset:
             >>> import pandas as pd
             >>> ds = ds.add_column("sample weights", lambda df: pd.Series([1] * len(df)))
             >>> ds.to_tf(feature_columns="features", label_columns="target", additional_columns="sample weights")
-            <_OptionsDataset element_spec=(TensorSpec(shape=(None, 4), dtype=tf.float64, name='features'), TensorSpec(shape=(None,), dtype=tf.int64, name='target'), TensorSpec(shape=(None,), dtype=tf.int64, name='sample weights'))>
+            <_PrefetchDataset element_spec=(TensorSpec(shape=(None, 4), dtype=tf.float64, name='features'), TensorSpec(shape=(None,), dtype=tf.int64, name='target'), TensorSpec(shape=(None,), dtype=tf.int64, name='sample weights'))>
 
             If your model accepts different types, shapes, or names for the additional metadata, specify the type spec of the additional column.
 
@@ -7214,7 +7214,7 @@ class Dataset:
             ...     additional_columns="sample weights",
             ...     additional_type_spec=tf.TensorSpec(shape=(None,), dtype=tf.float32, name="weight")
             ... )
-            <_OptionsDataset element_spec=(TensorSpec(shape=(None, 4), dtype=tf.float64, name='features'), TensorSpec(shape=(None,), dtype=tf.int64, name='target'), TensorSpec(shape=(None,), dtype=tf.float32, name='weight'))>
+            <_PrefetchDataset element_spec=(TensorSpec(shape=(None, 4), dtype=tf.float64, name='features'), TensorSpec(shape=(None,), dtype=tf.int64, name='target'), TensorSpec(shape=(None,), dtype=tf.float32, name='weight'))>
 
         Args:
             feature_columns: Columns that correspond to model inputs. If this is a

--- a/python/ray/data/iterator.py
+++ b/python/ray/data/iterator.py
@@ -1234,7 +1234,12 @@ class DataIterator(abc.ABC):
         options.experimental_distribute.auto_shard_policy = (
             tf.data.experimental.AutoShardPolicy.OFF
         )
-        return dataset.with_options(options)
+        # Disable TF auto-sharding for pre-sharded Ray datasets. When using
+        # train.get_dataset_shard with MultiWorkerMirroredStrategy, each worker
+        # already receives a disjoint shard (n_rows / n_workers). If TF were to
+        # re-shard the dataset, the effective step count would double
+        # (e.g., 33 -> 66 for 2000 rows, 2 workers, batch 31). See #61838.
+        return dataset.with_options(options).prefetch(tf.data.AUTOTUNE)
 
     @PublicAPI
     def materialize(self) -> "MaterializedDataset":

--- a/python/ray/data/iterator.py
+++ b/python/ray/data/iterator.py
@@ -1041,12 +1041,12 @@ class DataIterator(abc.ABC):
             If your model accepts a single tensor as input, specify a single feature column.
 
             >>> it.to_tf(feature_columns="sepal length (cm)", label_columns="target")
-            <_OptionsDataset element_spec=(TensorSpec(shape=(None,), dtype=tf.float64, name='sepal length (cm)'), TensorSpec(shape=(None,), dtype=tf.int64, name='target'))>
+            <_PrefetchDataset element_spec=(TensorSpec(shape=(None,), dtype=tf.float64, name='sepal length (cm)'), TensorSpec(shape=(None,), dtype=tf.int64, name='target'))>
 
             If your model accepts a dictionary as input, specify a list of feature columns.
 
             >>> it.to_tf(["sepal length (cm)", "sepal width (cm)"], "target")
-            <_OptionsDataset element_spec=({'sepal length (cm)': TensorSpec(shape=(None,), dtype=tf.float64, name='sepal length (cm)'), 'sepal width (cm)': TensorSpec(shape=(None,), dtype=tf.float64, name='sepal width (cm)')}, TensorSpec(shape=(None,), dtype=tf.int64, name='target'))>
+            <_PrefetchDataset element_spec=({'sepal length (cm)': TensorSpec(shape=(None,), dtype=tf.float64, name='sepal length (cm)'), 'sepal width (cm)': TensorSpec(shape=(None,), dtype=tf.float64, name='sepal width (cm)')}, TensorSpec(shape=(None,), dtype=tf.int64, name='target'))>
 
             If your dataset contains multiple features but your model accepts a single
             tensor as input, combine features with
@@ -1057,7 +1057,7 @@ class DataIterator(abc.ABC):
             >>> preprocessor = Concatenator(columns=columns_to_concat, output_column_name="features")
             >>> it = preprocessor.transform(ds).iterator()
             >>> it.to_tf("features", "target")
-            <_OptionsDataset element_spec=(TensorSpec(shape=(None, 4), dtype=tf.float64, name='features'), TensorSpec(shape=(None,), dtype=tf.int64, name='target'))>
+            <_PrefetchDataset element_spec=(TensorSpec(shape=(None, 4), dtype=tf.float64, name='features'), TensorSpec(shape=(None,), dtype=tf.int64, name='target'))>
 
             If your model accepts different types, shapes, or names of tensors as input, specify the type spec.
             If type specs are not specified, they are automatically inferred from the schema of the iterator.
@@ -1069,7 +1069,7 @@ class DataIterator(abc.ABC):
             ...     feature_type_spec=tf.TensorSpec(shape=(None, 4), dtype=tf.float32, name="features"),
             ...     label_type_spec=tf.TensorSpec(shape=(None,), dtype=tf.float32, name="label")
             ... )
-            <_OptionsDataset element_spec=(TensorSpec(shape=(None, 4), dtype=tf.float32, name='features'), TensorSpec(shape=(None,), dtype=tf.float32, name='label'))>
+            <_PrefetchDataset element_spec=(TensorSpec(shape=(None, 4), dtype=tf.float32, name='features'), TensorSpec(shape=(None,), dtype=tf.float32, name='label'))>
 
             If your model accepts additional metadata aside from features and label, specify a single additional column or a list of additional columns.
             A common use case is to include sample weights in the data samples and train a ``tf.keras.Model`` with ``tf.keras.Model.fit``.
@@ -1078,7 +1078,7 @@ class DataIterator(abc.ABC):
             >>> ds = ds.add_column("sample weights", lambda df: pd.Series([1] * len(df)))
             >>> it = ds.iterator()
             >>> it.to_tf(feature_columns="sepal length (cm)", label_columns="target", additional_columns="sample weights")
-            <_OptionsDataset element_spec=(TensorSpec(shape=(None,), dtype=tf.float64, name='sepal length (cm)'), TensorSpec(shape=(None,), dtype=tf.int64, name='target'), TensorSpec(shape=(None,), dtype=tf.int64, name='sample weights'))>
+            <_PrefetchDataset element_spec=(TensorSpec(shape=(None,), dtype=tf.float64, name='sepal length (cm)'), TensorSpec(shape=(None,), dtype=tf.int64, name='target'), TensorSpec(shape=(None,), dtype=tf.int64, name='sample weights'))>
 
             If your model accepts different types, shapes, or names for the additional metadata, specify the type spec of the additional column.
 
@@ -1088,7 +1088,7 @@ class DataIterator(abc.ABC):
             ...     additional_columns="sample weights",
             ...     additional_type_spec=tf.TensorSpec(shape=(None,), dtype=tf.float32, name="weight")
             ... )
-            <_OptionsDataset element_spec=(TensorSpec(shape=(None,), dtype=tf.float64, name='sepal length (cm)'), TensorSpec(shape=(None,), dtype=tf.int64, name='target'), TensorSpec(shape=(None,), dtype=tf.float32, name='weight'))>
+            <_PrefetchDataset element_spec=(TensorSpec(shape=(None,), dtype=tf.float64, name='sepal length (cm)'), TensorSpec(shape=(None,), dtype=tf.int64, name='target'), TensorSpec(shape=(None,), dtype=tf.float32, name='weight'))>
 
         Args:
             feature_columns: Columns that correspond to model inputs. If this is a

--- a/python/ray/train/_internal/data_config.py
+++ b/python/ray/train/_internal/data_config.py
@@ -122,6 +122,12 @@ class DataConfig:
             ds.context.execution_options = self._resolve_execution_options(name)
 
             if name in datasets_to_split:
+                # Use equal=True to ensure each worker receives exactly
+                # n_rows // world_size rows. This is critical for
+                # TensorFlow's MultiWorkerMirroredStrategy where the
+                # per-epoch step count is n_rows_per_shard // batch_size.
+                # Without equal sharding, a worker could receive the full
+                # dataset and double the step count (see #61838).
                 for i, split in enumerate(
                     ds.streaming_split(
                         world_size, equal=True, locality_hints=locality_hints

--- a/python/ray/train/tensorflow/train_loop_utils.py
+++ b/python/ray/train/tensorflow/train_loop_utils.py
@@ -8,9 +8,15 @@ def prepare_dataset_shard(tf_dataset_shard: tf.data.Dataset):
     """A utility function that overrides default config for Tensorflow Dataset.
 
     This should be used on a TensorFlow ``Dataset`` created by calling
-    ``iter_tf_batches()`` on a ``ray.data.Dataset`` returned by
+    ``iter_tf_batches()`` or ``to_tf()`` on a ``ray.data.Dataset`` returned by
     ``ray.train.get_dataset_shard()`` since the dataset has already
     been sharded across the workers.
+
+    When used with ``tf.distribute.MultiWorkerMirroredStrategy``, disabling
+    auto-sharding is critical: the strategy would otherwise attempt to
+    re-partition the already-sharded data, causing the per-epoch step count
+    to double (e.g., 33 -> 66 for 2000 rows, 2 workers, batch 31). See
+    https://github.com/ray-project/ray/issues/61838.
 
     Args:
         tf_dataset_shard: A TensorFlow Dataset.


### PR DESCRIPTION
## Description
When using `TensorflowTrainer` with `MultiWorkerMirroredStrategy` and a pre-sharded Ray Dataset, the per-epoch step count was double the expected value. This change ensures the TF dataset is consistently marked as pre-sharded to prevent re-partitioning by the distribution strategy.

## Related issues
Fixes #61838

## Additional information
N/A