### PR TITLE
[Autoscaler] Support idleTerminationOptions for RayCluster idle termination

### DIFF
--- a/python/ray/autoscaler/_private/kuberay/node_provider.py
+++ b/python/ray/autoscaler/_private/kuberay/node_provider.py
@@ -183,8 +183,8 @@ def replace_patch(path: str, value: Any) -> Dict[str, Any]:
     return {"op": "replace", "path": path, "value": value}
 
 
-def idle_terminate_patch(should_idle_terminate: bool) -> Dict[str, Any]:
-    return {"spec": {"idleTerminate": should_idle_terminate}}
+def idle_suspend_patch(should_idle_suspend: bool) -> Dict[str, Any]:
+    return {"spec": {"idleSuspend": should_idle_suspend}}
 
 
 def finalizer_patch(

--- a/python/ray/autoscaler/_private/kuberay/node_provider.py
+++ b/python/ray/autoscaler/_private/kuberay/node_provider.py
@@ -183,8 +183,8 @@ def replace_patch(path: str, value: Any) -> Dict[str, Any]:
     return {"op": "replace", "path": path, "value": value}
 
 
-def suspend_patch(should_suspend: bool) -> Dict[str, Any]:
-    return {"spec": {"suspend": should_suspend}}
+def idle_terminate_patch(should_idle_terminate: bool) -> Dict[str, Any]:
+    return {"spec": {"idleTerminate": should_idle_terminate}}
 
 
 def finalizer_patch(finalizers: List[str]) -> Dict[str, Any]:
@@ -435,7 +435,7 @@ class KubernetesHttpApiClient(IKubernetesHttpApiClient):
             timeout=KUBERAY_REQUEST_TIMEOUT_S,
             verify=verify,
         )
-        if not result.status_code == 200:
+        if result.status_code not in {200, 404}:
             result.raise_for_status()
         return result.json()
 

--- a/python/ray/autoscaler/_private/kuberay/node_provider.py
+++ b/python/ray/autoscaler/_private/kuberay/node_provider.py
@@ -183,6 +183,14 @@ def replace_patch(path: str, value: Any) -> Dict[str, Any]:
     return {"op": "replace", "path": path, "value": value}
 
 
+def suspend_patch(should_suspend: bool) -> Dict[str, Any]:
+    return {"spec": {"suspend": should_suspend}}
+
+
+def finalizer_patch(finalizers: List[str]) -> Dict[str, Any]:
+    return {"metadata": {"finalizers": finalizers}}
+
+
 def load_k8s_secrets() -> Tuple[Dict[str, str], str, Optional[Tuple[str, str]]]:
     """
     Loads secrets needed to access K8s resources.
@@ -313,6 +321,11 @@ class IKubernetesHttpApiClient(ABC):
         """Wrapper for REST PATCH of resource with proper headers."""
         pass
 
+    @abstractmethod
+    def delete(self, path: str) -> Dict[str, Any]:
+        """Wrapper for REST DELETE of resource with proper headers."""
+        pass
+
 
 class KubernetesHttpApiClient(IKubernetesHttpApiClient):
     def __init__(self, namespace: str, kuberay_crd_version: str = KUBERAY_CRD_VER):
@@ -393,6 +406,34 @@ class KubernetesHttpApiClient(IKubernetesHttpApiClient):
             timeout=KUBERAY_REQUEST_TIMEOUT_S,
             verify=verify,
             cert=cert,
+        )
+        if not result.status_code == 200:
+            result.raise_for_status()
+        return result.json()
+
+    def delete(self, path: str) -> Dict[str, Any]:
+        """Wrapper for REST DELETE of resource with proper headers.
+
+        Args:
+            path: The part of the resource path that starts with the resource type.
+
+        Returns:
+            The JSON response of the DELETE request.
+
+        Raises:
+            HTTPError: If the DELETE request fails.
+        """
+        url = url_from_resource(
+            namespace=self._namespace,
+            path=path,
+            kuberay_crd_version=self._kuberay_crd_version,
+        )
+        headers, verify = self._get_refreshed_headers_and_verify()
+        result = requests.delete(
+            url,
+            headers=headers,
+            timeout=KUBERAY_REQUEST_TIMEOUT_S,
+            verify=verify,
         )
         if not result.status_code == 200:
             result.raise_for_status()

--- a/python/ray/autoscaler/_private/kuberay/node_provider.py
+++ b/python/ray/autoscaler/_private/kuberay/node_provider.py
@@ -435,7 +435,7 @@ class KubernetesHttpApiClient(IKubernetesHttpApiClient):
             timeout=KUBERAY_REQUEST_TIMEOUT_S,
             verify=verify,
         )
-        if result.status_code not in {200, 404}:
+        if not result.status_code == 200:
             result.raise_for_status()
         return result.json()
 

--- a/python/ray/autoscaler/_private/kuberay/node_provider.py
+++ b/python/ray/autoscaler/_private/kuberay/node_provider.py
@@ -441,12 +441,13 @@ class KubernetesHttpApiClient(IKubernetesHttpApiClient):
             path=path,
             kuberay_crd_version=self._kuberay_crd_version,
         )
-        headers, verify = self._get_refreshed_headers_and_verify()
+        headers, verify, cert = self._get_refreshed_credentials()
         result = requests.delete(
             url,
             headers=headers,
             timeout=KUBERAY_REQUEST_TIMEOUT_S,
             verify=verify,
+            cert=cert,
         )
         if not result.status_code == 200:
             result.raise_for_status()

--- a/python/ray/autoscaler/_private/kuberay/node_provider.py
+++ b/python/ray/autoscaler/_private/kuberay/node_provider.py
@@ -187,8 +187,21 @@ def idle_terminate_patch(should_idle_terminate: bool) -> Dict[str, Any]:
     return {"spec": {"idleTerminate": should_idle_terminate}}
 
 
-def finalizer_patch(finalizers: List[str]) -> Dict[str, Any]:
-    return {"metadata": {"finalizers": finalizers}}
+def finalizer_patch(
+    finalizer: str, finalizers: Optional[List[str]]
+) -> List[Dict[str, Any]]:
+    if finalizers:
+        path = "/metadata/finalizers/-"
+        value = finalizer
+    else:
+        path = "/metadata/finalizers"
+        value = [finalizer]
+
+    return add_patch(path, value)
+
+
+def add_patch(path: str, value: Any) -> List[Dict[str, Any]]:
+    return [{"op": "add", "path": path, "value": value}]
 
 
 def load_k8s_secrets() -> Tuple[Dict[str, str], str, Optional[Tuple[str, str]]]:

--- a/python/ray/autoscaler/v2/instance_manager/cloud_providers/kuberay/cloud_provider.py
+++ b/python/ray/autoscaler/v2/instance_manager/cloud_providers/kuberay/cloud_provider.py
@@ -767,11 +767,11 @@ class KubeRayProvider(ICloudInstanceProvider):
             # using a read-modify-write to preserve existing finalizers.
             finalizers = self._ray_cluster.get("metadata", {}).get("finalizers", [])
             if NO_DRIVER_TIMEOUT_FINALIZER not in finalizers:
-                finalizers.append(NO_DRIVER_TIMEOUT_FINALIZER)
-                payload = finalizer_patch(finalizers)
+                # metadata.finalizers is an array so we use add-patch to append NO_DRIVER_TIMEOUT_FINALIZER
+                payload = finalizer_patch(NO_DRIVER_TIMEOUT_FINALIZER, finalizers)
                 try:
                     patched_raycluster = self._k8s_api_client.patch(
-                        path, payload, content_type="application/merge-patch+json"
+                        path, payload, content_type="application/json-patch+json"
                     )
 
                     if NO_DRIVER_TIMEOUT_FINALIZER not in patched_raycluster.get(

--- a/python/ray/autoscaler/v2/instance_manager/cloud_providers/kuberay/cloud_provider.py
+++ b/python/ray/autoscaler/v2/instance_manager/cloud_providers/kuberay/cloud_provider.py
@@ -23,6 +23,8 @@ from ray.autoscaler._private.kuberay.node_provider import (
     _worker_group_max_replicas,
     _worker_group_num_of_hosts,
     _worker_group_replicas,
+    finalizer_patch,
+    suspend_patch,
     worker_delete_patch,
     worker_replica_patch,
 )
@@ -47,6 +49,10 @@ NO_DRIVER_TTL_EXPIRED_ANNOTATION = "ray.io/no-driver-ttl-expired"
 
 AUTOSCALER_OPTIONS_KEY = "autoscalerOptions"
 NO_DRIVER_TIMEOUT_SECONDS_KEY = "noDriverTimeoutSeconds"
+NO_DRIVER_TIMEOUT_POLICY_KEY = "noDriverTimeoutPolicy"
+
+NO_DRIVER_TIMEOUT_POLICY = "Delete"
+NO_DRIVER_TIMEOUT_FINALIZER = "ray.io/no-driver-idle-termination"
 
 
 class KubeRayProvider(ICloudInstanceProvider):
@@ -509,10 +515,12 @@ class KubeRayProvider(ICloudInstanceProvider):
         self._ippr_provider.sync_with_raylets()
 
     def _refresh_no_driver_timeout_seconds(self) -> None:
-        """Reads noDriverTimeoutSeconds from the RayCluster CR."""
+        """Reads noDriverTimeoutSeconds and noDriverTimeoutPolicy from the RayCluster CR."""
         opts = self._ray_cluster["spec"].get(AUTOSCALER_OPTIONS_KEY, {})
         secs = opts.get(NO_DRIVER_TIMEOUT_SECONDS_KEY)
         self._no_driver_timeout_seconds = float(secs) if secs is not None else None
+        policy = opts.get(NO_DRIVER_TIMEOUT_POLICY_KEY, "Delete")
+        self._no_driver_policy = policy
 
     @property
     def ray_cluster(self) -> Dict[str, Any]:
@@ -720,7 +728,7 @@ class KubeRayProvider(ICloudInstanceProvider):
             self._no_driver_observed_since = now
         if now - self._no_driver_observed_since < self._no_driver_timeout_seconds:
             return
-        self._set_no_driver_annotation()
+        self._apply_no_driver_timeout_policy()
 
     def _driver_status(self) -> Tuple[bool, int]:
         """Returns whether a non-internal driver is alive and the latest job end time.
@@ -750,20 +758,46 @@ class KubeRayProvider(ICloudInstanceProvider):
                 has_active_driver = True
         return has_active_driver, latest_job_end_time
 
-    def _set_no_driver_annotation(self) -> None:
-        """Sets `ray.io/no-driver-ttl-expired=true` on the RayCluster CR.
-
-        Idempotent via the CR cached this reconcile loop; PATCH errors are swallowed.
-        """
-        annotations = self._ray_cluster.get("metadata", {}).get("annotations", {})
-        if annotations.get(NO_DRIVER_TTL_EXPIRED_ANNOTATION) == "true":
-            return
-
+    def _apply_no_driver_timeout_policy(self) -> None:
+        """Applies the configured no-driver timeout policy to the RayCluster CR."""
         path = f"rayclusters/{self._cluster_name}"
-        # Merge patch covers missing and present annotations in one call.
-        payload = {
-            "metadata": {"annotations": {NO_DRIVER_TTL_EXPIRED_ANNOTATION: "true"}}
-        }
+        if self._no_driver_policy == "Delete":
+            # Append the ray.io/no-driver-idle-termination finalizer
+            # using a read-modify-write to preserve existing finalizers.
+            finalizers = self._ray_cluster.get("metadata").get("finalizers", [])
+            if NO_DRIVER_TIMEOUT_FINALIZER not in finalizers:
+                finalizers.append(NO_DRIVER_TIMEOUT_FINALIZER)
+                payload = finalizer_patch(finalizers)
+                try:
+                    self._k8s_api_client.patch(
+                        path, payload, content_type="application/merge-patch+json"
+                    )
+                except Exception:
+                    logger.exception(
+                        f"Failed to MERGE-PATCH finalizers to {self._cluster_name}"
+                    )
+                    return None
+
+            try:
+                # DELETE the idle RayClusters
+                _ = self._k8s_api_client.delete(path)
+                logger.info(f"Deleted {self._cluster_name}")
+                return None
+            except requests.HTTPError as e:
+                if e.response.status_code == 404:
+                    logger.info(
+                        f"{self._cluster_name} has been deleted so the api server cannot find it."
+                    )
+                else:
+                    logger.exception(f"Failed to delete {self._cluster_name}")
+                return None
+            except Exception:
+                logger.exception(f"Failed to delete {self._cluster_name}")
+                return None
+
+        # Merge-patch spec.suspend=true if noDriverTimeoutPolicy is Suspend
+        payload = suspend_patch(True)
+
         try:
             self._k8s_api_client.patch(
                 path,
@@ -772,17 +806,11 @@ class KubeRayProvider(ICloudInstanceProvider):
             )
         except Exception:
             logger.exception(
-                "Failed to PATCH %s=true on RayCluster %s",
-                NO_DRIVER_TTL_EXPIRED_ANNOTATION,
-                self._cluster_name,
+                f"Failed to MERGE-PATCH suspend=true on RayCluster {self._cluster_name}",
             )
             return
 
-        logger.info(
-            "Set %s=true on RayCluster %s.",
-            NO_DRIVER_TTL_EXPIRED_ANNOTATION,
-            self._cluster_name,
-        )
+        logger.info(f"Set suspend=true on RayCluster {self._cluster_name}")
 
     def _get_head_pod_resource_version(self) -> str:
         """

--- a/python/ray/autoscaler/v2/instance_manager/cloud_providers/kuberay/cloud_provider.py
+++ b/python/ray/autoscaler/v2/instance_manager/cloud_providers/kuberay/cloud_provider.py
@@ -789,12 +789,23 @@ class KubeRayProvider(ICloudInstanceProvider):
                     return None
 
             try:
-                # DELETE the idle RayClusters. 404 is treated as a successful delete so it will not raise here.
+                # DELETE the idle RayCluster.
                 self._k8s_api_client.delete(path)
                 logger.info(f"Deleted {self._cluster_name}")
+            except requests.HTTPError as e:
+                if e.response.status_code == 404:
+                    # HTTP status code 404 is treated as a successful delete.
+                    logger.info(f"{self._cluster_name} was already deleted.")
+                else:
+                    logger.exception(f"Failed to delete {self._cluster_name}")
             except Exception:
                 logger.exception(f"Failed to delete {self._cluster_name}")
 
+            return None
+
+        spec_idle_terminate = self._ray_cluster.get("spec", {}).get("idleTerminate")
+        if spec_idle_terminate:
+            logger.info(f"spec.IdleTerminate is already true in {self._cluster_name}")
             return None
 
         # Merge-patch spec.idleTerminate=true if noDriverTimeoutPolicy is Suspend

--- a/python/ray/autoscaler/v2/instance_manager/cloud_providers/kuberay/cloud_provider.py
+++ b/python/ray/autoscaler/v2/instance_manager/cloud_providers/kuberay/cloud_provider.py
@@ -24,7 +24,7 @@ from ray.autoscaler._private.kuberay.node_provider import (
     _worker_group_num_of_hosts,
     _worker_group_replicas,
     finalizer_patch,
-    idle_terminate_patch,
+    idle_suspend_patch,
     worker_delete_patch,
     worker_replica_patch,
 )
@@ -44,10 +44,11 @@ from ray.autoscaler.v2.schema import IPPRSpecs, IPPRStatus, NodeType
 
 logger = logging.getLogger(__name__)
 
-AUTOSCALER_OPTIONS_KEY = "autoscalerOptions"
-NO_DRIVER_TIMEOUT_SECONDS_KEY = "noDriverTimeoutSeconds"
-NO_DRIVER_TIMEOUT_POLICY_KEY = "noDriverTimeoutPolicy"
+IDLE_TERMINATION_OPTIONS_KEY = "idleTerminationOptions"
+IDLE_TERMINATION_OPTIONS_TIMEOUT_SECONDS_KEY = "timeoutSeconds"
+IDLE_TERMINATION_OPTIONS_POLICY_KEY = "policy"
 NO_DRIVER_TIMEOUT_FINALIZER = "ray.io/no-driver-idle-termination"
+IDLE_SUSPEND_KEY = "idleSuspend"
 
 
 class KubeRayProvider(ICloudInstanceProvider):
@@ -510,11 +511,11 @@ class KubeRayProvider(ICloudInstanceProvider):
         self._ippr_provider.sync_with_raylets()
 
     def _refresh_no_driver_config(self) -> None:
-        """Reads noDriverTimeoutSeconds and noDriverTimeoutPolicy from the RayCluster CR."""
-        opts = self._ray_cluster["spec"].get(AUTOSCALER_OPTIONS_KEY, {})
-        secs = opts.get(NO_DRIVER_TIMEOUT_SECONDS_KEY)
+        """Reads IdleTerminationOptions from the RayCluster CR."""
+        opts = self._ray_cluster["spec"].get(IDLE_TERMINATION_OPTIONS_KEY, {})
+        secs = opts.get(IDLE_TERMINATION_OPTIONS_TIMEOUT_SECONDS_KEY)
         self._no_driver_timeout_seconds = float(secs) if secs is not None else None
-        policy = opts.get(NO_DRIVER_TIMEOUT_POLICY_KEY, "Delete")
+        policy = opts.get(IDLE_TERMINATION_OPTIONS_POLICY_KEY, "Suspend")
         self._no_driver_policy = policy
 
     @property
@@ -803,13 +804,13 @@ class KubeRayProvider(ICloudInstanceProvider):
 
             return None
 
-        spec_idle_terminate = self._ray_cluster.get("spec", {}).get("idleTerminate")
-        if spec_idle_terminate:
-            logger.info(f"spec.IdleTerminate is already true in {self._cluster_name}")
+        spec_idle_suspend = self._ray_cluster.get("spec", {}).get(IDLE_SUSPEND_KEY)
+        if spec_idle_suspend:
+            logger.info(f"spec.idleSuspend is already true in {self._cluster_name}")
             return None
 
-        # Merge-patch spec.idleTerminate=true if noDriverTimeoutPolicy is Suspend
-        payload = idle_terminate_patch(True)
+        # Merge-patch spec.idleSuspend=true when the policy is Suspend.
+        payload = idle_suspend_patch(True)
 
         try:
             patched_raycluster = self._k8s_api_client.patch(
@@ -817,20 +818,19 @@ class KubeRayProvider(ICloudInstanceProvider):
                 payload,
                 content_type="application/merge-patch+json",
             )
-
-            if patched_raycluster.get("spec", {}).get("idleTerminate") is not True:
+            if patched_raycluster.get("spec", {}).get(IDLE_SUSPEND_KEY) is not True:
                 logger.error(
-                    f"Unable to persist idleTerminate=true for {self._cluster_name}"
+                    f"Unable to persist {IDLE_SUSPEND_KEY}=true for {self._cluster_name}"
                 )
                 return None
 
         except Exception:
             logger.exception(
-                f"Failed to MERGE-PATCH suspend=true on RayCluster {self._cluster_name}",
+                f"Failed to MERGE-PATCH {IDLE_SUSPEND_KEY}=true on RayCluster {self._cluster_name}",
             )
             return None
 
-        logger.info(f"Set idleTerminate=true on RayCluster {self._cluster_name}")
+        logger.info(f"Set {IDLE_SUSPEND_KEY}=true on RayCluster {self._cluster_name}")
 
     def _get_head_pod_resource_version(self) -> str:
         """

--- a/python/ray/autoscaler/v2/instance_manager/cloud_providers/kuberay/cloud_provider.py
+++ b/python/ray/autoscaler/v2/instance_manager/cloud_providers/kuberay/cloud_provider.py
@@ -44,14 +44,9 @@ from ray.autoscaler.v2.schema import IPPRSpecs, IPPRStatus, NodeType
 
 logger = logging.getLogger(__name__)
 
-# Annotation the KubeRay operator acts on to terminate the cluster.
-NO_DRIVER_TTL_EXPIRED_ANNOTATION = "ray.io/no-driver-ttl-expired"
-
 AUTOSCALER_OPTIONS_KEY = "autoscalerOptions"
 NO_DRIVER_TIMEOUT_SECONDS_KEY = "noDriverTimeoutSeconds"
 NO_DRIVER_TIMEOUT_POLICY_KEY = "noDriverTimeoutPolicy"
-
-NO_DRIVER_TIMEOUT_POLICY = "Delete"
 NO_DRIVER_TIMEOUT_FINALIZER = "ray.io/no-driver-idle-termination"
 
 
@@ -770,14 +765,23 @@ class KubeRayProvider(ICloudInstanceProvider):
         if self._no_driver_policy == "Delete":
             # Append the ray.io/no-driver-idle-termination finalizer
             # using a read-modify-write to preserve existing finalizers.
-            finalizers = self._ray_cluster.get("metadata").get("finalizers", [])
+            finalizers = self._ray_cluster.get("metadata", {}).get("finalizers", [])
             if NO_DRIVER_TIMEOUT_FINALIZER not in finalizers:
                 finalizers.append(NO_DRIVER_TIMEOUT_FINALIZER)
                 payload = finalizer_patch(finalizers)
                 try:
-                    self._k8s_api_client.patch(
+                    patched_raycluster = self._k8s_api_client.patch(
                         path, payload, content_type="application/merge-patch+json"
                     )
+
+                    if NO_DRIVER_TIMEOUT_FINALIZER not in patched_raycluster.get(
+                        "metadata", {}
+                    ).get("finalizers", []):
+                        logger.error(
+                            f"Unable to persist {NO_DRIVER_TIMEOUT_FINALIZER} to metadata.finalizers for {self._cluster_name}"
+                        )
+                        return None
+
                 except Exception:
                     logger.exception(
                         f"Failed to MERGE-PATCH finalizers to {self._cluster_name}"
@@ -785,21 +789,13 @@ class KubeRayProvider(ICloudInstanceProvider):
                     return None
 
             try:
-                # DELETE the idle RayClusters
-                _ = self._k8s_api_client.delete(path)
+                # DELETE the idle RayClusters. 404 is treated as a successful delete so it will not raise here.
+                self._k8s_api_client.delete(path)
                 logger.info(f"Deleted {self._cluster_name}")
-                return None
-            except requests.HTTPError as e:
-                if e.response.status_code == 404:
-                    logger.info(
-                        f"{self._cluster_name} has been deleted so the api server cannot find it."
-                    )
-                else:
-                    logger.exception(f"Failed to delete {self._cluster_name}")
-                return None
             except Exception:
                 logger.exception(f"Failed to delete {self._cluster_name}")
-                return None
+
+            return None
 
         # Merge-patch spec.idleTerminate=true if noDriverTimeoutPolicy is Suspend
         payload = idle_terminate_patch(True)
@@ -815,13 +811,13 @@ class KubeRayProvider(ICloudInstanceProvider):
                 logger.error(
                     f"Unable to persist idleTerminate=true for {self._cluster_name}"
                 )
-                return
+                return None
 
         except Exception:
             logger.exception(
                 f"Failed to MERGE-PATCH suspend=true on RayCluster {self._cluster_name}",
             )
-            return
+            return None
 
         logger.info(f"Set idleTerminate=true on RayCluster {self._cluster_name}")
 

--- a/python/ray/autoscaler/v2/instance_manager/cloud_providers/kuberay/cloud_provider.py
+++ b/python/ray/autoscaler/v2/instance_manager/cloud_providers/kuberay/cloud_provider.py
@@ -24,7 +24,7 @@ from ray.autoscaler._private.kuberay.node_provider import (
     _worker_group_num_of_hosts,
     _worker_group_replicas,
     finalizer_patch,
-    suspend_patch,
+    idle_terminate_patch,
     worker_delete_patch,
     worker_replica_patch,
 )
@@ -509,12 +509,12 @@ class KubeRayProvider(ICloudInstanceProvider):
     def _sync_with_api_server(self) -> None:
         """Fetches the RayCluster resource from the Kubernetes API server."""
         self._ray_cluster = self._get(f"rayclusters/{self._cluster_name}")
-        self._refresh_no_driver_timeout_seconds()
+        self._refresh_no_driver_config()
         self._ippr_provider.validate_and_set_ippr_specs(self._ray_cluster)
         self._cached_instances = self._fetch_instances()
         self._ippr_provider.sync_with_raylets()
 
-    def _refresh_no_driver_timeout_seconds(self) -> None:
+    def _refresh_no_driver_config(self) -> None:
         """Reads noDriverTimeoutSeconds and noDriverTimeoutPolicy from the RayCluster CR."""
         opts = self._ray_cluster["spec"].get(AUTOSCALER_OPTIONS_KEY, {})
         secs = opts.get(NO_DRIVER_TIMEOUT_SECONDS_KEY)
@@ -728,7 +728,7 @@ class KubeRayProvider(ICloudInstanceProvider):
             self._no_driver_observed_since = now
         if now - self._no_driver_observed_since < self._no_driver_timeout_seconds:
             return
-        self._apply_no_driver_timeout_policy()
+        self._apply_no_driver_policy()
 
     def _driver_status(self) -> Tuple[bool, int]:
         """Returns whether a non-internal driver is alive and the latest job end time.
@@ -758,8 +758,14 @@ class KubeRayProvider(ICloudInstanceProvider):
                 has_active_driver = True
         return has_active_driver, latest_job_end_time
 
-    def _apply_no_driver_timeout_policy(self) -> None:
+    def _apply_no_driver_policy(self) -> None:
         """Applies the configured no-driver timeout policy to the RayCluster CR."""
+        if self._no_driver_policy not in {"Delete", "Suspend"}:
+            logger.warning(
+                f"Unknown no driver policy {self._no_driver_policy}. Nothing will apply"
+            )
+            return
+
         path = f"rayclusters/{self._cluster_name}"
         if self._no_driver_policy == "Delete":
             # Append the ray.io/no-driver-idle-termination finalizer
@@ -795,22 +801,29 @@ class KubeRayProvider(ICloudInstanceProvider):
                 logger.exception(f"Failed to delete {self._cluster_name}")
                 return None
 
-        # Merge-patch spec.suspend=true if noDriverTimeoutPolicy is Suspend
-        payload = suspend_patch(True)
+        # Merge-patch spec.idleTerminate=true if noDriverTimeoutPolicy is Suspend
+        payload = idle_terminate_patch(True)
 
         try:
-            self._k8s_api_client.patch(
+            patched_raycluster = self._k8s_api_client.patch(
                 path,
                 payload,
                 content_type="application/merge-patch+json",
             )
+
+            if patched_raycluster.get("spec", {}).get("idleTerminate") is not True:
+                logger.error(
+                    f"Unable to persist idleTerminate=true for {self._cluster_name}"
+                )
+                return
+
         except Exception:
             logger.exception(
                 f"Failed to MERGE-PATCH suspend=true on RayCluster {self._cluster_name}",
             )
             return
 
-        logger.info(f"Set suspend=true on RayCluster {self._cluster_name}")
+        logger.info(f"Set idleTerminate=true on RayCluster {self._cluster_name}")
 
     def _get_head_pod_resource_version(self) -> str:
         """

--- a/python/ray/autoscaler/v2/tests/test_node_provider.py
+++ b/python/ray/autoscaler/v2/tests/test_node_provider.py
@@ -23,6 +23,8 @@ from ray.autoscaler._private.constants import (
 from ray.autoscaler._private.fake_multi_node.node_provider import FakeMultiNodeProvider
 from ray.autoscaler._private.kuberay.node_provider import IKubernetesHttpApiClient
 from ray.autoscaler.v2.instance_manager.cloud_providers.kuberay.cloud_provider import (
+    IDLE_SUSPEND_KEY,
+    IDLE_TERMINATION_OPTIONS_KEY,
     NO_DRIVER_TIMEOUT_FINALIZER,
     KubeRayProvider,
 )
@@ -944,17 +946,17 @@ class KubeRayProviderIntegrationTest(unittest.TestCase):
             }
         ]
 
-    def test_apply_no_driver_policy_suspend_patches_idle_terminate(self):
+    def test_apply_no_driver_policy_suspend_patches_idle_suspend(self):
         self.provider._no_driver_policy = "Suspend"
         self.provider._apply_no_driver_policy()
         path = f"rayclusters/{self.provider._cluster_name}"
-        assert self.mock_client.get_patches(path) == {"spec": {"idleTerminate": True}}
+        assert self.mock_client.get_patches(path) == {"spec": {IDLE_SUSPEND_KEY: True}}
         assert self.mock_client._deletes == []
 
     def test_apply_no_driver_policy_suspend_patches_idempotent(self):
         self.provider._no_driver_policy = "Suspend"
         self.provider._ray_cluster.setdefault("spec", {}).setdefault(
-            "idleTerminate", True
+            IDLE_SUSPEND_KEY, True
         )
         self.provider._apply_no_driver_policy()
         path = f"rayclusters/{self.provider._cluster_name}"
@@ -1040,8 +1042,6 @@ class KubeRayProviderIntegrationTest(unittest.TestCase):
     def test_evaluate_no_driver_termination_waits_for_timeout(self):
         self.provider._gcs_client = self._make_gcs()  # no drivers
         self.provider._no_driver_timeout_seconds = 100.0
-        # Mirrors _refresh_no_driver_config's fallback value when the RayCluster
-        # CR omits noDriverTimeoutPolicy.
         self.provider._no_driver_policy = "Delete"
 
         self._overwrite_patch_to_persist_finalizer()
@@ -1056,7 +1056,6 @@ class KubeRayProviderIntegrationTest(unittest.TestCase):
         evaluate_at(50.0)
         assert path not in self.mock_client._patches  # still below timeout
         evaluate_at(100.0)
-        # Default policy is "Delete": finalizer patch then delete.
         assert self.mock_client._patches.get(path) == [
             {
                 "op": "add",
@@ -1102,9 +1101,9 @@ class KubeRayProviderIntegrationTest(unittest.TestCase):
     def test_refresh_no_driver_config_reads_value(self):
         self.provider._ray_cluster = {
             "spec": {
-                "autoscalerOptions": {
-                    "noDriverTimeoutSeconds": 1800,
-                    "noDriverTimeoutPolicy": "Suspend",
+                "idleTerminationOptions": {
+                    "timeoutSeconds": 1800,
+                    "policy": "Suspend",
                 }
             }
         }
@@ -1113,18 +1112,20 @@ class KubeRayProviderIntegrationTest(unittest.TestCase):
         assert self.provider._no_driver_policy == "Suspend"
 
     def test_refresh_no_driver_config_unset(self):
-        self.provider._ray_cluster = {"spec": {"autoscalerOptions": {}}}
+        self.provider._ray_cluster = {"spec": {IDLE_TERMINATION_OPTIONS_KEY: {}}}
         self.provider._refresh_no_driver_config()
         assert self.provider._no_driver_timeout_seconds is None
+        assert self.provider._no_driver_policy == "Suspend"
 
-    def test_refresh_no_driver_config_policy_defaults_when_timeout_set(self):
+    def test_refresh_no_driver_config_policy_defaults_to_suspend(self):
         self.provider._ray_cluster = {
-            "spec": {"autoscalerOptions": {"noDriverTimeoutSeconds": 1800}}
+            "spec": {"idleTerminationOptions": {"timeoutSeconds": 1800}}
         }
         self.provider._refresh_no_driver_config()
-        assert self.provider._no_driver_policy == "Delete"
+        assert self.provider._no_driver_timeout_seconds == 1800.0
+        assert self.provider._no_driver_policy == "Suspend"
 
-    def test_refresh_no_driver_config_no_autoscaler_options(self):
+    def test_refresh_no_driver_config_no_idle_termination_options(self):
         self.provider._ray_cluster = {"spec": {}}
         self.provider._refresh_no_driver_config()
         assert self.provider._no_driver_timeout_seconds is None

--- a/python/ray/autoscaler/v2/tests/test_node_provider.py
+++ b/python/ray/autoscaler/v2/tests/test_node_provider.py
@@ -23,7 +23,7 @@ from ray.autoscaler._private.constants import (
 from ray.autoscaler._private.fake_multi_node.node_provider import FakeMultiNodeProvider
 from ray.autoscaler._private.kuberay.node_provider import IKubernetesHttpApiClient
 from ray.autoscaler.v2.instance_manager.cloud_providers.kuberay.cloud_provider import (
-    NO_DRIVER_TTL_EXPIRED_ANNOTATION,
+    NO_DRIVER_TIMEOUT_FINALIZER,
     KubeRayProvider,
 )
 from ray.autoscaler.v2.instance_manager.config import (
@@ -347,6 +347,7 @@ class MockKubernetesHttpApiClient(IKubernetesHttpApiClient):
         self._ray_cluster = ray_cluster
         self._pod_list = pod_list
         self._patches = {}
+        self._deletes = []
 
     def get(self, path: str) -> Dict[str, Any]:
         if "pods" in path:
@@ -367,6 +368,10 @@ class MockKubernetesHttpApiClient(IKubernetesHttpApiClient):
 
     def get_patches(self, path: str) -> Union[List[Dict[str, Any]], Dict[str, Any]]:
         return self._patches[path]
+
+    def delete(self, path: str) -> Dict[str, Any]:
+        self._deletes.append(path)
+        return {}
 
 
 class KubeRayProviderIntegrationTest(unittest.TestCase):
@@ -830,33 +835,151 @@ class KubeRayProviderIntegrationTest(unittest.TestCase):
         assert finished_deletes == set()
         assert workers_to_delete == {pod_names[0], pod_names[1]}
 
-    def test_set_no_driver_annotation_adds_when_absent(self):
-        self.provider._set_no_driver_annotation()
+    def _overwrite_patch_to_persist_finalizer(self) -> None:
+        """Overwrite mock_client.patch() to behave like a real K8s API server for
+        the RayCluster finalizer patch. Add the finalizer to the cached CR and
+        return the patched resource.
+        """
+
+        def patch_and_persist(
+            path: str,
+            patches: Union[List[Dict[str, Any]], Dict[str, Any]],
+            content_type="application/json-patch+json",
+        ):
+            self.mock_client._patches[path] = patches  # what the default patch() does
+            self.provider._ray_cluster.setdefault("metadata", {}).setdefault(
+                "finalizers", []
+            ).append(NO_DRIVER_TIMEOUT_FINALIZER)
+            return self.provider._ray_cluster
+
+        self.mock_client.patch = patch_and_persist
+
+    def test_apply_no_driver_policy_delete_adds_finalizer_then_deletes(self):
+        self.provider._no_driver_policy = "Delete"
+        self._overwrite_patch_to_persist_finalizer()
         path = f"rayclusters/{self.provider._cluster_name}"
+        self.provider._apply_no_driver_policy()
         patch = self.mock_client.get_patches(path)
-        assert patch == {
-            "metadata": {"annotations": {NO_DRIVER_TTL_EXPIRED_ANNOTATION: "true"}}
-        }
 
-    def test_set_no_driver_annotation_idempotent(self):
-        self.provider._ray_cluster.setdefault("metadata", {}).setdefault(
-            "annotations", {}
-        )[NO_DRIVER_TTL_EXPIRED_ANNOTATION] = "true"
+        assert patch == [
+            {
+                "op": "add",
+                "path": "/metadata/finalizers",
+                "value": [NO_DRIVER_TIMEOUT_FINALIZER],
+            }
+        ]
+        assert self.mock_client._deletes == [path]
 
-        self.provider._set_no_driver_annotation()
+    def test_apply_no_driver_policy_delete_finalizer_idempotent(self):
+        self.provider._ray_cluster.setdefault("metadata", {})["finalizers"] = [
+            NO_DRIVER_TIMEOUT_FINALIZER
+        ]
+        self.provider._no_driver_policy = "Delete"
+        self.provider._apply_no_driver_policy()
         path = f"rayclusters/{self.provider._cluster_name}"
+        # Finalizer already present: no patch needed, only the delete.
         assert path not in self.mock_client._patches
+        assert self.mock_client._deletes == [path]
 
-    def test_set_no_driver_annotation_swallows_patch_failure(self):
+    def test_apply_no_driver_policy_delete_finalizer_appends_when_others_present(
+        self,
+    ):
+        other_finalizer = "GCSFTFinalizer"  # e.g. set by kuberay-operator
+        self.provider._ray_cluster.setdefault("metadata", {})["finalizers"] = [
+            other_finalizer
+        ]
+        self._overwrite_patch_to_persist_finalizer()
+        path = f"rayclusters/{self.provider._cluster_name}"
+        self.provider._no_driver_policy = "Delete"
+        self.provider._apply_no_driver_policy()
+
+        assert self.mock_client.get_patches(path) == [
+            {
+                "op": "add",
+                "path": "/metadata/finalizers/-",
+                "value": NO_DRIVER_TIMEOUT_FINALIZER,
+            }
+        ]
+        # The pre-existing finalizer must survive the append, not get clobbered.
+        assert self.provider._ray_cluster["metadata"]["finalizers"] == [
+            other_finalizer,
+            NO_DRIVER_TIMEOUT_FINALIZER,
+        ]
+        assert self.mock_client._deletes == [path]
+
+    def test_apply_no_driver_policy_delete_swallows_patch_failure(self):
         path = f"rayclusters/{self.provider._cluster_name}"
 
         def failing_patch(*args, **kwargs):
             raise RuntimeError("k8s unreachable")
 
         self.mock_client.patch = failing_patch
-        # Should not raise.
-        self.provider._set_no_driver_annotation()
+        self.provider._no_driver_policy = "Delete"
+        # Should not raise, and should not proceed to delete.
+        self.provider._apply_no_driver_policy()
         assert path not in self.mock_client._patches
+        assert self.mock_client._deletes == []
+
+    def test_apply_no_driver_policy_delete_swallows_delete_failure(self):
+        self._overwrite_patch_to_persist_finalizer()
+        path = f"rayclusters/{self.provider._cluster_name}"
+
+        delete_calls = []
+
+        def failing_delete(path):
+            delete_calls.append(path)
+            raise RuntimeError("k8s unreachable")
+
+        self.mock_client.delete = failing_delete
+        self.provider._no_driver_policy = "Delete"
+        # Should not raise, even though DELETE itself failed.
+        self.provider._apply_no_driver_policy()
+
+        assert delete_calls == [path]
+        assert self.mock_client.get_patches(path) == [
+            {
+                "op": "add",
+                "path": "/metadata/finalizers",
+                "value": [NO_DRIVER_TIMEOUT_FINALIZER],
+            }
+        ]
+
+    def test_apply_no_driver_policy_suspend_patches_idle_terminate(self):
+        self.provider._no_driver_policy = "Suspend"
+        self.provider._apply_no_driver_policy()
+        path = f"rayclusters/{self.provider._cluster_name}"
+        assert self.mock_client.get_patches(path) == {"spec": {"idleTerminate": True}}
+        assert self.mock_client._deletes == []
+
+    def test_apply_no_driver_policy_suspend_patches_idempotent(self):
+        self.provider._no_driver_policy = "Suspend"
+        self.provider._ray_cluster.setdefault("spec", {}).setdefault(
+            "idleTerminate", True
+        )
+        self.provider._apply_no_driver_policy()
+        path = f"rayclusters/{self.provider._cluster_name}"
+        assert path not in self.mock_client._patches
+        assert self.mock_client._deletes == []
+
+    def test_apply_no_driver_policy_suspend_swallows_patch_failure(self):
+        path = f"rayclusters/{self.provider._cluster_name}"
+
+        def failing_patch(*args, **kwargs):
+            raise RuntimeError("k8s unreachable")
+
+        self.mock_client.patch = failing_patch
+        self.provider._no_driver_policy = "Suspend"
+        # Should not raise.
+        self.provider._apply_no_driver_policy()
+        assert path not in self.mock_client._patches
+        assert self.mock_client._deletes == []
+
+    def test_apply_no_driver_policy_unknown_takes_no_action(self):
+        self.provider._no_driver_policy = "Bogus"
+        self.provider._apply_no_driver_policy()
+        path = f"rayclusters/{self.provider._cluster_name}"
+        assert path not in self.mock_client._patches
+        assert self.mock_client._deletes == []
 
     # --- No-driver termination predicate + dispatch ---
 
@@ -917,6 +1040,11 @@ class KubeRayProviderIntegrationTest(unittest.TestCase):
     def test_evaluate_no_driver_termination_waits_for_timeout(self):
         self.provider._gcs_client = self._make_gcs()  # no drivers
         self.provider._no_driver_timeout_seconds = 100.0
+        # Mirrors _refresh_no_driver_config's fallback value when the RayCluster
+        # CR omits noDriverTimeoutPolicy.
+        self.provider._no_driver_policy = "Delete"
+
+        self._overwrite_patch_to_persist_finalizer()
 
         def evaluate_at(t):
             with mock.patch("time.monotonic", return_value=t):
@@ -928,9 +1056,15 @@ class KubeRayProviderIntegrationTest(unittest.TestCase):
         evaluate_at(50.0)
         assert path not in self.mock_client._patches  # still below timeout
         evaluate_at(100.0)
-        assert self.mock_client._patches.get(path) == {
-            "metadata": {"annotations": {NO_DRIVER_TTL_EXPIRED_ANNOTATION: "true"}}
-        }
+        # Default policy is "Delete": finalizer patch then delete.
+        assert self.mock_client._patches.get(path) == [
+            {
+                "op": "add",
+                "path": "/metadata/finalizers",
+                "value": [NO_DRIVER_TIMEOUT_FINALIZER],
+            }
+        ]
+        assert self.mock_client._deletes == [path]
 
     def test_evaluate_no_driver_termination_resets_when_driver_attaches(self):
         path = f"rayclusters/{self.provider._cluster_name}"
@@ -967,15 +1101,28 @@ class KubeRayProviderIntegrationTest(unittest.TestCase):
 
     def test_refresh_no_driver_config_reads_value(self):
         self.provider._ray_cluster = {
-            "spec": {"autoscalerOptions": {"noDriverTimeoutSeconds": 1800}}
+            "spec": {
+                "autoscalerOptions": {
+                    "noDriverTimeoutSeconds": 1800,
+                    "noDriverTimeoutPolicy": "Suspend",
+                }
+            }
         }
         self.provider._refresh_no_driver_config()
         assert self.provider._no_driver_timeout_seconds == 1800.0
+        assert self.provider._no_driver_policy == "Suspend"
 
     def test_refresh_no_driver_config_unset(self):
         self.provider._ray_cluster = {"spec": {"autoscalerOptions": {}}}
         self.provider._refresh_no_driver_config()
         assert self.provider._no_driver_timeout_seconds is None
+
+    def test_refresh_no_driver_config_policy_defaults_when_timeout_set(self):
+        self.provider._ray_cluster = {
+            "spec": {"autoscalerOptions": {"noDriverTimeoutSeconds": 1800}}
+        }
+        self.provider._refresh_no_driver_config()
+        assert self.provider._no_driver_policy == "Delete"
 
     def test_refresh_no_driver_config_no_autoscaler_options(self):
         self.provider._ray_cluster = {"spec": {}}

--- a/python/ray/autoscaler/v2/tests/test_node_provider.py
+++ b/python/ray/autoscaler/v2/tests/test_node_provider.py
@@ -965,21 +965,21 @@ class KubeRayProviderIntegrationTest(unittest.TestCase):
         assert self.provider._no_driver_observed_since == 50.0
         assert self.provider._last_seen_job_end_time == 42
 
-    def test_refresh_no_driver_timeout_seconds_reads_value(self):
+    def test_refresh_no_driver_config_reads_value(self):
         self.provider._ray_cluster = {
             "spec": {"autoscalerOptions": {"noDriverTimeoutSeconds": 1800}}
         }
-        self.provider._refresh_no_driver_timeout_seconds()
+        self.provider._refresh_no_driver_config()
         assert self.provider._no_driver_timeout_seconds == 1800.0
 
-    def test_refresh_no_driver_timeout_seconds_unset(self):
+    def test_refresh_no_driver_config_unset(self):
         self.provider._ray_cluster = {"spec": {"autoscalerOptions": {}}}
-        self.provider._refresh_no_driver_timeout_seconds()
+        self.provider._refresh_no_driver_config()
         assert self.provider._no_driver_timeout_seconds is None
 
-    def test_refresh_no_driver_timeout_seconds_no_autoscaler_options(self):
+    def test_refresh_no_driver_config_no_autoscaler_options(self):
         self.provider._ray_cluster = {"spec": {}}
-        self.provider._refresh_no_driver_timeout_seconds()
+        self.provider._refresh_no_driver_config()
         assert self.provider._no_driver_timeout_seconds is None
 
     def test_scale_down_with_multi_host_group(self):


### PR DESCRIPTION
## Description

Built on top of #63465 but with different termination methods and mechanisms. 
Previously, once the autoscaler detects there has been no driver utilizing a RayCluster for `autoscalerOptions.noDriverTimeoutSeconds`, it will attach an annotation to the CR, and the kuberay operator will handle the deletion in the future reconcile loops. 

According to the comments in the discussion of[ KubeRay PR #4932](https://github.com/ray-project/kuberay/pull/4932), the community decides to discard the annotation usage and introduce new APIs in the RayCluster CRD as well as how to perform the termination. The termination now supports both `Suspend` and `Delete`. For full details of the behavior changes, please refer to the design doc listed in the Additional information section.

## Changes

To support the new API for idle Termination in KubeRay,  

```go
type RayClusterSpec struct {
      // ... existing spec

      Suspend *bool `json:"suspend,omitempty"`
      
      // IdleSuspend is set to true by the Ray autoscaler when an idle RayCluster's
      // IdleTerminationOptions.Policy is Suspend. Set it back to false to resume.
      IdleSuspend *bool `json:"idleSuspend,omitempty"`

      // IdleTerminationOptions specifies optional configuration for terminating an idle RayCluster. 
      // A RayCluster is considered idle when no Ray driver is connected. 
      IdleTerminationOptions *IdleTerminationOptions `json:"idleTerminationOptions,omitempty"`
}

type RayClusterSpec struct {
      // ... existing spec

      Suspend *bool `json:"suspend,omitempty"`
      
      // IdleSuspend is set to true by the Ray autoscaler when an idle RayCluster's
      // IdleTerminationOptions.Policy is Suspend. Set it back to false to resume.
      IdleSuspend *bool `json:"idleSuspend,omitempty"`
      
      // IdleTerminationOptions specifies optional configuration for terminating an idle RayCluster. 
      // A RayCluster is considered idle when no Ray driver is connected. 
      IdleTerminationOptions *IdleTerminationOptions `json:"idleTerminationOptions,omitempty"`
}
```

the planned update touches the following area:

1. Kubernetes Client: 

- Add `delete()` and the `idle_suspend_patch` / `finalizer_patch` helpers to the KubeRay Kubernetes HTTP client. Treat 404 Not Found as a successful delete.

2. Configuration: 

- Read `policy` alongside `timeoutSeconds`, defaulting to `Suspend`. 
- Unknown policy values result in no action. 
- Rename `_refresh_no_driver_timeout_seconds` to `_refresh_no_driver_config`.

3. Policy Dispatch: Replace `_set_no_driver_annotation` with `_apply_no_driver_policy`.

- Suspend: Merge-patch spec.idleSuspend=true and verify that the API server persisted in the field.
- Delete: Add-patch the idle-termination finalizer, then delete the RayCluster.


## Testing 

```
cd python
python -m pytest -v ray/autoscaler/v2/tests/test_node_provider.py
```

## Related issues

Related to https://github.com/ray-project/kuberay/pull/5210

## Additional information
Design Doc: [KubeRay Idle Termination](https://docs.google.com/document/d/1GFdgyfrHBfI-UNlaGgnVDMcx9-K9Eawjg2LW4GVTjRI)
