### PR TITLE
[Core] Run the memory store's unhandled-error callback outside the lock

### DIFF
--- a/src/ray/core_worker/store_provider/memory_store/memory_store.cc
+++ b/src/ray/core_worker/store_provider/memory_store/memory_store.cc
@@ -16,6 +16,7 @@
 
 #include <algorithm>
 #include <condition_variable>
+#include <exception>
 #include <memory>
 #include <utility>
 #include <vector>
@@ -483,9 +484,7 @@ void CoreWorkerMemoryStore::Delete(const absl::flat_hash_set<ObjectID> &object_i
     }
   }
 
-  for (const auto &unhandled_error : unhandled_errors) {
-    ReportUnhandledError(unhandled_error);
-  }
+  ReportUnhandledErrors(unhandled_errors);
 }
 
 void CoreWorkerMemoryStore::Delete(const std::vector<ObjectID> &object_ids) {
@@ -504,9 +503,7 @@ void CoreWorkerMemoryStore::Delete(const std::vector<ObjectID> &object_ids) {
     }
   }
 
-  for (const auto &unhandled_error : unhandled_errors) {
-    ReportUnhandledError(unhandled_error);
-  }
+  ReportUnhandledErrors(unhandled_errors);
 }
 
 bool CoreWorkerMemoryStore::Contains(const ObjectID &object_id, bool *in_plasma) {
@@ -523,6 +520,23 @@ bool CoreWorkerMemoryStore::Contains(const ObjectID &object_id, bool *in_plasma)
 
 void CoreWorkerMemoryStore::ReportUnhandledError(const std::shared_ptr<RayObject> &obj) {
   unhandled_exception_handler_(*obj);
+}
+
+void CoreWorkerMemoryStore::ReportUnhandledErrors(
+    const std::vector<std::shared_ptr<RayObject>> &unhandled_errors) {
+  std::exception_ptr first_exception;
+  for (const auto &unhandled_error : unhandled_errors) {
+    try {
+      ReportUnhandledError(unhandled_error);
+    } catch (...) {
+      if (first_exception == nullptr) {
+        first_exception = std::current_exception();
+      }
+    }
+  }
+  if (first_exception != nullptr) {
+    std::rethrow_exception(first_exception);
+  }
 }
 
 void CoreWorkerMemoryStore::NotifyUnhandledErrors() {
@@ -544,9 +558,7 @@ void CoreWorkerMemoryStore::NotifyUnhandledErrors() {
     }
   }
 
-  for (const auto &unhandled_error : unhandled_errors) {
-    ReportUnhandledError(unhandled_error);
-  }
+  ReportUnhandledErrors(unhandled_errors);
 }
 
 inline void CoreWorkerMemoryStore::EraseObjectAndUpdateStats(const ObjectID &object_id) {

--- a/src/ray/core_worker/store_provider/memory_store/memory_store.cc
+++ b/src/ray/core_worker/store_provider/memory_store/memory_store.cc
@@ -224,6 +224,12 @@ void CoreWorkerMemoryStore::Put(const RayObject &object,
       }
     }
 
+    // The async getters below receive this object, so mark it accessed before the
+    // unhandled-error check, the way GetRequest::Set does above for a waiting Get.
+    if (!async_callbacks.empty()) {
+      object_entry->SetAccessed();
+    }
+
     // Don't put it in the store, if we can't get a callback for deletion.
     // The exception here is if we are in local mode, put should still put the object in
     // the store.
@@ -236,10 +242,6 @@ void CoreWorkerMemoryStore::Put(const RayObject &object,
       if (IsUnhandledError(object_entry) && unhandled_exception_handler_ != nullptr) {
         unhandled_error = object_entry;
       }
-    }
-
-    if (!async_callbacks.empty()) {
-      object_entry->SetAccessed();
     }
   }
 

--- a/src/ray/core_worker/store_provider/memory_store/memory_store.cc
+++ b/src/ray/core_worker/store_provider/memory_store/memory_store.cc
@@ -141,6 +141,16 @@ CoreWorkerMemoryStore::CoreWorkerMemoryStore(
       unhandled_exception_handler_(std::move(unhandled_exception_handler)),
       object_allocator_(std::move(object_allocator)) {}
 
+inline bool IsUnhandledError(const std::shared_ptr<RayObject> &obj) {
+  rpc::ErrorType error_type;
+  // TODO(ekl) note that this doesn't warn on errors that are stored in plasma.
+  return obj->IsException(&error_type) &&
+         // Only warn on task failures (avoid actor died, for example).
+         (error_type == rpc::ErrorType::WORKER_DIED ||
+          error_type == rpc::ErrorType::TASK_EXECUTION_EXCEPTION) &&
+         !obj->WasAccessed();
+}
+
 void CoreWorkerMemoryStore::GetAsync(
     const ObjectID &object_id, std::function<void(std::shared_ptr<RayObject>)> callback) {
   absl::MutexLock lock(&mu_);
@@ -175,6 +185,7 @@ void CoreWorkerMemoryStore::Put(const RayObject &object,
                                 const ObjectID &object_id,
                                 const bool has_reference) {
   std::vector<std::function<void(std::shared_ptr<RayObject>)>> async_callbacks;
+  std::shared_ptr<RayObject> unhandled_error;
   RAY_LOG(DEBUG).WithField(object_id) << "Putting object into memory store.";
   std::shared_ptr<RayObject> object_entry = nullptr;
   if (object_allocator_ != nullptr) {
@@ -221,14 +232,22 @@ void CoreWorkerMemoryStore::Put(const RayObject &object,
     } else {
       // It is equivalent to the object being added and immediately deleted from the
       // store.
-      OnDelete(object_entry);
+      if (IsUnhandledError(object_entry) && unhandled_exception_handler_ != nullptr) {
+        unhandled_error = object_entry;
+      }
     }
 
     if (!async_callbacks.empty()) {
       object_entry->SetAccessed();
-    } else {
-      return;
     }
+  }
+
+  if (unhandled_error != nullptr) {
+    ReportUnhandledError(unhandled_error);
+  }
+
+  if (async_callbacks.empty()) {
+    return;
   }
 
   // It's important for performance to run the callbacks outside the lock.
@@ -445,30 +464,48 @@ Status CoreWorkerMemoryStore::Wait(const absl::flat_hash_set<ObjectID> &object_i
 
 void CoreWorkerMemoryStore::Delete(const absl::flat_hash_set<ObjectID> &object_ids,
                                    absl::flat_hash_set<ObjectID> *plasma_ids_to_delete) {
-  absl::MutexLock lock(&mu_);
-  for (const auto &object_id : object_ids) {
-    RAY_LOG(DEBUG) << "Delete an object from a memory store. ObjectId: " << object_id;
-    auto it = objects_.find(object_id);
-    if (it != objects_.end()) {
-      if (it->second->IsInPlasmaError()) {
-        plasma_ids_to_delete->insert(object_id);
-      } else {
-        OnDelete(it->second);
-        EraseObjectAndUpdateStats(object_id);
+  std::vector<std::shared_ptr<RayObject>> unhandled_errors;
+  {
+    absl::MutexLock lock(&mu_);
+    for (const auto &object_id : object_ids) {
+      RAY_LOG(DEBUG) << "Delete an object from a memory store. ObjectId: " << object_id;
+      auto it = objects_.find(object_id);
+      if (it != objects_.end()) {
+        if (it->second->IsInPlasmaError()) {
+          plasma_ids_to_delete->insert(object_id);
+        } else {
+          if (IsUnhandledError(it->second) && unhandled_exception_handler_ != nullptr) {
+            unhandled_errors.push_back(it->second);
+          }
+          EraseObjectAndUpdateStats(object_id);
+        }
       }
     }
+  }
+
+  for (const auto &unhandled_error : unhandled_errors) {
+    ReportUnhandledError(unhandled_error);
   }
 }
 
 void CoreWorkerMemoryStore::Delete(const std::vector<ObjectID> &object_ids) {
-  absl::MutexLock lock(&mu_);
-  for (const auto &object_id : object_ids) {
-    RAY_LOG(DEBUG) << "Delete an object from a memory store. ObjectId: " << object_id;
-    auto it = objects_.find(object_id);
-    if (it != objects_.end()) {
-      OnDelete(it->second);
-      EraseObjectAndUpdateStats(object_id);
+  std::vector<std::shared_ptr<RayObject>> unhandled_errors;
+  {
+    absl::MutexLock lock(&mu_);
+    for (const auto &object_id : object_ids) {
+      RAY_LOG(DEBUG) << "Delete an object from a memory store. ObjectId: " << object_id;
+      auto it = objects_.find(object_id);
+      if (it != objects_.end()) {
+        if (IsUnhandledError(it->second) && unhandled_exception_handler_ != nullptr) {
+          unhandled_errors.push_back(it->second);
+        }
+        EraseObjectAndUpdateStats(object_id);
+      }
     }
+  }
+
+  for (const auto &unhandled_error : unhandled_errors) {
+    ReportUnhandledError(unhandled_error);
   }
 }
 
@@ -484,36 +521,31 @@ bool CoreWorkerMemoryStore::Contains(const ObjectID &object_id, bool *in_plasma)
   return false;
 }
 
-inline bool IsUnhandledError(const std::shared_ptr<RayObject> &obj) {
-  rpc::ErrorType error_type;
-  // TODO(ekl) note that this doesn't warn on errors that are stored in plasma.
-  return obj->IsException(&error_type) &&
-         // Only warn on task failures (avoid actor died, for example).
-         (error_type == rpc::ErrorType::WORKER_DIED ||
-          error_type == rpc::ErrorType::TASK_EXECUTION_EXCEPTION) &&
-         !obj->WasAccessed();
-}
-
-void CoreWorkerMemoryStore::OnDelete(std::shared_ptr<RayObject> obj) {
-  if (IsUnhandledError(obj) && unhandled_exception_handler_ != nullptr) {
-    unhandled_exception_handler_(*obj);
-  }
+void CoreWorkerMemoryStore::ReportUnhandledError(const std::shared_ptr<RayObject> &obj) {
+  unhandled_exception_handler_(*obj);
 }
 
 void CoreWorkerMemoryStore::NotifyUnhandledErrors() {
-  absl::MutexLock lock(&mu_);
-  int64_t threshold = clock_.NowUnixNanos() - kUnhandledErrorGracePeriodNanos;
-  auto it = objects_.begin();
-  int count = 0;
-  while (it != objects_.end() && count < kMaxUnhandledErrorScanItems) {
-    const auto &obj = it->second;
-    if (IsUnhandledError(obj) && obj->CreationTimeNanos() < threshold &&
-        unhandled_exception_handler_ != nullptr) {
-      obj->SetAccessed();
-      unhandled_exception_handler_(*obj);
+  std::vector<std::shared_ptr<RayObject>> unhandled_errors;
+  {
+    absl::MutexLock lock(&mu_);
+    int64_t threshold = clock_.NowUnixNanos() - kUnhandledErrorGracePeriodNanos;
+    auto it = objects_.begin();
+    int count = 0;
+    while (it != objects_.end() && count < kMaxUnhandledErrorScanItems) {
+      const auto &obj = it->second;
+      if (IsUnhandledError(obj) && obj->CreationTimeNanos() < threshold &&
+          unhandled_exception_handler_ != nullptr) {
+        obj->SetAccessed();
+        unhandled_errors.push_back(obj);
+      }
+      it++;
+      count++;
     }
-    it++;
-    count++;
+  }
+
+  for (const auto &unhandled_error : unhandled_errors) {
+    ReportUnhandledError(unhandled_error);
   }
 }
 

--- a/src/ray/core_worker/store_provider/memory_store/memory_store.h
+++ b/src/ray/core_worker/store_provider/memory_store/memory_store.h
@@ -174,6 +174,7 @@ class CoreWorkerMemoryStore {
 
  private:
   FRIEND_TEST(TestMemoryStore, TestMemoryStoreStats);
+  FRIEND_TEST(TestMemoryStore, TestUnhandledErrorCallbacksRunOutsideLock);
 
   /// See the public version of `Get` for meaning of the other arguments.
   /// \param[in] abort_if_any_object_is_exception Whether we should abort if any object
@@ -189,8 +190,9 @@ class CoreWorkerMemoryStore {
                  bool abort_if_any_object_is_exception,
                  bool at_most_num_objects);
 
-  /// Called when an object is deleted from the store.
-  void OnDelete(std::shared_ptr<RayObject> obj);
+  /// Reports an unhandled error after releasing the store mutex.
+  void ReportUnhandledError(const std::shared_ptr<RayObject> &obj)
+      ABSL_LOCKS_EXCLUDED(mu_);
 
   /// Emplace the given object entry to the in-memory-store and update stats properly.
   void EmplaceObjectAndUpdateStats(const ObjectID &object_id,

--- a/src/ray/core_worker/store_provider/memory_store/memory_store.h
+++ b/src/ray/core_worker/store_provider/memory_store/memory_store.h
@@ -194,6 +194,11 @@ class CoreWorkerMemoryStore {
   void ReportUnhandledError(const std::shared_ptr<RayObject> &obj)
       ABSL_LOCKS_EXCLUDED(mu_);
 
+  /// Reports all unhandled errors, then rethrows the first callback exception.
+  void ReportUnhandledErrors(
+      const std::vector<std::shared_ptr<RayObject>> &unhandled_errors)
+      ABSL_LOCKS_EXCLUDED(mu_);
+
   /// Emplace the given object entry to the in-memory-store and update stats properly.
   void EmplaceObjectAndUpdateStats(const ObjectID &object_id,
                                    std::shared_ptr<RayObject> &object_entry)

--- a/src/ray/core_worker/tests/memory_store_test.cc
+++ b/src/ray/core_worker/tests/memory_store_test.cc
@@ -23,6 +23,8 @@
 
 #include "absl/container/flat_hash_set.h"
 #include "absl/synchronization/mutex.h"
+#include "absl/time/clock.h"
+#include "absl/time/time.h"
 #include "ray/common/status.h"
 #include "ray/common/status_or.h"
 #include "ray/common/test_utils.h"
@@ -92,6 +94,49 @@ TEST(TestMemoryStore, TestReportUnhandledErrors) {
   memory_store->GetAsync({id1}, [](std::shared_ptr<RayObject> obj) {});
   memory_store->Delete({id1, id2});
   ASSERT_EQ(unhandled_count, 0);
+}
+
+TEST(TestMemoryStore, TestUnhandledErrorCallbacksRunOutsideLock) {
+  InstrumentedIOContextWithThread io_context("TestUnhandledErrorCallbacksRunOutsideLock");
+  FakeClock clock(absl::Now() + absl::Seconds(10));
+  std::shared_ptr<CoreWorkerMemoryStore> memory_store;
+  int unhandled_count = 0;
+  memory_store = std::make_shared<CoreWorkerMemoryStore>(
+      io_context.GetIoService(),
+      clock,
+      /*reference_counting_enabled=*/true,
+      nullptr,
+      nullptr,
+      [&](const RayObject &) {
+        const bool lock_acquired = memory_store->mu_.TryLock();
+        EXPECT_TRUE(lock_acquired);
+        if (lock_acquired) {
+          memory_store->mu_.Unlock();
+          EXPECT_GE(memory_store->Size(), 0);
+        }
+        unhandled_count++;
+      });
+
+  RayObject unhandled_error(rpc::ErrorType::TASK_EXECUTION_EXCEPTION);
+
+  const auto vector_delete_id = ObjectID::FromRandom();
+  memory_store->Put(unhandled_error, vector_delete_id, /*has_reference=*/true);
+  memory_store->Delete(std::vector<ObjectID>{vector_delete_id});
+
+  const auto set_delete_id = ObjectID::FromRandom();
+  memory_store->Put(unhandled_error, set_delete_id, /*has_reference=*/true);
+  absl::flat_hash_set<ObjectID> plasma_ids_to_delete;
+  memory_store->Delete(absl::flat_hash_set<ObjectID>{set_delete_id},
+                       &plasma_ids_to_delete);
+
+  const auto no_reference_id = ObjectID::FromRandom();
+  memory_store->Put(unhandled_error, no_reference_id, /*has_reference=*/false);
+
+  const auto notify_id = ObjectID::FromRandom();
+  memory_store->Put(unhandled_error, notify_id, /*has_reference=*/true);
+  memory_store->NotifyUnhandledErrors();
+
+  EXPECT_EQ(unhandled_count, 4);
 }
 
 TEST(TestMemoryStore, TestMemoryStoreStats) {

--- a/src/ray/core_worker/tests/memory_store_test.cc
+++ b/src/ray/core_worker/tests/memory_store_test.cc
@@ -17,7 +17,9 @@
 #include <gtest/gtest.h>
 
 #include <memory>
+#include <stdexcept>
 #include <string>
+#include <thread>
 #include <utility>
 #include <vector>
 
@@ -41,6 +43,14 @@ std::shared_ptr<ray::LocalMemoryBuffer> MakeLocalMemoryBufferFromString(
   auto meta_buffer =
       std::make_shared<ray::LocalMemoryBuffer>(metadata, str.size(), /*copy_data=*/true);
   return meta_buffer;
+}
+
+bool TryLockAndUnlock(absl::Mutex *mutex) ABSL_NO_THREAD_SAFETY_ANALYSIS {
+  const bool lock_acquired = mutex->TryLock();
+  if (lock_acquired) {
+    mutex->Unlock();
+  }
+  return lock_acquired;
 }
 
 }  // namespace
@@ -108,10 +118,12 @@ TEST(TestMemoryStore, TestUnhandledErrorCallbacksRunOutsideLock) {
       nullptr,
       nullptr,
       [&](const RayObject &) {
-        const bool lock_acquired = memory_store->mu_.TryLock();
+        bool lock_acquired = false;
+        std::thread lock_probe(
+            [&] { lock_acquired = TryLockAndUnlock(&memory_store->mu_); });
+        lock_probe.join();
         EXPECT_TRUE(lock_acquired);
         if (lock_acquired) {
-          memory_store->mu_.Unlock();
           EXPECT_GE(memory_store->Size(), 0);
         }
         unhandled_count++;
@@ -137,6 +149,42 @@ TEST(TestMemoryStore, TestUnhandledErrorCallbacksRunOutsideLock) {
   memory_store->NotifyUnhandledErrors();
 
   EXPECT_EQ(unhandled_count, 4);
+}
+
+TEST(TestMemoryStore, TestUnhandledErrorCallbacksContinueAfterException) {
+  InstrumentedIOContextWithThread io_context(
+      "TestUnhandledErrorCallbacksContinueAfterException");
+  FakeClock clock(absl::Now() + absl::Seconds(10));
+  int unhandled_count = 0;
+  auto memory_store = std::make_shared<CoreWorkerMemoryStore>(
+      io_context.GetIoService(),
+      clock,
+      /*reference_counting_enabled=*/true,
+      nullptr,
+      nullptr,
+      [&](const RayObject &) {
+        unhandled_count++;
+        if (unhandled_count == 1) {
+          throw std::runtime_error("error reporting failed");
+        }
+      });
+  RayObject unhandled_error(rpc::ErrorType::TASK_EXECUTION_EXCEPTION);
+
+  const auto delete_id_1 = ObjectID::FromRandom();
+  const auto delete_id_2 = ObjectID::FromRandom();
+  memory_store->Put(unhandled_error, delete_id_1, /*has_reference=*/true);
+  memory_store->Put(unhandled_error, delete_id_2, /*has_reference=*/true);
+  EXPECT_THROW(memory_store->Delete(std::vector<ObjectID>{delete_id_1, delete_id_2}),
+               std::runtime_error);
+  EXPECT_EQ(unhandled_count, 2);
+
+  unhandled_count = 0;
+  const auto notify_id_1 = ObjectID::FromRandom();
+  const auto notify_id_2 = ObjectID::FromRandom();
+  memory_store->Put(unhandled_error, notify_id_1, /*has_reference=*/true);
+  memory_store->Put(unhandled_error, notify_id_2, /*has_reference=*/true);
+  EXPECT_THROW(memory_store->NotifyUnhandledErrors(), std::runtime_error);
+  EXPECT_EQ(unhandled_count, 2);
 }
 
 TEST(TestMemoryStore, TestMemoryStoreStats) {

--- a/src/ray/core_worker/tests/memory_store_test.cc
+++ b/src/ray/core_worker/tests/memory_store_test.cc
@@ -16,6 +16,7 @@
 
 #include <gtest/gtest.h>
 
+#include <atomic>
 #include <memory>
 #include <stdexcept>
 #include <string>
@@ -149,6 +150,36 @@ TEST(TestMemoryStore, TestUnhandledErrorCallbacksRunOutsideLock) {
   memory_store->NotifyUnhandledErrors();
 
   EXPECT_EQ(unhandled_count, 4);
+}
+
+TEST(TestMemoryStore, TestPutDeliveredToAsyncGetIsNotUnhandled) {
+  // Nothing holds a reference, so the store drops the object instead of keeping it, and
+  // that is the one path where Put itself reports an unhandled error. A pending GetAsync
+  // still receives the object, so it is handled and must not be reported.
+  InstrumentedIOContextWithThread io_context("TestPutDeliveredToAsyncGetIsNotUnhandled");
+  Clock clock;
+  int unhandled_count = 0;
+  std::atomic<bool> delivered{false};
+  auto memory_store = std::make_shared<CoreWorkerMemoryStore>(
+      io_context.GetIoService(),
+      clock,
+      /*reference_counting_enabled=*/true,
+      nullptr,
+      nullptr,
+      [&](const RayObject &) { unhandled_count++; });
+
+  const auto object_id = ObjectID::FromRandom();
+  memory_store->GetAsync(object_id, [&](std::shared_ptr<RayObject> obj) {
+    EXPECT_TRUE(obj->IsException());
+    delivered = true;
+  });
+
+  RayObject unhandled_error(rpc::ErrorType::TASK_EXECUTION_EXCEPTION);
+  memory_store->Put(unhandled_error, object_id, /*has_reference=*/false);
+
+  // Put reports synchronously, so the count is already final here.
+  EXPECT_EQ(unhandled_count, 0);
+  ASSERT_TRUE(WaitForCondition([&] { return delivered.load(); }, 5000));
 }
 
 TEST(TestMemoryStore, TestUnhandledErrorCallbacksContinueAfterException) {


### PR DESCRIPTION
## Description

`CoreWorkerMemoryStore` called the user-supplied `unhandled_exception_handler_` while holding `mu_`. All three `OnDelete` call sites were inside the lock — one in `Put`, two in `Delete` — as was the call in `NotifyUnhandledErrors`. A handler that touches the store again, directly or by running application code that does, self-deadlocks.

To be clear about what this is and is not: **no handler in the tree does that today**, so this is not a fix for an observed hang. The only production handler is built in `core_worker_process.cc` and does almost nothing under the lock — it filters end-of-stream sentinels and then `post`s to the io_service, with a comment explaining that user code must not run "from the middle of user operations". This change makes the store hold up its end of that arrangement rather than relying on every future caller to know it, in the same spirit as the async `Get` callbacks that were moved off the lock for #47649.

Two reasons it seemed worth doing rather than leaving as a comment. The constructor takes an arbitrary `std::function` from any caller, and the reentrancy is invisible at the call site. And in Ray's default build the failure is silent: `.bazelrc` sets `--compilation_mode=opt`, so `NDEBUG` compiles out absl's deadlock detector and a reentrant `Lock()` hangs instead of aborting with a diagnostic.

The predicate stays under the lock. `IsUnhandledError` reads `WasAccessed()`, which the waiting-getter bookkeeping sets inside the same critical section, so evaluating it after the lock is released would silently stop reporting whenever a `Get` is already waiting. The lock now collects the objects to report and the reporting happens after it is released. `Put` needed its early return restructured, since a report placed after the lock block would otherwise be skipped on that path.

The second commit handles a handler that throws: the remaining objects would not be reported. `ReportUnhandledErrors` now reports all of them, keeps the first exception, and rethrows it at the end.

The third commit is a behaviour change rather than a refactor, so it is the one worth reading closely. `Put`'s delete branch evaluated `IsUnhandledError` before marking the object accessed for a pending `GetAsync`, so an object that was about to be delivered to that getter got reported as unhandled anyway. A waiting synchronous `Get` was already exempt, because `GetRequest::Set` marks the object a few lines earlier in the same function, and `GetAsync`'s own fast path marks it before posting as well. So whether the report fired came down to whether `Put` or `GetAsync` ran first. Marking it before the check removes that ordering dependency, and `IsUnhandledError` is the only reader of `WasAccessed()` in the tree.

## Related issues

None. Found while auditing `core_worker` for callbacks invoked under a lock.

Not a duplicate: no open PR modifies `memory_store.cc` (checked every open PR's file list), and no open issue describes this.

## Additional information

`TestUnhandledErrorCallbacksRunOutsideLock` drives all four report sites — `Put` with no reference, both `Delete` overloads, and `NotifyUnhandledErrors` — and has the handler assert the lock is free. It probes with `TryLock` on a separate thread rather than asserting reentrancy directly: `TryLock` does not run absl's deadlock check, so a regression is an `EXPECT_TRUE` failure instead of a hang in opt builds or an abort in debug ones. `AssertNotHeld` would have been the obvious tool but it is compiled out under `NDEBUG`, so it would pass silently. `FakeClock` is set ten seconds ahead so `NotifyUnhandledErrors` clears its grace period without waiting.

`TestUnhandledErrorCallbacksContinueAfterException` has the first of two handlers throw and requires the second to still run.

`TestPutDeliveredToAsyncGetIsNotUnhandled` covers the third commit: a pending `GetAsync`, then a `Put` with no reference, requiring both that nothing was reported and that the callback received the object. Moving the mark back after the check fails it and nothing else, including the assertion in the test above that a no-reference `Put` does still report when no getter is waiting.

```
bazel build --dynamic_mode=off \
  --copt=-Wno-error=deprecated-builtins \
  --host_copt=-Wno-error=deprecated-builtins \
  //src/ray/core_worker/tests:memory_store_test
./bazel-bin/src/ray/core_worker/tests/memory_store_test
```

```
[==========] 9 tests from 2 test suites ran. (18 ms total)
[  PASSED  ] 9 tests.
```

macOS 15.5 / arm64, Apple clang 21. The two extra flags work around a deprecated builtin in the pinned absl on that toolchain, not this change. `pre-commit run clang-format` and `pre-commit run cpplint` pass on all three files.

## AI assistance

AI assistance was used for this change and for reviewing it. I have read every changed line and run the tests above locally.

