### PR TITLE
[data] Add unpickling guard to prevent RCE in delta sharing

### DIFF
--- a/python/ray/data/_internal/datasource/delta_sharing_datasource.py
+++ b/python/ray/data/_internal/datasource/delta_sharing_datasource.py
@@ -1,6 +1,8 @@
 import logging
 from json import loads
-from typing import TYPE_CHECKING, List, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple
+from urllib.parse import urlparse
+from urllib.request import getproxies
 
 import numpy as np
 import pyarrow as pa
@@ -11,6 +13,8 @@ from ray.data.block import BlockMetadata
 from ray.data.datasource.datasource import Datasource, ReadTask
 
 if TYPE_CHECKING:
+    import pandas as pd
+
     from ray.data.context import DataContext
 
 logger = logging.getLogger(__name__)
@@ -43,14 +47,20 @@ class DeltaSharingDatasource(Datasource):
 
     def _read_files(self, files, converters):
         """Read files with Delta Sharing."""
-        from delta_sharing.reader import DeltaSharingReader
-
         for file in files:
-            pdf = DeltaSharingReader._to_pandas(
-                action=file, converters=converters, for_cdf=False, limit=None
+            # Read into Arrow first. Converting to pandas materializes
+            # 'ray.data.arrow_pickled_object' columns, which unpickles the data and
+            # can execute arbitrary code, so the columns have to be rejected before
+            # that conversion happens.
+            table = _read_file_as_arrow(file)
+            raise_on_pickle_object_columns(table)
+            pdf = table.to_pandas(
+                date_as_object=True,
+                use_threads=False,
+                split_blocks=False,
+                self_destruct=True,
             )
-            raise_on_pickle_object_columns(pa.Table.from_pandas(pdf))
-            yield pdf
+            yield _add_missing_columns(pdf, file, converters)
 
     def setup_delta_sharing_connections(self, url: str):
         """
@@ -116,6 +126,54 @@ class DeltaSharingDatasource(Datasource):
             read_tasks.append(read_task)
 
         return read_tasks
+
+
+def _read_file_as_arrow(action) -> "pa.Table":
+    """Read a Delta Sharing file action into an Arrow table.
+
+    Mirrors ``DeltaSharingReader._to_pandas``, but stops short of the pandas
+    conversion so that the caller can inspect the Arrow schema first.
+    """
+    import fsspec
+    from pyarrow.dataset import dataset
+
+    url = urlparse(action.url)
+    if "storage.googleapis.com" in url.netloc.lower():
+        # Apply the yarl patch for GCS pre-signed URLs.
+        import delta_sharing._yarl_patch  # noqa: F401
+
+    if getproxies():
+        filesystem = fsspec.filesystem(url.scheme, client_kwargs={"trust_env": True})
+    else:
+        filesystem = fsspec.filesystem(url.scheme)
+
+    return dataset(
+        source=action.url, format="parquet", filesystem=filesystem
+    ).to_table()
+
+
+def _add_missing_columns(
+    pdf: "pd.DataFrame",
+    action,
+    converters: Dict[str, Callable[[str], Any]],
+) -> "pd.DataFrame":
+    """Add columns absent from the parquet file, mirroring ``_to_pandas``.
+
+    Partition columns aren't stored in the parquet file itself; they come from the
+    file action's partition values. Any remaining column in the table schema that
+    the file doesn't have is null-filled.
+    """
+    lowered_cols = {col.lower() for col in pdf.columns}
+    for col, converter in converters.items():
+        if col.lower() in lowered_cols:
+            continue
+        if col in action.partition_values:
+            if converter is None:
+                raise ValueError("Cannot partition on binary or complex columns")
+            pdf[col] = converter(action.partition_values[col])
+        else:
+            pdf[col] = None
+    return pdf
 
 
 def _parse_delta_sharing_url(url: str) -> Tuple[str, str, str, str]:

--- a/python/ray/data/_internal/datasource/delta_sharing_datasource.py
+++ b/python/ray/data/_internal/datasource/delta_sharing_datasource.py
@@ -14,6 +14,7 @@ from ray.data.datasource.datasource import Datasource, ReadTask
 
 if TYPE_CHECKING:
     import pandas as pd
+    from delta_sharing.protocol import FileAction
 
     from ray.data.context import DataContext
 
@@ -128,7 +129,7 @@ class DeltaSharingDatasource(Datasource):
         return read_tasks
 
 
-def _read_file_as_arrow(action) -> "pa.Table":
+def _read_file_as_arrow(action: "FileAction") -> "pa.Table":
     """Read a Delta Sharing file action into an Arrow table.
 
     Mirrors ``DeltaSharingReader._to_pandas``, but stops short of the pandas
@@ -138,6 +139,12 @@ def _read_file_as_arrow(action) -> "pa.Table":
     from pyarrow.dataset import dataset
 
     url = urlparse(action.url)
+    # Local paths / file:// URIs (used by tests). Delta Sharing file actions are
+    # normally https presigned URLs and take the fsspec branch below.
+    if url.scheme in ("", "file"):
+        source = url.path if url.scheme == "file" else action.url
+        return dataset(source=source, format="parquet").to_table()
+
     if "storage.googleapis.com" in url.netloc.lower():
         # Apply the yarl patch for GCS pre-signed URLs.
         import delta_sharing._yarl_patch  # noqa: F401
@@ -154,7 +161,7 @@ def _read_file_as_arrow(action) -> "pa.Table":
 
 def _add_missing_columns(
     pdf: "pd.DataFrame",
-    action,
+    action: "FileAction",
     converters: Dict[str, Callable[[str], Any]],
 ) -> "pd.DataFrame":
     """Add columns absent from the parquet file, mirroring ``_to_pandas``.

--- a/python/ray/data/_internal/datasource/delta_sharing_datasource.py
+++ b/python/ray/data/_internal/datasource/delta_sharing_datasource.py
@@ -3,7 +3,9 @@ from json import loads
 from typing import TYPE_CHECKING, List, Optional, Tuple
 
 import numpy as np
+import pyarrow as pa
 
+from ray.data._internal.object_extensions.arrow import raise_on_pickle_object_columns
 from ray.data._internal.util import _check_import
 from ray.data.block import BlockMetadata
 from ray.data.datasource.datasource import Datasource, ReadTask
@@ -44,9 +46,11 @@ class DeltaSharingDatasource(Datasource):
         from delta_sharing.reader import DeltaSharingReader
 
         for file in files:
-            yield DeltaSharingReader._to_pandas(
+            pdf = DeltaSharingReader._to_pandas(
                 action=file, converters=converters, for_cdf=False, limit=None
             )
+            raise_on_pickle_object_columns(pa.Table.from_pandas(pdf))
+            yield pdf
 
     def setup_delta_sharing_connections(self, url: str):
         """

--- a/python/ray/data/tests/datasource/test_delta_sharing.py
+++ b/python/ray/data/tests/datasource/test_delta_sharing.py
@@ -6,6 +6,7 @@ from unittest import mock
 from unittest.mock import MagicMock, patch
 
 import pyarrow as pa
+import pyarrow.parquet as pq
 import pytest
 from delta_sharing.protocol import Table
 from delta_sharing.rest_client import DataSharingRestClient
@@ -14,7 +15,10 @@ from ray.data._internal.datasource.delta_sharing_datasource import (
     DeltaSharingDatasource,
     _parse_delta_sharing_url,
 )
-from ray.data._internal.object_extensions.arrow import ArrowPythonObjectType
+from ray.data._internal.object_extensions.arrow import (
+    AUTOLOAD_PICKLE_OBJECT_SCALAR_ENV_VAR,
+    ArrowPythonObjectType,
+)
 from ray.data.block import BlockMetadata
 from ray.data.dataset import Dataset
 from ray.data.datasource.datasource import ReadTask
@@ -291,17 +295,25 @@ def test_read_delta_sharing_tables(
     assert kwargs["override_num_blocks"] == override_num_blocks
 
 
-def _mock_file_action(partition_values=None):
+def _mock_file_action(url=None, partition_values=None):
     action = MagicMock()
-    action.url = "https://bucket.s3.us-west-2.amazonaws.com/part-00000.snappy.parquet"
+    action.url = (
+        url or "https://bucket.s3.us-west-2.amazonaws.com/part-00000.snappy.parquet"
+    )
     action.partition_values = partition_values or {}
     return action
 
 
+def _write_object_column_parquet(path, obj):
+    ext_type = ArrowPythonObjectType()
+    storage = pa.array([pickle.dumps(obj)], type=ext_type.storage_type)
+    table = pa.table({"col": pa.ExtensionArray.from_storage(ext_type, storage)})
+    pq.write_table(table, path)
+
+
 def test_read_files_rejects_pickle_object_columns(monkeypatch, tmp_path):
-    # The guard has to run before the pandas conversion: converting a
-    # 'ray.data.arrow_pickled_object' column to pandas is what unpickles the data,
-    # so a guard placed after the conversion never prevents the payload from running.
+    """The guard fires on a real file, before anything unpickles it."""
+    monkeypatch.delenv(AUTOLOAD_PICKLE_OBJECT_SCALAR_ENV_VAR, raising=False)
     marker = tmp_path / "exploit_marker"
 
     class Exploit:
@@ -310,20 +322,17 @@ def test_read_files_rejects_pickle_object_columns(monkeypatch, tmp_path):
 
             return (os.system, (f"touch {marker}",))
 
-    ext_type = ArrowPythonObjectType()
-    storage = pa.array([pickle.dumps(Exploit())], type=ext_type.storage_type)
-    table = pa.table({"col": pa.ExtensionArray.from_storage(ext_type, storage)})
-
-    monkeypatch.setattr(
-        "ray.data._internal.datasource.delta_sharing_datasource._read_file_as_arrow",
-        lambda action: table,
-    )
+    path = tmp_path / "part-0.parquet"
+    _write_object_column_parquet(path, Exploit())
 
     datasource = DeltaSharingDatasource.__new__(DeltaSharingDatasource)
     with pytest.raises(ValueError, match="arrow_pickled_object"):
-        list(datasource._read_files([_mock_file_action()], converters={}))
-
-    assert not marker.exists(), "pickle.load executed attacker code"
+        list(
+            datasource._read_files(
+                [_mock_file_action(url=path.as_uri())], converters={}
+            )
+        )
+    assert not marker.exists(), "unpickling executed attacker code"
 
 
 def test_read_files_adds_partition_and_missing_columns(monkeypatch):

--- a/python/ray/data/tests/datasource/test_delta_sharing.py
+++ b/python/ray/data/tests/datasource/test_delta_sharing.py
@@ -1,9 +1,11 @@
 import json
+import pickle
 import unittest
 from typing import TYPE_CHECKING, Optional
 from unittest import mock
 from unittest.mock import MagicMock, patch
 
+import pyarrow as pa
 import pytest
 from delta_sharing.protocol import Table
 from delta_sharing.rest_client import DataSharingRestClient
@@ -12,6 +14,7 @@ from ray.data._internal.datasource.delta_sharing_datasource import (
     DeltaSharingDatasource,
     _parse_delta_sharing_url,
 )
+from ray.data._internal.object_extensions.arrow import ArrowPythonObjectType
 from ray.data.block import BlockMetadata
 from ray.data.dataset import Dataset
 from ray.data.datasource.datasource import ReadTask
@@ -286,6 +289,61 @@ def test_read_delta_sharing_tables(
     assert kwargs["ray_remote_args"] == ray_remote_args
     assert kwargs["concurrency"] == concurrency
     assert kwargs["override_num_blocks"] == override_num_blocks
+
+
+def _mock_file_action(partition_values=None):
+    action = MagicMock()
+    action.url = "https://bucket.s3.us-west-2.amazonaws.com/part-00000.snappy.parquet"
+    action.partition_values = partition_values or {}
+    return action
+
+
+def test_read_files_rejects_pickle_object_columns(monkeypatch, tmp_path):
+    # The guard has to run before the pandas conversion: converting a
+    # 'ray.data.arrow_pickled_object' column to pandas is what unpickles the data,
+    # so a guard placed after the conversion never prevents the payload from running.
+    marker = tmp_path / "exploit_marker"
+
+    class Exploit:
+        def __reduce__(self):
+            import os
+
+            return (os.system, (f"touch {marker}",))
+
+    ext_type = ArrowPythonObjectType()
+    storage = pa.array([pickle.dumps(Exploit())], type=ext_type.storage_type)
+    table = pa.table({"col": pa.ExtensionArray.from_storage(ext_type, storage)})
+
+    monkeypatch.setattr(
+        "ray.data._internal.datasource.delta_sharing_datasource._read_file_as_arrow",
+        lambda action: table,
+    )
+
+    datasource = DeltaSharingDatasource.__new__(DeltaSharingDatasource)
+    with pytest.raises(ValueError, match="arrow_pickled_object"):
+        list(datasource._read_files([_mock_file_action()], converters={}))
+
+    assert not marker.exists(), "pickle.load executed attacker code"
+
+
+def test_read_files_adds_partition_and_missing_columns(monkeypatch):
+    """Columns absent from the parquet file come from the file action or are null."""
+    table = pa.table({"eventTime": ["2021-04-28T23:33:48.719Z"]})
+
+    monkeypatch.setattr(
+        "ray.data._internal.datasource.delta_sharing_datasource._read_file_as_arrow",
+        lambda action: table,
+    )
+
+    action = _mock_file_action(partition_values={"date": "2021-04-28"})
+    converters = {"eventTime": str, "date": str, "absent": str}
+
+    datasource = DeltaSharingDatasource.__new__(DeltaSharingDatasource)
+    (pdf,) = list(datasource._read_files([action], converters=converters))
+
+    assert pdf["eventTime"].tolist() == ["2021-04-28T23:33:48.719Z"]
+    assert pdf["date"].tolist() == ["2021-04-28"]
+    assert pdf["absent"].isna().all()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description
As titled. Unpickling python objects can lead to RCE, so we are adding this guard

## Related issues
https://github.com/ray-project/ray/issues/65553

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
