### PR TITLE
[Data] Fix double-counted UDF time in fused map operators

### DIFF
--- a/python/ray/data/_internal/execution/operators/map_operator.py
+++ b/python/ray/data/_internal/execution/operators/map_operator.py
@@ -853,7 +853,10 @@ def _map_task(
                 _iter_sliced_blocks(blocks, slices) if slices else iter(blocks)
             )
             return map_transformer.apply_transform(
-                blocks_iter, ctx, op_stats_reporter.report, udf_time_scope
+                blocks_iter,
+                ctx,
+                op_stats_reporter.report,
+                udf_time_scope=udf_time_scope,
             )
 
         if retry_on:

--- a/python/ray/data/_internal/execution/operators/map_operator.py
+++ b/python/ray/data/_internal/execution/operators/map_operator.py
@@ -72,6 +72,7 @@ from ray.data._internal.execution.operators.map_transformer import (
     BlockMapTransformFn,
     CustomOpStatsReporter,
     MapTransformer,
+    UDFTimeScope,
 )
 from ray.data._internal.execution.util import (
     memory_string,
@@ -836,6 +837,10 @@ def _map_task(
         # This is owned by _map_task so it belongs to actual, possibly-fused, running task
         # rather than a transformer instance reused across tasks.
         op_stats_reporter = CustomOpStatsReporter()
+        # Likewise owned by _map_task: an actor pool shares one transformer
+        # across every task the actor runs, and with
+        # `max_concurrent_calls_per_actor > 1` several run at once.
+        udf_time_scope = UDFTimeScope()
 
         def transform_iter_factory():
             # Clear any per-task custom stats before each attempt (the reporter
@@ -843,11 +848,12 @@ def _map_task(
             # can't leak into this one. A producing transform repopulates it
             # before the first block is yielded.
             op_stats_reporter.clear()
+            udf_time_scope.drain()
             blocks_iter = (
                 _iter_sliced_blocks(blocks, slices) if slices else iter(blocks)
             )
             return map_transformer.apply_transform(
-                blocks_iter, ctx, op_stats_reporter.report
+                blocks_iter, ctx, op_stats_reporter.report, udf_time_scope
             )
 
         if retry_on:
@@ -872,7 +878,7 @@ def _map_task(
                 def build_metadata(block_ser_time_s):
                     exec_stats = blk_exec_stats_builder.build(
                         block_ser_time_s=block_ser_time_s,
-                        udf_time_s=map_transformer.udf_time_s(reset=True),
+                        udf_time_s=udf_time_scope.drain(),
                         task_idx=ctx.task_idx,
                     )
                     # NOTE: This tracks task duration up to this point, though we're

--- a/python/ray/data/_internal/execution/operators/map_transformer.py
+++ b/python/ray/data/_internal/execution/operators/map_transformer.py
@@ -204,9 +204,18 @@ class UDFTimeScope:
     creates one per task and threads it into ``apply_transform``, the same way it
     threads a :class:`CustomOpStatsReporter`.
 
-    ``attributed_s`` doubles as the nesting cursor. Each stage's timer records
-    how far it had advanced before its own call, so it can subtract whatever
-    upstream stages added in between.
+    ``attributed_s`` is a single running total that every timer in the chain adds
+    to, holding the time accumulated since the last :meth:`drain` (``_map_task``
+    drains after each output block). It covers the whole transform: input
+    batching, the UDF bodies, and output block building.
+
+    It is also the cursor each timer uses to find its own share. Stages are
+    chained behind lazy iterators, so a stage's ``next()`` runs everything
+    upstream of it before returning, and a timer can only measure inclusive
+    time. The change in ``attributed_s`` across that call is what the upstream
+    timers added during it, so subtracting it leaves this stage's own
+    contribution. Three fused UDFs sleeping 1s, 2s and 3s measure 1s, 3s and 6s
+    inclusive, subtract 0s, 1s and 3s, and add 1s, 2s and 3s.
     """
 
     __slots__ = ("attributed_s",)

--- a/python/ray/data/_internal/execution/operators/map_transformer.py
+++ b/python/ray/data/_internal/execution/operators/map_transformer.py
@@ -204,7 +204,11 @@ class MapTransformer:
     """
 
     class _UDFTimingIterator(Iterator[MapTransformFnData]):
-        """Iterator that times UDF execution"""
+        """Iterator that times UDF execution.
+
+        Times inclusively: pulling one item also runs every upstream stage, which
+        is why ``apply_transform`` wraps only the last UDF.
+        """
 
         def __init__(
             self, input: Iterable[MapTransformFnData], transformer: "MapTransformer"
@@ -305,11 +309,19 @@ class MapTransformer:
                 self.target_max_block_size_override
             )
 
+        # Only the last UDF is timed. The stages are chained behind lazy iterators,
+        # so its timer already covers every UDF ahead of it -- timing each stage
+        # and summing would count upstream stages once per downstream stage.
+        last_udf_idx = max(
+            (i for i, fn in enumerate(self._transform_fns) if fn._is_udf),
+            default=None,
+        )
+
         iter = input_blocks
         # Apply the transform functions sequentially to the input iterable.
-        for transform_fn in self._transform_fns:
+        for i, transform_fn in enumerate(self._transform_fns):
             iter = transform_fn(iter, ctx, report_custom_op_stats)
-            if transform_fn._is_udf:
+            if i == last_udf_idx:
                 iter = self._UDFTimingIterator(iter, self)
 
         return iter

--- a/python/ray/data/_internal/execution/operators/map_transformer.py
+++ b/python/ray/data/_internal/execution/operators/map_transformer.py
@@ -194,6 +194,34 @@ class MapTransformFn(ABC):
             return self._output_block_size_option.target_num_rows_per_block
 
 
+class UDFTimeScope:
+    """Running total of UDF time for one task, and the nesting state to get it.
+
+    ``_map_task`` creates one per task and threads it into ``apply_transform``,
+    the same way it threads a :class:`CustomOpStatsReporter`. Keeping it per
+    task rather than on the :class:`MapTransformer` matters because an actor
+    pool reuses one transformer across every task the actor runs, and with
+    ``max_concurrent_calls_per_actor > 1`` several of those run concurrently:
+    a total living on the transformer would mix their timings together and let
+    one task's reset discard another's work.
+
+    ``attributed_s`` doubles as the nesting cursor. Each stage's timer records
+    how far it had advanced before its own call, so it can subtract whatever
+    upstream stages added in between.
+    """
+
+    __slots__ = ("attributed_s",)
+
+    def __init__(self) -> None:
+        self.attributed_s: float = 0.0
+
+    def drain(self) -> float:
+        """Return the time accumulated since the last drain, and reset."""
+        elapsed_s = self.attributed_s
+        self.attributed_s = 0.0
+        return elapsed_s
+
+
 class MapTransformer:
     """Encapsulates the data transformation logic of a physical MapOperator.
 
@@ -204,27 +232,40 @@ class MapTransformer:
     """
 
     class _UDFTimingIterator(Iterator[MapTransformFnData]):
-        """Iterator that times UDF execution.
+        """Times one UDF stage, net of the stages feeding it.
 
-        Times inclusively: pulling one item also runs every upstream stage, which
-        is why ``apply_transform`` wraps only the last UDF.
+        ``__next__`` can only measure inclusive time: the stages are chained
+        behind lazy iterators, so pulling one item also runs every stage
+        upstream. Subtracting what upstream stages credited to ``scope`` during
+        the same window leaves this stage's own time, so the scope's running
+        total is the time actually spent in UDFs rather than a sum that counts
+        each stage once per stage downstream of it.
         """
 
         def __init__(
-            self, input: Iterable[MapTransformFnData], transformer: "MapTransformer"
+            self,
+            input: Iterable[MapTransformFnData],
+            scope: "UDFTimeScope",
         ):
             self._input = input
-            self._transformer = transformer
+            self._scope = scope
 
         def __iter__(self) -> "MapTransformer._UDFTimingIterator":
             return self
 
         def __next__(self) -> MapTransformFnData:
+            scope = self._scope
+            attributed_before_s = scope.attributed_s
             start = time.perf_counter()
             try:
                 return next(self._input)
             finally:
-                self._transformer._report_udf_time(time.perf_counter() - start)
+                inclusive_s = time.perf_counter() - start
+                upstream_s = scope.attributed_s - attributed_before_s
+                # Upstream stages' exclusive spans are disjoint sub-intervals of
+                # this window, so the difference is non-negative; clamp only to
+                # absorb floating-point rounding.
+                scope.attributed_s += max(0.0, inclusive_s - upstream_s)
 
     def __init__(
         self,
@@ -246,7 +287,6 @@ class MapTransformer:
         self._transform_fns: List[MapTransformFn] = []
         self._init_fn = init_fn if init_fn is not None else lambda: None
         self._output_block_size_option_override = output_block_size_option_override
-        self._udf_time_s = 0
 
         # Add transformations
         self.add_transform_fns(transform_fns)
@@ -286,6 +326,7 @@ class MapTransformer:
         input_blocks: Iterable[Block],
         ctx: TaskContext,
         report_custom_op_stats: CustomOpStatsReportFn = _noop_report_custom_op_stats,
+        udf_time_scope: Optional["UDFTimeScope"] = None,
     ) -> Iterable[Block]:
         """Apply the transform functions to the input blocks.
 
@@ -296,6 +337,9 @@ class MapTransformer:
                 its :class:`CustomOpStats`. ``_map_task`` passes its reporter's
                 ``report``; defaults to a stateless no-op for callers (e.g. tests)
                 that don't collect custom stats.
+            udf_time_scope: Where to accumulate this task's UDF time.
+                ``_map_task`` passes the scope it created for the task; callers
+                that don't collect timings get a throwaway one.
 
         Returns:
             An iterable of the transformed output blocks.
@@ -309,20 +353,22 @@ class MapTransformer:
                 self.target_max_block_size_override
             )
 
-        # Only the last UDF is timed. The stages are chained behind lazy iterators,
-        # so its timer already covers every UDF ahead of it -- timing each stage
-        # and summing would count upstream stages once per downstream stage.
-        last_udf_idx = max(
-            (i for i, fn in enumerate(self._transform_fns) if fn._is_udf),
-            default=None,
-        )
+        if udf_time_scope is None:
+            udf_time_scope = UDFTimeScope()
 
         iter = input_blocks
-        # Apply the transform functions sequentially to the input iterable.
-        for i, transform_fn in enumerate(self._transform_fns):
+        # Every UDF stage is timed, as it is built. Timing only the last one
+        # would be cheaper and would still cover the others -- but only if
+        # nothing pulls data before the chain is finished, and something does:
+        # `MapTransformFn.__call__` runs `_pre_process` eagerly, and with
+        # `batch_size="auto"` that peeks at a real block to size batches,
+        # dragging every upstream stage's work in ahead of any timer installed
+        # later. Installing each stage's timer before the next stage is built
+        # keeps that peek inside a timed window.
+        for transform_fn in self._transform_fns:
             iter = transform_fn(iter, ctx, report_custom_op_stats)
-            if i == last_udf_idx:
-                iter = self._UDFTimingIterator(iter, self)
+            if transform_fn._is_udf:
+                iter = self._UDFTimingIterator(iter, udf_time_scope)
 
         return iter
 
@@ -367,15 +413,6 @@ class MapTransformer:
         cls, ones: List[MapTransformFn], others: List[MapTransformFn]
     ) -> list[Any]:
         return ones + others
-
-    def udf_time_s(self, reset: bool) -> float:
-        cur_time_s = self._udf_time_s
-        if reset:
-            self._udf_time_s = 0
-        return cur_time_s
-
-    def _report_udf_time(self, udf_time: float) -> None:
-        self._udf_time_s += udf_time
 
 
 class RowMapTransformFn(MapTransformFn):

--- a/python/ray/data/_internal/execution/operators/map_transformer.py
+++ b/python/ray/data/_internal/execution/operators/map_transformer.py
@@ -197,13 +197,12 @@ class MapTransformFn(ABC):
 class UDFTimeScope:
     """Running total of UDF time for one task, and the nesting state to get it.
 
-    ``_map_task`` creates one per task and threads it into ``apply_transform``,
-    the same way it threads a :class:`CustomOpStatsReporter`. Keeping it per
-    task rather than on the :class:`MapTransformer` matters because an actor
-    pool reuses one transformer across every task the actor runs, and with
-    ``max_concurrent_calls_per_actor > 1`` several of those run concurrently:
-    a total living on the transformer would mix their timings together and let
-    one task's reset discard another's work.
+    Must stay per task, not per :class:`MapTransformer`: an actor pool reuses one
+    transformer for every task the actor runs, and ``max_concurrent_calls_per_actor
+    > 1`` runs several of those at once, so a shared total would mix their
+    timings and let one task's :meth:`drain` discard another's. ``_map_task``
+    creates one per task and threads it into ``apply_transform``, the same way it
+    threads a :class:`CustomOpStatsReporter`.
 
     ``attributed_s`` doubles as the nesting cursor. Each stage's timer records
     how far it had advanced before its own call, so it can subtract whatever
@@ -237,9 +236,8 @@ class MapTransformer:
         ``__next__`` can only measure inclusive time: the stages are chained
         behind lazy iterators, so pulling one item also runs every stage
         upstream. Subtracting what upstream stages credited to ``scope`` during
-        the same window leaves this stage's own time, so the scope's running
-        total is the time actually spent in UDFs rather than a sum that counts
-        each stage once per stage downstream of it.
+        the same window leaves this stage's own time, which is what keeps
+        ``scope``'s total from counting a stage once per stage below it.
         """
 
         def __init__(
@@ -357,14 +355,10 @@ class MapTransformer:
             udf_time_scope = UDFTimeScope()
 
         iter = input_blocks
-        # Every UDF stage is timed, as it is built. Timing only the last one
-        # would be cheaper and would still cover the others -- but only if
-        # nothing pulls data before the chain is finished, and something does:
+        # Each stage's timer has to be installed before the next stage is built:
         # `MapTransformFn.__call__` runs `_pre_process` eagerly, and with
-        # `batch_size="auto"` that peeks at a real block to size batches,
-        # dragging every upstream stage's work in ahead of any timer installed
-        # later. Installing each stage's timer before the next stage is built
-        # keeps that peek inside a timed window.
+        # `batch_size="auto"` that peeks at a real block to size batches, which
+        # pulls data through the stages already in the chain.
         for transform_fn in self._transform_fns:
             iter = transform_fn(iter, ctx, report_custom_op_stats)
             if transform_fn._is_udf:

--- a/python/ray/data/_internal/execution/operators/map_transformer.py
+++ b/python/ray/data/_internal/execution/operators/map_transformer.py
@@ -254,7 +254,9 @@ class MapTransformer:
             input: Iterable[MapTransformFnData],
             scope: "UDFTimeScope",
         ):
-            self._input = input
+            # `input` is an Iterable, but `__next__` needs an Iterator, and some
+            # callers hand `apply_transform` a plain list.
+            self._input = iter(input)
             self._scope = scope
 
         def __iter__(self) -> "MapTransformer._UDFTimingIterator":

--- a/python/ray/data/_internal/execution/operators/map_transformer.py
+++ b/python/ray/data/_internal/execution/operators/map_transformer.py
@@ -324,7 +324,8 @@ class MapTransformer:
         input_blocks: Iterable[Block],
         ctx: TaskContext,
         report_custom_op_stats: CustomOpStatsReportFn = _noop_report_custom_op_stats,
-        udf_time_scope: Optional["UDFTimeScope"] = None,
+        *,
+        udf_time_scope: "UDFTimeScope",
     ) -> Iterable[Block]:
         """Apply the transform functions to the input blocks.
 
@@ -335,9 +336,10 @@ class MapTransformer:
                 its :class:`CustomOpStats`. ``_map_task`` passes its reporter's
                 ``report``; defaults to a stateless no-op for callers (e.g. tests)
                 that don't collect custom stats.
-            udf_time_scope: Where to accumulate this task's UDF time.
-                ``_map_task`` passes the scope it created for the task; callers
-                that don't collect timings get a throwaway one.
+            udf_time_scope: Where to accumulate this task's UDF time. Required and
+                keyword-only on purpose: a caller that silently skipped it would
+                report a UDF time of zero rather than fail. Callers that don't
+                collect timings pass a throwaway ``UDFTimeScope()``.
 
         Returns:
             An iterable of the transformed output blocks.
@@ -350,9 +352,6 @@ class MapTransformer:
             last_transform.override_target_max_block_size(
                 self.target_max_block_size_override
             )
-
-        if udf_time_scope is None:
-            udf_time_scope = UDFTimeScope()
 
         iter = input_blocks
         # Each stage's timer has to be installed before the next stage is built:

--- a/python/ray/data/_internal/execution/operators/shuffle_operators/external_shuffle_tasks.py
+++ b/python/ray/data/_internal/execution/operators/shuffle_operators/external_shuffle_tasks.py
@@ -277,10 +277,16 @@ def _external_shuffle_reduce_task(
             return
         assert map_task_context is not None and data_context is not None
         with DataContext.current(data_context), TaskContext.current(map_task_context):
+            from ray.data._internal.execution.operators.map_transformer import (
+                UDFTimeScope,
+            )
+
             map_transformer.override_target_max_block_size(
                 map_task_context.target_max_block_size_override
             )
-            for out_block in map_transformer.apply_transform(blocks, map_task_context):
+            for out_block in map_transformer.apply_transform(
+                blocks, map_task_context, udf_time_scope=UDFTimeScope()
+            ):
                 yield from _yield_with_stats(out_block)
 
     # No shards for this partition. Yield a typed empty table so the

--- a/python/ray/data/_internal/execution/operators/shuffle_operators/shuffle_tasks.py
+++ b/python/ray/data/_internal/execution/operators/shuffle_operators/shuffle_tasks.py
@@ -343,10 +343,16 @@ def _shuffle_reduce_task(
     else:
         assert map_task_context is not None and data_context is not None
         with DataContext.current(data_context), TaskContext.current(map_task_context):
+            from ray.data._internal.execution.operators.map_transformer import (
+                UDFTimeScope,
+            )
+
             map_transformer.override_target_max_block_size(
                 map_task_context.target_max_block_size_override
             )
             for block in map_transformer.apply_transform(
-                _reduce_output_blocks(), map_task_context
+                _reduce_output_blocks(),
+                map_task_context,
+                udf_time_scope=UDFTimeScope(),
             ):
                 yield from _yield_with_stats(block)

--- a/python/ray/data/_internal/planner/random_shuffle.py
+++ b/python/ray/data/_internal/planner/random_shuffle.py
@@ -8,7 +8,10 @@ from ray.data._internal.execution.interfaces import (
 from ray.data._internal.execution.interfaces.transform_fn import (
     AllToAllTransformFnResult,
 )
-from ray.data._internal.execution.operators.map_transformer import MapTransformer
+from ray.data._internal.execution.operators.map_transformer import (
+    MapTransformer,
+    UDFTimeScope,
+)
 from ray.data._internal.execution.util import merge_label_selector
 from ray.data._internal.planner.exchange.pull_based_shuffle_task_scheduler import (
     PullBasedShuffleTaskScheduler,
@@ -56,7 +59,9 @@ def generate_random_shuffle_fn(
 
             def upstream_map_fn(blocks):
                 DataContext._set_current(data_context)
-                return map_transformer.apply_transform(blocks, ctx)
+                return map_transformer.apply_transform(
+                    blocks, ctx, udf_time_scope=UDFTimeScope()
+                )
 
             # If there is a fused upstream operator,
             # also use the ray_remote_args from the fused upstream operator.

--- a/python/ray/data/_internal/planner/repartition.py
+++ b/python/ray/data/_internal/planner/repartition.py
@@ -8,7 +8,10 @@ from ray.data._internal.execution.interfaces import (
 from ray.data._internal.execution.interfaces.transform_fn import (
     AllToAllTransformFnResult,
 )
-from ray.data._internal.execution.operators.map_transformer import MapTransformer
+from ray.data._internal.execution.operators.map_transformer import (
+    MapTransformer,
+    UDFTimeScope,
+)
 from ray.data._internal.execution.util import merge_label_selector
 from ray.data._internal.planner.exchange.pull_based_shuffle_task_scheduler import (
     PullBasedShuffleTaskScheduler,
@@ -48,7 +51,9 @@ def generate_repartition_fn(
 
             def upstream_map_fn(blocks):
                 DataContext._set_current(data_context)
-                return map_transformer.apply_transform(blocks, ctx)
+                return map_transformer.apply_transform(
+                    blocks, ctx, udf_time_scope=UDFTimeScope()
+                )
 
         shuffle_spec = ShuffleTaskSpec(
             target_shuffle_max_block_size=(

--- a/python/ray/data/tests/test_checkpoint.py
+++ b/python/ray/data/tests/test_checkpoint.py
@@ -18,6 +18,9 @@ from ray.data._internal.datasource.csv_datasource import CSVDatasource
 from ray.data._internal.datasource.parquet_datasink import ParquetDatasink
 from ray.data._internal.execution.interfaces import TaskContext
 from ray.data._internal.execution.operators.map_operator import MapOperator
+from ray.data._internal.execution.operators.map_transformer import (
+    UDFTimeScope,
+)
 from ray.data._internal.logical.interfaces.logical_plan import LogicalPlan
 from ray.data._internal.logical.operators import Read, Write
 from ray.data._internal.logical.optimizers import get_execution_plan
@@ -1417,6 +1420,7 @@ def test_checkpoint_map_transformer(
     filtered_blocks = map_transformer.apply_transform(
         input_blocks=[block],
         ctx=TaskContext(task_idx=0, op_name="test_checkpoint"),
+        udf_time_scope=UDFTimeScope(),
     )
 
     filtered_block = next(iter(filtered_blocks))

--- a/python/ray/data/tests/test_map_transformer.py
+++ b/python/ray/data/tests/test_map_transformer.py
@@ -10,6 +10,7 @@ from ray.data._internal.execution.interfaces.task_context import TaskContext
 from ray.data._internal.execution.operators.map_transformer import (
     BatchMapTransformFn,
     MapTransformer,
+    UDFTimeScope,
 )
 from ray.data._internal.output_buffer import OutputBlockSizeOption
 from ray.data._internal.planner.plan_udf_map_op import (
@@ -171,15 +172,18 @@ def test_chained_transforms_dont_double_count_udf_time():
         for i in range(NUM_BATCHES):
             yield pd.DataFrame({"id": [i]})
 
+    scope = UDFTimeScope()
     start_s = time.perf_counter()
-    blocks = list(transformer.apply_transform(make_input_blocks(), ctx))
+    blocks = list(
+        transformer.apply_transform(make_input_blocks(), ctx, udf_time_scope=scope)
+    )
     wall_s = time.perf_counter() - start_s
 
     # Assert on rows rather than block count, which depends on block shaping.
     assert sum(BlockAccessor.for_block(b).num_rows() for b in blocks) == NUM_BATCHES
     assert num_calls > 0
 
-    reported_s = transformer.udf_time_s(reset=False)
+    reported_s = scope.attributed_s
     # Measured, not assumed: block shaping decides how many batches each stage sees.
     slept_s = num_calls * SLEEP_S
 

--- a/python/ray/data/tests/test_map_transformer.py
+++ b/python/ray/data/tests/test_map_transformer.py
@@ -185,6 +185,9 @@ def test_chained_transforms_dont_double_count_udf_time():
     assert sum(BlockAccessor.for_block(b).num_rows() for b in blocks) == NUM_BATCHES
     assert num_calls > 0
 
+    # The whole transform chain, not just the sleeps: for each stage it covers
+    # turning input blocks into batches, the UDF body, and building output
+    # blocks. The sleeps are therefore a floor on it, never an equality.
     reported_s = scope.attributed_s
     # Measured, not assumed: block shaping decides how many batches each stage sees.
     slept_s = num_calls * SLEEP_S
@@ -198,6 +201,69 @@ def test_chained_transforms_dont_double_count_udf_time():
     assert reported_s >= slept_s * 0.9, (
         f"reported UDF time {reported_s:.4f}s is below the {slept_s:.4f}s slept "
         f"across {num_calls} UDF calls"
+    )
+
+
+def test_chained_transforms_total_is_independent_of_distribution():
+    """The total must be right however unevenly the time is spread.
+
+    The test above gives every stage the same sleep, so a bug that shifted time
+    from one stage to another would leave the total intact and go unnoticed.
+    Uneven sleeps remove that cover: the subtraction has to land on the right
+    stage for the sum to come out.
+    """
+    SLEEPS_S = [0.05, 0.1, 0.15]
+    NUM_BATCHES = 2
+
+    calls_per_stage = [0] * len(SLEEPS_S)
+
+    def make_udf(stage_idx: int) -> "callable":
+        def udf(batch: DataBatch) -> DataBatch:
+            calls_per_stage[stage_idx] += 1
+            time.sleep(SLEEPS_S[stage_idx])
+            return pd.DataFrame({"id": batch["id"]})
+
+        return udf
+
+    transform_fns = [
+        BatchMapTransformFn(
+            _generate_transform_fn_for_map_batches(make_udf(i)),
+            is_udf=True,
+            batch_format="pandas",
+            batch_size=1,
+            output_block_size_option=OutputBlockSizeOption.of(target_max_block_size=1),
+        )
+        for i in range(len(SLEEPS_S))
+    ]
+    transformer = MapTransformer(transform_fns)
+    ctx = TaskContext(task_idx=0, op_name="test")
+
+    def make_input_blocks():
+        for i in range(NUM_BATCHES):
+            yield pd.DataFrame({"id": [i]})
+
+    scope = UDFTimeScope()
+    start_s = time.perf_counter()
+    blocks = list(
+        transformer.apply_transform(make_input_blocks(), ctx, udf_time_scope=scope)
+    )
+    wall_s = time.perf_counter() - start_s
+
+    assert sum(BlockAccessor.for_block(b).num_rows() for b in blocks) == NUM_BATCHES
+    assert all(n > 0 for n in calls_per_stage), calls_per_stage
+
+    reported_s = scope.attributed_s
+    slept_s = sum(n * s for n, s in zip(calls_per_stage, SLEEPS_S))
+
+    # Summing the stages' inclusive times would give 0.05 + 0.15 + 0.30 = 0.50s
+    # against 0.30s of real sleeping -- 1.7x. The subtraction has to cancel that
+    # exactly, not approximately.
+    assert (
+        reported_s <= wall_s * 1.05
+    ), f"reported UDF time {reported_s:.4f}s exceeds chain wall time {wall_s:.4f}s"
+    assert reported_s >= slept_s * 0.9, (
+        f"reported UDF time {reported_s:.4f}s is below the {slept_s:.4f}s slept "
+        f"across stages {calls_per_stage}"
     )
 
 

--- a/python/ray/data/tests/test_map_transformer.py
+++ b/python/ray/data/tests/test_map_transformer.py
@@ -188,7 +188,7 @@ def test_chained_transforms_dont_double_count_udf_time():
     slept_s = num_calls * SLEEP_S
 
     # Can't exceed the wall time of the chain that produced it. The headroom
-    # absorbs timing noise; the bug inflated this by ~2x at 3 stages.
+    # absorbs timing noise; double counting shows up at ~2x for 3 stages.
     assert (
         reported_s <= wall_s * 1.05
     ), f"reported UDF time {reported_s:.4f}s exceeds chain wall time {wall_s:.4f}s"

--- a/python/ray/data/tests/test_map_transformer.py
+++ b/python/ray/data/tests/test_map_transformer.py
@@ -18,11 +18,16 @@ from ray.data._internal.planner.plan_udf_map_op import (
 from ray.data.block import BlockAccessor, DataBatch
 
 
-def _create_chained_transformer(udf, n):
-    """Create a MapTransformer with chained batch transforms that track intermediates."""
+def _create_chained_transformer(udf, n, *, is_udf=False):
+    """Create a MapTransformer with chained batch transforms that track intermediates.
+
+    ``is_udf`` mirrors what the planner sets for real ``map_batches`` stages; it
+    gates UDF timing, so tests that assert on ``udf_time_s`` must pass True.
+    """
     transform_fns = [
         BatchMapTransformFn(
             _generate_transform_fn_for_map_batches(udf),
+            is_udf=is_udf,
             batch_format="pandas",
             batch_size=1,
             output_block_size_option=OutputBlockSizeOption.of(target_max_block_size=1),
@@ -150,11 +155,16 @@ def test_chained_transforms_dont_double_count_udf_time():
     NUM_BATCHES = 2
     SLEEP_S = 0.05
 
+    num_calls = 0
+
     def udf(batch: DataBatch) -> DataBatch:
+        nonlocal num_calls
+        num_calls += 1
         time.sleep(SLEEP_S)
         return pd.DataFrame({"id": batch["id"]})
 
-    transformer = _create_chained_transformer(udf, NUM_CHAINED_TRANSFORMS)
+    # is_udf=True is what gates timing; without it no stage is timed at all.
+    transformer = _create_chained_transformer(udf, NUM_CHAINED_TRANSFORMS, is_udf=True)
     ctx = TaskContext(task_idx=0, op_name="test")
 
     def make_input_blocks():
@@ -167,9 +177,11 @@ def test_chained_transforms_dont_double_count_udf_time():
 
     # Assert on rows rather than block count, which depends on block shaping.
     assert sum(BlockAccessor.for_block(b).num_rows() for b in blocks) == NUM_BATCHES
+    assert num_calls > 0
 
     reported_s = transformer.udf_time_s(reset=False)
-    slept_s = NUM_CHAINED_TRANSFORMS * NUM_BATCHES * SLEEP_S
+    # Measured, not assumed: block shaping decides how many batches each stage sees.
+    slept_s = num_calls * SLEEP_S
 
     # Can't exceed the wall time of the chain that produced it. The headroom
     # absorbs timing noise; the bug inflated this by ~2x at 3 stages.
@@ -177,9 +189,9 @@ def test_chained_transforms_dont_double_count_udf_time():
         reported_s <= wall_s * 1.05
     ), f"reported UDF time {reported_s:.4f}s exceeds chain wall time {wall_s:.4f}s"
     # ...and the stages' time must still be measured, not dropped.
-    assert reported_s >= slept_s, (
+    assert reported_s >= slept_s * 0.9, (
         f"reported UDF time {reported_s:.4f}s is below the {slept_s:.4f}s slept "
-        "inside the UDFs"
+        f"across {num_calls} UDF calls"
     )
 
 

--- a/python/ray/data/tests/test_map_transformer.py
+++ b/python/ray/data/tests/test_map_transformer.py
@@ -1,4 +1,5 @@
 import gc
+import time
 import weakref
 from collections import deque
 
@@ -137,6 +138,49 @@ def _trace_back_refs(intermediates: list, label: str = ""):
                         )
                 else:
                     print(f"    -> {type(r).__name__}")
+
+
+def test_chained_transforms_dont_double_count_udf_time():
+    """Chained UDF stages must not each re-count their upstream stages' time.
+
+    Timing every stage and summing reported n(n+1)/2x the real time, which could
+    exceed the wall time of the chain that produced it.
+    """
+    NUM_CHAINED_TRANSFORMS = 3
+    NUM_BATCHES = 2
+    SLEEP_S = 0.05
+
+    def udf(batch: DataBatch) -> DataBatch:
+        time.sleep(SLEEP_S)
+        return pd.DataFrame({"id": batch["id"]})
+
+    transformer = _create_chained_transformer(udf, NUM_CHAINED_TRANSFORMS)
+    ctx = TaskContext(task_idx=0, op_name="test")
+
+    def make_input_blocks():
+        for i in range(NUM_BATCHES):
+            yield pd.DataFrame({"id": [i]})
+
+    start_s = time.perf_counter()
+    blocks = list(transformer.apply_transform(make_input_blocks(), ctx))
+    wall_s = time.perf_counter() - start_s
+
+    # Assert on rows rather than block count, which depends on block shaping.
+    assert sum(BlockAccessor.for_block(b).num_rows() for b in blocks) == NUM_BATCHES
+
+    reported_s = transformer.udf_time_s(reset=False)
+    slept_s = NUM_CHAINED_TRANSFORMS * NUM_BATCHES * SLEEP_S
+
+    # Can't exceed the wall time of the chain that produced it. The headroom
+    # absorbs timing noise; the bug inflated this by ~2x at 3 stages.
+    assert (
+        reported_s <= wall_s * 1.05
+    ), f"reported UDF time {reported_s:.4f}s exceeds chain wall time {wall_s:.4f}s"
+    # ...and the stages' time must still be measured, not dropped.
+    assert reported_s >= slept_s, (
+        f"reported UDF time {reported_s:.4f}s is below the {slept_s:.4f}s slept "
+        "inside the UDFs"
+    )
 
 
 if __name__ == "__main__":

--- a/python/ray/data/tests/test_map_transformer.py
+++ b/python/ray/data/tests/test_map_transformer.py
@@ -67,7 +67,9 @@ def test_chained_transforms_release_intermediates_between_batches():
         for i in range(NUM_BATCHES):
             yield pd.DataFrame({"id": [i + 1]})
 
-    result_iter = transformer.apply_transform(make_input_blocks(), ctx)
+    result_iter = transformer.apply_transform(
+        make_input_blocks(), ctx, udf_time_scope=UDFTimeScope()
+    )
 
     for i in range(NUM_BATCHES):
         # Consume batch

--- a/python/ray/data/tests/test_stats.py
+++ b/python/ray/data/tests/test_stats.py
@@ -1623,6 +1623,39 @@ def test_streaming_stats_full(ray_start_regular_shared, restore_data_context):
     assert stats_summary.iter_stats is not None
 
 
+def test_fused_udf_time_within_wall_time(ray_start_regular_shared):
+    """A fused operator's UDF time must not exceed its own remote wall time.
+
+    Timing each fused stage and summing counted upstream stages repeatedly,
+    reporting more UDF time than the tasks spent running.
+    """
+    sleep_s = 0.1
+    num_blocks = 4
+
+    def slow(batch):
+        time.sleep(sleep_s)
+        return batch
+
+    ds = (
+        ray.data.range(num_blocks, override_num_blocks=num_blocks)
+        .map_batches(slow, batch_size=None)
+        .map_batches(slow, batch_size=None)
+        .materialize()
+    )
+
+    op = get_operator(ds.get_stats_summary(), name_pattern="MapBatches")
+    # Both stages must actually have fused, otherwise this asserts nothing.
+    assert "MapBatches(slow)->MapBatches(slow)" in op.operator_name
+
+    # The headroom absorbs timing noise; the bug inflated this to ~1.5x.
+    assert op.udf_time.sum <= op.wall_time.sum * 1.05, (
+        f"UDF time {op.udf_time.sum:.4f}s exceeds remote wall time "
+        f"{op.wall_time.sum:.4f}s"
+    )
+    # Both stages' sleeps are still accounted for.
+    assert op.udf_time.sum >= 2 * num_blocks * sleep_s * 0.9
+
+
 def test_write_ds_stats(ray_start_regular_shared, tmp_path):
     # Test 1: Basic write_parquet - stats stored in _write_ds
     ds1 = ray.data.range(100, override_num_blocks=100)

--- a/python/ray/data/tests/test_stats.py
+++ b/python/ray/data/tests/test_stats.py
@@ -1648,7 +1648,7 @@ def test_fused_udf_time_within_wall_time(ray_start_regular_shared):
     # Both stages must actually have fused, otherwise this asserts nothing.
     assert "MapBatches(slow)->MapBatches(slow)" in op.operator_name
 
-    # The headroom absorbs timing noise; the bug inflated this to ~1.5x.
+    # The headroom absorbs timing noise; double counting shows up at ~1.5x.
     assert op.udf_time.sum <= op.wall_time.sum * 1.05, (
         f"UDF time {op.udf_time.sum:.4f}s exceeds remote wall time "
         f"{op.wall_time.sum:.4f}s"
@@ -1663,8 +1663,9 @@ def test_fused_udf_time_survives_auto_batch_size(ray_start_regular_shared):
     ``MapTransformFn.__call__`` runs ``_pre_process`` eagerly, so with
     ``batch_size="auto"`` the second stage peeks at a real block to size its
     batches while the chain is still being built. That peek runs the first
-    stage's UDF, so any timer installed after the chain is assembled misses it
-    entirely -- half the work here.
+    stage's UDF, and with one block per task it is the only time that stage
+    ever runs -- so a chain whose timers aren't in place by then loses half
+    the work measured here.
     """
     sleep_s = 0.1
     num_blocks = 4
@@ -1709,7 +1710,7 @@ def test_udf_time_is_not_shared_across_concurrent_actor_tasks(
 
     Every block here does exactly one ``sleep``, so the total and the mean stay
     plausible even when attribution is broken -- only the per-block spread shows
-    it. Before this was fixed the same run reported min=0.000s and max=0.767s.
+    it. A shared total reports min=0.000s and max=0.767s on this workload.
     """
     sleep_s = 0.25
     num_blocks = 8

--- a/python/ray/data/tests/test_stats.py
+++ b/python/ray/data/tests/test_stats.py
@@ -37,6 +37,7 @@ from ray.data._internal.execution.operators.map_transformer import (
     BlockMapTransformFn,
     CustomOpStatsReporter,
     MapTransformer,
+    UDFTimeScope,
 )
 from ray.data._internal.execution.streaming_executor import StreamingExecutor
 from ray.data._internal.stats import (
@@ -222,7 +223,11 @@ def test_map_transformer_custom_op_stats():
     ctx = TaskContext(task_idx=0, op_name="test")
     block = pa.table({"id": list(range(expected.num_rows))})
     # apply_transform takes the report callback, not the reporter object.
-    list(transformer.apply_transform([block], ctx, reporter.report))
+    list(
+        transformer.apply_transform(
+            [block], ctx, reporter.report, udf_time_scope=UDFTimeScope()
+        )
+    )
     assert reporter.get_stats() == [expected]
 
 

--- a/python/ray/data/tests/test_stats.py
+++ b/python/ray/data/tests/test_stats.py
@@ -20,6 +20,7 @@ from ray._common.test_utils import (
     run_string_as_driver,
     wait_for_condition,
 )
+from ray.data import ActorPoolStrategy
 from ray.data._internal.block_batching.iter_batches import BatchIterator
 from ray.data._internal.execution.backpressure_policy import (
     ENABLED_BACKPRESSURE_POLICIES_CONFIG_KEY,
@@ -1654,6 +1655,97 @@ def test_fused_udf_time_within_wall_time(ray_start_regular_shared):
     )
     # Both stages' sleeps are still accounted for.
     assert op.udf_time.sum >= 2 * num_blocks * sleep_s * 0.9
+
+
+def test_fused_udf_time_survives_auto_batch_size(ray_start_regular_shared):
+    """An upstream fused stage must be timed even when a later one peeks.
+
+    ``MapTransformFn.__call__`` runs ``_pre_process`` eagerly, so with
+    ``batch_size="auto"`` the second stage peeks at a real block to size its
+    batches while the chain is still being built. That peek runs the first
+    stage's UDF, so any timer installed after the chain is assembled misses it
+    entirely -- half the work here.
+    """
+    sleep_s = 0.1
+    num_blocks = 4
+
+    def slow_a(batch):
+        time.sleep(sleep_s)
+        return batch
+
+    def slow_b(batch):
+        time.sleep(sleep_s)
+        return batch
+
+    ds = (
+        ray.data.range(num_blocks, override_num_blocks=num_blocks)
+        .map_batches(slow_a, batch_size=None)
+        .map_batches(slow_b, batch_size="auto")
+        .materialize()
+    )
+
+    op = get_operator(ds.get_stats_summary(), name_pattern="MapBatches")
+    # Both stages must actually have fused, otherwise this asserts nothing.
+    assert "MapBatches(slow_a)->MapBatches(slow_b)" in op.operator_name
+
+    real_s = 2 * num_blocks * sleep_s
+    assert op.udf_time.sum >= real_s * 0.9, (
+        f"UDF time {op.udf_time.sum:.4f}s covers only "
+        f"{op.udf_time.sum / real_s * 100:.0f}% of the {real_s:.2f}s spent in UDFs; "
+        "the stage that ran during the auto-batch-size peek was not timed"
+    )
+    assert op.udf_time.sum <= op.wall_time.sum * 1.05
+
+
+def test_udf_time_is_not_shared_across_concurrent_actor_tasks(
+    ray_start_regular_shared,
+):
+    """Tasks sharing an actor must not be credited with each other's UDF time.
+
+    An actor reuses one ``MapTransformer`` for every task it runs, and
+    ``max_concurrent_calls_per_actor > 1`` runs several at once. A UDF-time
+    total living on the transformer mixes those tasks together, and one task's
+    read-and-reset takes whatever the others had accumulated.
+
+    Every block here does exactly one ``sleep``, so the total and the mean stay
+    plausible even when attribution is broken -- only the per-block spread shows
+    it. Before this was fixed the same run reported min=0.000s and max=0.767s.
+    """
+    sleep_s = 0.25
+    num_blocks = 8
+
+    class Slow:
+        def __call__(self, batch):
+            time.sleep(sleep_s)
+            return batch
+
+    ds = (
+        ray.data.range(num_blocks, override_num_blocks=num_blocks)
+        .map_batches(
+            Slow,
+            batch_size=None,
+            compute=ActorPoolStrategy(
+                size=1,
+                max_concurrent_calls_per_actor=4,
+                enable_true_multi_threading=True,
+            ),
+        )
+        .materialize()
+    )
+
+    op = get_operator(ds.get_stats_summary(), name_pattern="MapBatches")
+    assert op.udf_time.count == num_blocks
+
+    # No block may be starved of the time it spent, ...
+    assert op.udf_time.min >= sleep_s * 0.5, (
+        f"a block reports {op.udf_time.min:.4f}s of UDF time for one {sleep_s}s "
+        "call; another task drained its total"
+    )
+    # ... nor credited with a sibling task's.
+    assert op.udf_time.max <= sleep_s * 2.0, (
+        f"a block reports {op.udf_time.max:.4f}s of UDF time for one {sleep_s}s "
+        "call; it absorbed another task's total"
+    )
 
 
 def test_write_ds_stats(ray_start_regular_shared, tmp_path):

--- a/python/ray/data/tests/test_stats.py
+++ b/python/ray/data/tests/test_stats.py
@@ -1663,14 +1663,16 @@ def test_fused_udf_time_within_wall_time(ray_start_regular_shared):
 
 
 def test_fused_udf_time_survives_auto_batch_size(ray_start_regular_shared):
-    """An upstream fused stage must be timed even when a later one peeks.
+    """An upstream fused stage must be timed even when a later one pulls it early.
 
-    ``MapTransformFn.__call__`` runs ``_pre_process`` eagerly, so with
-    ``batch_size="auto"`` the second stage peeks at a real block to size its
-    batches while the chain is still being built. That peek runs the first
-    stage's UDF, and with one block per task it is the only time that stage
-    ever runs -- so a chain whose timers aren't in place by then loses half
-    the work measured here.
+    ``_pre_process`` always runs while the chain is being built, but only
+    ``batch_size="auto"`` makes it consume: sizing batches needs a real block, so
+    it pulls one through the stages already in the chain, where a fixed
+    ``batch_size`` just builds a lazy generator and moves no data.
+    ``_peek_first_nonempty_block`` caches the block it pulled, so those stages
+    are never re-entered for it -- with one block per task, that peek is the only
+    time the first stage runs at all. A timer installed after the chain is
+    assembled sees none of it, which is the missing half measured here.
     """
     sleep_s = 0.1
     num_blocks = 4

--- a/python/ray/data/tests/unit/test_auto_batch_size.py
+++ b/python/ray/data/tests/unit/test_auto_batch_size.py
@@ -7,6 +7,7 @@ from ray.data._internal.execution.interfaces.task_context import TaskContext
 from ray.data._internal.execution.operators.map_transformer import (
     BatchMapTransformFn,
     MapTransformer,
+    UDFTimeScope,
     _compute_auto_batch_size,
 )
 from ray.data._internal.output_buffer import OutputBlockSizeOption
@@ -84,7 +85,7 @@ def test_auto_batches_respect_target_size():
         ]
     )
     ctx = TaskContext(task_idx=0, op_name="test")
-    list(transformer.apply_transform(iter([block]), ctx))
+    list(transformer.apply_transform(iter([block]), ctx, udf_time_scope=UDFTimeScope()))
 
     assert sum(received_sizes) == 1000
     assert all(s == 10 for s in received_sizes[:-1])


### PR DESCRIPTION
## Why are these changes needed?

`ds.stats()` reports a "UDF time" per operator. Two things are wrong with it on master: a fused operator over-reports, and concurrent tasks sharing an actor corrupt each other's figures. This PR fixes both.

### 1. Double counting across fused stages

`apply_transform` wrapped every UDF stage in a timer and summed the readings. But the stages are chained behind lazy iterators, so pulling one item through a stage also runs every stage upstream of it: each timer measured **inclusive** time, and stage `k` was counted once for every stage at or downstream of it. An operator with `n` fused UDFs reported `n(n+1)/2` times the real per-stage time, which at `n≥2` exceeds the operator's own remote wall time — an impossible number.

```python
import time, ray

def slow(batch):
    time.sleep(0.5)
    return batch

ds = (
    ray.data.range(4, override_num_blocks=4)
    .map_batches(slow, batch_size=None)
    .map_batches(slow, batch_size=None)
    .materialize()
)
print(ds.stats())
```

4 tasks × 2 UDFs × 0.5s = **4.0s** of real UDF work:

```
Operator 1 ReadRange->MapBatches(slow)->MapBatches(slow): 4 tasks executed
* Remote wall time: 1.0s min, 1.01s max, 1.0s mean, 4.02s total
* UDF time:         1.5s min, 1.51s max, 1.51s mean, 6.02s total
```

| fused UDFs | real | reported | ratio |
| --- | --- | --- | --- |
| 1 | 0.80s | 0.81s | 1.01x |
| 2 | 1.60s | 2.42s | 1.51x |
| 3 | 2.40s | 4.84s | 2.02x |
| 4 | 3.20s | 8.07s | 2.52x |

### 2. Concurrent tasks on one actor corrupt each other

`_MapWorker` holds one `MapTransformer` per actor and reuses it for every task that actor runs. `compute.py:96-104` documents that `max_concurrent_calls_per_actor > 1` runs several tasks at once — it is the recommended setup for GPU pipelines, to hide input batching behind inference. With the running total on the transformer, each output block read and reset a counter every concurrent task was writing to, so one task was credited with its siblings' time and another with nothing. `+=` on a shared float is also load-add-store, so updates could be lost outright.

```python
import time, ray
from ray.data import ActorPoolStrategy

class Slow:
    def __call__(self, batch):
        time.sleep(0.25)
        return batch

ds = (
    ray.data.range(8, override_num_blocks=8)
    .map_batches(
        Slow,
        batch_size=None,
        compute=ActorPoolStrategy(
            size=1,
            max_concurrent_calls_per_actor=4,
            enable_true_multi_threading=True,
        ),
    )
    .materialize()
)
op = ds.get_stats_summary().operators_stats[-1]
print(
    f"udf per block: min={op.udf_time.min:.3f}s max={op.udf_time.max:.3f}s "
    f"mean={op.udf_time.mean:.3f}s sum={op.udf_time.sum:.3f}s"
)
```

Eight blocks, each doing exactly one 0.25s call, so every figure should be 0.25s:

```
udf per block: min=0.000s max=0.767s mean=0.255s sum=2.044s
```

One block is credited with nothing, another with three calls' worth it never made. Note that `sum` (against 2.00s of real work) and `mean` both look correct — only the spread shows the damage, and `ds.stats()` prints min, max and mean.

## What this change does

Time **every** UDF stage, and give **each task** its own total.

- **Each stage's timer is installed as that stage is built**, before the next stage is constructed. A later stage's eager peek therefore pulls through timers that already exist, so nothing escapes measurement.
- **A timer measures inclusive time, then subtracts whatever the scope gained during its own call**, leaving only its own contribution. Upstream spans are disjoint sub-intervals of the window, so the subtraction is non-negative; the clamp only absorbs float rounding. This is what keeps the total from re-counting upstream stages.
- **The total lives in a `UDFTimeScope` that `_map_task` creates per task** and threads into `apply_transform` — the same lifetime and call path as the `CustomOpStatsReporter` it already threads that way. Nothing is shared across tasks, so there is no interleaving to get wrong and no lock to take.

`UDFTimeScope.attributed_s` doubles as the running total and the nesting cursor, so this costs one float per task and no per-stage bookkeeping. `MapTransformer._udf_time_s`, `udf_time_s()` and `_report_udf_time()` are removed.

### Scope

What "UDF time" *covers* is unchanged: the timed window still spans batch formatting, the user's function, and output block building, so it remains map-stage time rather than time inside the user's function. Splitting those, and attributing per fused stage rather than per operator, is follow-up work.

## How this PR changed

The diff is larger than where it started, and the approach reversed once. Worth stating directly rather than leaving a reviewer to infer it from the history.

**It opened timing only the last UDF stage.** Since pulling one item through the last stage also runs every stage before it, one timer looked sufficient for the total, and it fixed bug 1 in three lines. That rested on an assumption I did not check: that no data moves until the chain is fully built.

**`batch_size="auto"` breaks that assumption**, as Cursor Bugbot pointed out on the PR. `MapTransformFn.__call__` has no `yield`, so it runs `_pre_process` **eagerly** while the chain is still being assembled. With `batch_size="auto"` that calls `_compute_auto_batch_size`, which peeks at a real block to measure bytes-per-row — pulling a block through every upstream stage before any later timer exists. `_peek_first_nonempty_block` then caches that block, so those stages are never re-run during consumption and their time is simply gone:

```python
for label, batch_size in [("control", None), ("auto", "auto")]:
    ds = (
        ray.data.range(1, override_num_blocks=1)
        .map_batches(slow_a, batch_size=None)      # sleeps 0.5s
        .map_batches(slow_b, batch_size=batch_size)  # sleeps 0.5s
        .materialize()
    )
    op = ds.get_stats_summary().operators_stats[-1]
    print(f"{label:8} udf={op.udf_time.sum:.2f}s wall={op.wall_time.sum:.2f}s")
```

Against that earlier version of this PR, with 1.0s of real UDF work:

```
control  udf=1.02s wall=1.02s     <- correct
auto     udf=0.50s wall=1.01s     <- slow_a is gone: it ran during the peek
```

This was a regression introduced by this PR, not a defect on master — master installs each stage's timer as that stage is built, so the peek pulls through a live timer and the time is counted (twice, per bug 1, but counted).

**Fixing it properly is what produced the current design.** Keeping the peek inside a timed window means timing every stage again, which brings back the double count, which requires the nesting subtraction to cancel. That subtraction needs somewhere per-task to hold the running total — and once that exists, bug 2 is fixed as a consequence rather than needing its own PR.

## Related issue number

None. Closed #55052 raised adjacent complaints about operator-level metric granularity and was addressed by `ds.explain()`; it did not cover this accounting.

## Checks

- [x] I've signed off every commit (`git commit -s`).
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've added any new APIs to the API Reference. *(no new public API)*
- [x] I've made sure the tests are passing.
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(

## Testing

Three tests. Each was confirmed to fail before being confirmed to pass — the first two against the earlier version of this PR, the third against both that and master:

| test | covers | fails as |
| --- | --- | --- |
| `test_stats.py::test_fused_udf_time_within_wall_time` | bug 1 | udf 6.02s > wall 4.02s |
| `test_stats.py::test_fused_udf_time_survives_auto_batch_size` | the regression above | `UDF time 0.4172s covers only 52%` |
| `test_stats.py::test_udf_time_is_not_shared_across_concurrent_actor_tasks` | bug 2 | `a block reports 0.0000s of UDF time for one 0.25s call` |

The third asserts on per-block **min and max**, deliberately not on the total — under the concurrency bug the same run reported `sum=2.044s` against 2.00s of real work and `mean=0.256s` for a 0.25s call, both of which look correct. A test written against the total would have certified the broken code.

`test_map_transformer.py::test_chained_transforms_dont_double_count_udf_time` covers the same invariant at unit level, without a cluster.

Run locally against a source build:

```bash
pytest -q python/ray/data/tests/test_map_transformer.py
pytest -q python/ray/data/tests/test_stats.py
pytest -q python/ray/data/tests/test_actor_pool_map_operator.py
pytest -q python/ray/data/tests/unit/test_auto_batch_size.py
```

**CI is green on this branch** — `buildkite/microcheck` [#53036](https://buildkite.com/ray-project/microcheck/builds/53036) passed, along with every other required check.

Locally: `test_map_transformer.py` and `unit/test_auto_batch_size.py` 9 passed; `test_actor_pool_map_operator.py` 56 passed; full `test_stats.py` run rather than a filtered selection, after a narrowed `-k` earlier hid a break in `test_map_transformer_custom_op_stats` (`_UDFTimingIterator` stored its `Iterable` without calling `iter()`, which fails for the callers that pass a plain list — fixed).

`test_dataset_stats.py` reports 24 failures in `TestDatasetSummary` on my machine from the optional `datasketches` package being absent, unrelated to this change.

## AI assistance

AI assistance (Claude Code) was used to investigate the accounting bugs, write the fix and the tests, and draft this description. Per `AGENTS.md`, the author has reviewed every changed line, and the test results reported above were run locally in addition to CI.

## Duplicate check

`gh pr list --repo ray-project/ray --state open` was searched for `udf time stats`, `map_transformer`, and `fused operator stats attribution`; `gh search issues` for `udf time double count`. The open PRs touching nearby code — #61379 (caching the serialized map transformer), #64090 (per-actor placement groups), #65663 (exposing backpressure policy in diagnostics) — do not touch UDF timing. No open issue or PR covers this.

