### PR TITLE
[Data] Add Unpickling Guard to Prevent RCE when reading Hudi

### DIFF
--- a/python/ray/data/_internal/datasource/hudi_datasource.py
+++ b/python/ray/data/_internal/datasource/hudi_datasource.py
@@ -3,6 +3,7 @@ import os
 from enum import Enum
 from typing import TYPE_CHECKING, Dict, Iterator, List, Optional, Tuple
 
+from ray.data._internal.object_extensions.arrow import raise_on_pickle_object_columns
 from ray.data._internal.util import _check_import
 from ray.data.block import BlockMetadata
 from ray.data.datasource.datasource import Datasource, ReadTask
@@ -61,7 +62,11 @@ class HudiDatasource(Datasource):
             for p in base_file_paths:
                 file_group_reader = HudiFileGroupReader(table_uri, options)
                 batch = file_group_reader.read_file_slice_by_base_file_path(p)
-                yield pyarrow.Table.from_batches([batch])
+                table = pyarrow.Table.from_batches([batch])
+                # Unpickling untrusted data can execute arbitrary code. Reject object
+                # columns unless the user has explicitly opted in.
+                raise_on_pickle_object_columns(table)
+                yield table
 
         hudi_table = (
             HudiTableBuilder.from_base_uri(self._table_uri)

--- a/python/ray/data/tests/datasource/test_hudi.py
+++ b/python/ray/data/tests/datasource/test_hudi.py
@@ -1,11 +1,14 @@
 import os
 import zipfile
 
+import pyarrow as pa
+import pyarrow.parquet as pq
 import pytest
 from packaging.version import parse as parse_version
 from pytest_lazy_fixtures import lf as lazy_fixture
 
 import ray
+from ray.data._internal.object_extensions.arrow import ArrowPythonObjectArray
 from ray.data._internal.utils.arrow_utils import get_pyarrow_version
 from ray.data.datasource.path_util import (
     _resolve_paths_and_filesystem,
@@ -153,6 +156,39 @@ def test_hudi_incremental_query_v6_trips_table(ray_start_regular_shared, fs, dat
             "fare": 25.0,
         },
     ]
+
+
+@pytest.mark.skipif(
+    not PYARROW_VERSION_MEETS_REQUIREMENT,
+    reason=PYARROW_HUDI_TEST_SKIP_REASON,
+)
+def test_hudi_rejects_pickle_object_columns(ray_start_regular_shared, local_path):
+    """A tampered base data file must not be able to run its embedded pickle."""
+    table_path = _get_hudi_table_path(None, local_path, "v6_trips_8i1u")
+    marker = os.path.join(local_path, "exploit_marker")
+
+    class Exploit:
+        def __reduce__(self):
+            return (os.system, (f"touch {marker}",))
+
+    # Swap a column of one base data file for an attacker-controlled pickled object.
+    victim = next(
+        os.path.join(root, f)
+        for root, _, files in os.walk(table_path)
+        for f in files
+        if f.endswith(".parquet")
+    )
+    original = pq.ParquetFile(victim).read()
+    columns = {name: original.column(name) for name in original.schema.names}
+    columns["rider"] = ArrowPythonObjectArray.from_objects(
+        [Exploit()] * original.num_rows
+    )
+    pq.write_table(pa.table(columns), victim)
+
+    with pytest.raises(ValueError, match="arrow_pickled_object"):
+        ray.data.read_hudi(table_uri=table_path).take_all()
+
+    assert not os.path.exists(marker), "pickle.load executed attacker code"
 
 
 if __name__ == "__main__":

--- a/python/ray/data/tests/datasource/test_hudi.py
+++ b/python/ray/data/tests/datasource/test_hudi.py
@@ -172,12 +172,7 @@ def test_hudi_rejects_pickle_object_columns(ray_start_regular_shared, local_path
             return (os.system, (f"touch {marker}",))
 
     # Swap a column of one base data file for an attacker-controlled pickled object.
-    victim = next(
-        os.path.join(root, f)
-        for root, _, files in os.walk(table_path)
-        for f in files
-        if f.endswith(".parquet")
-    )
+    victim = ray.data.read_hudi(table_uri=table_path).input_files()[0]
     original = pq.ParquetFile(victim).read()
     columns = {name: original.column(name) for name in original.schema.names}
     columns["rider"] = ArrowPythonObjectArray.from_objects(


### PR DESCRIPTION
## Description
Adding unpickling guard to hudi datasource to address the same RCE issue mentioned in #65553 and #65769.

## Related issues
Related to #65553.

## Additional information
Added regression test that would reproduce the exact vulnerability without the fix.