### PR TITLE
[Data] Add head-node memory limit to tiny-object benchmark

### DIFF
--- a/release/nightly_tests/dataset/backpressure_benchmark.py
+++ b/release/nightly_tests/dataset/backpressure_benchmark.py
@@ -189,19 +189,18 @@ def main(args: argparse.Namespace):
         max_head_node_memory_bytes=MAX_HEAD_NODE_MEMORY_BYTES_BY_CASE.get(args.case)
     )
 
-    try:
-        if args.case == "fast-producer-slow-consumer":
-            benchmark.run_fn(args.case, run_fast_producer_slow_consumer)
-        elif args.case == "many-tiny-objects":
-            benchmark.run_fn(args.case, run_many_tiny_objects)
-        elif args.case == "training-prefetch":
-            benchmark.run_fn(args.case, run_training_prefetch, num_trainers=8)
-        elif args.case == "training-prefetch-single-node":
-            benchmark.run_fn(args.case, run_training_prefetch, num_trainers=1)
-        else:
-            raise ValueError(f"Unexpected benchmark case: {args.case}")
-    finally:
-        benchmark.write_result()
+    if args.case == "fast-producer-slow-consumer":
+        benchmark.run_fn(args.case, run_fast_producer_slow_consumer)
+    elif args.case == "many-tiny-objects":
+        benchmark.run_fn(args.case, run_many_tiny_objects)
+    elif args.case == "training-prefetch":
+        benchmark.run_fn(args.case, run_training_prefetch, num_trainers=8)
+    elif args.case == "training-prefetch-single-node":
+        benchmark.run_fn(args.case, run_training_prefetch, num_trainers=1)
+    else:
+        raise ValueError(f"Unexpected benchmark case: {args.case}")
+
+    benchmark.write_result()
 
 
 if __name__ == "__main__":

--- a/release/nightly_tests/dataset/backpressure_benchmark.py
+++ b/release/nightly_tests/dataset/backpressure_benchmark.py
@@ -10,7 +10,9 @@ from benchmark import Benchmark
 
 
 # Allow 20% headroom over the observed 10.8 GiB baseline.
-MANY_TINY_OBJECTS_MAX_HEAD_NODE_MEMORY_BYTES = 13 * 1024**3
+MAX_HEAD_NODE_MEMORY_BYTES_BY_CASE = {
+    "many-tiny-objects": 13 * 1024**3,
+}
 
 
 def parse_args() -> argparse.Namespace:
@@ -183,12 +185,9 @@ class Trainer:
 
 
 def main(args: argparse.Namespace):
-    max_head_node_memory_bytes = (
-        MANY_TINY_OBJECTS_MAX_HEAD_NODE_MEMORY_BYTES
-        if args.case == "many-tiny-objects"
-        else None
+    benchmark = Benchmark(
+        max_head_node_memory_bytes=MAX_HEAD_NODE_MEMORY_BYTES_BY_CASE.get(args.case)
     )
-    benchmark = Benchmark(max_head_node_memory_bytes=max_head_node_memory_bytes)
 
     try:
         if args.case == "fast-producer-slow-consumer":

--- a/release/nightly_tests/dataset/backpressure_benchmark.py
+++ b/release/nightly_tests/dataset/backpressure_benchmark.py
@@ -9,6 +9,10 @@ import ray
 from benchmark import Benchmark
 
 
+# Allow 20% headroom over the observed 10.8 GiB baseline.
+MANY_TINY_OBJECTS_MAX_HEAD_NODE_MEMORY_BYTES = 13 * 1024**3
+
+
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Backpressure benchmark")
     parser.add_argument(
@@ -179,20 +183,26 @@ class Trainer:
 
 
 def main(args: argparse.Namespace):
-    benchmark = Benchmark()
+    max_head_node_memory_bytes = (
+        MANY_TINY_OBJECTS_MAX_HEAD_NODE_MEMORY_BYTES
+        if args.case == "many-tiny-objects"
+        else None
+    )
+    benchmark = Benchmark(max_head_node_memory_bytes=max_head_node_memory_bytes)
 
-    if args.case == "fast-producer-slow-consumer":
-        benchmark.run_fn(args.case, run_fast_producer_slow_consumer)
-    elif args.case == "many-tiny-objects":
-        benchmark.run_fn(args.case, run_many_tiny_objects)
-    elif args.case == "training-prefetch":
-        benchmark.run_fn(args.case, run_training_prefetch, num_trainers=8)
-    elif args.case == "training-prefetch-single-node":
-        benchmark.run_fn(args.case, run_training_prefetch, num_trainers=1)
-    else:
-        raise ValueError(f"Unexpected benchmark case: {args.case}")
-
-    benchmark.write_result()
+    try:
+        if args.case == "fast-producer-slow-consumer":
+            benchmark.run_fn(args.case, run_fast_producer_slow_consumer)
+        elif args.case == "many-tiny-objects":
+            benchmark.run_fn(args.case, run_many_tiny_objects)
+        elif args.case == "training-prefetch":
+            benchmark.run_fn(args.case, run_training_prefetch, num_trainers=8)
+        elif args.case == "training-prefetch-single-node":
+            benchmark.run_fn(args.case, run_training_prefetch, num_trainers=1)
+        else:
+            raise ValueError(f"Unexpected benchmark case: {args.case}")
+    finally:
+        benchmark.write_result()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Summary

- Set a 13 GiB head-node memory limit for `backpressure_many_tiny_objects`.
- Keep about 20% headroom over the observed 10.8 GiB peak.
- Write benchmark results even when the memory check fails.

This applies the guard from #65727 to the benchmark from #65717 and completes the remaining work in #65702.


---

Closes #65702