### PR TITLE
[Data] Add batch_size to MCAPDatasource for streaming reads

### DIFF
--- a/python/ray/data/_internal/datasource/mcap_datasource.py
+++ b/python/ray/data/_internal/datasource/mcap_datasource.py
@@ -177,10 +177,7 @@ class MCAPDatasource(FileBasedDatasource):
             message_data = self._message_to_dict(schema, channel, message, path)
             builder.add(message_data)
 
-            if (
-                self._batch_size is not None
-                and builder.num_rows() >= self._batch_size
-            ):
+            if self._batch_size is not None and builder.num_rows() >= self._batch_size:
                 yield builder.build()
                 builder = DelegatingBlockBuilder()
 

--- a/python/ray/data/_internal/datasource/mcap_datasource.py
+++ b/python/ray/data/_internal/datasource/mcap_datasource.py
@@ -94,6 +94,7 @@ class MCAPDatasource(FileBasedDatasource):
         time_range: Optional[TimeRange] = None,
         message_types: Optional[Union[List[str], Set[str]]] = None,
         include_metadata: bool = True,
+        batch_size: Optional[int] = None,
         **file_based_datasource_kwargs,
     ):
         """Initialize MCAP datasource.
@@ -110,17 +111,28 @@ class MCAPDatasource(FileBasedDatasource):
             include_metadata: Whether to include MCAP metadata fields in the output.
                 Defaults to True. When True, includes schema, channel, and message
                 metadata.
+            batch_size: Optional number of messages per output block. When set,
+                ``_read_stream`` yields one block per batch instead of one block
+                per file. Defaults to ``None`` (whole-file block). Must be
+                positive if set.
             **file_based_datasource_kwargs: Additional arguments for FileBasedDatasource.
         """
         super().__init__(paths, **file_based_datasource_kwargs)
 
         _check_import(self, module="mcap", package="mcap")
 
+        if batch_size is not None:
+            if not isinstance(batch_size, int) or batch_size <= 0:
+                raise ValueError(
+                    f"batch_size must be a positive integer, got {batch_size!r}"
+                )
+
         # Convert to sets for faster lookup
         self._topics = set(topics) if topics else None
         self._message_types = set(message_types) if message_types else None
         self._time_range = time_range
         self._include_metadata = include_metadata
+        self._batch_size = batch_size
 
     def _read_stream(self, f: "pyarrow.NativeFile", path: str) -> Iterator[Block]:
         """Read MCAP file and yield blocks of message data.
@@ -164,6 +176,13 @@ class MCAPDatasource(FileBasedDatasource):
             # Convert message to dictionary format
             message_data = self._message_to_dict(schema, channel, message, path)
             builder.add(message_data)
+
+            if (
+                self._batch_size is not None
+                and builder.num_rows() >= self._batch_size
+            ):
+                yield builder.build()
+                builder = DelegatingBlockBuilder()
 
         # Yield the block if we have any messages
         if builder.num_rows() > 0:

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -3215,6 +3215,7 @@ def read_mcap(
     ignore_missing_paths: bool = False,
     shuffle: Optional[Union[Literal["files"], FileShuffleConfig]] = None,
     file_extensions: Optional[List[str]] = None,
+    batch_size: Optional[int] = None,
     concurrency: Optional[int] = None,
     override_num_blocks: Optional[int] = None,
     # Advanced Ray remote parameters
@@ -3306,6 +3307,10 @@ def read_mcap(
             shuffle the input files. Defaults to not shuffle with ``None``.
         file_extensions: A list of file extensions to filter files by.
             Defaults to ``["mcap"]``.
+        batch_size: Optional number of messages per output block. When set,
+            each read task yields one block per batch instead of one block
+            per file. Defaults to ``None`` (whole-file block). Must be
+            positive if set.
         concurrency: The maximum number of Ray tasks to run concurrently. Set this
             to control number of tasks to run concurrently. This doesn't change the
             total number of tasks run or the total number of output blocks. By default,
@@ -3349,6 +3354,7 @@ def read_mcap(
         time_range=time_range,
         message_types=message_types,
         include_metadata=include_metadata,
+        batch_size=batch_size,
         filesystem=filesystem,
         meta_provider=DefaultFileMetadataProvider(),
         partition_filter=partition_filter,


### PR DESCRIPTION
## Description
MCAPDatasource._read_stream previously accumulated all messages of a file into a single block and yielded once at the end. For large MCAP recordings this makes peak memory scale with file size times concurrent read tasks and prevents downstream stages from overlapping with the read within a file.

This change adds an optional `batch_size` (message count) to `MCAPDatasource` and `ray.data.read_mcap`. When set, `_read_stream` yields one block per batch instead of one block per file. `batch_size=None` (default) keeps the current behavior exactly; output schema and predicate pushdown are unchanged, only block boundaries change. The implementation follows the existing `Iterator[Block]` protocol already used by CSV/JSON/Parquet datasources and aligns with Daft's `read_mcap(batch_size=1000)` precedent.

## Related issues
Closes #65641

No open PR currently addresses this issue. The change is limited to the MCAP datasource and its public read API.

## Additional information
- Validation: stubbed local reproduction with mcap 1.4.0 + pyarrow 25.0.1 confirms batch boundaries (5 messages: None -> [5], 2 -> [2,2,1], 1 -> [1,1,1,1,1]), invalid batch_size raises ValueError, empty file yields 0 blocks, topic-filtered reads respect filtered count, and schemas are stable across batches. `python -m py_compile` and `git diff --check` pass.
- Compatibility: default `None` preserves byte-identical behavior; existing `test_mcap.py` expectations remain valid. Full `test_mcap.py` suite requires a complete Ray build and is expected to run in CI.