### PR TITLE
[tune] Fix PBT selecting the whole population when quantile_fraction is 0

### DIFF
--- a/python/ray/tune/schedulers/pbt.py
+++ b/python/ray/tune/schedulers/pbt.py
@@ -994,7 +994,14 @@ class PopulationBasedTraining(FIFOScheduler):
             )
             if num_trials_in_quantile > len(trials) / 2:
                 num_trials_in_quantile = int(math.floor(len(trials) / 2))
-            return (trials[:num_trials_in_quantile], trials[-num_trials_in_quantile:])
+            # The upper end is indexed from the front rather than written as
+            # `trials[-num_trials_in_quantile:]`, which is the whole population when the
+            # count is zero. `quantile_fraction=0` is a documented way to turn
+            # exploitation off, and it produces exactly that count.
+            return (
+                trials[:num_trials_in_quantile],
+                trials[len(trials) - num_trials_in_quantile :],
+            )
 
     def choose_trial_to_run(self, tune_controller: "TuneController") -> Optional[Trial]:
         """Ensures all trials get fair share of time (as defined by time_attr).

--- a/python/ray/tune/schedulers/pbt.py
+++ b/python/ray/tune/schedulers/pbt.py
@@ -994,10 +994,8 @@ class PopulationBasedTraining(FIFOScheduler):
             )
             if num_trials_in_quantile > len(trials) / 2:
                 num_trials_in_quantile = int(math.floor(len(trials) / 2))
-            # The upper end is indexed from the front rather than written as
-            # `trials[-num_trials_in_quantile:]`, which is the whole population when the
-            # count is zero. `quantile_fraction=0` is a documented way to turn
-            # exploitation off, and it produces exactly that count.
+            # Indexed from the front as `trials[-num_trials_in_quantile:]` is the
+            # whole population
             return (
                 trials[:num_trials_in_quantile],
                 trials[len(trials) - num_trials_in_quantile :],

--- a/python/ray/tune/tests/test_trial_scheduler_pbt.py
+++ b/python/ray/tune/tests/test_trial_scheduler_pbt.py
@@ -899,6 +899,31 @@ class PopulationBasedTrainingNanScoreTest(unittest.TestCase):
                 self.assertEqual(abs(min_ordered_results[-1]), 10)
 
 
+def test_pbt_quantile_fraction_zero_selects_no_trials():
+    """`quantile_fraction=0` is documented as doing no exploitation at all.
+
+    The upper end of the quantile was sliced as `trials[-num_trials_in_quantile:]`, and
+    `-0` is `0`, so a count of zero returned the whole population instead of nothing and
+    every trial was told to checkpoint on every perturbation interval.
+    """
+    trials = [DummyTrial(f"t{i}") for i in range(4)]
+    scheduler = PopulationBasedTraining(
+        metric="reward",
+        mode="max",
+        quantile_fraction=0.0,
+        hyperparam_mutations={"lr": [1e-4, 1e-3]},
+    )
+    scheduler._trial_state = {
+        trial: DummyState(last_score=float(i)) for i, trial in enumerate(trials)
+    }
+
+    assert scheduler._quantiles() == ([], [])
+
+    # a fraction that does select trials is unchanged
+    scheduler._quantile_fraction = 0.25
+    assert scheduler._quantiles() == ([trials[0]], [trials[3]])
+
+
 def _create_pb2_scheduler(
     metric="score",
     mode="max",


### PR DESCRIPTION
## Description

`PopulationBasedTraining._quantiles` slices the upper end of the population as `trials[-num_trials_in_quantile:]`. `-0` is `0`, so a count of zero returns `trials[0:]`, the entire population, while the lower end correctly returns nothing:

```python
scheduler = PopulationBasedTraining(
    metric="reward", mode="max", quantile_fraction=0.0,
    hyperparam_mutations={"lr": [1e-4, 1e-3]},
)
scheduler._trial_state = {t: DummyState(last_score=float(i)) for i, t in enumerate(trials)}

scheduler._quantiles()
# quantile_fraction=0.0 -> ([], [t0, t1, t2, t3])     <- whole population is "top"
# quantile_fraction=0.25 -> ([t0], [t3])
# quantile_fraction=0.5  -> ([t0, t1], [t2, t3])
```

`quantile_fraction=0` is accepted by the constructor (`if quantile_fraction > 0.5 or quantile_fraction < 0: raise`) and documented as "Needs to be between 0 and 0.5. Setting it to 0 essentially implies doing no exploitation at all." It is also the only value that can produce a count of zero, because the count is a `ceil`, so this is the one input the branch was never right for.

The consequence is not just a wrong return value. `_checkpoint_or_exploit` does:

```python
if trial in upper_quantile:
    ...
    state.last_checkpoint = tune_controller._schedule_trial_save(trial, result=state.last_result)
    self._num_checkpoints += 1
else:
    state.last_checkpoint = None  # not a top trial
```

With every trial in the upper quantile, all of them are told to save on every perturbation interval and each is counted in `_num_checkpoints` (which `debug_string()` reports). Nothing ever exploits those checkpoints, since the lower quantile is empty, so a user who set `quantile_fraction=0` to turn exploitation off still pays the full PBT checkpoint cost and sees a checkpoint count that says otherwise.

The fix indexes the upper end from the front. `num_trials_in_quantile` is already capped at `floor(len(trials) / 2)`, so no clamp is needed and every other `quantile_fraction` slices exactly as before.

## Related issues

None. Searched open and closed issues and PRs for `pbt quantile_fraction`, `quantile_fraction 0` and `_quantiles pbt`: the only hits are #4881 / #4912 (2019, which added the parameter) and #57160 (a merged fix to the same function for NaN ordering). Nothing covers the zero case, and no open PR touches `_quantiles`.

## Additional information

`test_pbt_quantile_fraction_zero_selects_no_trials` in `python/ray/tune/tests/test_trial_scheduler_pbt.py`, using the `DummyTrial` / `DummyState` helpers the NaN test already uses. It asserts both quantiles are empty at `quantile_fraction=0` and that `0.25` still selects the expected trials.

Commands run and their results:

```
$ pytest test_trial_scheduler_pbt.py -k "quantile_fraction_zero or nan_scores"
# without the source change
E       assert ([], [<DummyTrial>, <DummyTrial>, <DummyTrial>, <DummyTrial>]) == ([], [])
FAILED test_trial_scheduler_pbt.py::test_pbt_quantile_fraction_zero_selects_no_trials
1 failed, 1 passed, 18 deselected

# with the source change
3 passed, 17 deselected      (adding -k "... or pb2_perturbation")

$ pytest test_trial_scheduler_pbt.py -k "pb2 or nan or quantile or fill_config or explore"
8 passed, 12 deselected
```

Those are the tests in the file that run without a Ray cluster; the cluster-backed ones in the same module were not run locally and are left to CI. `test_pb2_perturbation` is included above because it asserts `pb2._quantiles() == ([trials[0]], [trials[1]])`, so it pins the unchanged path.

`black` reports no change on the edited hunk or on the test file (the one reformat it wants in `pbt.py` is a pre-existing `Optional[dict[...]]` annotation elsewhere in the file, untouched here).

AI assistance was used in preparing this change.
