### PR TITLE
[core][rdt] Fix NIXL registration cache extent reuse

### DIFF
--- a/python/ray/experimental/rdt/nixl_tensor_transport.py
+++ b/python/ray/experimental/rdt/nixl_tensor_transport.py
@@ -5,6 +5,7 @@ import os
 import threading
 import time
 import traceback
+import weakref
 from collections import OrderedDict
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
@@ -96,14 +97,21 @@ class NixlTransportMetadata(TensorTransportMetadata):
     __hash__ = object.__hash__
 
 
-@dataclass
+@dataclass(eq=False)
 class TensorDesc:
     # nixlRegDList handle, or None for pool-managed tensors (pool memory is
     # registered once at pool creation, so individual tensors don't need their
     # own NIXL registration).
     reg_desc: Any
-    # tracks the number of NIXL metadata containing the tensor.
+    # Tracks references owned by ObjectRef metadata, receiver transfers, and
+    # explicit register_nixl_memory() pins.
     metadata_count: int
+    # The extent and storage generation represented by reg_desc. Keeping a
+    # weak reference distinguishes a recycled address from an in-place resize
+    # without extending the lifetime of explicitly registered storage.
+    data_ptr: int
+    storage_nbytes: int
+    storage_ref: Any
 
 
 @dataclass
@@ -119,12 +127,14 @@ class NixlFetchRequest(FetchRequest):
         nixl_agent: Reference to the NIXL agent.
         remote_name: Name of the remote NIXL agent.
         remove_tensor_descs: Whether to remove tensor descriptors from the cache during cleanup.
+        tensor_desc_refs: The exact descriptor generations owned by this transfer.
     """
 
     xfer_handle: Any = None
     nixl_agent: Any = None
     remote_name: Optional[str] = None
     remove_tensor_descs: bool = False
+    tensor_desc_refs: Optional[List[TensorDesc]] = None
     transport: Any = None
 
     def __del__(self):
@@ -135,6 +145,7 @@ class NixlFetchRequest(FetchRequest):
                 self.xfer_handle,
                 self.remote_name,
                 self.remove_tensor_descs,
+                self.tensor_desc_refs,
             )
 
 
@@ -144,15 +155,28 @@ class NixlTensorTransport(TensorTransportManager):
         self._nixl_agent = None
         self._aborted_transfer_obj_ids = set()
         self._aborted_transfer_obj_ids_lock = threading.Lock()
-        # Mapping from tensor storage data pointer to the NIXL descriptor and reference count.
+        # Mapping from tensor storage data pointer to the current NIXL descriptor
+        # generation and reference count.
         # Unlike _managed_meta_nixl, we only deregister tensors when ALL metadata containing the tensor is freed.
         # For pool-managed tensors, reg_desc is None and the pool block is returned instead of deregistering.
         self._tensor_desc_cache: Dict[int, TensorDesc] = {}
+        # Weak storage identity lets us recognize an in-place resize even when
+        # it changes data_ptr(), while allowing preregistered storage to die.
+        self._storage_to_tensor_desc = weakref.WeakKeyDictionary()
+        # Explicit registrations need their own ownership records so a later
+        # deregister call releases the generation acquired by the matching
+        # register call, rather than whichever generation currently uses the
+        # same address.
+        self._explicit_tensor_desc_refs = weakref.WeakKeyDictionary()
         # Mapping from object ID to the NIXL managed meta.
         # The lifetime of _managed_meta_nixl is tied to the object ref and freed when the ref goes out of scope.
         self._managed_meta_nixl: Dict[str, Any] = {}
-        # Lock protecting _tensor_desc_cache and _managed_meta_nixl since they can be
-        # accessed from the main task execution thread or the _ray_system thread.
+        # Descriptor-generation references owned by each ObjectRef's metadata.
+        # These are local-only and must not be serialized to a receiver.
+        self._managed_tensor_desc_refs: Dict[str, List[TensorDesc]] = {}
+        # Lock protecting the descriptor indexes, ownership records, and managed
+        # metadata since they can be accessed from the main task execution thread
+        # or the _ray_system thread.
         self._cache_lock = threading.RLock()
         # LRU cache of remote agent names. When full, the least
         # recently used remote agent is evicted and remove_remote_agent is called.
@@ -186,8 +210,21 @@ class NixlTensorTransport(TensorTransportManager):
         return True
 
     def register_nixl_memory(self, tensor: "torch.Tensor") -> None:
-        """Registers the tensor's memory with NIXL and bumps the reference count so the memory region is never deregistered."""
-        self._add_tensor_descs([tensor])
+        """Register and explicitly pin a tensor's storage with NIXL.
+
+        Resizing a preregistered storage requires deregistering and registering
+        its new extent. Prefer allocating the maximum required size before
+        preregistration when possible.
+
+        Storage resizing must not race with registration or an active transfer;
+        _cache_lock serializes cache operations, not external storage mutation.
+        Resize only when no live RDT ObjectRef metadata refers to the storage,
+        because already-published transfer descriptors cannot be rewritten.
+        """
+        with self._cache_lock:
+            tensor_desc = self._add_tensor_descs([tensor])[0]
+            storage = tensor.untyped_storage()
+            self._explicit_tensor_desc_refs.setdefault(storage, []).append(tensor_desc)
 
     def register_nixl_memory_pool(self, size: int, device: "torch.device") -> None:
         """Pre-allocates a memory pool and registers it with NIXL.
@@ -213,7 +250,19 @@ class NixlTensorTransport(TensorTransportManager):
         """Decrements the reference count for the tensor's NIXL memory registration.
         If the count reaches 0, the memory is deregistered from NIXL.
         """
-        self._remove_tensor_descs([tensor])
+        with self._cache_lock:
+            storage = tensor.untyped_storage()
+            refs = self._explicit_tensor_desc_refs.get(storage)
+            if not refs:
+                return
+            tensor_desc = refs.pop()
+            try:
+                self._remove_tensor_descs([tensor], [tensor_desc])
+            except Exception:
+                refs.append(tensor_desc)
+                raise
+            if not refs:
+                self._explicit_tensor_desc_refs.pop(storage, None)
 
     def select_backend(self) -> str:
         """Returns the NIXL backend to attempt.
@@ -276,6 +325,7 @@ class NixlTensorTransport(TensorTransportManager):
         with self._cache_lock:
             device = None
             tensor_meta = []
+            tensor_desc_refs: List[TensorDesc] = []
 
             if rdt_object:
                 # We assume all tensors in one RDT object have the same device type,
@@ -332,10 +382,16 @@ class NixlTensorTransport(TensorTransportManager):
                     )
                 )
                 if pool_eligible:
-                    xfer_descs = self._allocate_pool_xfer_descs(rdt_object)
+                    xfer_descs, tensor_desc_refs = self._allocate_pool_xfer_descs(
+                        rdt_object
+                    )
                 else:
-                    self._add_tensor_descs(rdt_object)
-                    xfer_descs = nixl_agent.get_xfer_descs(rdt_object)
+                    tensor_desc_refs = self._add_tensor_descs(rdt_object)
+                    try:
+                        xfer_descs = nixl_agent.get_xfer_descs(rdt_object)
+                    except Exception:
+                        self._remove_tensor_descs(rdt_object, tensor_desc_refs)
+                        raise
 
                 serialized_descs = nixl_agent.get_serialized_descs(xfer_descs)
                 agent_meta = nixl_agent.get_agent_metadata()
@@ -353,7 +409,7 @@ class NixlTensorTransport(TensorTransportManager):
                 nixl_agent_name=agent_name,
                 nixl_agent_meta_version=agent_meta_version,
             )
-            self._put_meta(obj_id, ret)
+            self._put_meta(obj_id, ret, tensor_desc_refs)
             return ret
 
     def get_communicator_metadata(
@@ -408,6 +464,7 @@ class NixlTensorTransport(TensorTransportManager):
         remote_name = None
         xfer_handle = None
         added_tensor_descs = False
+        tensor_desc_refs: List[TensorDesc] = []
 
         assert tensors
 
@@ -415,7 +472,7 @@ class NixlTensorTransport(TensorTransportManager):
             nixl_agent = self.get_nixl_agent()
             remote_xfer_descs = nixl_agent.deserialize_descs(nixl_serialized_descs)
             # This creates a placeholder for the tensor in the tensor_desc_cache even though it doesn't have an object ref for caching purposes.
-            self._add_tensor_descs(tensors)
+            tensor_desc_refs = self._add_tensor_descs(tensors)
             added_tensor_descs = True
             local_xfer_descs = nixl_agent.get_xfer_descs(tensors)
 
@@ -461,11 +518,17 @@ class NixlTensorTransport(TensorTransportManager):
                 nixl_agent=nixl_agent,
                 remote_name=remote_name,
                 remove_tensor_descs=added_tensor_descs,
+                tensor_desc_refs=tensor_desc_refs,
                 transport=self,
             )
         except Exception:
             self._cleanup_transfer(
-                obj_id, tensors, xfer_handle, remote_name, added_tensor_descs
+                obj_id,
+                tensors,
+                xfer_handle,
+                remote_name,
+                added_tensor_descs,
+                tensor_desc_refs,
             )
             # TODO(swang): There is a circular import error because ray.util
             # currently depends on ray.experimental.internal_kv.
@@ -541,6 +604,7 @@ class NixlTensorTransport(TensorTransportManager):
         xfer_handle: Any,
         remote_name: Optional[str],
         remove_tensor_descs: bool,
+        tensor_desc_refs: Optional[List[TensorDesc]] = None,
     ) -> None:
         """Cleans up resources after a transfer completes or fails."""
         # We could raise errors or NIXL could raise errors like NIXL_ERR_REMOTE_DISCONNECT,
@@ -557,7 +621,7 @@ class NixlTensorTransport(TensorTransportManager):
         if NIXL_REMOTE_AGENT_CACHE_MAXSIZE == 0 and remote_name:
             nixl_agent.remove_remote_agent(remote_name)
         if remove_tensor_descs:
-            self._remove_tensor_descs(tensors)
+            self._remove_tensor_descs(tensors, tensor_desc_refs)
 
     def recv_multiple_tensors(
         self,
@@ -593,7 +657,8 @@ class NixlTensorTransport(TensorTransportManager):
             if obj_id not in self._managed_meta_nixl:
                 return
             self._managed_meta_nixl.pop(obj_id, None)
-            self._remove_tensor_descs(tensors)
+            tensor_desc_refs = self._managed_tensor_desc_refs.pop(obj_id, None)
+            self._remove_tensor_descs(tensors, tensor_desc_refs)
 
     def abort_transport(
         self,
@@ -616,131 +681,272 @@ class NixlTensorTransport(TensorTransportManager):
                 return self._managed_meta_nixl[object_id]
             return None
 
-    def _put_meta(self, object_id: str, meta: NixlTransportMetadata):
+    def _put_meta(
+        self,
+        object_id: str,
+        meta: NixlTransportMetadata,
+        tensor_desc_refs: Optional[List[TensorDesc]] = None,
+    ):
         """
         Store the NIXL transport metadata for the given object ID
         """
         with self._cache_lock:
             self._managed_meta_nixl[object_id] = meta
+            self._managed_tensor_desc_refs[object_id] = tensor_desc_refs or []
 
-    def _remove_tensor_descs(self, tensors: List["torch.Tensor"]):
+    def _remove_tensor_descs(
+        self,
+        tensors: List["torch.Tensor"],
+        tensor_desc_refs: Optional[List[TensorDesc]] = None,
+    ):
         """
-        Decrements the reference count for each tensor. If the count reaches 0,
-        traditionally-registered memory is deregistered from NIXL, while
-        pool-managed blocks (reg_desc is None) are returned to the pool.
+        Release descriptor-generation references for tensors.
+
+        A captured TensorDesc is an ownership token. If its generation is no
+        longer current, cleanup is intentionally a no-op so an old allocation
+        cannot decrement a registration installed for a recycled address.
         """
         with self._cache_lock:
+            if tensor_desc_refs is not None and len(tensors) != len(tensor_desc_refs):
+                raise ValueError("Tensor and descriptor reference counts must match.")
             pool_return_tensors: List["torch.Tensor"] = []
-            for tensor in tensors:
-                key = tensor.untyped_storage().data_ptr()
-                if key not in self._tensor_desc_cache:
+            refs = tensor_desc_refs or [
+                self._tensor_desc_cache.get(t.untyped_storage().data_ptr())
+                for t in tensors
+            ]
+            for tensor, tensor_desc in zip(tensors, refs):
+                if tensor_desc is None:
                     continue
-                tensor_desc = self._tensor_desc_cache[key]
-                tensor_desc.metadata_count -= 1
-                if tensor_desc.metadata_count == 0:
-                    self._tensor_desc_cache.pop(key)
-                    if tensor_desc.reg_desc is not None:
-                        # Traditional path: deregister NIXL memory.
-                        self.get_nixl_agent().deregister_memory(tensor_desc.reg_desc)
-                        self._nixl_agent_meta_version += 1
-                    else:
-                        # Pool path: return block to pool.
-                        pool_return_tensors.append(tensor)
+                current = self._tensor_desc_cache.get(tensor_desc.data_ptr)
+                if current is not tensor_desc:
+                    continue
+                if tensor_desc.metadata_count > 1:
+                    tensor_desc.metadata_count -= 1
+                    continue
+
+                if tensor_desc.reg_desc is not None:
+                    # Deregister before mutating the cache. On failure the
+                    # generation and its last reference remain retryable.
+                    self.get_nixl_agent().deregister_memory(tensor_desc.reg_desc)
+                    self._nixl_agent_meta_version += 1
+                else:
+                    pool_return_tensors.append(tensor)
+                self._discard_tensor_desc(tensor_desc)
             if pool_return_tensors and self._memory_pool is not None:
                 self._memory_pool.free_tensors(pool_return_tensors)
 
-    def _add_tensor_descs(self, tensors: List["torch.Tensor"]):
+    def _discard_tensor_desc(self, tensor_desc: TensorDesc) -> None:
+        """Remove a descriptor generation from the lookup indexes."""
+        if self._tensor_desc_cache.get(tensor_desc.data_ptr) is tensor_desc:
+            self._tensor_desc_cache.pop(tensor_desc.data_ptr)
+        storage = tensor_desc.storage_ref()
+        if (
+            storage is not None
+            and self._storage_to_tensor_desc.get(storage) is tensor_desc
+        ):
+            self._storage_to_tensor_desc.pop(storage, None)
+
+    def _register_tensor_storage(
+        self, tensor: "torch.Tensor", data_ptr: int, storage_nbytes: int
+    ) -> Any:
+        """Register one full PyTorch storage and return its NIXL handle."""
+        mem_type = "cuda" if tensor.is_cuda else "cpu"
+        # The GPU ID is unused for CPU tensors, but NIXL expects an unsigned value.
+        gpu_id = max(tensor.get_device(), 0)
+        try:
+            return self.get_nixl_agent().register_memory(
+                [(data_ptr, storage_nbytes, gpu_id, "")], mem_type=mem_type
+            )
+        except Exception as e:
+            # TODO(xyuzh): Remove the warning after nixl surfaces the error message
+            if self._backend == "LIBFABRIC":
+                troubleshooting = (
+                    "See https://github.com/ai-dynamo/nixl/blob/main/src/plugins/libfabric/README.md "
+                    "for LIBFABRIC troubleshooting. "
+                    "Set FI_LOG_LEVEL=Debug for libfabric diagnostics."
+                )
+            else:
+                troubleshooting = (
+                    "See https://docs.ray.io/en/latest/ray-core/direct-transport/direct-transport.html "
+                    "for NIXL/UCX configuration. "
+                    "Set UCX_LOG_LEVEL=debug for UCX diagnostics."
+                )
+            vmm_hint = ""
+            alloc_conf = os.environ.get("PYTORCH_CUDA_ALLOC_CONF", "").lower()
+            if mem_type == "cuda" and "expandable_segments:true" in alloc_conf:
+                vmm_hint = (
+                    " PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True is set; "
+                    "CUDA VMM memory can't be RDMA-registered — allocate "
+                    "transferred tensors without expandable_segments."
+                )
+            raise RuntimeError(
+                f"Failed to register {mem_type} memory with NIXL "
+                f"(backend={self._backend}, size={storage_nbytes} bytes, "
+                f"gpu_id={gpu_id}).{vmm_hint} {troubleshooting}"
+            ) from e
+
+    def _replace_tensor_desc(
+        self,
+        tensor: "torch.Tensor",
+        storage: Any,
+        old_desc: TensorDesc,
+        data_ptr: int,
+        storage_nbytes: int,
+        preserve_generation: bool,
+    ) -> TensorDesc:
+        """Replace a stale extent, preserving owners only for the same storage."""
+        # NIXL does not support overlapping registrations, so the stale extent
+        # must be removed first. A failed deregistration leaves all local state
+        # untouched and retryable.
+        self.get_nixl_agent().deregister_memory(old_desc.reg_desc)
+        self._nixl_agent_meta_version += 1
+        self._discard_tensor_desc(old_desc)
+
+        # From this point the old registration is truly gone. If registration
+        # fails, leaving the cache empty is the only truthful state. Captured
+        # references to old_desc cannot affect a later generation.
+        reg_desc = self._register_tensor_storage(tensor, data_ptr, storage_nbytes)
+        if preserve_generation:
+            tensor_desc = old_desc
+            tensor_desc.reg_desc = reg_desc
+            tensor_desc.metadata_count += 1
+            tensor_desc.data_ptr = data_ptr
+            tensor_desc.storage_nbytes = storage_nbytes
+            tensor_desc.storage_ref = weakref.ref(storage)
+        else:
+            tensor_desc = TensorDesc(
+                reg_desc=reg_desc,
+                metadata_count=1,
+                data_ptr=data_ptr,
+                storage_nbytes=storage_nbytes,
+                storage_ref=weakref.ref(storage),
+            )
+        self._tensor_desc_cache[data_ptr] = tensor_desc
+        self._storage_to_tensor_desc[storage] = tensor_desc
+        return tensor_desc
+
+    def _add_tensor_descs(self, tensors: List["torch.Tensor"]) -> List[TensorDesc]:
         """
         If this is the first time the tensor is being registered, we register the
-        full underlying pytorch storage object with NIXL. Otherwise, we increment the reference count.
+        full underlying pytorch storage object with NIXL. Otherwise, we increment
+        the reference count for that exact descriptor generation.
         """
         with self._cache_lock:
-            for tensor in tensors:
-                key = tensor.untyped_storage().data_ptr()
-                if key in self._tensor_desc_cache:
-                    self._tensor_desc_cache[key].metadata_count += 1
-                    continue
-                mem_type = "cuda" if tensor.is_cuda else "cpu"
-                # the GPU ID of the device the tensor is on.
-                # NOTE: we clip this to 0 since the GPU ID is not used for
-                # CPU tensors, and get_device returns -1 for CPU tensors.
-                # This triggers an error in nixl since it expects an unsigned.
-                gpu_id = max(tensor.get_device(), 0)
-                # Registering the full underlying pytorch storage object by
-                # constructing a memory region with the data pointer, size,
-                # GPU ID, and meta info. Doing the equivalent of what nixl
-                # does for pytorch tensors internally:
-                # https://github.com/ai-dynamo/nixl/blob/dd23ef01bd366aef89fa552f2b042f89a0b45fcb/src/api/python/_api.py#L1034
-                try:
-                    reg_desc = self.get_nixl_agent().register_memory(
-                        [
-                            (
-                                tensor.untyped_storage().data_ptr(),
-                                tensor.untyped_storage().nbytes(),
-                                gpu_id,
-                                "",
-                            )
-                        ],
-                        mem_type=mem_type,
-                    )
-                except Exception as e:
-                    # TODO(xyuzh): Remove the warning after nixl surfaces the error message
-                    if self._backend == "LIBFABRIC":
-                        troubleshooting = (
-                            "See https://github.com/ai-dynamo/nixl/blob/main/src/plugins/libfabric/README.md "
-                            "for LIBFABRIC troubleshooting. "
-                            "Set FI_LOG_LEVEL=Debug for libfabric diagnostics."
+            tensor_desc_refs: List[TensorDesc] = []
+            try:
+                for tensor in tensors:
+                    storage = tensor.untyped_storage()
+                    data_ptr = storage.data_ptr()
+                    storage_nbytes = storage.nbytes()
+                    storage_desc = self._storage_to_tensor_desc.get(storage)
+                    pointer_desc = self._tensor_desc_cache.get(data_ptr)
+
+                    if storage_desc is not None and storage_desc.reg_desc is None:
+                        # An explicit pin of a pool-backed tensor owns the pool
+                        # descriptor rather than creating a second entry for
+                        # the same source storage.
+                        storage_desc.metadata_count += 1
+                        tensor_desc_refs.append(storage_desc)
+                        continue
+
+                    if storage_desc is not None and storage_desc.reg_desc is not None:
+                        if (
+                            storage_desc.data_ptr == data_ptr
+                            and storage_desc.storage_nbytes == storage_nbytes
+                        ):
+                            storage_desc.metadata_count += 1
+                            tensor_desc_refs.append(storage_desc)
+                            continue
+                        tensor_desc = self._replace_tensor_desc(
+                            tensor,
+                            storage,
+                            storage_desc,
+                            data_ptr,
+                            storage_nbytes,
+                            preserve_generation=True,
+                        )
+                        tensor_desc_refs.append(tensor_desc)
+                        continue
+
+                    if pointer_desc is not None and pointer_desc.reg_desc is not None:
+                        tensor_desc = self._replace_tensor_desc(
+                            tensor,
+                            storage,
+                            pointer_desc,
+                            data_ptr,
+                            storage_nbytes,
+                            preserve_generation=False,
                         )
                     else:
-                        troubleshooting = (
-                            "See https://docs.ray.io/en/latest/ray-core/direct-transport/direct-transport.html "
-                            "for NIXL/UCX configuration. "
-                            "Set UCX_LOG_LEVEL=debug for UCX diagnostics."
+                        reg_desc = self._register_tensor_storage(
+                            tensor, data_ptr, storage_nbytes
                         )
-                    vmm_hint = ""
-                    alloc_conf = os.environ.get("PYTORCH_CUDA_ALLOC_CONF", "").lower()
-                    if mem_type == "cuda" and "expandable_segments:true" in alloc_conf:
-                        vmm_hint = (
-                            " PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True is set; "
-                            "CUDA VMM memory can't be RDMA-registered — allocate "
-                            "transferred tensors without expandable_segments."
+                        tensor_desc = TensorDesc(
+                            reg_desc=reg_desc,
+                            metadata_count=1,
+                            data_ptr=data_ptr,
+                            storage_nbytes=storage_nbytes,
+                            storage_ref=weakref.ref(storage),
                         )
-                    raise RuntimeError(
-                        f"Failed to register {mem_type} memory with NIXL "
-                        f"(backend={self._backend}, "
-                        f"size={tensor.untyped_storage().nbytes()} bytes, "
-                        f"gpu_id={gpu_id}).{vmm_hint} {troubleshooting}"
-                    ) from e
-                self._tensor_desc_cache[key] = TensorDesc(reg_desc, 1)
+                        self._tensor_desc_cache[data_ptr] = tensor_desc
+                        self._storage_to_tensor_desc[storage] = tensor_desc
+                    tensor_desc_refs.append(tensor_desc)
+                return tensor_desc_refs
+            except Exception:
+                # Roll back references acquired earlier in this batch. Cleanup
+                # is best effort so it cannot hide the registration failure.
+                try:
+                    self._remove_tensor_descs(
+                        tensors[: len(tensor_desc_refs)], tensor_desc_refs
+                    )
+                except Exception:
+                    logger.exception(
+                        "Failed to roll back NIXL tensor registrations after "
+                        "registration failure."
+                    )
+                raise
 
     def _tensor_memory_registered(self, t: "torch.Tensor") -> bool:
         """Check if the tensor's memory has been registered with NIXL."""
-        entry = self._tensor_desc_cache.get(t.untyped_storage().data_ptr())
+        storage = t.untyped_storage()
+        entry = self._storage_to_tensor_desc.get(storage)
+        if entry is None:
+            entry = self._tensor_desc_cache.get(storage.data_ptr())
         return entry is not None and entry.reg_desc is not None
 
-    def _add_pool_tensor_descs(self, tensors: List["torch.Tensor"]):
+    def _add_pool_tensor_descs(self, tensors: List["torch.Tensor"]) -> List[TensorDesc]:
         """Add pool-managed tensor entries to the unified _tensor_desc_cache.
 
         Pool-managed tensors use reg_desc=None since pool memory is registered
         once at pool creation. The metadata_count tracks reference counting
         just like traditional tensors.
 
-        Note: Entries are keyed by the source tensor's storage ``data_ptr()``.
-        If PyTorch frees and reallocates that storage address before GC runs,
-        a stale cache entry could map to an unrelated tensor. This is the same
-        constraint as the traditional (non-pool) path and is mitigated by the
-        fact that pool blocks hold a reference to pool memory, not the source
-        storage.
+        Pool allocation lookup remains keyed by the source storage's
+        ``data_ptr()``. Live ObjectRef metadata retains the source tensor until
+        this entry is released; unlike direct preregistration, that lifetime
+        prevents the source allocation from being recycled while the block is
+        in use.
         """
         with self._cache_lock:
+            tensor_desc_refs: List[TensorDesc] = []
             for tensor in tensors:
-                key = tensor.untyped_storage().data_ptr()
+                storage = tensor.untyped_storage()
+                key = storage.data_ptr()
                 if key in self._tensor_desc_cache:
-                    self._tensor_desc_cache[key].metadata_count += 1
+                    tensor_desc = self._tensor_desc_cache[key]
+                    tensor_desc.metadata_count += 1
                 else:
-                    self._tensor_desc_cache[key] = TensorDesc(
-                        reg_desc=None, metadata_count=1
+                    tensor_desc = TensorDesc(
+                        reg_desc=None,
+                        metadata_count=1,
+                        data_ptr=key,
+                        storage_nbytes=storage.nbytes(),
+                        storage_ref=weakref.ref(storage),
                     )
+                    self._tensor_desc_cache[key] = tensor_desc
+                    self._storage_to_tensor_desc[storage] = tensor_desc
+                tensor_desc_refs.append(tensor_desc)
+            return tensor_desc_refs
 
     def _allocate_pool_xfer_descs(self, tensors: List["torch.Tensor"]) -> Any:
         """Allocate pool memory for tensors and return NIXL transfer descriptors.
@@ -765,5 +971,5 @@ class NixlTensorTransport(TensorTransportManager):
             if new_tensors:
                 pool.free_tensors(new_tensors)
             raise
-        self._add_pool_tensor_descs(tensors)
-        return xfer_descs
+        tensor_desc_refs = self._add_pool_tensor_descs(tensors)
+        return xfer_descs, tensor_desc_refs

--- a/python/ray/experimental/rdt/util.py
+++ b/python/ray/experimental/rdt/util.py
@@ -226,6 +226,13 @@ def register_nixl_memory(tensor: "torch.Tensor") -> None:
 
     If called on a tensor that is already registered with NIXL, we still prevent the tensor's memory from being deregistered.
 
+    Resizing a preregistered tensor storage requires Ray to deregister the old
+    NIXL extent and register the resized extent. If the maximum required size is
+    known, allocate that size before calling this function to avoid repeated
+    registration work. Do not resize the storage concurrently with registration
+    or an active RDT transfer, or while a live RDT ``ObjectRef`` refers to it;
+    already-published transfer descriptors cannot be rewritten.
+
     Args:
         tensor: A PyTorch tensor whose memory should be registered with NIXL.
 

--- a/python/ray/tests/BUILD.bazel
+++ b/python/ray/tests/BUILD.bazel
@@ -636,6 +636,7 @@ py_test_module_list(
     files = [
         "rdt/test_nixl_backend_selection.py",
         "rdt/test_nixl_memory_pool.py",
+        "rdt/test_nixl_registration_cache.py",
         "rdt/test_rdt_custom.py",
         "rdt/test_rdt_gloo.py",
     ],

--- a/python/ray/tests/rdt/test_nixl_registration_cache.py
+++ b/python/ray/tests/rdt/test_nixl_registration_cache.py
@@ -1,0 +1,335 @@
+import pytest
+
+from ray.experimental.rdt.nixl_tensor_transport import NixlTensorTransport
+
+
+class FakeStorage:
+    def __init__(self, data_ptr, nbytes):
+        self.data_ptr_value = data_ptr
+        self.nbytes_value = nbytes
+
+    def data_ptr(self):
+        return self.data_ptr_value
+
+    def nbytes(self):
+        return self.nbytes_value
+
+
+class FakeDevice:
+    type = "cpu"
+
+
+class FakeTensor:
+    is_cuda = False
+    dtype = "fake-dtype"
+    device = FakeDevice()
+
+    def __init__(self, storage):
+        self._storage = storage
+        self.shape = (storage.nbytes(),)
+
+    def untyped_storage(self):
+        return self._storage
+
+    def get_device(self):
+        return -1
+
+    def is_contiguous(self):
+        return True
+
+
+class FakeNixlAgent:
+    name = "fake-agent"
+
+    def __init__(self):
+        self.calls = []
+        self.active = {}
+        self.next_registration = 0
+        self.fail_next_registration = False
+        self.fail_next_deregistration = False
+
+    def register_memory(self, regions, mem_type):
+        data_ptr, nbytes, _gpu_id, _metadata = regions[0]
+        self.calls.append(("register", data_ptr, nbytes, mem_type))
+        if self.fail_next_registration:
+            self.fail_next_registration = False
+            raise RuntimeError("registration failed")
+        self.next_registration += 1
+        reg_desc = f"registration-{self.next_registration}"
+        self.active[reg_desc] = (data_ptr, nbytes)
+        return reg_desc
+
+    def deregister_memory(self, reg_desc):
+        self.calls.append(("deregister", reg_desc))
+        if self.fail_next_deregistration:
+            self.fail_next_deregistration = False
+            raise RuntimeError("deregistration failed")
+        self.active.pop(reg_desc)
+
+    def get_xfer_descs(self, tensors):
+        return [
+            (t.untyped_storage().data_ptr(), t.untyped_storage().nbytes())
+            for t in tensors
+        ]
+
+    def get_serialized_descs(self, xfer_descs):
+        return repr(xfer_descs).encode()
+
+    def get_agent_metadata(self):
+        return repr(sorted(self.active.values())).encode()
+
+
+class FakeMemoryPool:
+    def __init__(self):
+        self.freed = []
+
+    def free_tensors(self, tensors):
+        self.freed.extend(tensors)
+
+
+@pytest.fixture
+def transport_and_agent():
+    transport = NixlTensorTransport()
+    agent = FakeNixlAgent()
+    transport._nixl_agent = agent
+    transport._backend = "UCX"
+    return transport, agent
+
+
+def test_same_storage_and_extent_reuses_registration(transport_and_agent):
+    transport, agent = transport_and_agent
+    tensor = FakeTensor(FakeStorage(data_ptr=1000, nbytes=64))
+
+    transport.register_nixl_memory(tensor)
+    transport.register_nixl_memory(tensor)
+
+    tensor_desc = transport._tensor_desc_cache[1000]
+    assert tensor_desc.metadata_count == 2
+    assert [call[0] for call in agent.calls] == ["register"]
+
+    transport.deregister_nixl_memory(tensor)
+    assert tensor_desc.metadata_count == 1
+    transport.deregister_nixl_memory(tensor)
+    assert 1000 not in transport._tensor_desc_cache
+    assert [call[0] for call in agent.calls] == ["register", "deregister"]
+
+
+def test_recycled_pointer_replaces_generation_without_carrying_old_refs(
+    transport_and_agent,
+):
+    transport, agent = transport_and_agent
+    old_tensor = FakeTensor(FakeStorage(data_ptr=1000, nbytes=64))
+    new_tensor = FakeTensor(FakeStorage(data_ptr=1000, nbytes=128))
+
+    transport.register_nixl_memory(old_tensor)
+    transport.register_nixl_memory(old_tensor)
+    old_desc = transport._tensor_desc_cache[1000]
+    transport.register_nixl_memory(new_tensor)
+
+    new_desc = transport._tensor_desc_cache[1000]
+    assert new_desc is not old_desc
+    assert new_desc.storage_nbytes == 128
+    assert new_desc.metadata_count == 1
+    assert agent.calls == [
+        ("register", 1000, 64, "cpu"),
+        ("deregister", "registration-1"),
+        ("register", 1000, 128, "cpu"),
+    ]
+
+    # Both old explicit pins release old_desc and cannot touch new_desc.
+    transport.deregister_nixl_memory(old_tensor)
+    transport.deregister_nixl_memory(old_tensor)
+    assert transport._tensor_desc_cache[1000] is new_desc
+    assert new_desc.metadata_count == 1
+
+    transport.deregister_nixl_memory(new_tensor)
+    assert 1000 not in transport._tensor_desc_cache
+
+
+def test_same_size_recycled_pointer_is_not_a_storage_cache_hit(transport_and_agent):
+    transport, agent = transport_and_agent
+    old_tensor = FakeTensor(FakeStorage(data_ptr=1000, nbytes=64))
+    new_tensor = FakeTensor(FakeStorage(data_ptr=1000, nbytes=64))
+    transport.register_nixl_memory(old_tensor)
+    old_desc = transport._tensor_desc_cache[1000]
+
+    transport.register_nixl_memory(new_tensor)
+
+    new_desc = transport._tensor_desc_cache[1000]
+    assert new_desc is not old_desc
+    assert new_desc.metadata_count == 1
+    assert [call[0] for call in agent.calls] == [
+        "register",
+        "deregister",
+        "register",
+    ]
+
+    transport.deregister_nixl_memory(old_tensor)
+    assert transport._tensor_desc_cache[1000] is new_desc
+
+
+def test_in_place_resize_preserves_same_storage_owners(transport_and_agent):
+    transport, agent = transport_and_agent
+    storage = FakeStorage(data_ptr=1000, nbytes=64)
+    tensor = FakeTensor(storage)
+    transport.register_nixl_memory(tensor)
+    tensor_desc = transport._tensor_desc_cache[1000]
+
+    storage.data_ptr_value = 2000
+    storage.nbytes_value = 128
+    transport.register_nixl_memory(tensor)
+
+    assert 1000 not in transport._tensor_desc_cache
+    assert transport._tensor_desc_cache[2000] is tensor_desc
+    assert tensor_desc.storage_nbytes == 128
+    assert tensor_desc.metadata_count == 2
+    assert [call[0] for call in agent.calls] == [
+        "register",
+        "deregister",
+        "register",
+    ]
+
+    transport.deregister_nixl_memory(tensor)
+    transport.deregister_nixl_memory(tensor)
+    assert 2000 not in transport._tensor_desc_cache
+
+
+def test_replacement_deregistration_failure_is_retryable(transport_and_agent):
+    transport, agent = transport_and_agent
+    old_tensor = FakeTensor(FakeStorage(data_ptr=1000, nbytes=64))
+    new_tensor = FakeTensor(FakeStorage(data_ptr=1000, nbytes=128))
+    transport.register_nixl_memory(old_tensor)
+    old_desc = transport._tensor_desc_cache[1000]
+
+    agent.fail_next_deregistration = True
+    with pytest.raises(RuntimeError, match="deregistration failed"):
+        transport.register_nixl_memory(new_tensor)
+
+    assert transport._tensor_desc_cache[1000] is old_desc
+    assert old_desc.metadata_count == 1
+    assert transport._nixl_agent_meta_version == 0
+
+    transport.register_nixl_memory(new_tensor)
+    assert transport._tensor_desc_cache[1000].storage_nbytes == 128
+    assert transport._nixl_agent_meta_version == 1
+
+
+def test_registration_failure_after_replacement_leaves_truthful_generation(
+    transport_and_agent,
+):
+    transport, agent = transport_and_agent
+    old_tensor = FakeTensor(FakeStorage(data_ptr=1000, nbytes=64))
+    new_tensor = FakeTensor(FakeStorage(data_ptr=1000, nbytes=128))
+    transport.register_nixl_memory(old_tensor)
+
+    agent.fail_next_registration = True
+    with pytest.raises(RuntimeError, match="Failed to register cpu memory"):
+        transport.register_nixl_memory(new_tensor)
+
+    assert 1000 not in transport._tensor_desc_cache
+    assert transport._nixl_agent_meta_version == 1
+    assert not agent.active
+
+    transport.register_nixl_memory(new_tensor)
+    new_desc = transport._tensor_desc_cache[1000]
+    transport.deregister_nixl_memory(old_tensor)
+    assert transport._tensor_desc_cache[1000] is new_desc
+    assert new_desc.metadata_count == 1
+
+    transport.deregister_nixl_memory(new_tensor)
+    assert 1000 not in transport._tensor_desc_cache
+    assert transport._nixl_agent_meta_version == 2
+
+
+def test_metadata_after_replacement_contains_new_extent(transport_and_agent):
+    transport, _agent = transport_and_agent
+    old_tensor = FakeTensor(FakeStorage(data_ptr=1000, nbytes=64))
+    new_tensor = FakeTensor(FakeStorage(data_ptr=1000, nbytes=128))
+    transport.register_nixl_memory(old_tensor)
+    transport.register_nixl_memory(new_tensor)
+
+    metadata = transport.extract_tensor_transport_metadata("new-object", [new_tensor])
+
+    assert metadata.nixl_agent_meta_version == 1
+    assert metadata.nixl_agent_meta == b"[(1000, 128)]"
+    transport.garbage_collect("new-object", metadata, [new_tensor])
+    assert transport._tensor_desc_cache[1000].metadata_count == 1
+
+
+def test_old_object_metadata_cleanup_cannot_release_new_generation(
+    transport_and_agent,
+):
+    transport, _agent = transport_and_agent
+    old_tensor = FakeTensor(FakeStorage(data_ptr=1000, nbytes=64))
+    new_tensor = FakeTensor(FakeStorage(data_ptr=1000, nbytes=128))
+    old_metadata = transport.extract_tensor_transport_metadata(
+        "old-object", [old_tensor]
+    )
+    old_desc = transport._tensor_desc_cache[1000]
+
+    transport.register_nixl_memory(new_tensor)
+    new_desc = transport._tensor_desc_cache[1000]
+    assert new_desc is not old_desc
+
+    transport.garbage_collect("old-object", old_metadata, [old_tensor])
+
+    assert transport._tensor_desc_cache[1000] is new_desc
+    assert new_desc.metadata_count == 1
+
+
+def test_pool_descriptor_reference_cleanup_does_not_deregister(
+    transport_and_agent,
+):
+    transport, agent = transport_and_agent
+    tensor = FakeTensor(FakeStorage(data_ptr=1000, nbytes=64))
+    pool = FakeMemoryPool()
+    transport._memory_pool = pool
+
+    refs = transport._add_pool_tensor_descs([tensor])
+    transport._remove_tensor_descs([tensor], refs)
+
+    assert 1000 not in transport._tensor_desc_cache
+    assert pool.freed == [tensor]
+    assert agent.calls == []
+    assert transport._nixl_agent_meta_version == 0
+
+
+def test_explicit_pin_preserves_pool_backed_descriptor(transport_and_agent):
+    transport, agent = transport_and_agent
+    tensor = FakeTensor(FakeStorage(data_ptr=1000, nbytes=64))
+    pool = FakeMemoryPool()
+    transport._memory_pool = pool
+    refs = transport._add_pool_tensor_descs([tensor])
+    pool_desc = refs[0]
+
+    transport.register_nixl_memory(tensor)
+
+    assert transport._tensor_desc_cache[1000] is pool_desc
+    assert pool_desc.metadata_count == 2
+    assert agent.calls == []
+
+    transport.deregister_nixl_memory(tensor)
+    assert pool_desc.metadata_count == 1
+    transport._remove_tensor_descs([tensor], refs)
+    assert pool.freed == [tensor]
+
+
+def test_ordinary_deregistration_failure_keeps_last_reference(
+    transport_and_agent,
+):
+    transport, agent = transport_and_agent
+    tensor = FakeTensor(FakeStorage(data_ptr=1000, nbytes=64))
+    refs = transport._add_tensor_descs([tensor])
+    tensor_desc = refs[0]
+
+    agent.fail_next_deregistration = True
+    with pytest.raises(RuntimeError, match="deregistration failed"):
+        transport._remove_tensor_descs([tensor], refs)
+
+    assert transport._tensor_desc_cache[1000] is tensor_desc
+    assert tensor_desc.metadata_count == 1
+    assert transport._nixl_agent_meta_version == 0
+
+    transport._remove_tensor_descs([tensor], refs)
+    assert 1000 not in transport._tensor_desc_cache
+    assert transport._nixl_agent_meta_version == 1


### PR DESCRIPTION
## Why

Fixes #65701.

`register_nixl_memory()` previously keyed the NIXL registration cache only by storage `data_ptr()`. When an allocation was resized or a freed address was recycled with a different extent, the cache could incorrectly reuse the old registration.

## What changed

- Track storage identity and registered storage size in cache entries.
- Reuse a registration only when the storage generation and extent match.
- Re-register a new extent when a storage is resized or a pointer is recycled.
- Prevent cleanup from an old generation from releasing a newer registration.
- Make deregistration failures retryable.
- Preserve pool-backed registration behavior.
- Add CPU-only tests covering registration replacement and lifecycle failures.
- Document the resizing behavior and recommended allocation pattern.

## Tests

Passed:

- CPU-only registration-cache tests: 11 passed
- `ruff format --check`
- `ruff check`
- `py_compile`
- `git diff --check`

Full Ray/NIXL integration tests could not be run because this checkout does not have the compiled `ray._raylet` extension and the required NIXL/GPU runtime.

## AI Assistance

AI assistance was used to investigate, implement, test, and review this change. The human submitter reviewed the changed code and understands the implementation.