### PR TITLE
[Data] Remove redundant computation in shuffle v2

### DIFF
--- a/python/ray/data/_internal/execution/operators/shuffle_operators/external_shuffle_reduce_operator.py
+++ b/python/ray/data/_internal/execution/operators/shuffle_operators/external_shuffle_reduce_operator.py
@@ -372,7 +372,8 @@ class ExternalHashShuffleReduceOp(PhysicalOperator, SubProgressBarMixin):
         return upstream.num_output_rows_total()
 
     def current_logical_usage(self) -> ExecutionResources:
-        cpu = memory = 0
+        cpu: float = 0
+        memory: float = 0
         for task in self._shuffle_reduce_tasks.values():
             bundle = task.get_requested_resource_bundle()
             if bundle is None:

--- a/python/ray/data/_internal/execution/operators/shuffle_operators/external_shuffle_reduce_operator.py
+++ b/python/ray/data/_internal/execution/operators/shuffle_operators/external_shuffle_reduce_operator.py
@@ -372,13 +372,14 @@ class ExternalHashShuffleReduceOp(PhysicalOperator, SubProgressBarMixin):
         return upstream.num_output_rows_total()
 
     def current_logical_usage(self) -> ExecutionResources:
-        usage = ExecutionResources.zero()
+        cpu = memory = 0
         for task in self._shuffle_reduce_tasks.values():
             bundle = task.get_requested_resource_bundle()
             if bundle is None:
                 continue
-            usage = usage.add(ExecutionResources(cpu=bundle.cpu, memory=bundle.memory))
-        return usage
+            cpu += bundle.cpu
+            memory += bundle.memory
+        return ExecutionResources(cpu=cpu, memory=memory)
 
     def incremental_resource_usage(self) -> ExecutionResources:
         """Per-task resource ask for the framework's budget allocator."""

--- a/python/ray/data/_internal/execution/operators/shuffle_operators/shuffle_map_operator.py
+++ b/python/ray/data/_internal/execution/operators/shuffle_operators/shuffle_map_operator.py
@@ -395,7 +395,7 @@ class ShuffleMapOp(InternalQueueOperatorMixin, PhysicalOperator, SubProgressBarM
         return super().has_execution_finished()
 
     def has_completed(self) -> bool:
-        return self.has_execution_finished()
+        return self.has_execution_finished() and super().has_completed()
 
     def _do_shutdown(self, force: bool = False) -> None:
         super()._do_shutdown(force)

--- a/python/ray/data/_internal/execution/operators/shuffle_operators/shuffle_map_operator.py
+++ b/python/ray/data/_internal/execution/operators/shuffle_operators/shuffle_map_operator.py
@@ -395,7 +395,7 @@ class ShuffleMapOp(InternalQueueOperatorMixin, PhysicalOperator, SubProgressBarM
         return super().has_execution_finished()
 
     def has_completed(self) -> bool:
-        return self.has_execution_finished() and super().has_completed()
+        return self.has_execution_finished()
 
     def _do_shutdown(self, force: bool = False) -> None:
         super()._do_shutdown(force)

--- a/python/ray/data/_internal/execution/operators/shuffle_operators/shuffle_map_operator.py
+++ b/python/ray/data/_internal/execution/operators/shuffle_operators/shuffle_map_operator.py
@@ -395,13 +395,7 @@ class ShuffleMapOp(InternalQueueOperatorMixin, PhysicalOperator, SubProgressBarM
         return super().has_execution_finished()
 
     def has_completed(self) -> bool:
-        return (
-            not self._shuffle_map_tasks
-            and not self._merge_buffer_refs_by_node
-            and self._partition_bundles_emitted
-            and not self._output_queue.has_next()
-            and super().has_completed()
-        )
+        return self.has_execution_finished()
 
     def _do_shutdown(self, force: bool = False) -> None:
         super()._do_shutdown(force)

--- a/python/ray/data/_internal/execution/operators/shuffle_operators/shuffle_reduce_operator.py
+++ b/python/ray/data/_internal/execution/operators/shuffle_operators/shuffle_reduce_operator.py
@@ -436,7 +436,8 @@ class ShuffleReduceOp(PhysicalOperator, SubProgressBarMixin):
         return upstream.num_output_rows_total()
 
     def current_logical_usage(self) -> ExecutionResources:
-        cpu = memory = 0
+        cpu: float = 0
+        memory: float = 0
         for task in self._shuffle_reduce_tasks.values():
             bundle = task.get_requested_resource_bundle()
             if bundle is None:

--- a/python/ray/data/_internal/execution/operators/shuffle_operators/shuffle_reduce_operator.py
+++ b/python/ray/data/_internal/execution/operators/shuffle_operators/shuffle_reduce_operator.py
@@ -436,13 +436,14 @@ class ShuffleReduceOp(PhysicalOperator, SubProgressBarMixin):
         return upstream.num_output_rows_total()
 
     def current_logical_usage(self) -> ExecutionResources:
-        usage = ExecutionResources.zero()
+        cpu = memory = 0
         for task in self._shuffle_reduce_tasks.values():
             bundle = task.get_requested_resource_bundle()
             if bundle is None:
                 continue
-            usage = usage.add(ExecutionResources(cpu=bundle.cpu, memory=bundle.memory))
-        return usage
+            cpu += bundle.cpu
+            memory += bundle.memory
+        return ExecutionResources(cpu=cpu, memory=memory)
 
     def incremental_resource_usage(self) -> ExecutionResources:
         """Per-task resource ask for the framework's budget allocator."""


### PR DESCRIPTION
## Description
I observed that there are some redundant computation in shuffle v2 that can become bottlenecks:
- Creating too many redundant `ExecutionResources` class instance in `current_logical_usage` every time we're trying calculate usage when iterating all running reducers. -> Hoisted the `ExecutionResources` creation outside the loop
- `has_completed` in `shuffle_map` check all the output queues length every time it's called while we already have signal `has_execution_finished` (coming from `_partition_bundles_emitted`).

This fix cut down the shuffle v2 join test sf 1000 from 240s to 190s
## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
