### PR TITLE
[Core][Autoscaler] Support node IDs as SSH proxy targets

### DIFF
--- a/python/ray/autoscaler/_private/command_runner.py
+++ b/python/ray/autoscaler/_private/command_runner.py
@@ -452,6 +452,7 @@ class SSHCommandRunner(CommandRunnerInterface):
 
     def run_rsync_down(self, source, target, options=None):
         ssh_target = self._get_ssh_target()
+        options = options or {}
 
         # on Windows use scp -r instead of rsync
         if sys.platform == "win32":

--- a/python/ray/autoscaler/_private/command_runner.py
+++ b/python/ray/autoscaler/_private/command_runner.py
@@ -197,6 +197,7 @@ class SSHCommandRunner(CommandRunnerInterface):
         self.ssh_control_path = ssh_control_path
         self.ssh_ip = None
         self.ssh_proxy_command = auth_config.get("ssh_proxy_command", None)
+        self.ssh_proxy_use_node_id = auth_config.get("ssh_proxy_use_node_id", False)
         self.ssh_options = SSHOptions(
             self.ssh_private_key,
             self.ssh_control_path,
@@ -208,6 +209,23 @@ class SSHCommandRunner(CommandRunnerInterface):
             return self.provider.internal_ip(self.node_id)
         else:
             return self.provider.external_ip(self.node_id)
+
+    def _ensure_ssh_control_path(self):
+        if self.ssh_control_path is not None:
+            try:
+                os.makedirs(self.ssh_control_path, mode=0o700, exist_ok=True)
+            except OSError as e:
+                cli_logger.warning("{}", str(e))  # todo: msg
+
+    def _get_ssh_target(self):
+        self._ensure_ssh_control_path()
+
+        if self.ssh_proxy_use_node_id:
+            return self.node_id
+
+        self._set_ssh_ip_if_required()
+        assert self.ssh_ip is not None
+        return self.ssh_ip
 
     def _wait_for_ip(self, deadline):
         # if we have IP do not print waiting info
@@ -246,15 +264,6 @@ class SSHCommandRunner(CommandRunnerInterface):
             assert ip is not None, "Unable to find IP of node"
 
         self.ssh_ip = ip
-
-        # This should run before any SSH commands and therefore ensure that
-        #   the ControlPath directory exists, allowing SSH to maintain
-        #   persistent sessions later on.
-        if self.ssh_control_path is not None:
-            try:
-                os.makedirs(self.ssh_control_path, mode=0o700, exist_ok=True)
-            except OSError as e:
-                cli_logger.warning("{}", str(e))  # todo: msg
 
     def _run_helper(
         self,
@@ -351,7 +360,7 @@ class SSHCommandRunner(CommandRunnerInterface):
             ssh_options, SSHOptions
         ), "ssh_options must be of type SSHOptions, got {}".format(type(ssh_options))
 
-        self._set_ssh_ip_if_required()
+        ssh_target = self._get_ssh_target()
 
         if is_using_login_shells():
             ssh = ["ssh", "-tt"]
@@ -373,7 +382,7 @@ class SSHCommandRunner(CommandRunnerInterface):
         final_cmd = (
             ssh
             + ssh_options.to_ssh_options_list(timeout=timeout)
-            + ["{}@{}".format(self.ssh_user, self.ssh_ip)]
+            + ["{}@{}".format(self.ssh_user, ssh_target)]
         )
         if cmd:
             if environment_variables:
@@ -417,7 +426,7 @@ class SSHCommandRunner(CommandRunnerInterface):
         return [arg for args_list in exclude_args + filter_args for arg in args_list]
 
     def run_rsync_up(self, source, target, options=None):
-        self._set_ssh_ip_if_required()
+        ssh_target = self._get_ssh_target()
         options = options or {}
 
         # on windows use scp -r instead of rsync
@@ -425,7 +434,7 @@ class SSHCommandRunner(CommandRunnerInterface):
             # Use scp as fallback for Windows
             command = ["scp", "-r"]
             command += self.ssh_options.to_ssh_options_list(timeout=120)
-            command += [source, "{}@{}:{}".format(self.ssh_user, self.ssh_ip, target)]
+            command += [source, "{}@{}:{}".format(self.ssh_user, ssh_target, target)]
         else:
             command = ["rsync"]
             command += [
@@ -436,20 +445,20 @@ class SSHCommandRunner(CommandRunnerInterface):
             ]
             command += ["-avz"]
             command += self._create_rsync_filter_args(options=options)
-            command += [source, "{}@{}:{}".format(self.ssh_user, self.ssh_ip, target)]
+            command += [source, "{}@{}:{}".format(self.ssh_user, ssh_target, target)]
 
         cli_logger.verbose("Running `{}`", cf.bold(" ".join(command)))
         self._run_helper(command, silent=is_rsync_silent())
 
     def run_rsync_down(self, source, target, options=None):
-        self._set_ssh_ip_if_required()
+        ssh_target = self._get_ssh_target()
 
         # on Windows use scp -r instead of rsync
         if sys.platform == "win32":
             # Use scp as fallback for Windows
             command = ["scp", "-r"]
             command += self.ssh_options.to_ssh_options_list(timeout=120)
-            command += ["{}@{}:{}".format(self.ssh_user, self.ssh_ip, source), target]
+            command += ["{}@{}:{}".format(self.ssh_user, ssh_target, source), target]
         else:
             command = ["rsync"]
             command += [
@@ -460,20 +469,20 @@ class SSHCommandRunner(CommandRunnerInterface):
             ]
             command += ["-avz"]
             command += self._create_rsync_filter_args(options=options)
-            command += ["{}@{}:{}".format(self.ssh_user, self.ssh_ip, source), target]
+            command += ["{}@{}:{}".format(self.ssh_user, ssh_target, source), target]
 
         cli_logger.verbose("Running `{}`", cf.bold(" ".join(command)))
         self._run_helper(command, silent=is_rsync_silent())
 
     def remote_shell_command_str(self):
+        ssh_target = self._get_ssh_target()
+
         if self.ssh_private_key:
             return "ssh -o IdentitiesOnly=yes -i {} {}@{}\n".format(
-                self.ssh_private_key, self.ssh_user, self.ssh_ip
+                self.ssh_private_key, self.ssh_user, ssh_target
             )
         else:
-            return "ssh -o IdentitiesOnly=yes {}@{}\n".format(
-                self.ssh_user, self.ssh_ip
-            )
+            return "ssh -o IdentitiesOnly=yes {}@{}\n".format(self.ssh_user, ssh_target)
 
 
 class DockerCommandRunner(CommandRunnerInterface):

--- a/python/ray/autoscaler/_private/commands.py
+++ b/python/ray/autoscaler/_private/commands.py
@@ -1073,6 +1073,7 @@ def _set_up_config_for_head_node(
     # drop proxy options if they exist, otherwise
     # head node won't be able to connect to workers
     remote_config["auth"].pop("ssh_proxy_command", None)
+    remote_config["auth"].pop("ssh_proxy_use_node_id", None)
 
     # Drop the head_node field if it was introduced. It is technically not a
     # valid field in the config, but it may have been introduced after

--- a/python/ray/autoscaler/ray-schema.json
+++ b/python/ray/autoscaler/ray-schema.json
@@ -218,6 +218,11 @@
                 "ssh_proxy_command": {
                     "description": "A value for ProxyCommand ssh option, for connecting through proxies. Example: nc -x proxy.example.com:1234 %h %p",
                     "type": "string"
+                },
+                "ssh_proxy_use_node_id": {
+                    "description": "Whether to use the provider node ID instead of the node IP as the SSH target. This is useful for proxy commands that require a node ID.",
+                    "type": "boolean",
+                    "default": false
                 }
             }
         },

--- a/python/ray/autoscaler/ray-schema.json
+++ b/python/ray/autoscaler/ray-schema.json
@@ -204,6 +204,25 @@
             "type": "object",
             "description": "How Ray will authenticate with newly launched nodes.",
             "additionalProperties": false,
+            "allOf": [
+                {
+                    "if": {
+                        "properties": {
+                            "ssh_proxy_use_node_id": {
+                                "const": true
+                            }
+                        },
+                        "required": [
+                            "ssh_proxy_use_node_id"
+                        ]
+                    },
+                    "then": {
+                        "required": [
+                            "ssh_proxy_command"
+                        ]
+                    }
+                }
+            ],
             "properties": {
                 "ssh_user": {
                     "type": "string",

--- a/python/ray/tests/test_autoscaler.py
+++ b/python/ray/tests/test_autoscaler.py
@@ -505,6 +505,16 @@ class AutoscalingTest(unittest.TestCase):
         with pytest.raises(ValidationError):
             validate_config(config)
 
+        # Enabling node-ID proxy targets requires a proxy command.
+        config = copy.deepcopy(SMALL_CLUSTER)
+        config["auth"]["ssh_proxy_use_node_id"] = True
+        with pytest.raises(ValidationError):
+            validate_config(config)
+
+        # Disabling node-ID proxy targets does not require a proxy command.
+        config["auth"]["ssh_proxy_use_node_id"] = False
+        validate_config(config)
+
     def testValidateDefaultConfig(self):
         config = {}
         config["provider"] = {

--- a/python/ray/tests/test_autoscaler.py
+++ b/python/ray/tests/test_autoscaler.py
@@ -492,6 +492,19 @@ class AutoscalingTest(unittest.TestCase):
         with pytest.raises(ValidationError):
             validate_config(config)
 
+    def testValidateSshProxyUseNodeId(self):
+        config = copy.deepcopy(SMALL_CLUSTER)
+        config["auth"]["ssh_proxy_command"] = "aws ssm start-session --target %h"
+        config["auth"]["ssh_proxy_use_node_id"] = True
+
+        # Boolean values should be accepted.
+        validate_config(config)
+
+        # Strings that merely look like booleans must be rejected.
+        config["auth"]["ssh_proxy_use_node_id"] = "true"
+        with pytest.raises(ValidationError):
+            validate_config(config)
+
     def testValidateDefaultConfig(self):
         config = {}
         config["provider"] = {
@@ -504,6 +517,29 @@ class AutoscalingTest(unittest.TestCase):
             validate_config(config)
         except ValidationError:
             self.fail("Default config did not pass validation test!")
+
+    def testHeadNodeConfigDropsSshProxyOptions(self):
+        config = copy.deepcopy(SMALL_CLUSTER)
+        config["auth"]["ssh_proxy_command"] = "aws ssm start-session --target %h"
+        config["auth"]["ssh_proxy_use_node_id"] = True
+
+        updated_config, remote_config_file = commands._set_up_config_for_head_node(
+            config,
+            MockProvider(),
+            no_restart=False,
+        )
+
+        try:
+            remote_config_path = updated_config["file_mounts"][
+                "~/ray_bootstrap_config.yaml"
+            ]
+            with open(remote_config_path, encoding="utf-8") as file:
+                remote_config = json.load(file)
+        finally:
+            remote_config_file.close()
+
+        assert "ssh_proxy_command" not in remote_config["auth"]
+        assert "ssh_proxy_use_node_id" not in remote_config["auth"]
 
     def testGetOrCreateHeadNode(self):
         config = copy.deepcopy(SMALL_CLUSTER)

--- a/python/ray/tests/test_command_runner.py
+++ b/python/ray/tests/test_command_runner.py
@@ -1,6 +1,7 @@
 import hashlib
 import sys
 from getpass import getuser
+from unittest.mock import patch
 
 import pytest
 
@@ -122,6 +123,99 @@ def test_ssh_command_runner():
     for x, y in zip(process_runner.calls[0], expected):
         assert x == y
     process_runner.assert_has_call("1.2.3.4", exact=expected)
+
+
+def test_ssh_command_runner_uses_node_id_as_proxy_target():
+    process_runner = MockProcessRunner()
+    provider = MockProvider()
+
+    node_id = "i-0123456789abcdef0"
+    proxy_command = (
+        "aws ssm start-session --target %h "
+        "--document-name AWS-StartSSHSession "
+        "--parameters portNumber=%p"
+    )
+
+    def fail_if_ip_is_requested(_):
+        pytest.fail("SSH through a node-ID proxy should not request an external IP.")
+
+    provider.external_ip = fail_if_ip_is_requested
+
+    cmd_runner = SSHCommandRunner(
+        log_prefix="prefix",
+        node_id=node_id,
+        provider=provider,
+        auth_config={
+            **auth_config,
+            "ssh_proxy_command": proxy_command,
+            "ssh_proxy_use_node_id": True,
+        },
+        cluster_name="cluster",
+        process_runner=process_runner,
+        use_internal_ip=False,
+    )
+
+    with patch(
+        "ray.autoscaler._private.command_runner.os.makedirs"
+    ) as make_control_path:
+        cmd_runner.run("true")
+
+    make_control_path.assert_called_once_with(
+        cmd_runner.ssh_control_path,
+        mode=0o700,
+        exist_ok=True,
+    )
+
+    command = process_runner.calls[0]
+
+    assert f"ProxyCommand={proxy_command}" in command
+    assert f"ray@{node_id}" in command
+    assert cmd_runner.remote_shell_command_str() == (
+        f"ssh -o IdentitiesOnly=yes -i 8265.pem ray@{node_id}\n"
+    )
+
+
+def test_rsync_uses_node_id_as_proxy_target():
+    process_runner = MockProcessRunner()
+    provider = MockProvider()
+
+    node_id = "i-0123456789abcdef0"
+    proxy_command = (
+        "aws ssm start-session --target %h "
+        "--document-name AWS-StartSSHSession "
+        "--parameters portNumber=%p"
+    )
+
+    def fail_if_ip_is_requested(_):
+        pytest.fail("Rsync through a node-ID proxy should not request an external IP.")
+
+    provider.external_ip = fail_if_ip_is_requested
+
+    cmd_runner = SSHCommandRunner(
+        log_prefix="prefix",
+        node_id=node_id,
+        provider=provider,
+        auth_config={
+            **auth_config,
+            "ssh_proxy_command": proxy_command,
+            "ssh_proxy_use_node_id": True,
+        },
+        cluster_name="cluster",
+        process_runner=process_runner,
+        use_internal_ip=False,
+    )
+
+    cmd_runner.run_rsync_up("/local/source", "/remote/target", options={})
+
+    upload_command = process_runner.calls[0]
+    assert f"ray@{node_id}:/remote/target" in upload_command
+
+    process_runner.clear_history()
+
+    cmd_runner.run_rsync_down("/remote/source", "/local/target", options={})
+
+    download_command = process_runner.calls[0]
+    assert f"ray@{node_id}:/remote/source" in download_command
 
 
 def test_docker_command_runner():

--- a/python/ray/tests/test_command_runner.py
+++ b/python/ray/tests/test_command_runner.py
@@ -212,7 +212,7 @@ def test_rsync_uses_node_id_as_proxy_target():
 
     process_runner.clear_history()
 
-    cmd_runner.run_rsync_down("/remote/source", "/local/target", options={})
+    cmd_runner.run_rsync_down("/remote/source", "/local/target")
 
     download_command = process_runner.calls[0]
     assert f"ray@{node_id}:/remote/source" in download_command


### PR DESCRIPTION
## Description

AWS Systems Manager SSH sessions use OpenSSH's `%h` substitution as the SSM target. Ray currently resolves an internal or external IP for SSH and rsync destinations, but AWS SSM requires the EC2 instance ID as that target.

This PR adds the opt-in `auth.ssh_proxy_use_node_id` setting. When enabled, the SSH command runner uses `node_id` for:

- SSH commands
- Rsync uploads
- Rsync downloads
- Remote shell command rendering

The option defaults to `false`, preserving the existing IP-based behavior.

The implementation also moves SSH ControlPath directory creation into the common target-resolution path. Real AWS validation exposed that returning the node ID before IP resolution bypassed the previous ControlPath setup and caused OpenSSH to fail with `unix_listener: cannot bind to path ...: No such file or directory`.

`remote_shell_command_str()` now resolves the destination through the same target-selection path, so node-ID proxy configurations render `user@<node-id>`. It retains its existing concise output format and does not embed the ProxyCommand.

Proxy-only auth settings are removed from the bootstrap configuration copied to the head node.

## Related issues

Fixes #38885

## Additional information

### Configuration

The new option is intended to be used with an SSH ProxyCommand whose `%h` value must be the cloud provider's node ID:

```yaml
auth:
  ssh_user: ec2-user
  ssh_private_key: /path/to/private-key.pem
  ssh_proxy_command: >-
    aws ssm start-session
    --region <region>
    --target %h
    --document-name AWS-StartSSHSession
    --parameters portNumber=%p
  ssh_proxy_use_node_id: true
```

Configurations that omit the new option continue to resolve and use node IP addresses as before.

### Duplicate check

This PR implements #38885. I reviewed the issue discussion and searched open PRs for `38885`, SSH proxy/node-ID work, and `ssh_proxy_use_node_id`. No open PR implements this fix.

### Testing

Command-runner test suite:

```bash
python -m pytest -q python/ray/tests/test_command_runner.py
```

Result:

```text
12 passed
```

Focused schema and bootstrap-config tests:

```bash
python -m pytest -q \
  python/ray/tests/test_autoscaler.py \
  -k 'ValidateSshProxyUseNodeId or HeadNodeConfigDropsSshProxyOptions'
```

Result:

```text
2 passed, 70 deselected
```

Pre-commit on all modified files:

```bash
CGO_ENABLED=1 pre-commit run --files \
  python/ray/autoscaler/_private/command_runner.py \
  python/ray/autoscaler/_private/commands.py \
  python/ray/autoscaler/ray-schema.json \
  python/ray/tests/test_autoscaler.py \
  python/ray/tests/test_command_runner.py
```

Result: all applicable hooks passed or skipped without modifying files.

```bash
git diff --check
```

Result: passed with no output.

### AWS SSM smoke test

I tested the change against a real EC2 instance in `us-east-1` using AWS CLI v2, Session Manager Plugin, OpenSSH, and rsync.

The test used:

- One `t3.micro` head node and zero workers
- An SSM-managed instance profile
- `ssh_proxy_use_node_id: true`
- `aws ssm start-session --target %h`
- A security group with no inbound permissions (`IpPermissions == []`)
- No inbound TCP/22 rule

Results:

```text
ray up exit code: 0
RAY_EXEC_SSM_OK
RAY_SSM_HEAD_OK
RAY_RSYNC_UP_OK
RAY_RSYNC_DOWN_OK
```

The successful transfer tests used:

```text
ray rsync-up
ray rsync-down
```

The SSH destination was the EC2 instance ID, and the final run did not reproduce the earlier ControlPath `unix_listener` error. The EC2 instance was terminated after the test.

### AI assistance

I used ChatGPT/Codex to help analyze the issue, review the implementation, draft tests, and prepare the PR description. I reviewed every changed line, ran the tests listed above, understand the change end-to-end, and take full responsibility for this submission.