### PR TITLE
[serve] Fix DeploymentHandle typing to avoid claiming NoReturn is awaitable

### DIFF
--- a/python/ray/serve/handle.py
+++ b/python/ray/serve/handle.py
@@ -317,9 +317,9 @@ class _DeploymentHandleBase(Generic[T]):
 
     async def shutdown_async(self):
         if self._router:
-            shutdown_future: Union[
-                asyncio.Future, concurrent.futures.Future
-            ] = self._router.shutdown()
+            shutdown_future: Union[asyncio.Future, concurrent.futures.Future] = (
+                self._router.shutdown()
+            )
             if self._is_router_running_in_separate_loop:
                 await asyncio.wrap_future(shutdown_future)
             else:
@@ -1140,9 +1140,7 @@ class DeploymentHandle(_DeploymentHandleBase[T]):
             response_serialization=response_serialization,
         )
 
-    def remote(
-        self, *args: Any, **kwargs: Any
-    ) -> DeploymentResponse[Any]:
+    def remote(self, *args: Any, **kwargs: Any) -> DeploymentResponse[Any]:
         """Issue a remote call to a method of the deployment.
 
         By default, the result is a `DeploymentResponse` that can be awaited to fetch

--- a/python/ray/serve/handle.py
+++ b/python/ray/serve/handle.py
@@ -13,14 +13,14 @@ from typing import (
     Generic,
     Iterator,
     List,
+    NoReturn,
     Optional,
     Tuple,
-    TypeVar,
     Union,
     cast,
 )
 
-from typing_extensions import AsyncContextManager
+from typing_extensions import AsyncContextManager, TypeVar
 
 import ray
 from ray import serve
@@ -60,9 +60,9 @@ from ray.util.annotations import DeveloperAPI, PublicAPI
 logger = logging.getLogger(SERVE_LOGGER_NAME)
 
 # TypeVar for the deployment class type in DeploymentHandle[T]
-T = TypeVar("T")
+T = TypeVar("T", default=Any)
 # TypeVar for the response/result type in DeploymentResponse[R]
-R = TypeVar("R")
+R = TypeVar("R", default=Any)
 
 
 class _DeploymentHandleBase(Generic[T]):
@@ -712,7 +712,7 @@ class DeploymentResponseGenerator(_DeploymentResponseBase[R]):
     `DeploymentHandle` call.
     """
 
-    def __await__(self):
+    def __await__(self) -> NoReturn:
         raise TypeError(
             "`DeploymentResponseGenerator` cannot be awaited directly. Use `async for` "
             "or `await response.__anext__() instead`."
@@ -1142,7 +1142,7 @@ class DeploymentHandle(_DeploymentHandleBase[T]):
 
     def remote(
         self, *args: Any, **kwargs: Any
-    ) -> Union[DeploymentResponse[Any], DeploymentResponseGenerator[Any]]:
+    ) -> DeploymentResponse[Any]:
         """Issue a remote call to a method of the deployment.
 
         By default, the result is a `DeploymentResponse` that can be awaited to fetch
@@ -1150,7 +1150,10 @@ class DeploymentHandle(_DeploymentHandleBase[T]):
         deployments.
 
         If `handle.options(stream=True)` is set and a generator method is called, this
-        returns a `DeploymentResponseGenerator` instead.
+        returns a `DeploymentResponseGenerator` instead. ``DeploymentResponseGenerator``
+        is not awaitable — use ``async for`` or ``await anext()`` instead — so the
+        awaitable return is ``DeploymentResponse`` only. This avoids claiming
+        ``NoReturn`` (from the generator's ``__await__``) is awaitable.
 
         Example:
 
@@ -1177,10 +1180,13 @@ class DeploymentHandle(_DeploymentHandleBase[T]):
 
         future, request_metadata = self._remote(args, kwargs)
         if self.handle_options.stream:
-            return DeploymentResponseGenerator(
-                future,
-                request_metadata,
-                _is_router_running_in_separate_loop=self._is_router_running_in_separate_loop(),
+            return cast(
+                DeploymentResponse[Any],
+                DeploymentResponseGenerator(
+                    future,
+                    request_metadata,
+                    _is_router_running_in_separate_loop=self._is_router_running_in_separate_loop(),
+                ),
             )
         else:
             return DeploymentResponse(
@@ -1222,7 +1228,7 @@ class DeploymentHandle(_DeploymentHandleBase[T]):
         selection: ReplicaSelection,
         *args: Any,
         **kwargs: Any,
-    ) -> Union[DeploymentResponse[Any], DeploymentResponseGenerator[Any]]:
+    ) -> DeploymentResponse[Any]:
         """Dispatch a request to a previously selected replica.
 
         By default, the result is a `DeploymentResponse` that can be awaited to fetch
@@ -1255,10 +1261,13 @@ class DeploymentHandle(_DeploymentHandleBase[T]):
         future, request_metadata = self._dispatch(selection, args, kwargs)
         # Use the stream flag captured at choose_replica time
         if request_metadata.is_streaming:
-            return DeploymentResponseGenerator(
-                future,
-                request_metadata,
-                _is_router_running_in_separate_loop=self._is_router_running_in_separate_loop(),
+            return cast(
+                DeploymentResponse[Any],
+                DeploymentResponseGenerator(
+                    future,
+                    request_metadata,
+                    _is_router_running_in_separate_loop=self._is_router_running_in_separate_loop(),
+                ),
             )
         else:
             return DeploymentResponse(

--- a/python/ray/serve/handle.py
+++ b/python/ray/serve/handle.py
@@ -317,9 +317,9 @@ class _DeploymentHandleBase(Generic[T]):
 
     async def shutdown_async(self):
         if self._router:
-            shutdown_future: Union[asyncio.Future, concurrent.futures.Future] = (
-                self._router.shutdown()
-            )
+            shutdown_future: Union[
+                asyncio.Future, concurrent.futures.Future
+            ] = self._router.shutdown()
             if self._is_router_running_in_separate_loop:
                 await asyncio.wrap_future(shutdown_future)
             else:

--- a/python/ray/serve/tests/typing_files/check_handle_typing.py
+++ b/python/ray/serve/tests/typing_files/check_handle_typing.py
@@ -9,7 +9,7 @@ on handle classes work correctly. Run with:
 mypy will fail if any assert_type() call doesn't match the expected type.
 """
 
-from typing import Any, AsyncIterator, Iterator, Union
+from typing import Any, AsyncIterator, Iterator
 
 from typing_extensions import assert_type
 

--- a/python/ray/serve/tests/typing_files/check_handle_typing.py
+++ b/python/ray/serve/tests/typing_files/check_handle_typing.py
@@ -109,13 +109,12 @@ def test_deployment_handle_types() -> None:
     new_handle = handle.options(method_name="get_string")
     assert_type(new_handle, DeploymentHandle[MyDeployment])
 
-    # remote() returns Union[DeploymentResponse[Any], DeploymentResponseGenerator[Any]]
-    # (until plugin is implemented to infer the actual return type)
+    # remote() returns DeploymentResponse[Any] for unary calls.
+    # Streaming calls return DeploymentResponseGenerator via options(stream=True);
+    # the base remote() is typed as awaitable only, so it does not claim
+    # DeploymentResponseGenerator (whose __await__ is NoReturn) is awaitable.
     response = handle.remote()
-    assert_type(
-        response,
-        Union[DeploymentResponse[Any], DeploymentResponseGenerator[Any]],
-    )
+    assert_type(response, DeploymentResponse[Any])
 
     broadcast_response = handle.broadcast("get_string")
     assert_type(broadcast_response, DeploymentBroadcastResponse)


### PR DESCRIPTION
## Description
Fixes `pyright` error `"NoReturn" is not awaitable` on `await handle.method.remote(...)`. `DeploymentHandle.remote` and `dispatch` previously returned `Union[DeploymentResponse, DeploymentResponseGenerator]` while `DeploymentResponseGenerator.__await__` is `NoReturn`, so the union incorrectly claimed `NoReturn` is awaitable. Narrow the awaitable surface to `DeploymentResponse[Any]` and make the generator explicitly non-awaitable, with a default `Any` for bare `DeploymentHandle`.

## Related issues
Fixes #52491

## Additional information
Type-only change, no runtime behavior change.