### PR TITLE
[core][rdt] GC metadata on borrowers

### DIFF
--- a/python/ray/_private/serialization.py
+++ b/python/ray/_private/serialization.py
@@ -128,6 +128,9 @@ def _rdt_ref_deserializer(
     )
     rdt_manager = ray._private.worker.global_worker.rdt_manager
     rdt_manager.set_rdt_metadata(obj_ref.hex(), rdt_meta)
+    ray._private.worker.global_worker.core_worker.add_borrowed_object_out_of_scope_callback(
+        obj_ref, rdt_manager.remove_borrowed_rdt_metadata
+    )
 
     return obj_ref
 

--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -4632,6 +4632,39 @@ cdef class CoreWorker:
             cpython.Py_DECREF(callback)
         return registered
 
+    def add_borrowed_object_out_of_scope_callback(
+            self, ObjectRef object_ref, callback: Callable[[bytes], None]):
+        """Register a Python callable for a borrowed object going out of scope.
+
+        This is an internal Ray API used by RDT to release per-borrower
+        metadata. Owned objects are ignored because their lifecycle is handled
+        by the owner-side callback.
+
+        The callback has the same threading and non-blocking requirements as
+        ``add_object_out_of_scope_callback``.
+
+        Returns:
+            True if registered; False if the object is owned by this worker or
+            is already out of scope.
+        """
+        if not callable(callback):
+            raise TypeError(
+                f"callback must be callable, got {type(callback).__name__!r}"
+            )
+        cdef CObjectID c_object_id = object_ref.native()
+        if CCoreWorkerProcess.GetCoreWorker().CheckObjectOwnedByUs(
+                c_object_id).ok():
+            return False
+        cpython.Py_INCREF(callback)
+        registered = CCoreWorkerProcess.GetCoreWorker() \
+            .AddObjectOutOfScopeOrFreedCallback(
+                c_object_id,
+                _invoke_object_out_of_scope_callback,
+                <void *>callback)
+        if not registered:
+            cpython.Py_DECREF(callback)
+        return registered
+
     def get_owner_address(self, ObjectRef object_ref):
         cdef:
             CObjectID c_object_id = object_ref.native()

--- a/python/ray/experimental/rdt/rdt_manager.py
+++ b/python/ray/experimental/rdt/rdt_manager.py
@@ -184,9 +184,9 @@ class RDTManager:
         # they can be accessed from the user's python thread or the CoreWorker's main io service thread.
         self._lock = threading.Lock()
 
-        # A dictionary that maps from owned object's ID to RDTMeta.
-        # This dictionary is hosted on the "driver" process of the actors that
-        # store and send/receive RDT objects.
+        # A dictionary that maps from an owned or borrowed object's ID to RDTMeta.
+        # This dictionary is process-local to drivers and actor workers that
+        # manage, send, or receive RDT objects.
         self._managed_rdt_metadata: Dict[str, RDTMeta] = {}
         # Condition variable to wait for the tensor transport meta to be set.
         self._tensor_transport_meta_cv = threading.Condition(self._lock)
@@ -299,6 +299,11 @@ class RDTManager:
     def get_rdt_metadata(self, obj_id: str) -> Optional[RDTMeta]:
         with self._lock:
             return self._managed_rdt_metadata.get(obj_id, None)
+
+    def remove_borrowed_rdt_metadata(self, obj_id_binary: bytes):
+        """Remove local metadata after a borrowed RDT ref goes out of scope."""
+        with self._lock:
+            self._managed_rdt_metadata.pop(obj_id_binary.hex(), None)
 
     def wait_for_tensor_transport_metadata(
         self, obj_id: str, timeout: float
@@ -1003,8 +1008,6 @@ class RDTManager:
         Otherwise, queue up the free operation until the tensor metadata is available.
         """
         # NOTE: This may have to change if we support lineage reconstruction for RDT
-        # TODO(#57962): Metadata is currently not removed on borrowers that borrow through
-        # the NIXL ray.put / ray.get
         with self._lock:
             self._queued_transfers.pop(object_id, None)
             rdt_meta = self._managed_rdt_metadata[object_id]

--- a/python/ray/tests/rdt/test_rdt_gloo.py
+++ b/python/ray/tests/rdt/test_rdt_gloo.py
@@ -56,6 +56,28 @@ class GPUTestActor:
         rdt_manager = ray._private.worker.global_worker.rdt_manager
         return rdt_manager.rdt_store.get_num_objects()
 
+    def retain_borrowed_rdt_ref(self, refs):
+        if not hasattr(self, "_borrowed_rdt_refs"):
+            self._borrowed_rdt_refs = []
+        self._borrowed_rdt_refs.append(refs[0])
+        obj_id = refs[0].hex()
+        rdt_manager = ray._private.worker.global_worker.rdt_manager
+        return obj_id, rdt_manager.is_managed_object(obj_id)
+
+    def release_one_borrowed_rdt_ref(self):
+        ref = self._borrowed_rdt_refs.pop()
+        obj_id = ref.hex()
+        del ref
+        return ray._private.worker.global_worker.rdt_manager.is_managed_object(obj_id)
+
+    def release_borrowed_rdt_refs(self):
+        obj_id = self._borrowed_rdt_refs[0].hex()
+        del self._borrowed_rdt_refs
+        return obj_id
+
+    def has_rdt_metadata(self, obj_id):
+        return ray._private.worker.global_worker.rdt_manager.is_managed_object(obj_id)
+
     def fail(self, error_message):
         raise Exception(error_message)
 
@@ -146,6 +168,45 @@ def test_gc_rdt_metadata(ray_start_regular):
     wait_for_condition(
         lambda: not rdt_manager.is_managed_object(rdt_ref_id),
     )
+
+
+def test_gc_borrowed_rdt_metadata(ray_start_regular):
+    actors = [GPUTestActor.remote() for _ in range(2)]
+    create_collective_group(actors, backend="gloo")
+
+    tensor = torch.randn((100, 100))
+    ref = actors[0].echo.remote(tensor)
+    rdt_ref_id = ref.hex()
+    rdt_manager = ray._private.worker.global_worker.rdt_manager
+    wait_for_condition(
+        lambda: rdt_manager.get_rdt_metadata(rdt_ref_id).tensor_transport_meta
+        is not None,
+    )
+    # The driver owns this ref, so the borrower-only callback must not be
+    # registered on the owner lifecycle path.
+    assert not ray._private.worker.global_worker.core_worker.add_borrowed_object_out_of_scope_callback(
+        ref, lambda _: None
+    )
+
+    for _ in range(2):
+        borrowed_id, has_metadata = ray.get(
+            actors[1].retain_borrowed_rdt_ref.remote([ref])
+        )
+        assert borrowed_id == rdt_ref_id
+        assert has_metadata
+
+    # Releasing one independently deserialized ref must not remove metadata
+    # while another ref remains live in the borrowing process.
+    assert ray.get(actors[1].release_one_borrowed_rdt_ref.remote())
+    assert ray.get(actors[1].has_rdt_metadata.remote(rdt_ref_id))
+
+    # The borrower's metadata should be removed after its final local reference
+    # goes out of scope, without affecting the owner's copy on the driver.
+    assert ray.get(actors[1].release_borrowed_rdt_refs.remote()) == rdt_ref_id
+    wait_for_condition(
+        lambda: not ray.get(actors[1].has_rdt_metadata.remote(rdt_ref_id)),
+    )
+    assert rdt_manager.is_managed_object(rdt_ref_id)
 
 
 @pytest.mark.parametrize("data_size_bytes", [100])


### PR DESCRIPTION
## Description

Borrowed RDT `ObjectRef`s register transport metadata in every borrowing process, but only the owner's metadata was released. This retained borrower-local `RDTMeta`, including its source actor handle, after the borrower's references left scope.

This PR registers a borrower-only callback with Ray Core's existing aggregate reference counter. The callback removes process-local RDT metadata only after the final borrowed reference leaves scope. Owner-side primary-copy cleanup remains unchanged, and repeated callback registrations are safe because removal is idempotent.

The regression test deserializes the same RDT ref twice in a borrowing actor. It verifies that releasing one reference preserves metadata, releasing the final reference removes borrower metadata, and neither path removes the owner's metadata.

## Related issues

Fixes #61096

## Additional information

Duplicate/ownership check on 2026-08-31: #61096 was open, unassigned, and had no comments. #57671 implemented owner-side GC and left borrower cleanup as follow-up; searches for `borrower RDT`, `GC RDT metadata`, and `61096` found no semantic duplicate PR.

Validation at exact base `3281306dd05f033016e152339137760c0b14c524`:

- Exact-base A/B with the final regression test: the base timed out waiting 10 seconds for final borrower metadata cleanup; the patch passed.
- `../venv/bin/python -m pytest -q python/ray/tests/rdt/test_rdt_gloo.py::test_gc_borrowed_rdt_metadata` (repository-pinned `pytest==7.4.4`): `1 passed`.
- `../venv/bin/python -m pytest -q python/ray/tests/rdt/test_rdt_gloo.py`: `40 passed, 4 skipped`.
- `../venv/bin/python -m pytest -sv python/ray/tests/rdt/test_rdt_gloo.py::test_gc_rdt_metadata python/ray/tests/rdt/test_rdt_gloo.py::test_gc_borrowed_rdt_metadata python/ray/tests/test_object_out_of_scope_callback.py`: `5 passed`.
- The targeted regression passed in three consecutive runs.
- `uvx ruff==0.8.4 check python/ray/_private/serialization.py python/ray/experimental/rdt/rdt_manager.py python/ray/tests/rdt/test_rdt_gloo.py`: passed.
- `uvx --python 3.12 black==22.10.0 --check python/ray/_private/serialization.py python/ray/experimental/rdt/rdt_manager.py python/ray/tests/rdt/test_rdt_gloo.py`: passed.
- `git diff --check`: passed.
- The modified Cython extension was built from source on macOS arm64 with Python 3.14.7 and exercised by the tests above. This Core reference-lifecycle claim is transport-independent, so Gloo CPU multi-process actors provide the relevant coverage; no GPU was used.

AI assistance disclosure: I used an AI coding assistant to help investigate the issue, implement the change, and draft tests. I reviewed every changed line, ran the exact-base A/B validation and the listed checks, and take responsibility for the patch.
