### PR TITLE
[ci] Add a script to cut a Ray release branch

### DIFF
--- a/ci/ray_ci/automation/BUILD.bazel
+++ b/ci/ray_ci/automation/BUILD.bazel
@@ -100,6 +100,38 @@ py_binary(
 )
 
 py_library(
+    name = "cut_release_branch_lib",
+    srcs = ["cut_release_branch_lib.py"],
+    visibility = ["//ci/ray_ci/automation:__subpackages__"],
+    deps = [],
+)
+
+py_test(
+    name = "test_cut_release_branch_lib",
+    size = "small",
+    srcs = ["test_cut_release_branch_lib.py"],
+    exec_compatible_with = ["//bazel:py3"],
+    tags = [
+        "ci_unit",
+        "team:ci",
+    ],
+    deps = [
+        ci_require("pytest"),
+        ":cut_release_branch_lib",
+    ],
+)
+
+py_binary(
+    name = "cut_release_branch",
+    srcs = ["cut_release_branch.py"],
+    exec_compatible_with = ["//bazel:py3"],
+    deps = [
+        ci_require("click"),
+        ":cut_release_branch_lib",
+    ],
+)
+
+py_library(
     name = "crane_lib",
     srcs = ["crane_lib.py"],
     data = [

--- a/ci/ray_ci/automation/cut_release_branch.py
+++ b/ci/ray_ci/automation/cut_release_branch.py
@@ -1,0 +1,81 @@
+import os
+from typing import Optional
+
+import click
+
+from ci.ray_ci.automation.cut_release_branch_lib import (
+    assert_branch_absent,
+    assert_clean_worktree,
+    assert_commit_exists,
+    commit_version_bump,
+    create_branch,
+    get_release_branch_name,
+    push_branch,
+    update_version,
+    validate_version,
+)
+
+
+@click.command()
+@click.option("--ray_version", required=True, type=str, help="Release version, X.Y.Z.")
+@click.option(
+    "--commit", required=True, type=str, help="Commit to cut the release branch from."
+)
+@click.option(
+    "--root_dir",
+    required=False,
+    type=str,
+    help="Ray repository to cut the branch in. Defaults to the Bazel workspace.",
+)
+@click.option("--remote", default="origin", type=str, help="Remote to check and push.")
+@click.option(
+    "--push/--no-push",
+    default=False,
+    help="Push the branch to the remote. Off by default.",
+)
+@click.option(
+    "--dry_run", is_flag=True, default=False, help="Print the steps without running."
+)
+def main(
+    ray_version: str,
+    commit: str,
+    root_dir: Optional[str],
+    remote: str,
+    push: bool,
+    dry_run: bool,
+):
+    """
+    Cut a Ray release branch from a commit and set the version on it.
+
+    Creates releases/<ray_version> at <commit>, runs update_version so the tree
+    carries <ray_version>, and commits that. The branch is only pushed with
+    --push.
+    """
+    if not root_dir:
+        root_dir = os.environ.get("BUILD_WORKSPACE_DIRECTORY")
+        if not root_dir:
+            raise Exception("Please specify --root_dir when not running with Bazel.")
+
+    validate_version(ray_version)
+    branch = get_release_branch_name(ray_version)
+
+    assert_clean_worktree(root_dir)
+    full_commit = assert_commit_exists(root_dir, commit)
+    assert_branch_absent(root_dir, branch, remote)
+
+    click.echo(f"Cutting {branch} from {full_commit} in {root_dir}")
+    create_branch(root_dir, branch, full_commit, dry_run)
+    update_version(root_dir, ray_version, dry_run)
+    commit_version_bump(root_dir, ray_version, full_commit, dry_run)
+
+    if push:
+        push_branch(root_dir, branch, remote, dry_run)
+        click.echo(f"Pushed {branch} to {remote}.")
+    else:
+        click.echo(
+            f"Created {branch} locally. Push it with: git push {remote} {branch}"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/ci/ray_ci/automation/cut_release_branch_lib.py
+++ b/ci/ray_ci/automation/cut_release_branch_lib.py
@@ -1,0 +1,158 @@
+import re
+import subprocess
+from typing import List, Optional
+
+RELEASE_BRANCH_PREFIX = "releases/"
+
+# Release versions are plain X.Y.Z. Release candidates and dev versions are not
+# cut as release branches, so they are rejected rather than silently accepted.
+VERSION_PATTERN = re.compile(r"^\d+\.\d+\.\d+$")
+
+
+def validate_version(version: str) -> None:
+    """
+    Raise if the version is not a X.Y.Z release version.
+    """
+    if not VERSION_PATTERN.match(version):
+        raise ValueError(
+            f"Invalid Ray version: {version}. Expected a release version of the "
+            "form X.Y.Z, for example 2.59.0."
+        )
+
+
+def get_release_branch_name(version: str) -> str:
+    """
+    Return the release branch name for a Ray version.
+    """
+    validate_version(version)
+    return f"{RELEASE_BRANCH_PREFIX}{version}"
+
+
+def get_update_version_command(version: str) -> List[str]:
+    """
+    Return the command that updates the Ray version in the tree.
+    """
+    # TODO(elliot-barn): Remove the Bazel indirection and call
+    # update_version_lib.update_file_version() in process. update_version is
+    # invoked as a Bazel target for now so that this script updates the version
+    # exactly the way the release process already does, rather than
+    # reimplementing which files carry a version.
+    return [
+        "bazel",
+        "run",
+        "//ci/ray_ci/automation:update_version",
+        "--",
+        f"--new_version={version}",
+    ]
+
+
+def get_commit_message(version: str, commit: str) -> str:
+    """
+    Return the message for the version bump commit on the release branch.
+    """
+    return f"[release] Cut {get_release_branch_name(version)} from {commit}"
+
+
+def run_command(
+    command: List[str],
+    cwd: str,
+    dry_run: bool = False,
+    capture: bool = True,
+) -> str:
+    """
+    Run a command in cwd and return its stdout. Skipped when dry_run is set,
+    unless the command only reads state (capture and read-only callers pass
+    dry_run=False explicitly).
+    """
+    if dry_run:
+        print(f"[dry-run] {' '.join(command)}")
+        return ""
+    if capture:
+        return subprocess.check_output(command, cwd=cwd, text=True).strip()
+    subprocess.check_call(command, cwd=cwd)
+    return ""
+
+
+def git(args: List[str], cwd: str, dry_run: bool = False) -> str:
+    return run_command(["git"] + args, cwd=cwd, dry_run=dry_run)
+
+
+def assert_clean_worktree(repo_dir: str) -> None:
+    """
+    Refuse to run against a dirty tree, so the version bump commit cannot pick
+    up unrelated local changes.
+    """
+    status = git(["status", "--porcelain"], cwd=repo_dir)
+    if status:
+        raise RuntimeError(
+            "The working tree has uncommitted changes; commit or stash them "
+            f"before cutting a release branch:\n{status}"
+        )
+
+
+def assert_commit_exists(repo_dir: str, commit: str) -> str:
+    """
+    Return the full sha of commit, raising if it is not a commit in this repo.
+    """
+    try:
+        return git(["rev-parse", "--verify", f"{commit}^{{commit}}"], cwd=repo_dir)
+    except subprocess.CalledProcessError:
+        raise RuntimeError(f"Commit {commit} does not exist in {repo_dir}.")
+
+
+def assert_branch_absent(repo_dir: str, branch: str, remote: Optional[str]) -> None:
+    """
+    Raise if the release branch already exists locally or on the remote, so an
+    existing release branch is never moved.
+    """
+    local = subprocess.run(
+        ["git", "rev-parse", "--verify", "--quiet", f"refs/heads/{branch}"],
+        cwd=repo_dir,
+        capture_output=True,
+        text=True,
+    )
+    if local.returncode == 0:
+        raise RuntimeError(f"Branch {branch} already exists locally.")
+
+    if remote:
+        remote_refs = git(["ls-remote", "--heads", remote, branch], cwd=repo_dir)
+        if remote_refs:
+            raise RuntimeError(f"Branch {branch} already exists on {remote}.")
+
+
+def create_branch(repo_dir: str, branch: str, commit: str, dry_run: bool) -> None:
+    git(["checkout", "-b", branch, commit], cwd=repo_dir, dry_run=dry_run)
+
+
+def update_version(repo_dir: str, version: str, dry_run: bool) -> None:
+    run_command(
+        get_update_version_command(version),
+        cwd=repo_dir,
+        dry_run=dry_run,
+        capture=False,
+    )
+
+
+def commit_version_bump(
+    repo_dir: str, version: str, commit: str, dry_run: bool
+) -> None:
+    """
+    Commit whatever update_version changed. Raises if it changed nothing, which
+    means the tree was already at this version.
+    """
+    if not dry_run:
+        changed = git(["status", "--porcelain"], cwd=repo_dir)
+        if not changed:
+            raise RuntimeError(
+                f"update_version made no changes; is the tree already at {version}?"
+            )
+    git(["add", "-A"], cwd=repo_dir, dry_run=dry_run)
+    git(
+        ["commit", "-s", "-m", get_commit_message(version, commit)],
+        cwd=repo_dir,
+        dry_run=dry_run,
+    )
+
+
+def push_branch(repo_dir: str, branch: str, remote: str, dry_run: bool) -> None:
+    git(["push", "--set-upstream", remote, branch], cwd=repo_dir, dry_run=dry_run)

--- a/ci/ray_ci/automation/test_cut_release_branch_lib.py
+++ b/ci/ray_ci/automation/test_cut_release_branch_lib.py
@@ -1,0 +1,54 @@
+import sys
+
+import pytest
+
+from ci.ray_ci.automation.cut_release_branch_lib import (
+    get_commit_message,
+    get_release_branch_name,
+    get_update_version_command,
+    validate_version,
+)
+
+
+@pytest.mark.parametrize("version", ["2.59.0", "3.0.0", "10.20.30"])
+def test_validate_version_accepts_release_versions(version):
+    validate_version(version)
+
+
+@pytest.mark.parametrize(
+    "version",
+    ["2.59", "2.59.0rc0", "2.59.0.dev0", "v2.59.0", "", "releases/2.59.0"],
+)
+def test_validate_version_rejects_non_release_versions(version):
+    with pytest.raises(ValueError):
+        validate_version(version)
+
+
+def test_get_release_branch_name():
+    assert get_release_branch_name("2.59.0") == "releases/2.59.0"
+
+
+def test_get_release_branch_name_validates():
+    with pytest.raises(ValueError):
+        get_release_branch_name("2.59.0rc0")
+
+
+def test_get_update_version_command():
+    assert get_update_version_command("2.59.0") == [
+        "bazel",
+        "run",
+        "//ci/ray_ci/automation:update_version",
+        "--",
+        "--new_version=2.59.0",
+    ]
+
+
+def test_get_commit_message():
+    assert (
+        get_commit_message("2.59.0", "abc123")
+        == "[release] Cut releases/2.59.0 from abc123"
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-vv", __file__]))


### PR DESCRIPTION
## What

Adds `//ci/ray_ci/automation:cut_release_branch`, which cuts a Ray release branch from a chosen commit and sets the version on it.

```bash
bazel run //ci/ray_ci/automation:cut_release_branch -- \
    --ray_version 2.59.0 --commit <sha>
```

It creates `releases/2.59.0` at `<sha>`, runs `update_version` so the tree carries the new version, and commits the result. `--push` pushes the branch (off by default), `--dry_run` prints the steps without running them, `--remote` selects the remote to check against and push to.

Layout follows `update_version`'s: `cut_release_branch_lib.py` for the logic, `cut_release_branch.py` for the click entrypoint, `test_cut_release_branch_lib.py` for unit tests, and `py_library` / `py_binary` / `py_test` targets in the same BUILD file.

## Why

Cutting a release branch is a manual sequence today — branch from a commit, run `update_version`, commit — with no checks around it. The steps themselves are simple; the risk is in the ordering and in the states you must not be in when you run them.

## Guards

A release branch is something other people build releases from, so the script refuses rather than guesses:

- **Dirty working tree** — otherwise the version bump commit silently absorbs unrelated local changes.
- **Unknown commit** — `--commit` is resolved with `rev-parse --verify` before anything is created.
- **Branch already exists**, locally *or on the remote* — so an existing release branch can never be moved.
- **`update_version` changed nothing** — which would mean the tree was already at that version.
- **Non-release versions** — `2.59.0rc0`, `2.59`, `v2.59.0` are rejected; release branches are cut for `X.Y.Z`.

`--push` is opt-in. Cutting the branch locally is reversible; pushing `releases/X.Y.Z` is effectively not, because CI and downstream tooling key off it immediately.

## On calling update_version through Bazel

`update_version` is invoked as a Bazel target rather than imported:

```python
# TODO(elliot-barn): Remove the Bazel indirection and call
# update_version_lib.update_file_version() in process. update_version is
# invoked as a Bazel target for now so that this script updates the version
# exactly the way the release process already does, rather than
# reimplementing which files carry a version.
```

Keeping it as the existing target means there is one definition of which files carry a version, and this script cannot drift from it. The TODO is to drop the indirection later.

## Testing

Unit tests:

```
$ bazel test //ci/ray_ci/automation:test_cut_release_branch_lib
  //ci/ray_ci/automation:test_cut_release_branch_lib   PASSED in 1.5s
  Executed 1 out of 1 test: 1 test passes.

$ python -m pytest ci/ray_ci/automation/test_cut_release_branch_lib.py -q
  13 passed
```

End to end, cutting a throwaway `releases/2.99.0` from HEAD — the Bazel `update_version` call updated all 10 version-carrying files:

```
[release] Cut releases/2.99.0 from 46ac12487967c2dbf65625e78a43bb58ce7d49ec

  python/ray/_version.py        -version = "3.0.0.dev0"   → +version = "2.99.0"
  rayci.env                     -RAY_VERSION=3.0.0.dev0   → +RAY_VERSION=2.99.0
  ci/ray_ci/utils.py, src/ray/common/constants.h
  java/pom.xml + 5 × pom_template.xml
  10 files changed, 11 insertions(+), 11 deletions(-)
```

That branch was deleted afterwards; nothing was pushed. Both guards were also confirmed firing: the dirty-tree check refused a run with uncommitted files, and `--ray_version 2.99.0rc0` was rejected by validation.

## Not a duplicate

`gh pr list --state all --search "cut_release_branch"` returns nothing, and no open PR touches `ci/ray_ci/automation/update_version*` or adds release-branch tooling.

## AI assistance

AI assistance was used to write the script and its tests, and to run the verification above. Every changed line was reviewed and every command and output quoted here was run and confirmed.
