### PR TITLE
[serve.llm] support oci:// model sources via llmman serve

### DIFF
--- a/python/ray/llm/_internal/common/utils/llmman_utils.py
+++ b/python/ray/llm/_internal/common/utils/llmman_utils.py
@@ -1,0 +1,271 @@
+"""Client for a running ``llmman serve`` daemon.
+
+Used to acquire models published as CNCF ModelPack
+(https://github.com/modelpack/model-spec) OCI artifacts. The daemon owns the
+registry work -- ModelPack media types, registry auth, resumable blob download
+and a content-addressed store -- so it is not reimplemented here.
+
+Contract (from llmman's src/cmd/serve.rs and src/daemon.rs):
+  - LLMMAN_HOST is ``[scheme://]host[:port][/path]``, default 127.0.0.1:17434.
+    A wildcard bind host (0.0.0.0, ::) is rewritten to loopback, since a client
+    cannot connect to "every interface".
+  - ``GET /api/version`` -> ``{"version":..., "exe":..., "pid":...}``.
+  - ``POST /api/pull`` ``{"model": ref}`` -> NDJSON stream of ``{"status":...}``
+    objects, terminated by ``{"status":"success"}`` or ``{"error":"..."}``.
+    An error can arrive in-band at HTTP 200.
+  - ``llmman resolve --no-pull <ref>`` -> one line of JSON carrying ``path``.
+"""
+
+import ipaddress
+import json
+import logging
+import os
+import shutil
+import subprocess
+import urllib.error
+import urllib.request
+
+logger = logging.getLogger(__name__)
+
+HOST_ENV = "LLMMAN_HOST"
+BIN_ENV = "RAY_LLMMAN_BIN"
+
+DEFAULT_HOST = "127.0.0.1"
+DEFAULT_PORT = 17434
+
+PROBE_TIMEOUT_SECONDS = 5
+
+
+def _connectable_host(host: str) -> str:
+    """Rewrite a wildcard bind host to its loopback equivalent."""
+    try:
+        ip = ipaddress.ip_address(host.strip("[]"))
+    except ValueError:
+        return host
+    if not ip.is_unspecified:
+        return host
+    return "127.0.0.1" if ip.version == 4 else "::1"
+
+
+def endpoint() -> str:
+    """The http origin of the llmman daemon, honouring LLMMAN_HOST."""
+    raw = os.getenv(HOST_ENV, "").strip().strip("\"'")
+    if not raw:
+        return f"http://{DEFAULT_HOST}:{DEFAULT_PORT}"
+
+    if "://" in raw:
+        raw = raw.split("://", 1)[1]
+    raw = raw.split("/", 1)[0]
+
+    host, port = raw, DEFAULT_PORT
+    if raw.startswith("["):  # bracketed IPv6, optionally with :port
+        close = raw.find("]")
+        if close != -1:
+            host = raw[: close + 1]
+            rest = raw[close + 1 :]
+            if rest.startswith(":") and rest[1:].isdigit():
+                port = int(rest[1:])
+    elif raw.count(":") == 1:
+        maybe_host, maybe_port = raw.rsplit(":", 1)
+        if maybe_port.isdigit():
+            host, port = maybe_host, int(maybe_port)
+
+    host = host or DEFAULT_HOST
+    resolved = _connectable_host(host)
+    if ":" in resolved and not resolved.startswith("["):
+        resolved = f"[{resolved}]"
+    return f"http://{resolved}:{port}"
+
+
+def llmman_bin() -> str:
+    """The llmman executable name, overridable per project."""
+    return os.getenv(BIN_ENV, "").strip() or "llmman"
+
+
+def check_daemon(base: str) -> None:
+    """Confirm an llmman daemon is listening and is actually llmman."""
+    url = base + "/api/version"
+    try:
+        with urllib.request.urlopen(url, timeout=PROBE_TIMEOUT_SECONDS) as resp:
+            if resp.status != 200:
+                raise RuntimeError(
+                    f"llmman daemon at {base} answered /api/version with HTTP {resp.status}"
+                )
+            payload = json.loads(resp.read().decode("utf-8"))
+    except urllib.error.URLError as exc:
+        raise RuntimeError(
+            f"no llmman daemon reachable at {base} ({exc.reason}). Start one with "
+            f"`llmman serve`, or point {HOST_ENV} at an existing daemon."
+        ) from exc
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(
+            f"the server at {base} is not an llmman daemon (unparseable /api/version)"
+        ) from exc
+
+    if not isinstance(payload, dict) or not payload.get("version"):
+        raise RuntimeError(
+            f"the server at {base} is not an llmman daemon (no version in /api/version)"
+        )
+
+
+def pull(base: str, reference: str, progress=None) -> None:
+    """Stream POST /api/pull until the daemon reports success.
+
+    ``progress`` receives ``(status, completed, total)``. An error can arrive
+    in-band at HTTP 200, and a stream that ends without ``success`` is also a
+    failure -- neither is treated as a completed pull.
+    """
+    body = json.dumps({"model": reference}).encode("utf-8")
+    req = urllib.request.Request(
+        base + "/api/pull",
+        data=body,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+
+    succeeded = False
+    try:
+        with urllib.request.urlopen(req) as resp:
+            if resp.status != 200:
+                raise RuntimeError(
+                    f"llmman pull of {reference!r} failed: HTTP {resp.status}"
+                )
+            for raw_line in resp:
+                line = raw_line.decode("utf-8").strip()
+                if not line:
+                    continue
+                try:
+                    obj = json.loads(line)
+                except json.JSONDecodeError:
+                    # Tolerate a non-JSON diagnostic rather than aborting a
+                    # pull that may still be progressing.
+                    continue
+                if not isinstance(obj, dict):
+                    continue
+                if obj.get("error"):
+                    raise RuntimeError(
+                        f"llmman pull of {reference!r} failed: {obj['error']}"
+                    )
+                status = obj.get("status")
+                if status == "success":
+                    succeeded = True
+                    continue
+                if progress is not None and status:
+                    progress(status, obj.get("completed", 0), obj.get("total", 0))
+    except urllib.error.HTTPError as exc:
+        raise RuntimeError(
+            f"llmman pull of {reference!r} failed: HTTP {exc.code}"
+        ) from exc
+    except urllib.error.URLError as exc:
+        raise RuntimeError(
+            f"llmman pull of {reference!r} failed: {exc.reason}"
+        ) from exc
+
+    if not succeeded:
+        raise RuntimeError(
+            f"llmman pull of {reference!r} ended without reporting success"
+        )
+
+
+def parse_resolve_output(stdout: str, reference: str) -> str:
+    """Parse ``llmman resolve`` stdout into the resolved local path."""
+    lines = [line.strip() for line in stdout.splitlines() if line.strip()]
+    if not lines:
+        raise RuntimeError(f"llmman resolve {reference!r}: no output on stdout")
+
+    try:
+        payload = json.loads(lines[-1])
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(
+            f"llmman resolve {reference!r}: could not parse output as JSON: {lines[-1]}"
+        ) from exc
+
+    if not isinstance(payload, dict):
+        raise RuntimeError(
+            f"llmman resolve {reference!r}: expected a JSON object, got {lines[-1]}"
+        )
+
+    path = payload.get("path")
+    if not isinstance(path, str) or not path.strip():
+        raise RuntimeError(f"llmman resolve {reference!r}: returned an empty path")
+    if not os.path.exists(path):
+        raise RuntimeError(
+            f"llmman resolve {reference!r}: reported path {path!r} does not exist"
+        )
+    return path
+
+
+def resolve(reference: str) -> str:
+    """Ask the CLI where the daemon's pull left the model on disk.
+
+    ``--no-pull`` guarantees this only reports on bytes ``/api/pull`` already
+    fetched, so the daemon stays the only thing that touches the network.
+    """
+    binary = llmman_bin()
+    if shutil.which(binary) is None and not os.path.isfile(binary):
+        raise RuntimeError(
+            f"{binary!r} not found. Install llmman "
+            "(https://github.com/llmmanorg/llmman) and put it on PATH, or set "
+            f"{BIN_ENV} to its location."
+        )
+
+    completed = subprocess.run(
+        [binary, "resolve", "--no-pull", reference],
+        capture_output=True,
+        stdin=subprocess.DEVNULL,
+        text=True,
+        check=False,
+    )
+    if completed.returncode != 0:
+        raise RuntimeError(
+            f"`{binary} resolve --no-pull {reference}` failed with exit code "
+            f"{completed.returncode}: {completed.stderr.strip()}"
+        )
+    return parse_resolve_output(completed.stdout, reference)
+
+
+def pull_and_resolve(reference: str, progress=None) -> str:
+    """Full acquisition: probe the daemon, pull through it, report the path."""
+    base = endpoint()
+    check_daemon(base)
+    logger.info("Pulling %s via llmman daemon at %s", reference, base)
+    pull(base, reference, progress)
+    return resolve(reference)
+
+
+SCHEME = "oci://"
+
+
+def is_oci_path(path) -> bool:
+    """Whether ``path`` carries the ``oci://`` scheme.
+
+    An explicit scheme is required rather than sniffing a bare
+    ``registry/name:tag``: that shape is indistinguishable from a HuggingFace
+    repo id, so guessing would silently hijack existing model_source values.
+    """
+    if not path:
+        return False
+    return str(path).lower().startswith(SCHEME)
+
+
+def strip_scheme(path) -> str:
+    """Drop the ``oci://`` prefix, leaving the bare registry reference."""
+    text = str(path)
+    if is_oci_path(text):
+        return text[len(SCHEME) :]
+    return text
+
+
+def resolve_oci_model(path) -> str:
+    """Pull an ``oci://`` reference through llmman and return the local path."""
+    reference = strip_scheme(path).strip()
+    if not reference:
+        raise ValueError(f"empty OCI model reference: {path!r}")
+
+    def _progress(status, completed, total):
+        if total:
+            logger.info("llmman: %s (%s/%s bytes)", status, completed, total)
+        else:
+            logger.info("llmman: %s", status)
+
+    return pull_and_resolve(reference, progress=_progress)

--- a/python/ray/llm/_internal/serve/core/configs/llm_config.py
+++ b/python/ray/llm/_internal/serve/core/configs/llm_config.py
@@ -132,8 +132,8 @@ class ModelLoadingConfig(BaseModelExtended):
         description=(
             "Where to obtain the model weights from. "
             "Should be a HuggingFace model ID, S3 mirror config, GCS mirror config, "
-            "or a local path. When omitted, defaults to the model_id as a "
-            "HuggingFace model ID."
+            "an oci:// reference to a CNCF ModelPack artifact, or a local path. "
+            "When omitted, defaults to the model_id as a HuggingFace model ID."
         ),
     )
     tokenizer_source: Optional[str] = Field(

--- a/python/ray/llm/_internal/serve/engines/vllm/vllm_models.py
+++ b/python/ray/llm/_internal/serve/engines/vllm/vllm_models.py
@@ -9,6 +9,7 @@ from vllm.entrypoints.openai.cli_args import FrontendArgs
 from ray.llm._internal.common.base_pydantic import BaseModelExtended
 from ray.llm._internal.common.placement import PlacementGroupConfig
 from ray.llm._internal.common.utils.cloud_utils import CloudMirrorConfig, is_remote_path
+from ray.llm._internal.common.utils.llmman_utils import is_oci_path, resolve_oci_model
 from ray.llm._internal.common.utils.import_utils import try_import
 from ray.llm._internal.serve.constants import (
     ALLOW_NEW_PLACEMENT_GROUPS_IN_DEPLOYMENT,
@@ -193,7 +194,12 @@ class VLLMEngineConfig(BaseModelExtended):
             hf_model_id = llm_config.model_id
         elif isinstance(llm_config.model_loading_config.model_source, str):
             model_source = llm_config.model_loading_config.model_source
-            if is_remote_path(model_source):
+            if is_oci_path(model_source):
+                # A CNCF ModelPack artifact is pulled through an llmman daemon
+                # and extracted; from here it is an ordinary local directory,
+                # so no mirror config is needed and vLLM loads it directly.
+                hf_model_id = resolve_oci_model(model_source)
+            elif is_remote_path(model_source):
                 # Remote URIs (s3://, gs://, …) are download addresses,
                 # not HuggingFace IDs.  Using the URI verbatim as
                 # hf_model_id propagates the scheme and slashes into the
@@ -332,7 +338,7 @@ class VLLMEngineConfig(BaseModelExtended):
 
     @staticmethod
     def _detect_fractional_gpu_from_pg(
-        placement_group_config: Optional[Dict[str, Any]]
+        placement_group_config: Optional[Dict[str, Any]],
     ) -> Optional[float]:
         if not placement_group_config:
             return None

--- a/python/ray/llm/tests/common/test_llmman_utils.py
+++ b/python/ray/llm/tests/common/test_llmman_utils.py
@@ -1,0 +1,197 @@
+"""The `llmman serve` client, and `oci://` model sources.
+
+The daemon protocol is exercised against a real HTTP server on a loopback port
+rather than mocks, so the NDJSON streaming contract is genuinely tested.
+"""
+
+import http.server
+import json
+import socketserver
+import sys
+import tempfile
+import threading
+
+import pytest
+
+from ray.llm._internal.common.utils import llmman_utils as llmman
+
+
+def _ndjson(*objs):
+    return "".join(json.dumps(o) + "\n" for o in objs)
+
+
+class _FakeDaemon:
+    """A minimal stand-in for `llmman serve`, on a real loopback port."""
+
+    def __init__(self):
+        self.version = {"version": "0.1.0", "pid": 1}
+        self.pull_body = _ndjson({"status": "success"})
+        self.pull_status = 200
+        self.last_request = None
+        daemon = self
+
+        class Handler(http.server.BaseHTTPRequestHandler):
+            def log_message(self, *args):
+                pass
+
+            def _send(self, status, body, ctype):
+                raw = body.encode()
+                self.send_response(status)
+                self.send_header("Content-Type", ctype)
+                self.send_header("Content-Length", str(len(raw)))
+                self.end_headers()
+                self.wfile.write(raw)
+
+            def do_GET(self):
+                self._send(200, json.dumps(daemon.version), "application/json")
+
+            def do_POST(self):
+                length = int(self.headers.get("Content-Length", 0))
+                daemon.last_request = json.loads(self.rfile.read(length))
+                self._send(daemon.pull_status, daemon.pull_body, "application/x-ndjson")
+
+        self._server = socketserver.TCPServer(("127.0.0.1", 0), Handler)
+        self.url = f"http://127.0.0.1:{self._server.server_address[1]}"
+        threading.Thread(target=self._server.serve_forever, daemon=True).start()
+
+    def close(self):
+        self._server.shutdown()
+        self._server.server_close()
+
+
+@pytest.fixture
+def daemon():
+    d = _FakeDaemon()
+    yield d
+    d.close()
+
+
+def test_accepts_a_llmman_daemon(daemon):
+    llmman.check_daemon(daemon.url)
+
+
+def test_rejects_a_non_llmman_server(daemon):
+    daemon.version = {"hello": "world"}
+    with pytest.raises(RuntimeError, match="not an llmman daemon"):
+        llmman.check_daemon(daemon.url)
+
+
+def test_reports_nothing_listening_actionably():
+    with pytest.raises(RuntimeError, match="llmman serve"):
+        llmman.check_daemon("http://127.0.0.1:1")
+
+
+def test_pull_succeeds_and_forwards_progress(daemon):
+    daemon.pull_body = _ndjson(
+        {"status": "pulling manifest"},
+        {"status": "pulling blobs", "completed": 50, "total": 100},
+        {"status": "success"},
+    )
+    seen = []
+    llmman.pull(daemon.url, "ghcr.io/org/model:tag", lambda *a: seen.append(a))
+
+    assert daemon.last_request == {"model": "ghcr.io/org/model:tag"}
+    assert seen == [("pulling manifest", 0, 0), ("pulling blobs", 50, 100)]
+
+
+def test_reports_an_in_band_error_at_http_200(daemon):
+    # The daemon streams errors in-band, so a 200 does not mean success.
+    daemon.pull_body = _ndjson({"status": "pulling"}, {"error": "unauthorized"})
+    with pytest.raises(RuntimeError, match="unauthorized"):
+        llmman.pull(daemon.url, "ref")
+
+
+def test_rejects_a_stream_that_ends_without_success(daemon):
+    daemon.pull_body = _ndjson({"status": "pulling blobs"})
+    with pytest.raises(RuntimeError, match="without reporting success"):
+        llmman.pull(daemon.url, "ref")
+
+
+def test_reports_a_non_ok_status(daemon):
+    daemon.pull_status = 400
+    daemon.pull_body = '{"error":"bad request"}'
+    with pytest.raises(RuntimeError):
+        llmman.pull(daemon.url, "ref")
+
+
+def test_tolerates_a_non_json_diagnostic_line(daemon):
+    daemon.pull_body = "not json\n" + _ndjson({"status": "success"})
+    llmman.pull(daemon.url, "ref")
+
+
+def test_recognizes_the_oci_scheme():
+    assert llmman.is_oci_path("oci://ghcr.io/org/model:tag")
+    assert llmman.is_oci_path("OCI://ghcr.io/org/model:tag")
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "meta-llama/Llama-3-8B",
+        "ghcr.io/org/model:tag",
+        "s3://bucket/key",
+        "gs://bucket/key",
+        "/local/path/to/model",
+        "",
+        None,
+    ],
+)
+def test_leaves_every_other_source_alone(value):
+    # HF repo ids and cloud mirror URIs must never be claimed.
+    assert not llmman.is_oci_path(value)
+
+
+def test_strips_the_scheme_only_when_present():
+    assert llmman.strip_scheme("oci://ghcr.io/org/model:tag") == "ghcr.io/org/model:tag"
+    assert llmman.strip_scheme("meta-llama/Llama-3-8B") == "meta-llama/Llama-3-8B"
+
+
+@pytest.mark.parametrize("ref", ["oci://", "oci://   "])
+def test_rejects_an_empty_reference(ref):
+    with pytest.raises(ValueError):
+        llmman.resolve_oci_model(ref)
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        "",
+        "   \n\n",
+        "not json",
+        '["a", "list"]',
+        '{"no_path": 1}',
+        '{"path": ""}',
+        '{"path": "/nonexistent/xyzzy"}',
+    ],
+)
+def test_rejects_malformed_resolve_output(bad):
+    with pytest.raises(RuntimeError):
+        llmman.parse_resolve_output(bad, "ref")
+
+
+def test_parses_the_resolve_contract():
+    with tempfile.TemporaryDirectory() as path:
+        line = json.dumps({"reference": "r", "path": path, "format": "safetensors"})
+        assert llmman.parse_resolve_output(line, "r") == path
+        # A leaked diagnostic must not break resolution.
+        assert llmman.parse_resolve_output(f"pulling...\n{line}\n", "r") == path
+
+
+@pytest.mark.parametrize(
+    "host,want",
+    [
+        ("", "http://127.0.0.1:17434"),
+        ("1.2.3.4:9999", "http://1.2.3.4:9999"),
+        ("1.2.3.4", "http://1.2.3.4:17434"),
+        # A wildcard bind is meaningful to the server but not to a client.
+        ("0.0.0.0:9999", "http://127.0.0.1:9999"),
+        ("[::]:9999", "http://[::1]:9999"),
+    ],
+)
+def test_endpoint_parsing(monkeypatch, host, want):
+    monkeypatch.setenv(llmman.HOST_ENV, host)
+    assert llmman.endpoint() == want
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-v", __file__]))


### PR DESCRIPTION
## Why are these changes needed?

`ModelLoadingConfig.model_source` accepts a HuggingFace id, an S3/GCS mirror config, or a local path. This adds `oci://`, so a model published as a [CNCF ModelPack](https://github.com/modelpack/model-spec) artifact can be served directly:

```yaml
model_loading_config:
  model_id: my-model
  model_source: oci://ghcr.io/org/model:tag
```

Model distribution is increasingly moving to OCI registries -- the same registries, credentials, mirroring and air-gap tooling a deployment already uses for container images. Usually easier to run air-gapped than reaching the Hub, and it reuses the registry credentials a Ray cluster already has for its container images.

## Implementation

`VLLMEngineConfig.from_llm_config` is the single dispatch point, and this is one branch there:

```python
if is_oci_path(model_source):
    hf_model_id = resolve_oci_model(model_source)
elif is_remote_path(model_source):
    ...  # unchanged
```

An `oci://` source resolves to a **local directory** used directly as `hf_model_id`, so no `CloudMirrorConfig` is involved and vLLM loads it as it would any local path. The `is_remote_path` branch -- including its cache-directory workaround for `models--s3:----bucket--…` -- is untouched, as are plain HuggingFace ids and explicit `CloudMirrorConfig` sources.

Acquisition is delegated to a running [`llmman serve`](https://github.com/llmmanorg/llmman) rather than hand-rolled: llmman already implements the ModelPack media types, registry auth, resumable blob download and a content-addressed store.

New `ray/llm/_internal/common/utils/llmman_utils.py` is the daemon client, stdlib-only (`urllib`), **no new dependency**:

- `GET /api/version` probes reachability *and* identity -- a server answering without a `version` field is reported as "not an llmman daemon", worth distinguishing from nothing listening.
- `POST /api/pull` streams NDJSON so a multi-gigabyte fetch is not silent. An error arrives **in-band at HTTP 200**, and a stream that ends without `success` is also a failure -- both are errors, not a completed pull.
- `llmman resolve --no-pull` reports where the bytes landed; `--no-pull` keeps the daemon the only thing that touches the network.
- `LLMMAN_HOST` is honoured with llmman's own parsing, including rewriting a wildcard bind (`0.0.0.0`, `[::]`) to loopback.

A pull needs both the daemon reachable and the binary on `PATH` (or `RAY_LLMMAN_BIN`); each missing piece has its own actionable error, and neither is required unless an `oci://` source is used.

**Explicit scheme, no sniffing.** A bare `registry/name:tag` is indistinguishable from a HuggingFace repo id; guessing would silently hijack existing `model_source` values. `s3://` and `gs://` are explicitly not claimed, which the tests pin.

## Related issue number

N/A -- additive feature.

## Checks

- [x] I've signed off every commit (`git commit -s`)
- [x] I've run `scripts/format.sh` equivalents: `black` clean on all four touched files
- [x] I've made sure the tests are passing
- [x] Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(

New `python/ray/llm/tests/common/test_llmman_utils.py`, running against a **real HTTP server on a loopback port** rather than mocks, so the NDJSON contract is genuinely exercised.

```
$ pytest python/ray/llm/tests/common/test_llmman_utils.py
32 passed
```

**All 32 executed here.** Coverage: `/api/version` accepted, a non-llmman server rejected, nothing-listening reported actionably; pull success with forwarded byte progress and the exact request body asserted; in-band error at HTTP 200; a stream ending without `success`; non-OK status; a non-JSON diagnostic tolerated; scheme detection incl. case-insensitivity; that a HF repo id, a bare registry ref, `s3://`, `gs://` and a local path are **not** claimed; `strip_scheme` round-trips; empty reference rejected; the resolve contract plus seven malformed-output cases; every `LLMMAN_HOST` form incl. wildcard-to-loopback.

Not verified here, flagged rather than implied: no end-to-end Serve deployment against a live `llmman serve` backed by a real registry -- that needs vLLM and a GPU. The `from_llm_config` branch itself is covered by inspection rather than execution.

> Disclosure: written with AI assistance.
