### PR TITLE
[Data] Remove `large_string` casting and add projection before aggregation

### DIFF
--- a/release/nightly_tests/dataset/groupby_benchmark.py
+++ b/release/nightly_tests/dataset/groupby_benchmark.py
@@ -77,6 +77,8 @@ def main(args):
 
         if args.aggregate:
             ds = ds.select_columns(list(dict.fromkeys([*args.group_by, "column05"])))
+        else:
+            ds = ds.map_batches(_cast_strings_to_large, batch_format="pyarrow")
         grouped_ds = ds.groupby(args.group_by)
         consume_fn(grouped_ds)
 

--- a/release/nightly_tests/dataset/groupby_benchmark.py
+++ b/release/nightly_tests/dataset/groupby_benchmark.py
@@ -74,11 +74,9 @@ def main(args):
             else None
         )
         ds = ray.data.read_parquet(path, override_num_blocks=override_num_blocks)
-        # Cast string columns to large_string: on low-cardinality keys a single
-        # group's string data can exceed 2GB per column, overflowing Arrow's
-        # int32 string offsets when the shuffle reduce sorts the partition
-        # into one contiguous table.
-        ds = ds.map_batches(_cast_strings_to_large, batch_format="pyarrow")
+
+        if args.aggregate:
+            ds = ds.select_columns(list(dict.fromkeys([*args.group_by, "column05"])))
         grouped_ds = ds.groupby(args.group_by)
         consume_fn(grouped_ds)
 


### PR DESCRIPTION
## Description
As title, we found that the string casting isn't necessary if we do projection first in aggregate groups.  This gives us more focused and accurate benchmark results.

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
