### PR TITLE
[core][runtime_env] Add per-worker container resource limits

### DIFF
--- a/python/ray/_private/runtime_env/agent/runtime_env_agent.py
+++ b/python/ray/_private/runtime_env/agent/runtime_env_agent.py
@@ -19,7 +19,11 @@ from ray._private.ray_logging import setup_component_logger
 from ray._private.runtime_env.conda import CondaPlugin
 from ray._private.runtime_env.context import RuntimeEnvContext
 from ray._private.runtime_env.default_impl import get_image_uri_plugin_cls
-from ray._private.runtime_env.image_uri import ContainerPlugin
+from ray._private.runtime_env.image_uri import (
+    ContainerPlugin,
+    apply_worker_resource_limits,
+    validate_worker_resource_limits_support,
+)
 from ray._private.runtime_env.java_jars import JavaJarsPlugin
 from ray._private.runtime_env.nsight import NsightPlugin
 from ray._private.runtime_env.pip import PipPlugin
@@ -56,6 +60,29 @@ class CreatedEnvResult:
     result: str
     # The time to create a runtime env in ms.
     creation_time_ms: int
+
+
+def _apply_worker_resource_limits(request, serialized_context: str) -> str:
+    limits = request.worker_resource_limits
+    validation_error = getattr(limits, "validation_error", "")
+    if validation_error:
+        raise ValueError(validation_error)
+    if (
+        limits.cpu_period_us == 0
+        and limits.cpu_quota_us == 0
+        and limits.memory_bytes == 0
+    ):
+        return serialized_context
+
+    validate_worker_resource_limits_support()
+    context = RuntimeEnvContext.deserialize(serialized_context)
+    apply_worker_resource_limits(
+        context,
+        limits.cpu_period_us,
+        limits.cpu_quota_us,
+        limits.memory_bytes,
+    )
+    return context.serialize()
 
 
 # e.g., "working_dir"
@@ -625,10 +652,24 @@ class RuntimeEnvAgent:
 
         async with self._env_locks[serialized_env]:
             if serialized_env in self._env_cache:
-                serialized_context = self._env_cache[serialized_env]
                 result = self._env_cache[serialized_env]
                 if result.success:
-                    context = result.result
+                    try:
+                        context = _apply_worker_resource_limits(request, result.result)
+                    except Exception as e:
+                        self._logger.exception(
+                            "Failed to apply per-worker container resource limits."
+                        )
+                        self._reference_table.decrease_reference(
+                            runtime_env, serialized_env, request.source_process
+                        )
+                        error_message = "".join(
+                            traceback.format_exception(type(e), e, e.__traceback__)
+                        )
+                        return runtime_env_agent_pb2.GetOrCreateRuntimeEnvReply(
+                            status=runtime_env_agent_pb2.AGENT_RPC_STATUS_FAILED,
+                            error_message=f"{self._node_prefix}{error_message}",
+                        )
                     self._logger.info(
                         "Runtime env already created "
                         f"successfully. Env: {serialized_env}, "
@@ -690,12 +731,28 @@ class RuntimeEnvAgent:
                 serialized_context if successful else error_message,
                 creation_time_ms,
             )
+            if successful:
+                try:
+                    serialized_context = _apply_worker_resource_limits(
+                        request, serialized_context
+                    )
+                except Exception as e:
+                    self._logger.exception(
+                        "Failed to apply per-worker container resource limits."
+                    )
+                    self._reference_table.decrease_reference(
+                        runtime_env, serialized_env, request.source_process
+                    )
+                    error_message = "".join(
+                        traceback.format_exception(type(e), e, e.__traceback__)
+                    )
+                    successful = False
             # Reply the RPC
             return runtime_env_agent_pb2.GetOrCreateRuntimeEnvReply(
                 status=runtime_env_agent_pb2.AGENT_RPC_STATUS_OK
                 if successful
                 else runtime_env_agent_pb2.AGENT_RPC_STATUS_FAILED,
-                serialized_runtime_env_context=serialized_context,
+                serialized_runtime_env_context=serialized_context if successful else "",
                 error_message=f"{self._node_prefix}{error_message}"
                 if not successful
                 else "",

--- a/python/ray/_private/runtime_env/image_uri.py
+++ b/python/ray/_private/runtime_env/image_uri.py
@@ -1,13 +1,70 @@
 import asyncio
 import logging
 import os
+import sys
 import tempfile
+from pathlib import Path
 from typing import List, Optional
 
 from ray._private.runtime_env.context import RuntimeEnvContext
 from ray._private.runtime_env.plugin import RuntimeEnvPlugin
 
 default_logger = logging.getLogger(__name__)
+
+
+def validate_worker_resource_limits_support() -> None:
+    """Fail early for the Podman configuration known not to support cgroup limits."""
+    if sys.platform != "linux":
+        raise RuntimeError(
+            "Per-worker container CPU and memory limits are supported only on Linux."
+        )
+    if os.geteuid() != 0 and not Path("/sys/fs/cgroup/cgroup.controllers").exists():
+        raise RuntimeError(
+            "Per-worker container CPU and memory limits require cgroup v2 when "
+            "Podman runs rootless. Use cgroup v2 or run Podman as root."
+        )
+
+
+def apply_worker_resource_limits(
+    context: RuntimeEnvContext,
+    cpu_period_us: int,
+    cpu_quota_us: int,
+    memory_bytes: int,
+) -> None:
+    """Add one worker's normalized cgroup limits to its Podman command."""
+    if (cpu_period_us == 0) != (cpu_quota_us == 0):
+        raise ValueError("CPU period and quota must either both be set or both be zero")
+    if cpu_period_us < 0 or cpu_quota_us < 0 or memory_bytes < 0:
+        raise ValueError("Worker resource limits cannot be negative")
+    if cpu_period_us > 0 and not 1000 <= cpu_period_us <= 1_000_000:
+        raise ValueError("CPU period must be between 1000 and 1000000 microseconds")
+    if 0 < cpu_quota_us < 1000:
+        raise ValueError("CPU quota must be at least 1000 microseconds")
+    if cpu_period_us == 0 and memory_bytes == 0:
+        return
+
+    marker = " --entrypoint python "
+    command_prefix, separator, command_suffix = context.py_executable.rpartition(marker)
+    if not separator or not command_prefix.startswith("podman run "):
+        raise RuntimeError(
+            "Cannot apply per-worker resource limits: the image_uri runtime "
+            "environment did not produce the expected Podman worker command."
+        )
+
+    options = []
+    if cpu_period_us > 0:
+        options.extend(
+            [
+                f"--cpu-period={cpu_period_us}",
+                f"--cpu-quota={cpu_quota_us}",
+            ]
+        )
+    if memory_bytes > 0:
+        options.append(f"--memory={memory_bytes}b")
+
+    context.py_executable = (
+        f"{command_prefix} {' '.join(options)}{marker}{command_suffix}"
+    )
 
 
 async def _create_impl(image_uri: str, logger: logging.Logger):
@@ -121,7 +178,6 @@ def _modify_context_impl(
 
     if run_options:
         container_command.extend(run_options)
-    # TODO(chenk008): add resource limit
     container_command.append("--entrypoint")
     container_command.append("python")
     container_command.append(image_uri)

--- a/python/ray/tests/runtime_env_container/test_worker_resource_limits.py
+++ b/python/ray/tests/runtime_env_container/test_worker_resource_limits.py
@@ -1,0 +1,41 @@
+import argparse
+import os
+from pathlib import Path
+
+import ray
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--image", required=True)
+args = parser.parse_args()
+
+ray.init(
+    num_cpus=4,
+    _system_config={"worker_resource_limits_enabled": True},
+)
+
+
+@ray.remote(runtime_env={"image_uri": args.image})
+def read_limits():
+    return {
+        "pid": os.getpid(),
+        "cpu": Path("/sys/fs/cgroup/cpu.max").read_text().strip(),
+        "memory": Path("/sys/fs/cgroup/memory.max").read_text().strip(),
+    }
+
+
+def run_with_limits(cpus, memory_bytes):
+    result = ray.get(read_limits.options(num_cpus=cpus, memory=memory_bytes).remote())
+    assert result["cpu"] == f"{round(cpus * 100000)} 100000", result
+    assert result["memory"] == str(memory_bytes), result
+    return result["pid"]
+
+
+memory_bytes = 256 * 1024 * 1024
+half_cpu_pid = run_with_limits(0.5, memory_bytes)
+assert run_with_limits(0.5, memory_bytes) == half_cpu_pid
+
+one_cpu_pid = run_with_limits(1.0, memory_bytes)
+one_and_half_cpu_pid = run_with_limits(1.5, memory_bytes)
+different_memory_pid = run_with_limits(0.5, 512 * 1024 * 1024)
+
+assert len({half_cpu_pid, one_cpu_pid, one_and_half_cpu_pid, different_memory_pid}) == 4

--- a/python/ray/tests/test_runtime_env_agent.py
+++ b/python/ray/tests/test_runtime_env_agent.py
@@ -4,6 +4,7 @@ import os
 import re
 import sys
 import time
+from types import SimpleNamespace
 from typing import List, Tuple
 
 import pytest
@@ -11,11 +12,14 @@ import pytest
 import ray
 from ray._common.test_utils import wait_for_condition
 from ray._private import ray_constants
+from ray._private.runtime_env import image_uri
+from ray._private.runtime_env.agent import runtime_env_agent
 from ray._private.runtime_env.agent.runtime_env_agent import (
     ReferenceTable,
     SetupLoggerFactory,
     UriType,
 )
+from ray._private.runtime_env.context import RuntimeEnvContext
 from ray._private.test_utils import (
     get_error_message,
     init_error_pubsub,
@@ -26,6 +30,83 @@ from ray.runtime_env import RuntimeEnv
 import psutil
 
 logger = logging.getLogger(__name__)
+
+
+@pytest.mark.parametrize("cpu_quota_us", [50000, 100000, 150000])
+def test_worker_resource_limits_do_not_contaminate_cached_context(
+    monkeypatch, cpu_quota_us
+):
+    monkeypatch.setattr(
+        runtime_env_agent, "validate_worker_resource_limits_support", lambda: None
+    )
+    base_context = RuntimeEnvContext(
+        py_executable=(
+            "podman run --network=host --entrypoint python "
+            "podman://rayproject/ray:latest"
+        )
+    ).serialize()
+    request = SimpleNamespace(
+        worker_resource_limits=SimpleNamespace(
+            cpu_period_us=100000,
+            cpu_quota_us=cpu_quota_us,
+            memory_bytes=256 * 1024 * 1024,
+        )
+    )
+
+    limited_context = RuntimeEnvContext.deserialize(
+        runtime_env_agent._apply_worker_resource_limits(request, base_context)
+    )
+
+    assert "--cpu-period=100000" in limited_context.py_executable
+    assert f"--cpu-quota={cpu_quota_us}" in limited_context.py_executable
+    assert "--memory=268435456b" in limited_context.py_executable
+    assert (
+        "--cpu-period" not in RuntimeEnvContext.deserialize(base_context).py_executable
+    )
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="cgroup is Linux-specific")
+def test_worker_resource_limits_reject_rootless_cgroup_v1(monkeypatch):
+    monkeypatch.setattr(image_uri.os, "geteuid", lambda: 1000)
+    monkeypatch.setattr(
+        image_uri, "Path", lambda _: SimpleNamespace(exists=lambda: False)
+    )
+
+    with pytest.raises(RuntimeError, match="require cgroup v2"):
+        image_uri.validate_worker_resource_limits_support()
+
+
+def test_worker_resource_limits_reject_unrepresentable_cpu():
+    request = SimpleNamespace(
+        worker_resource_limits=SimpleNamespace(
+            cpu_period_us=0,
+            cpu_quota_us=0,
+            memory_bytes=0,
+            validation_error=(
+                "Per-worker container CPU limits below 0.001 CPU cannot be represented"
+            ),
+        )
+    )
+
+    with pytest.raises(ValueError, match="below 0.001 CPU"):
+        runtime_env_agent._apply_worker_resource_limits(request, "")
+
+
+def test_worker_resource_limits_reject_kernel_invalid_cfs_quota():
+    context = RuntimeEnvContext(
+        py_executable=(
+            "podman run --network=host --entrypoint python "
+            "podman://rayproject/ray:latest"
+        )
+    )
+
+    with pytest.raises(ValueError, match="quota must be at least 1000"):
+        image_uri.apply_worker_resource_limits(
+            context,
+            cpu_period_us=1_000_000,
+            cpu_quota_us=999,
+            memory_bytes=0,
+        )
 
 
 def test_reference_table():

--- a/python/ray/tests/test_runtime_env_container.py
+++ b/python/ray/tests/test_runtime_env_container.py
@@ -66,6 +66,19 @@ def test_ray_env_vars(podman_docker_cluster, use_image_uri_api):
 
 
 @pytest.mark.skipif(sys.platform != "linux", reason="Only works on Linux.")
+def test_worker_resource_limits(podman_docker_cluster):
+    """Verify cgroup v2 CPU/memory limits and profile-aware worker reuse."""
+    container_id = podman_docker_cluster
+    cmd = [
+        "python",
+        "tests/test_worker_resource_limits.py",
+        "--image",
+        NESTED_IMAGE_NAME,
+    ]
+    run_in_container([cmd], container_id)
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="Only works on Linux.")
 def test_container_with_env_vars(podman_docker_cluster):
     """Test blah blah."""
 

--- a/src/mock/ray/raylet/worker_pool.h
+++ b/src/mock/ray/raylet/worker_pool.h
@@ -24,6 +24,11 @@ class MockWorkerPool : public WorkerPoolInterface {
               PopWorker,
               (const LeaseSpecification &lease_spec, const PopWorkerCallback &callback),
               (override));
+  void PopWorker(const LeaseSpecification &lease_spec,
+                 const rpc::WorkerResourceLimits &,
+                 const PopWorkerCallback &callback) override {
+    PopWorker(lease_spec, callback);
+  }
   MOCK_METHOD(void,
               PushWorker,
               (const std::shared_ptr<WorkerInterface> &worker),

--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -745,6 +745,10 @@ RAY_CONFIG(int64_t, gcs_server_request_timeout_seconds, 60)
 /// Whether to enable worker prestarting: https://github.com/ray-project/ray/issues/12052
 RAY_CONFIG(bool, enable_worker_prestart, false)
 
+/// Whether to enforce the CPU and memory resources assigned to each container worker.
+/// This is experimental and currently applies only to image_uri workers.
+RAY_CONFIG(bool, worker_resource_limits_enabled, false)
+
 /// Whether to enable worker prestarting on first driver
 /// TODO(clarng): reconcile with enable_worker_prestart
 RAY_CONFIG(bool, prestart_worker_first_driver, true)

--- a/src/ray/protobuf/runtime_env_agent.proto
+++ b/src/ray/protobuf/runtime_env_agent.proto
@@ -26,6 +26,18 @@ enum AgentRpcStatus {
   AGENT_RPC_STATUS_FAILED = 1;
 }
 
+/// Operating-system resource limits applied to one container worker.
+/// A zero value means that the corresponding limit is not set.
+message WorkerResourceLimits {
+  int64 cpu_period_us = 1;
+  int64 cpu_quota_us = 2;
+  uint64 memory_bytes = 3;
+  /// Set when the requested limits cannot be represented by the container runtime.
+  /// The runtime env agent must fail worker setup instead of starting an unlimited or
+  /// less strictly limited worker.
+  string validation_error = 4;
+}
+
 message GetOrCreateRuntimeEnvRequest {
   /// Json serialized [RuntimeEnv].
   /// For details, checkout "//python/ray/runtime_env/runtime_env.py".
@@ -36,6 +48,7 @@ message GetOrCreateRuntimeEnvRequest {
   /// For details, checkout "//src/ray/common/id.h".
   bytes job_id = 3;
   string source_process = 4;
+  WorkerResourceLimits worker_resource_limits = 5;
 }
 
 message GetOrCreateRuntimeEnvReply {

--- a/src/ray/raylet/BUILD.bazel
+++ b/src/ray/raylet/BUILD.bazel
@@ -103,6 +103,21 @@ ray_cc_library(
 )
 
 ray_cc_library(
+    name = "worker_resource_limits",
+    srcs = ["worker_resource_limits.cc"],
+    hdrs = ["worker_resource_limits.h"],
+    visibility = [":__subpackages__"],
+    deps = [
+        "//src/ray/common:ray_config",
+        "//src/ray/common/scheduling:placement_group_util",
+        "//src/ray/common/scheduling:resource_set",
+        "//src/ray/protobuf:runtime_env_agent_cc_proto",
+        "@com_google_absl//absl/strings",
+        "@nlohmann_json",
+    ],
+)
+
+ray_cc_library(
     name = "worker_pool",
     srcs = ["worker_pool.cc"],
     hdrs = ["worker_pool.h"],
@@ -111,6 +126,7 @@ ray_cc_library(
         ":metrics",
         ":runtime_env_agent_client",
         ":worker_interface",
+        ":worker_resource_limits",
         "//src/ray/asio:periodical_runner_interface",
         "//src/ray/common:constants",
         "//src/ray/common:lease",

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -2009,6 +2009,7 @@ void NodeManager::HandlePrestartWorkers(rpc::PrestartWorkersRequest request,
       request.runtime_env_info(),
       /*runtime_env_hash=*/
       CalculateRuntimeEnvHash(request.runtime_env_info().serialized_runtime_env()),
+      /*worker_resource_limits=*/rpc::WorkerResourceLimits(),
       /*options=*/std::vector<std::string>{},
       absl::Seconds(request.keep_alive_duration_secs()),
       /*callback=*/

--- a/src/ray/raylet/runtime_env_agent_client.cc
+++ b/src/ray/raylet/runtime_env_agent_client.cc
@@ -370,12 +370,25 @@ class HttpRuntimeEnvAgentClient : public RuntimeEnvAgentClient {
                              const std::string &serialized_runtime_env,
                              const rpc::RuntimeEnvConfig &runtime_env_config,
                              GetOrCreateRuntimeEnvCallback callback) override {
+    GetOrCreateRuntimeEnv(job_id,
+                          serialized_runtime_env,
+                          runtime_env_config,
+                          rpc::WorkerResourceLimits(),
+                          std::move(callback));
+  }
+
+  void GetOrCreateRuntimeEnv(const JobID &job_id,
+                             const std::string &serialized_runtime_env,
+                             const rpc::RuntimeEnvConfig &runtime_env_config,
+                             const rpc::WorkerResourceLimits &worker_resource_limits,
+                             GetOrCreateRuntimeEnvCallback callback) override {
     RetryInvokeOnNotFoundWithDeadline<rpc::GetOrCreateRuntimeEnvReply>(
         [=](SuccCallback<rpc::GetOrCreateRuntimeEnvReply> succ_callback,
             FailCallback fail_callback) {
           return TryGetOrCreateRuntimeEnv(job_id,
                                           serialized_runtime_env,
                                           runtime_env_config,
+                                          worker_resource_limits,
                                           succ_callback,
                                           fail_callback);
         },
@@ -421,12 +434,14 @@ class HttpRuntimeEnvAgentClient : public RuntimeEnvAgentClient {
       const JobID &job_id,
       const std::string &serialized_runtime_env,
       const rpc::RuntimeEnvConfig &runtime_env_config,
+      const rpc::WorkerResourceLimits &worker_resource_limits,
       std::function<void(rpc::GetOrCreateRuntimeEnvReply)> succ_callback,
       std::function<void(ray::Status)> fail_callback) {
     rpc::GetOrCreateRuntimeEnvRequest request;
     request.set_job_id(job_id.Hex());
     request.set_serialized_runtime_env(serialized_runtime_env);
     request.mutable_runtime_env_config()->CopyFrom(runtime_env_config);
+    request.mutable_worker_resource_limits()->CopyFrom(worker_resource_limits);
     std::string payload = request.SerializeAsString();
 
     auto session = Session::Create(

--- a/src/ray/raylet/runtime_env_agent_client.h
+++ b/src/ray/raylet/runtime_env_agent_client.h
@@ -27,6 +27,7 @@
 #include "ray/util/clock.h"
 #include "src/ray/protobuf/gcs.pb.h"
 #include "src/ray/protobuf/public/runtime_environment.pb.h"
+#include "src/ray/protobuf/runtime_env_agent.pb.h"
 
 namespace ray {
 namespace raylet {
@@ -73,6 +74,15 @@ class RuntimeEnvAgentClient {
                                      const std::string &serialized_runtime_env,
                                      const rpc::RuntimeEnvConfig &runtime_env_config,
                                      GetOrCreateRuntimeEnvCallback callback) = 0;
+
+  /// Request a runtime env context with per-worker resource limits. The limits are
+  /// applied to the returned context and are not part of the cached base runtime env.
+  virtual void GetOrCreateRuntimeEnv(
+      const JobID &job_id,
+      const std::string &serialized_runtime_env,
+      const rpc::RuntimeEnvConfig &runtime_env_config,
+      const rpc::WorkerResourceLimits &worker_resource_limits,
+      GetOrCreateRuntimeEnvCallback callback) = 0;
 
   /// Request agent to decrease the runtime env reference. This API is not idempotent. The
   /// client automatically retries on network errors.

--- a/src/ray/raylet/scheduling/BUILD.bazel
+++ b/src/ray/raylet/scheduling/BUILD.bazel
@@ -95,6 +95,7 @@ ray_cc_library(
         "//src/ray/raylet:metrics",
         "//src/ray/raylet:worker_interface",
         "//src/ray/raylet:worker_pool",
+        "//src/ray/raylet:worker_resource_limits",
         "//src/ray/raylet/scheduling:cluster_resource_scheduler",
         "//src/ray/raylet/scheduling:local_lease_manager_interface",
         "//src/ray/raylet/scheduling:scheduler_internal",

--- a/src/ray/raylet/scheduling/local_lease_manager.cc
+++ b/src/ray/raylet/scheduling/local_lease_manager.cc
@@ -26,6 +26,7 @@
 
 #include "ray/common/scheduling/cluster_resource_data.h"
 #include "ray/common/scheduling/placement_group_util.h"
+#include "ray/raylet/worker_resource_limits.h"
 #include "ray/util/logging.h"
 
 namespace ray {
@@ -392,6 +393,8 @@ void LocalLeaseManager::GrantScheduledLeasesToWorkers() {
         // task might be hanging.
         worker_pool_.PopWorker(
             spec,
+            BuildWorkerResourceLimits(spec.SerializedRuntimeEnv(),
+                                      allocated_instances->ToResourceSet()),
             [this, lease_id, scheduling_class, work, is_detached_actor, owner_address](
                 const std::shared_ptr<WorkerInterface> worker,
                 PopWorkerStatus status,

--- a/src/ray/raylet/scheduling/tests/BUILD.bazel
+++ b/src/ray/raylet/scheduling/tests/BUILD.bazel
@@ -61,6 +61,7 @@ ray_cc_test(
         "//src/ray/asio:periodical_runner",
         "//src/ray/common:id",
         "//src/ray/common:lease",
+        "//src/ray/common:ray_config",
         "//src/ray/common:task_common",
         "//src/ray/common:test_utils",
         "//src/ray/observability:fake_metric",

--- a/src/ray/raylet/scheduling/tests/cluster_lease_manager_test.cc
+++ b/src/ray/raylet/scheduling/tests/cluster_lease_manager_test.cc
@@ -59,6 +59,12 @@ class MockWorkerPool : public WorkerPoolInterface {
     callbacks[runtime_env_hash].push_back(callback);
   }
 
+  void PopWorker(const LeaseSpecification &lease_spec,
+                 const rpc::WorkerResourceLimits &worker_resource_limits,
+                 const PopWorkerCallback &callback) override {
+    PopWorker(lease_spec, callback);
+  }
+
   void PushWorker(const std::shared_ptr<WorkerInterface> &worker) override {
     workers.push_front(worker);
   }

--- a/src/ray/raylet/scheduling/tests/local_lease_manager_test.cc
+++ b/src/ray/raylet/scheduling/tests/local_lease_manager_test.cc
@@ -30,6 +30,7 @@
 #include "ray/asio/periodical_runner.h"
 #include "ray/common/id.h"
 #include "ray/common/lease/lease.h"
+#include "ray/common/ray_config.h"
 #include "ray/common/task/task_util.h"
 #include "ray/common/test_utils.h"
 #include "ray/observability/fake_metric.h"
@@ -50,6 +51,13 @@ class MockWorkerPool : public WorkerPoolInterface {
     num_pops++;
     const int runtime_env_hash = lease_spec.GetRuntimeEnvHash();
     callbacks[runtime_env_hash].push_back(callback);
+  }
+
+  void PopWorker(const LeaseSpecification &lease_spec,
+                 const rpc::WorkerResourceLimits &worker_resource_limits,
+                 const PopWorkerCallback &callback) override {
+    last_worker_resource_limits = worker_resource_limits;
+    PopWorker(lease_spec, callback);
   }
 
   void PushWorker(const std::shared_ptr<WorkerInterface> &worker) override {
@@ -246,6 +254,7 @@ class MockWorkerPool : public WorkerPoolInterface {
 
   std::list<std::shared_ptr<WorkerInterface>> workers;
   absl::flat_hash_map<int, std::list<PopWorkerCallback>> callbacks;
+  rpc::WorkerResourceLimits last_worker_resource_limits;
   int num_pops;
 };
 
@@ -276,7 +285,8 @@ std::shared_ptr<ClusterResourceScheduler> CreateSingleNodeScheduler(
 
 RayLease CreateLease(const std::unordered_map<std::string, double> &required_resources,
                      const std::string &task_name = "default",
-                     const std::vector<std::unique_ptr<TaskArg>> &args = {}) {
+                     const std::vector<std::unique_ptr<TaskArg>> &args = {},
+                     const std::string &serialized_runtime_env = "") {
   TaskSpecBuilder spec_builder;
   TaskID id = RandomTaskId();
   JobID job_id = RandomJobId();
@@ -313,6 +323,8 @@ RayLease CreateLease(const std::unordered_map<std::string, double> &required_res
   TaskSpecification spec = std::move(spec_builder).ConsumeAndBuild();
   LeaseSpecification lease_spec(spec.GetMessage());
   lease_spec.GetMutableMessage().set_lease_id(LeaseID::FromRandom().Binary());
+  lease_spec.GetMutableMessage().mutable_runtime_env_info()->set_serialized_runtime_env(
+      serialized_runtime_env);
   return RayLease(std::move(lease_spec));
 }
 
@@ -364,10 +376,15 @@ class LocalLeaseManagerTest : public ::testing::Test {
             /*clock=*/clock_)) {}
 
   void SetUp() override {
+    RayConfig::instance().initialize(R"({"worker_resource_limits_enabled": false})");
     static rpc::GcsNodeAddressAndLiveness node_info;
     ON_CALL(*gcs_client_->mock_node_accessor,
             GetNodeAddressAndLiveness(::testing::_, ::testing::_))
         .WillByDefault(::testing::Return(node_info));
+  }
+
+  void TearDown() override {
+    RayConfig::instance().initialize(R"({"worker_resource_limits_enabled": false})");
   }
 
   RayObject *MakeDummyArg() {
@@ -519,6 +536,29 @@ TEST_F(LocalLeaseManagerTest, TestLeaseGrantingOrder) {
   auto leases_to_grant_ = local_lease_manager_->GetLeasesToGrant();
   // Out of the leases in the second batch, only lease g is granted due to fair scheduling
   ASSERT_EQ(leases_to_grant_.size(), 1);
+}
+
+TEST_F(LocalLeaseManagerTest, PassesAllocatedResourcesAsWorkerLimits) {
+  RayConfig::instance().initialize(R"({"worker_resource_limits_enabled": true})");
+  auto lease = CreateLease({{kCPU_ResourceLabel, 0.5}},
+                           "limited_worker",
+                           {},
+                           R"({"image_uri":"podman://ray:latest"})");
+  rpc::RequestWorkerLeaseReply reply;
+  auto empty_callback =
+      [](Status status, std::function<void()> success, std::function<void()> failure) {};
+  local_lease_manager_->QueueAndScheduleLease(std::make_shared<internal::Work>(
+      lease,
+      false,
+      false,
+      std::vector<internal::ReplyCallback>{
+          internal::ReplyCallback(empty_callback, &reply)},
+      internal::WorkStatus::WAITING));
+
+  ASSERT_EQ(pool_.num_pops, 1);
+  EXPECT_EQ(pool_.last_worker_resource_limits.cpu_period_us(), 100000);
+  EXPECT_EQ(pool_.last_worker_resource_limits.cpu_quota_us(), 50000);
+  EXPECT_EQ(pool_.last_worker_resource_limits.memory_bytes(), 0);
 }
 
 TEST_F(LocalLeaseManagerTest, TestNoLeakOnImpossibleInfeasibleLease) {

--- a/src/ray/raylet/tests/BUILD.bazel
+++ b/src/ray/raylet/tests/BUILD.bazel
@@ -28,6 +28,19 @@ ray_cc_test(
 )
 
 ray_cc_test(
+    name = "worker_resource_limits_test",
+    size = "small",
+    srcs = ["worker_resource_limits_test.cc"],
+    tags = ["team:core"],
+    deps = [
+        "//src/ray/common:ray_config",
+        "//src/ray/common/scheduling:resource_set",
+        "//src/ray/raylet:worker_resource_limits",
+        "@com_google_absl//absl/container:flat_hash_map",
+    ],
+)
+
+ray_cc_test(
     name = "worker_pool_test",
     size = "small",
     srcs = ["worker_pool_test.cc"],

--- a/src/ray/raylet/tests/runtime_env_agent_client_test.cc
+++ b/src/ray/raylet/tests/runtime_env_agent_client_test.cc
@@ -209,6 +209,10 @@ TEST(RuntimeEnvAgentClientTest, GetOrCreateRuntimeEnvOK) {
         ASSERT_EQ(req.job_id(), "7b000000");  // Hex 7B == Int 123
         ASSERT_EQ(req.runtime_env_config().setup_timeout_seconds(), 12);
         ASSERT_EQ(req.serialized_runtime_env(), "serialized_runtime_env");
+        ASSERT_EQ(req.worker_resource_limits().cpu_period_us(), 100000);
+        ASSERT_EQ(req.worker_resource_limits().cpu_quota_us(), 50000);
+        ASSERT_EQ(req.worker_resource_limits().memory_bytes(), 256 * 1024 * 1024);
+        ASSERT_EQ(req.worker_resource_limits().validation_error(), "validation error");
         ASSERT_EQ(request.find(http::field::authorization), request.end());
 
         rpc::GetOrCreateRuntimeEnvReply reply;
@@ -237,6 +241,11 @@ TEST(RuntimeEnvAgentClientTest, GetOrCreateRuntimeEnvOK) {
   std::string serialized_runtime_env = "serialized_runtime_env";
   ray::rpc::RuntimeEnvConfig runtime_env_config;
   runtime_env_config.set_setup_timeout_seconds(12);
+  ray::rpc::WorkerResourceLimits worker_resource_limits;
+  worker_resource_limits.set_cpu_period_us(100000);
+  worker_resource_limits.set_cpu_quota_us(50000);
+  worker_resource_limits.set_memory_bytes(256 * 1024 * 1024);
+  worker_resource_limits.set_validation_error("validation error");
 
   size_t called_times = 0;
   auto callback = [&](bool successful,
@@ -248,8 +257,11 @@ TEST(RuntimeEnvAgentClientTest, GetOrCreateRuntimeEnvOK) {
     called_times += 1;
   };
 
-  client->GetOrCreateRuntimeEnv(
-      job_id, serialized_runtime_env, runtime_env_config, callback);
+  client->GetOrCreateRuntimeEnv(job_id,
+                                serialized_runtime_env,
+                                runtime_env_config,
+                                worker_resource_limits,
+                                callback);
 
   ioc.run();
   ASSERT_EQ(called_times, 1);

--- a/src/ray/raylet/tests/worker_pool_test.cc
+++ b/src/ray/raylet/tests/worker_pool_test.cc
@@ -129,6 +129,16 @@ class MockRuntimeEnvAgentClient : public RuntimeEnvAgentClient {
     }
   };
 
+  void GetOrCreateRuntimeEnv(const JobID &job_id,
+                             const std::string &serialized_runtime_env,
+                             const rpc::RuntimeEnvConfig &runtime_env_config,
+                             const rpc::WorkerResourceLimits &worker_resource_limits,
+                             GetOrCreateRuntimeEnvCallback callback) override {
+    last_worker_resource_limits = worker_resource_limits;
+    GetOrCreateRuntimeEnv(
+        job_id, serialized_runtime_env, runtime_env_config, std::move(callback));
+  }
+
   void DeleteRuntimeEnvIfPossible(const std::string &serialized_runtime_env,
                                   DeleteRuntimeEnvIfPossibleCallback callback) override {
     auto it = runtime_env_reference.find(serialized_runtime_env);
@@ -137,6 +147,8 @@ class MockRuntimeEnvAgentClient : public RuntimeEnvAgentClient {
     RAY_CHECK(runtime_env_reference[serialized_runtime_env] >= 0);
     callback(true);
   };
+
+  rpc::WorkerResourceLimits last_worker_resource_limits;
 };
 
 class WorkerPoolMock : public WorkerPool {
@@ -404,6 +416,26 @@ class WorkerPoolMock : public WorkerPool {
     return popped_worker;
   }
 
+  std::shared_ptr<WorkerInterface> PopWorkerWithResourceLimitsSync(
+      const LeaseSpecification &lease_spec,
+      const rpc::WorkerResourceLimits &worker_resource_limits) {
+    std::shared_ptr<WorkerInterface> popped_worker = nullptr;
+    std::promise<bool> promise;
+    this->PopWorker(lease_spec,
+                    worker_resource_limits,
+                    [&popped_worker, &promise](
+                        const std::shared_ptr<WorkerInterface> worker,
+                        PopWorkerStatus status,
+                        const std::string &runtime_env_setup_error_message) -> bool {
+                      popped_worker = worker;
+                      promise.set_value(true);
+                      return true;
+                    });
+    PushWorkers(/*timeout_worker_number=*/0, lease_spec.JobId());
+    promise.get_future().get();
+    return popped_worker;
+  }
+
   int num_available_cpus_ = POOL_SIZE_SOFT_LIMIT;
 
  private:
@@ -427,7 +459,8 @@ class WorkerPoolTest : public ::testing::Test {
         std::to_string(WORKER_REGISTER_TIMEOUT_SECONDS) +
         R"(, "object_spilling_config": "dummy", "max_io_workers": )" +
         std::to_string(MAX_IO_WORKER_SIZE) + R"(, "kill_idle_workers_interval_ms": 0)" +
-        R"(, "enable_worker_prestart": true)" + "}");
+        R"(, "enable_worker_prestart": true)" +
+        R"(, "worker_resource_limits_enabled": true)" + "}");
     SetWorkerCommands({{Language::PYTHON, {"dummy_py_worker_command"}},
                        {Language::JAVA,
                         {"java", "RAY_WORKER_DYNAMIC_OPTION_PLACEHOLDER", "MainClass"}}});
@@ -439,7 +472,9 @@ class WorkerPoolTest : public ::testing::Test {
       io_service_.run();
     }));
     promise.get_future().get();
-    worker_pool_->SetRuntimeEnvAgentClient(std::make_unique<MockRuntimeEnvAgentClient>());
+    auto runtime_env_agent_client = std::make_unique<MockRuntimeEnvAgentClient>();
+    runtime_env_agent_client_ = runtime_env_agent_client.get();
+    worker_pool_->SetRuntimeEnvAgentClient(std::move(runtime_env_agent_client));
   }
 
   void TearDown() override {
@@ -524,6 +559,7 @@ class WorkerPoolTest : public ::testing::Test {
   instrumented_io_context io_service_;
   std::unique_ptr<std::thread> thread_io_service_;
   std::unique_ptr<WorkerPoolMock> worker_pool_;
+  MockRuntimeEnvAgentClient *runtime_env_agent_client_ = nullptr;
   std::unique_ptr<gcs::MockGcsClient> mock_gcs_client_ =
       std::make_unique<gcs::MockGcsClient>();
 
@@ -707,6 +743,29 @@ TEST_F(WorkerPoolDriverRegisteredTest, TestPrestartingWorkersWithRuntimeEnv) {
   ASSERT_EQ(worker_pool_->NumWorkersStarting(), POOL_SIZE_SOFT_LIMIT);
 }
 
+TEST_F(WorkerPoolDriverRegisteredTest, TestPrestartingWorkersWithResourceLimits) {
+  constexpr uint64_t kMemoryBytes = 256 * 1024 * 1024;
+  auto runtime_env_info =
+      ExampleRuntimeEnvInfoFromString(R"({"image_uri":"podman://ray:latest"})");
+  LeaseSpecification lease_spec =
+      ExampleLeaseSpec(ActorID::Nil(),
+                       Language::PYTHON,
+                       JOB_ID,
+                       {},
+                       LeaseID::Nil(),
+                       runtime_env_info,
+                       {{"CPU", 0.5}, {"memory", kMemoryBytes}});
+
+  worker_pool_->PrestartWorkers(lease_spec, 1);
+
+  ASSERT_EQ(worker_pool_->NumWorkersStarting(), 1);
+  EXPECT_EQ(runtime_env_agent_client_->last_worker_resource_limits.cpu_period_us(),
+            100000);
+  EXPECT_EQ(runtime_env_agent_client_->last_worker_resource_limits.cpu_quota_us(), 50000);
+  EXPECT_EQ(runtime_env_agent_client_->last_worker_resource_limits.memory_bytes(),
+            kMemoryBytes);
+}
+
 TEST_F(WorkerPoolDriverRegisteredTest, HandleWorkerPushPop) {
   std::shared_ptr<WorkerInterface> popped_worker;
   const LeaseSpecification lease_spec = ExampleLeaseSpec();
@@ -857,6 +916,7 @@ TEST_F(WorkerPoolDriverRegisteredTest, TestWorkerStartupKeepAliveDuration) {
           /*actor_worker=*/std::nullopt,
           runtime_env_info,
           CalculateRuntimeEnvHash(runtime_env_info.serialized_runtime_env()),
+          /*worker_resource_limits=*/rpc::WorkerResourceLimits(),
           /*options=*/std::vector<std::string>{},
           keep_alive_duration,
           /*callback=*/
@@ -2211,6 +2271,43 @@ TEST_F(WorkerPoolDriverRegisteredTest, CacheWorkersByRuntimeEnvHash) {
   // Check that we got the pushed worker.
   ASSERT_EQ(popped_worker, worker);
   worker_pool_->ClearProcesses();
+}
+
+TEST_F(WorkerPoolDriverRegisteredTest, WorkerResourceLimitsParticipateInReuse) {
+  const LeaseSpecification lease_spec = ExampleLeaseSpec();
+  rpc::WorkerResourceLimits one_cpu;
+  one_cpu.set_cpu_period_us(100000);
+  one_cpu.set_cpu_quota_us(100000);
+  one_cpu.set_memory_bytes(256 * 1024 * 1024);
+
+  rpc::WorkerResourceLimits four_cpus = one_cpu;
+  four_cpus.set_cpu_quota_us(400000);
+
+  auto one_cpu_worker =
+      worker_pool_->PopWorkerWithResourceLimitsSync(lease_spec, one_cpu);
+  ASSERT_NE(one_cpu_worker, nullptr);
+  ASSERT_EQ(worker_pool_->GetProcessSize(), 1);
+
+  worker_pool_->PushWorker(one_cpu_worker);
+  auto reused_worker = worker_pool_->PopWorkerWithResourceLimitsSync(lease_spec, one_cpu);
+  ASSERT_EQ(reused_worker, one_cpu_worker);
+  ASSERT_EQ(worker_pool_->GetProcessSize(), 1);
+
+  worker_pool_->PushWorker(reused_worker);
+  auto four_cpu_worker =
+      worker_pool_->PopWorkerWithResourceLimitsSync(lease_spec, four_cpus);
+  ASSERT_NE(four_cpu_worker, nullptr);
+  ASSERT_NE(four_cpu_worker, one_cpu_worker);
+  ASSERT_EQ(worker_pool_->GetProcessSize(), 2);
+  ASSERT_EQ(worker_pool_->GetIdleWorkerSize(), 1);
+
+  rpc::WorkerResourceLimits different_memory = one_cpu;
+  different_memory.set_memory_bytes(512 * 1024 * 1024);
+  auto different_memory_worker =
+      worker_pool_->PopWorkerWithResourceLimitsSync(lease_spec, different_memory);
+  ASSERT_NE(different_memory_worker, nullptr);
+  ASSERT_NE(different_memory_worker, one_cpu_worker);
+  ASSERT_EQ(worker_pool_->GetProcessSize(), 3);
 }
 
 TEST_F(WorkerPoolDriverRegisteredTest, WorkerNoLeaks) {

--- a/src/ray/raylet/tests/worker_resource_limits_test.cc
+++ b/src/ray/raylet/tests/worker_resource_limits_test.cc
@@ -1,0 +1,115 @@
+// Copyright 2026 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "ray/raylet/worker_resource_limits.h"
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "absl/container/flat_hash_map.h"
+#include "ray/common/ray_config.h"
+#include "ray/common/scheduling/resource_set.h"
+
+namespace ray::raylet {
+
+class WorkerResourceLimitsTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    RayConfig::instance().initialize(R"({"worker_resource_limits_enabled": true})");
+  }
+};
+
+TEST_F(WorkerResourceLimitsTest, PreservesFractionalCpuAndExactMemory) {
+  constexpr uint64_t kMemoryBytes = 256 * 1024 * 1024;
+  for (const auto &[cpus, expected_quota] : std::vector<std::pair<double, int64_t>>{
+           {0.5, 50000}, {1.0, 100000}, {1.5, 150000}}) {
+    const ResourceSet resources(absl::flat_hash_map<std::string, double>{
+        {"CPU", cpus}, {"memory", kMemoryBytes}});
+    const auto limits =
+        BuildWorkerResourceLimits(R"({"image_uri":"podman://ray:latest"})", resources);
+
+    EXPECT_EQ(limits.cpu_period_us(), 100000);
+    EXPECT_EQ(limits.cpu_quota_us(), expected_quota);
+    EXPECT_EQ(limits.memory_bytes(), kMemoryBytes);
+  }
+}
+
+TEST_F(WorkerResourceLimitsTest, UsesLegalCfsValuesForSmallFractionalCpu) {
+  for (const auto &[cpus, expected_quota] : std::vector<std::pair<double, int64_t>>{
+           {0.001, 1000}, {0.005, 5000}, {0.0099, 9900}}) {
+    const ResourceSet resources(absl::flat_hash_map<std::string, double>{{"CPU", cpus}});
+    const auto limits =
+        BuildWorkerResourceLimits(R"({"image_uri":"podman://ray:latest"})", resources);
+
+    EXPECT_EQ(limits.cpu_period_us(), 1000000);
+    EXPECT_EQ(limits.cpu_quota_us(), expected_quota);
+    EXPECT_TRUE(limits.validation_error().empty());
+  }
+
+  const ResourceSet resources(absl::flat_hash_map<std::string, double>{{"CPU", 0.01}});
+  const auto limits =
+      BuildWorkerResourceLimits(R"({"image_uri":"podman://ray:latest"})", resources);
+  EXPECT_EQ(limits.cpu_period_us(), 100000);
+  EXPECT_EQ(limits.cpu_quota_us(), 1000);
+}
+
+TEST_F(WorkerResourceLimitsTest, RejectsUnrepresentableCpu) {
+  const ResourceSet resources(absl::flat_hash_map<std::string, double>{{"CPU", 0.0001}});
+  const auto limits =
+      BuildWorkerResourceLimits(R"({"image_uri":"podman://ray:latest"})", resources);
+
+  EXPECT_EQ(limits.cpu_period_us(), 0);
+  EXPECT_EQ(limits.cpu_quota_us(), 0);
+  EXPECT_NE(limits.validation_error().find("below 0.001 CPU"), std::string::npos);
+  EXPECT_TRUE(HasWorkerResourceLimits(limits));
+}
+
+TEST_F(WorkerResourceLimitsTest, DeduplicatesPlacementGroupAliases) {
+  constexpr uint64_t kMemoryBytes = 128 * 1024 * 1024;
+  const ResourceSet resources(absl::flat_hash_map<std::string, double>{
+      {"CPU_group_deadbeef", 1.5},
+      {"CPU_group_0_deadbeef", 1.5},
+      {"memory_group_deadbeef", kMemoryBytes},
+      {"memory_group_0_deadbeef", kMemoryBytes},
+  });
+
+  const auto limits =
+      BuildWorkerResourceLimits(R"({"image_uri":"podman://ray:latest"})", resources);
+  EXPECT_EQ(limits.cpu_quota_us(), 150000);
+  EXPECT_EQ(limits.memory_bytes(), kMemoryBytes);
+}
+
+TEST_F(WorkerResourceLimitsTest, LeavesNonImageRuntimeEnvUnchanged) {
+  const ResourceSet resources(
+      absl::flat_hash_map<std::string, double>{{"CPU", 1}, {"memory", 1024}});
+
+  EXPECT_FALSE(HasWorkerResourceLimits(
+      BuildWorkerResourceLimits(R"({"env_vars":{"KEY":"value"}})", resources)));
+  EXPECT_FALSE(HasWorkerResourceLimits(BuildWorkerResourceLimits("{}", resources)));
+}
+
+TEST_F(WorkerResourceLimitsTest, DisabledLeavesImageRuntimeEnvUnchanged) {
+  RayConfig::instance().initialize(R"({"worker_resource_limits_enabled": false})");
+  const ResourceSet resources(
+      absl::flat_hash_map<std::string, double>{{"CPU", 1}, {"memory", 1024}});
+
+  EXPECT_FALSE(HasWorkerResourceLimits(
+      BuildWorkerResourceLimits(R"({"image_uri":"podman://ray:latest"})", resources)));
+}
+
+}  // namespace ray::raylet

--- a/src/ray/raylet/worker_pool.cc
+++ b/src/ray/raylet/worker_pool.cc
@@ -36,6 +36,7 @@
 #include "ray/common/runtime_env_common.h"
 #include "ray/common/status.h"
 #include "ray/core_worker_rpc_client/core_worker_client_interface.h"
+#include "ray/raylet/worker_resource_limits.h"
 #include "ray/util/container_util.h"
 #include "ray/util/logging.h"
 #include "ray/util/network_util.h"
@@ -245,7 +246,8 @@ const ProcessInterface &WorkerPool::AddWorkerProcess(
     SteadyTimePoint start,
     const rpc::RuntimeEnvInfo &runtime_env_info,
     const std::vector<std::string> &dynamic_options,
-    std::optional<absl::Duration> worker_startup_keep_alive_duration) {
+    std::optional<absl::Duration> worker_startup_keep_alive_duration,
+    const rpc::WorkerResourceLimits &worker_resource_limits) {
   auto [it, _] = state.worker_processes.emplace(
       worker_id,
       WorkerProcessInfo{/*is_pending_registration=*/true,
@@ -253,6 +255,7 @@ const ProcessInterface &WorkerPool::AddWorkerProcess(
                         std::move(proc),
                         start,
                         runtime_env_info,
+                        worker_resource_limits,
                         dynamic_options,
                         worker_startup_keep_alive_duration});
   return *it->second.proc;
@@ -468,7 +471,8 @@ std::tuple<const ProcessInterface &, WorkerID> WorkerPool::StartWorkerProcess(
     const int runtime_env_hash,
     const std::string &serialized_runtime_env_context,
     const rpc::RuntimeEnvInfo &runtime_env_info,
-    std::optional<absl::Duration> worker_startup_keep_alive_duration) {
+    std::optional<absl::Duration> worker_startup_keep_alive_duration,
+    const rpc::WorkerResourceLimits &worker_resource_limits) {
   rpc::JobConfig *job_config = nullptr;
   if (!job_id.IsNil()) {
     auto it = all_jobs_.find(job_id);
@@ -542,7 +546,8 @@ std::tuple<const ProcessInterface &, WorkerID> WorkerPool::StartWorkerProcess(
                        start,
                        runtime_env_info,
                        dynamic_options,
-                       worker_startup_keep_alive_duration);
+                       worker_startup_keep_alive_duration,
+                       worker_resource_limits);
   if (IsIOWorkerType(worker_type)) {
     auto &io_worker_state = GetIOWorkerStateFromWorkerType(worker_type, state);
     io_worker_state.num_starting_io_workers++;
@@ -1367,6 +1372,10 @@ WorkerUnfitForLeaseReason WorkerPool::WorkerFitForLease(
       pop_worker_request.dynamic_options_) {
     return WorkerUnfitForLeaseReason::DYNAMIC_OPTIONS_MISMATCH;
   }
+  if (!WorkerResourceLimitsEqual(LookupWorkerResourceLimits(worker.WorkerId()),
+                                 pop_worker_request.worker_resource_limits_)) {
+    return WorkerUnfitForLeaseReason::RUNTIME_ENV_MISMATCH;
+  }
   return WorkerUnfitForLeaseReason::NONE;
 }
 
@@ -1389,7 +1398,8 @@ void WorkerPool::StartNewWorker(
                            request->runtime_env_hash_,
                            serialized_runtime_env_context,
                            request->runtime_env_info_,
-                           request->worker_startup_keep_alive_duration_);
+                           request->worker_startup_keep_alive_duration_,
+                           request->worker_resource_limits_);
     if (status == PopWorkerStatus::OK) {
       RAY_CHECK(proc.IsValid());
       WarnAboutSize();
@@ -1415,6 +1425,7 @@ void WorkerPool::StartNewWorker(
         serialized_runtime_env,
         pop_worker_request->runtime_env_info_.runtime_env_config(),
         pop_worker_request->job_id_,
+        pop_worker_request->worker_resource_limits_,
         [this, start_worker_process_fn, pop_worker_request](
             bool successful,
             const std::string &serialized_runtime_env_context,
@@ -1436,6 +1447,12 @@ void WorkerPool::StartNewWorker(
 
 void WorkerPool::PopWorker(const LeaseSpecification &lease_spec,
                            const PopWorkerCallback &callback) {
+  PopWorker(lease_spec, rpc::WorkerResourceLimits(), callback);
+}
+
+void WorkerPool::PopWorker(const LeaseSpecification &lease_spec,
+                           const rpc::WorkerResourceLimits &worker_resource_limits,
+                           const PopWorkerCallback &callback) {
   auto pop_worker_request = std::make_shared<PopWorkerRequest>(
       lease_spec.GetLanguage(),
       rpc::WorkerType::WORKER,
@@ -1445,6 +1462,7 @@ void WorkerPool::PopWorker(const LeaseSpecification &lease_spec,
       /*is_actor_worker=*/lease_spec.IsActorCreationTask(),
       lease_spec.RuntimeEnvInfo(),
       lease_spec.GetRuntimeEnvHash(),
+      worker_resource_limits,
       lease_spec.DynamicWorkerOptionsOrEmpty(),
       /*worker_startup_keep_alive_duration=*/std::nullopt,
       [this, lease_spec, callback](
@@ -1571,6 +1589,8 @@ void WorkerPool::PrestartWorkers(const LeaseSpecification &lease_spec,
 void WorkerPool::PrestartWorkersInternal(const LeaseSpecification &lease_spec,
                                          int64_t num_needed) {
   RAY_LOG(DEBUG) << "PrestartWorkers " << num_needed;
+  const auto worker_resource_limits = BuildWorkerResourceLimits(
+      lease_spec.SerializedRuntimeEnv(), lease_spec.GetRequiredResources());
   for (int ii = 0; ii < num_needed; ++ii) {
     // Prestart worker with no runtime env.
     if (IsRuntimeEnvEmpty(lease_spec.SerializedRuntimeEnv())) {
@@ -1581,28 +1601,32 @@ void WorkerPool::PrestartWorkersInternal(const LeaseSpecification &lease_spec,
     }
 
     // Prestart worker with runtime env.
-    GetOrCreateRuntimeEnv(
-        lease_spec.SerializedRuntimeEnv(),
-        lease_spec.RuntimeEnvConfig(),
-        lease_spec.JobId(),
-        [this, lease_spec = lease_spec](bool successful,
-                                        const std::string &serialized_runtime_env_context,
-                                        const std::string &setup_error_message) {
-          if (!successful) {
-            RAY_LOG(ERROR) << "Fails to create or get runtime env "
-                           << setup_error_message;
-            return;
-          }
-          PopWorkerStatus status;
-          StartWorkerProcess(lease_spec.GetLanguage(),
-                             rpc::WorkerType::WORKER,
-                             lease_spec.JobId(),
-                             &status,
-                             /*dynamic_options=*/{},
-                             lease_spec.GetRuntimeEnvHash(),
-                             serialized_runtime_env_context,
-                             lease_spec.RuntimeEnvInfo());
-        });
+    GetOrCreateRuntimeEnv(lease_spec.SerializedRuntimeEnv(),
+                          lease_spec.RuntimeEnvConfig(),
+                          lease_spec.JobId(),
+                          worker_resource_limits,
+                          [this, lease_spec = lease_spec, worker_resource_limits](
+                              bool successful,
+                              const std::string &serialized_runtime_env_context,
+                              const std::string &setup_error_message) {
+                            if (!successful) {
+                              RAY_LOG(ERROR) << "Fails to create or get runtime env "
+                                             << setup_error_message;
+                              return;
+                            }
+                            PopWorkerStatus status;
+                            StartWorkerProcess(
+                                lease_spec.GetLanguage(),
+                                rpc::WorkerType::WORKER,
+                                lease_spec.JobId(),
+                                &status,
+                                /*dynamic_options=*/{},
+                                lease_spec.GetRuntimeEnvHash(),
+                                serialized_runtime_env_context,
+                                lease_spec.RuntimeEnvInfo(),
+                                /*worker_startup_keep_alive_duration=*/std::nullopt,
+                                worker_resource_limits);
+                          });
   }
 }
 
@@ -1870,12 +1894,26 @@ void WorkerPool::GetOrCreateRuntimeEnv(const std::string &serialized_runtime_env
                                        const rpc::RuntimeEnvConfig &runtime_env_config,
                                        const JobID &job_id,
                                        const GetOrCreateRuntimeEnvCallback &callback) {
+  GetOrCreateRuntimeEnv(serialized_runtime_env,
+                        runtime_env_config,
+                        job_id,
+                        rpc::WorkerResourceLimits(),
+                        callback);
+}
+
+void WorkerPool::GetOrCreateRuntimeEnv(
+    const std::string &serialized_runtime_env,
+    const rpc::RuntimeEnvConfig &runtime_env_config,
+    const JobID &job_id,
+    const rpc::WorkerResourceLimits &worker_resource_limits,
+    const GetOrCreateRuntimeEnvCallback &callback) {
   RAY_LOG(DEBUG) << "GetOrCreateRuntimeEnv for job " << job_id << " with runtime_env "
                  << serialized_runtime_env;
   runtime_env_agent_client_->GetOrCreateRuntimeEnv(
       job_id,
       serialized_runtime_env,
       runtime_env_config,
+      worker_resource_limits,
       [job_id, serialized_runtime_env, runtime_env_config, callback](
           bool successful,
           const std::string &serialized_runtime_env_context,
@@ -1917,6 +1955,18 @@ const std::vector<std::string> &WorkerPool::LookupWorkerDynamicOptions(
   }
   static std::vector<std::string> kNoDynamicOptions;
   return kNoDynamicOptions;
+}
+
+const rpc::WorkerResourceLimits &WorkerPool::LookupWorkerResourceLimits(
+    const WorkerID &worker_id) const {
+  for (const auto &[lang, state] : states_by_lang_) {
+    auto it = state.worker_processes.find(worker_id);
+    if (it != state.worker_processes.end()) {
+      return it->second.worker_resource_limits;
+    }
+  }
+  static rpc::WorkerResourceLimits kNoWorkerResourceLimits;
+  return kNoWorkerResourceLimits;
 }
 
 const NodeID &WorkerPool::GetNodeID() const { return node_id_; }

--- a/src/ray/raylet/worker_pool.h
+++ b/src/ray/raylet/worker_pool.h
@@ -101,6 +101,7 @@ struct PopWorkerRequest {
   const std::optional<bool> is_actor_worker_;
   const rpc::RuntimeEnvInfo runtime_env_info_;
   const int runtime_env_hash_;
+  const rpc::WorkerResourceLimits worker_resource_limits_;
   const std::vector<std::string> dynamic_options_;
   std::optional<absl::Duration> worker_startup_keep_alive_duration_;
 
@@ -114,6 +115,7 @@ struct PopWorkerRequest {
                    std::optional<bool> actor_worker,
                    rpc::RuntimeEnvInfo runtime_env_info,
                    int runtime_env_hash,
+                   rpc::WorkerResourceLimits worker_resource_limits,
                    std::vector<std::string> options,
                    std::optional<absl::Duration> worker_startup_keep_alive_duration,
                    PopWorkerCallback callback)
@@ -125,6 +127,7 @@ struct PopWorkerRequest {
         is_actor_worker_(actor_worker),
         runtime_env_info_(std::move(runtime_env_info)),
         runtime_env_hash_(runtime_env_hash),
+        worker_resource_limits_(std::move(worker_resource_limits)),
         dynamic_options_(std::move(options)),
         worker_startup_keep_alive_duration_(worker_startup_keep_alive_duration),
         callback_(std::move(callback)) {}
@@ -176,6 +179,12 @@ class WorkerPoolInterface : public IOWorkerPoolInterface {
   /// Case 2: An suitable worker registered to raylet.
   /// The corresponding PopWorkerStatus will be passed to the callback.
   virtual void PopWorker(const LeaseSpecification &lease_spec,
+                         const PopWorkerCallback &callback) = 0;
+
+  /// Pop a worker that was started with the same resource limit profile, or start a
+  /// new worker with this profile.
+  virtual void PopWorker(const LeaseSpecification &lease_spec,
+                         const rpc::WorkerResourceLimits &worker_resource_limits,
                          const PopWorkerCallback &callback) = 0;
   /// Add an idle worker to the pool.
   ///
@@ -487,6 +496,10 @@ class WorkerPool : public WorkerPoolInterface {
   void PopWorker(const LeaseSpecification &lease_spec,
                  const PopWorkerCallback &callback) override;
 
+  void PopWorker(const LeaseSpecification &lease_spec,
+                 const rpc::WorkerResourceLimits &worker_resource_limits,
+                 const PopWorkerCallback &callback) override;
+
   /// Try to prestart a number of workers suitable the given lease spec. Prestarting
   /// is needed since core workers request one lease at a time, if starting is slow,
   /// then it means it takes a long time to scale up.
@@ -596,7 +609,9 @@ class WorkerPool : public WorkerPoolInterface {
       int runtime_env_hash = 0,
       const std::string &serialized_runtime_env_context = "{}",
       const rpc::RuntimeEnvInfo &runtime_env_info = rpc::RuntimeEnvInfo(),
-      std::optional<absl::Duration> worker_startup_keep_alive_duration = std::nullopt);
+      std::optional<absl::Duration> worker_startup_keep_alive_duration = std::nullopt,
+      const rpc::WorkerResourceLimits &worker_resource_limits =
+          rpc::WorkerResourceLimits());
 
   /// The implementation of how to start a new worker process with command arguments.
   /// The lifetime of the process is tied to that of the returned object,
@@ -625,6 +640,9 @@ class WorkerPool : public WorkerPoolInterface {
   const std::vector<std::string> &LookupWorkerDynamicOptions(
       const WorkerID &worker_id) const;
 
+  const rpc::WorkerResourceLimits &LookupWorkerResourceLimits(
+      const WorkerID &worker_id) const;
+
   struct IOWorkerState {
     /// The pool of idle I/O workers.
     std::unordered_set<std::shared_ptr<WorkerInterface>> idle_io_workers;
@@ -649,6 +667,8 @@ class WorkerPool : public WorkerPoolInterface {
     SteadyTimePoint start_time;
     /// The runtime env Info.
     rpc::RuntimeEnvInfo runtime_env_info;
+    /// Operating-system resource limits used to start this worker process.
+    rpc::WorkerResourceLimits worker_resource_limits;
     /// The dynamic_options.
     std::vector<std::string> dynamic_options;
     /// The duration to keep the newly created worker alive before it's assigned a lease.
@@ -822,6 +842,12 @@ class WorkerPool : public WorkerPoolInterface {
                              const JobID &job_id,
                              const GetOrCreateRuntimeEnvCallback &callback);
 
+  void GetOrCreateRuntimeEnv(const std::string &serialized_runtime_env,
+                             const rpc::RuntimeEnvConfig &runtime_env_config,
+                             const JobID &job_id,
+                             const rpc::WorkerResourceLimits &worker_resource_limits,
+                             const GetOrCreateRuntimeEnvCallback &callback);
+
   /// Delete runtime env asynchronously by runtime env agent.
   void DeleteRuntimeEnvIfPossible(const std::string &serialized_runtime_env);
 
@@ -833,7 +859,8 @@ class WorkerPool : public WorkerPoolInterface {
       SteadyTimePoint start,
       const rpc::RuntimeEnvInfo &runtime_env_info,
       const std::vector<std::string> &dynamic_options,
-      std::optional<absl::Duration> worker_startup_keep_alive_duration);
+      std::optional<absl::Duration> worker_startup_keep_alive_duration,
+      const rpc::WorkerResourceLimits &worker_resource_limits);
 
   void RemoveWorkerProcess(State &state, const WorkerID &worker_id);
 

--- a/src/ray/raylet/worker_resource_limits.cc
+++ b/src/ray/raylet/worker_resource_limits.cc
@@ -1,0 +1,125 @@
+// Copyright 2026 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "ray/raylet/worker_resource_limits.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <string>
+
+#include "absl/strings/str_cat.h"
+#include "nlohmann/json.hpp"
+#include "ray/common/ray_config.h"
+#include "ray/common/scheduling/placement_group_util.h"
+#include "ray/common/scheduling/scheduling_ids.h"
+
+namespace ray {
+namespace raylet {
+namespace {
+
+constexpr int64_t kDefaultCpuPeriodUs = 100000;
+constexpr int64_t kMaxCpuPeriodUs = 1000000;
+constexpr int64_t kMinCpuQuotaUs = 1000;
+constexpr double kMinRepresentableCpus =
+    static_cast<double>(kMinCpuQuotaUs) / kMaxCpuPeriodUs;
+
+bool IsImageUriRuntimeEnv(const std::string &serialized_runtime_env) {
+  try {
+    const auto runtime_env = nlohmann::json::parse(serialized_runtime_env);
+    const auto image_uri = runtime_env.find("image_uri");
+    return image_uri != runtime_env.end() && image_uri->is_string() &&
+           !image_uri->get_ref<const std::string &>().empty();
+  } catch (const nlohmann::json::exception &) {
+    return false;
+  }
+}
+
+double GetNormalizedResourceQuantity(const ResourceSet &resources,
+                                     const scheduling::ResourceID &target) {
+  double quantity = 0;
+  for (const auto &resource_id : resources.ResourceIds()) {
+    std::string resource_name = resource_id.Binary();
+    const auto placement_group_resource =
+        ParsePgFormattedResource(resource_name,
+                                 /*for_wildcard_resource=*/true,
+                                 /*for_indexed_resource=*/true);
+    if (placement_group_resource.has_value()) {
+      resource_name = placement_group_resource->original_resource;
+    }
+    if (resource_name == target.Binary()) {
+      // Placement group allocations contain both wildcard and indexed aliases for the
+      // same allocation. Taking the maximum preserves the actual quantity once.
+      quantity = std::max(quantity, resources.Get(resource_id).Double());
+    }
+  }
+  return quantity;
+}
+
+}  // namespace
+
+rpc::WorkerResourceLimits BuildWorkerResourceLimits(
+    const std::string &serialized_runtime_env, const ResourceSet &resources) {
+  rpc::WorkerResourceLimits limits;
+  if (!RayConfig::instance().worker_resource_limits_enabled() ||
+      !IsImageUriRuntimeEnv(serialized_runtime_env)) {
+    return limits;
+  }
+
+  const double cpus =
+      GetNormalizedResourceQuantity(resources, scheduling::ResourceID::CPU());
+  if (cpus > 0) {
+    if (cpus < kMinRepresentableCpus) {
+      limits.set_validation_error(
+          absl::StrCat("Per-worker container CPU limits below ",
+                       kMinRepresentableCpus,
+                       " CPU cannot be represented by Linux CFS. Requested: ",
+                       cpus,
+                       " CPU."));
+    } else {
+      // Linux CFS requires quota >= 1 ms and period <= 1 second. Use a longer
+      // period for small fractional requests so their quota remains legal without
+      // changing the requested CPU fraction.
+      const int64_t period_us =
+          cpus < static_cast<double>(kMinCpuQuotaUs) / kDefaultCpuPeriodUs
+              ? kMaxCpuPeriodUs
+              : kDefaultCpuPeriodUs;
+      limits.set_cpu_period_us(period_us);
+      limits.set_cpu_quota_us(std::llround(cpus * period_us));
+    }
+  }
+
+  const double memory =
+      GetNormalizedResourceQuantity(resources, scheduling::ResourceID::Memory());
+  if (memory > 0) {
+    limits.set_memory_bytes(static_cast<uint64_t>(std::llround(memory)));
+  }
+  return limits;
+}
+
+bool WorkerResourceLimitsEqual(const rpc::WorkerResourceLimits &left,
+                               const rpc::WorkerResourceLimits &right) {
+  return left.cpu_period_us() == right.cpu_period_us() &&
+         left.cpu_quota_us() == right.cpu_quota_us() &&
+         left.memory_bytes() == right.memory_bytes() &&
+         left.validation_error() == right.validation_error();
+}
+
+bool HasWorkerResourceLimits(const rpc::WorkerResourceLimits &limits) {
+  return limits.cpu_period_us() > 0 || limits.cpu_quota_us() > 0 ||
+         limits.memory_bytes() > 0 || !limits.validation_error().empty();
+}
+
+}  // namespace raylet
+}  // namespace ray

--- a/src/ray/raylet/worker_resource_limits.h
+++ b/src/ray/raylet/worker_resource_limits.h
@@ -1,0 +1,37 @@
+// Copyright 2026 The Ray Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <string>
+
+#include "ray/common/scheduling/resource_set.h"
+#include "src/ray/protobuf/runtime_env_agent.pb.h"
+
+namespace ray {
+namespace raylet {
+
+/// Build a normalized per-worker limit profile from resources assigned to a lease.
+/// Placement group aliases are deduplicated. An empty profile is returned when the
+/// feature is disabled or the runtime environment is not an image_uri environment.
+rpc::WorkerResourceLimits BuildWorkerResourceLimits(
+    const std::string &serialized_runtime_env, const ResourceSet &resources);
+
+bool WorkerResourceLimitsEqual(const rpc::WorkerResourceLimits &left,
+                               const rpc::WorkerResourceLimits &right);
+
+bool HasWorkerResourceLimits(const rpc::WorkerResourceLimits &limits);
+
+}  // namespace raylet
+}  // namespace ray


### PR DESCRIPTION
## Description

Propagate normalized CPU and memory profiles from lease allocation to Podman worker startup and include them in worker reuse matching.

## Related issues

Closes #16871 and #65751
