### PR TITLE
[Core] Stop sending the FREED object status and reserve the value

### DIFF
--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -3908,11 +3908,6 @@ void CoreWorker::HandleGetObjectStatus(rpc::GetObjectStatusRequest request,
     return;
   }
   RAY_CHECK(owner_address.worker_id() == request.owner_worker_id());
-  if (reference_counter_->IsPlasmaObjectFreed(object_id)) {
-    reply->set_status(rpc::GetObjectStatusReply::FREED);
-    send_reply_callback(Status::OK(), nullptr, nullptr);
-    return;
-  }
   // Send the reply once the value has become available. The value is
   // guaranteed to become available eventually because we own the object and
   // its ref count is > 0.

--- a/src/ray/core_worker/reference_counter.cc
+++ b/src/ray/core_worker/reference_counter.cc
@@ -898,8 +898,8 @@ bool ReferenceCounter::AddObjectOutOfScopeOrFreedCallback(
     // not set the deletion callback because it may never get called.
     return false;
   } else if (freed_objects_.contains(object_id)) {
-    // The object has been freed by the language frontend, so it
-    // should be deleted immediately.
+    // The object's plasma copy was dropped on purpose, so it should be deleted
+    // immediately.
     return false;
   }
 
@@ -937,7 +937,8 @@ void ReferenceCounter::UpdateObjectPinnedAtRaylet(const ObjectID &object_id,
   auto it = object_id_refs_.find(object_id);
   if (it != object_id_refs_.end()) {
     if (freed_objects_.contains(object_id)) {
-      // The object has been freed by the language frontend.
+      // The object's plasma copy was dropped on purpose, so do not start
+      // tracking a location for it again.
       return;
     }
 

--- a/src/ray/core_worker/tests/core_worker_test.cc
+++ b/src/ray/core_worker/tests/core_worker_test.cc
@@ -775,7 +775,7 @@ TEST_F(CoreWorkerTest, HandleGetObjectStatusObjectPutAfterFirstRequest) {
   EXPECT_EQ("meta", reply2.object().metadata());
 }
 
-TEST_F(CoreWorkerTest, HandleGetObjectStatusObjectFreedBetweenRequests) {
+TEST_F(CoreWorkerTest, HandleGetObjectStatusObjectDeletedFromStoreBetweenRequests) {
   auto object_id = ObjectID::FromRandom();
   auto ray_object = MakeRayObject("test_data", "meta");
 
@@ -827,7 +827,7 @@ TEST_F(CoreWorkerTest, HandleGetObjectStatusObjectFreedBetweenRequests) {
                   std::function<void()> success,
                   std::function<void()> failure) { promise2.set_value(s); });
 
-  // Object is freed, so the callback is stored until the object is put back in the store
+  // The object is gone from the store, so the callback is held until it is put back
   ASSERT_FALSE(io_service_.poll_one());
 }
 
@@ -886,6 +886,54 @@ TEST_F(CoreWorkerTest, HandleGetObjectStatusObjectOutOfScope) {
   // Not calling io_service_.run_one() because the callback is called on the main thread
   ASSERT_TRUE(future2.get().ok());
   EXPECT_EQ(reply2.status(), rpc::GetObjectStatusReply::OUT_OF_SCOPE);
+}
+
+// An object whose plasma copy the owner dropped on purpose is still answered, from the
+// in-plasma marker SealExisting leaves in the store, not held like the deleted-from-store
+// case above. SealExisting itself is not covered: this fixture has no plasma store
+// provider.
+TEST_F(CoreWorkerTest, HandleGetObjectStatusPlasmaFreedObjectStillAnswered) {
+  auto object_id = ObjectID::FromRandom();
+
+  rpc::Address owner_address;
+  owner_address.set_worker_id(core_worker_->GetWorkerID().Binary());
+  reference_counter_->AddOwnedObject(object_id,
+                                     {},
+                                     owner_address,
+                                     "",
+                                     0,
+                                     LineageReconstructionEligibility::INELIGIBLE_PUT,
+                                     true);
+
+  // Same order as SealExisting takes on its pin_object == false path.
+  reference_counter_->FreePlasmaObjects({object_id});
+  RayObject in_plasma(rpc::ErrorType::OBJECT_IN_PLASMA);
+  memory_store_->Put(in_plasma, object_id, reference_counter_->HasReference(object_id));
+
+  rpc::GetObjectStatusRequest request;
+  request.set_object_id(object_id.Binary());
+  request.set_owner_worker_id(core_worker_->GetWorkerID().Binary());
+
+  std::promise<Status> promise;
+  auto future = promise.get_future();
+  rpc::GetObjectStatusReply reply;
+
+  core_worker_->HandleGetObjectStatus(
+      request,
+      &reply,
+      [&promise](Status s, std::function<void()>, std::function<void()>) {
+        promise.set_value(s);
+      });
+
+  // poll_one rather than run_one: a regression fails here instead of blocking forever.
+  ASSERT_TRUE(io_service_.poll_one());
+  ASSERT_TRUE(future.get().ok());
+  EXPECT_EQ(reply.status(), rpc::GetObjectStatusReply::CREATED);
+  // The borrower is pointed at plasma, which is what the owner dropping the copy without
+  // pinning it means.
+  EXPECT_TRUE(reply.object().data().empty());
+  EXPECT_EQ(reply.object().metadata(),
+            std::to_string(static_cast<int>(rpc::ErrorType::OBJECT_IN_PLASMA)));
 }
 
 namespace {

--- a/src/ray/core_worker/tests/future_resolver_test.cc
+++ b/src/ray/core_worker/tests/future_resolver_test.cc
@@ -99,28 +99,13 @@ class FutureResolverTest : public ::testing::Test {
   FutureResolver resolver_;
 };
 
-// FREED is the one status named in this build that no branch handles, so it reaches the
-// catch-all without a cast.
-TEST_F(FutureResolverTest, ProcessResolvedObjectFreedStoresError) {
-  ObjectID object_id = NewObjectWithLocalRef();
-  rpc::GetObjectStatusReply reply;
-  reply.set_status(rpc::GetObjectStatusReply::FREED);
-
-  resolver_.ProcessResolvedObject(object_id, rpc::Address(), Status::OK(), reply);
-
-  auto object = memory_store_->GetIfExists(object_id);
-  ASSERT_NE(object, nullptr);
-  rpc::ErrorType error_type;
-  ASSERT_TRUE(object->IsException(&error_type));
-  ASSERT_EQ(error_type, rpc::ErrorType::OBJECT_LOST);
-}
-
 // A value this build has no name for. One case the catch-all exists for: proto3 enums
-// are open, so a reply can carry one.
+// are open, so a reply can carry one. 2 is such a value now that FREED is reserved, and
+// an owner on an older build can still send it.
 TEST_F(FutureResolverTest, ProcessResolvedObjectUnknownStatusStoresError) {
   ObjectID object_id = NewObjectWithLocalRef();
   rpc::GetObjectStatusReply reply;
-  reply.set_status(static_cast<rpc::GetObjectStatusReply::ObjectStatus>(99));
+  reply.set_status(static_cast<rpc::GetObjectStatusReply::ObjectStatus>(2));
 
   resolver_.ProcessResolvedObject(object_id, rpc::Address(), Status::OK(), reply);
 

--- a/src/ray/protobuf/core_worker.proto
+++ b/src/ray/protobuf/core_worker.proto
@@ -208,7 +208,12 @@ message GetObjectStatusReply {
   enum ObjectStatus {
     CREATED = 0;
     OUT_OF_SCOPE = 1;
-    FREED = 2;
+    // 2 was FREED: the owner replied this when it had dropped the object's
+    // plasma copy on purpose. No borrower branches on it, so it lands in the
+    // catch-all like any unnamed value. Do not reuse the value: an owner on an
+    // older build can still send it.
+    reserved 2;
+    reserved "FREED";
   }
   ObjectStatus status = 1;
   // The Ray object: either a concrete value, an in-Plasma indicator, or an


### PR DESCRIPTION
## Description

`GetObjectStatusReply.ObjectStatus` had `FREED = 2`, which the owner sent when it had dropped an object's plasma copy on purpose. No borrower branches on it: `FutureResolver::ProcessResolvedObject` handles `OUT_OF_SCOPE` and `CREATED`, and everything else lands in the catch-all added by #65270, which logs the numeric status and stores `OBJECT_LOST`. Nothing outside that function reads the field, in C++ or in Python and Java.

The value is now reserved and the owner side goes with it. `reserved` rather than a plain delete, following `usage.proto`, so nobody assigns 2 a different meaning later: an owner on an older build still sends it, and it would then hit a named branch instead of the catch-all.

Two things this deliberately does not touch. `freed_objects_` keeps its other job, which is what `AddObjectOutOfScopeOrFreedCallback` and `UpdateObjectPinnedAtRaylet` consult so a deliberately dropped plasma copy does not get a location tracked for it again. And `IsPlasmaObjectFreed` stays, now with no production caller, because `TestFree` uses it to assert that state directly rather than inferring it from the two behaviours above.

## Related issues

Follow-up to #65270, where @Yicheng-Lu-llll asked for the unused status to go ([comment](https://github.com/ray-project/ray/pull/65270#issuecomment-5387558375)).

Not a duplicate: no open PR touches `core_worker.proto` or `HandleGetObjectStatus`.

## Additional information

Worth being precise about reachability, because #65269 was not. `freed_objects_` is written in one production place, `SealExisting` on its `pin_object == false` path. Of the three callers that reach it, only `ray.put(_is_experimental_channel=True)` inserts anything: the other two go through `CreateExisting`, which never registers the object with the reference counter, so `FreePlasmaObjects` skips them. For a Compiled Graphs channel the owner puts an in-plasma marker in its own store, so serializing the ref populates the status and a Python borrower never sends the RPC at all. The one gap I have not closed is a Java borrower, which always sends an empty status and therefore always sends the RPC, but Compiled Graphs is a Python path and those refs do not reach a Java worker. So I did not find a path that produces the status today, rather than having proved there is none.

That makes this a schema and dead-branch change in practice, with one behaviour change if the path ever did fire: the borrower would get `CREATED` with the in-plasma marker and go to plasma for a copy the owner had released, instead of an immediate `ObjectLostError`. For a mutable channel that is closer to the intent, since readers pin those themselves, but it is a change and not a cleanup.

The second commit pins what this change now depends on. Removing the early return moves an object whose plasma copy was dropped onto the long-polling `GetAsync` path, and nothing in the handler guarantees it gets answered there any more: that rests on `SealExisting` putting the in-plasma marker into the store on the same path that marks the object freed. `HandleGetObjectStatusPlasmaFreedObjectStillAnswered` asserts the reply is posted rather than the callback held, and asserts the marker the borrower gets, which is the behaviour change above. Restoring an early return that consults `freed_objects_` fails that test and nothing else. It does not cover `SealExisting` itself, since the fixture has no plasma store provider, and the comment says so. The neighbouring test is renamed in the same commit: its "freed" meant deleted from the memory store, which is a different thing to have in the same file.

`ProcessResolvedObjectFreedStoresError` existed because `FREED` was the one named status with no branch, so it could reach the catch-all without a cast. With the name gone that case is the same as the neighbouring test, which now uses 2 instead of 99: the comment there already explained why 2 is the interesting unnamed value, and the assertion may as well use it. If someone later reuses 2 and gives it a branch, that test fails and points back at the proto comment.

```
bazel build --dynamic_mode=off \
  --copt=-Wno-error=deprecated-builtins \
  --host_copt=-Wno-error=deprecated-builtins \
  //src/ray/protobuf:core_worker_cc_proto \
  //src/ray/core_worker:core_worker_lib \
  //src/ray/core_worker/tests:future_resolver_test \
  //src/ray/core_worker/tests:reference_counter_test \
  //src/ray/core_worker/tests:core_worker_test
./bazel-bin/src/ray/core_worker/tests/future_resolver_test
./bazel-bin/src/ray/core_worker/tests/reference_counter_test
./bazel-bin/src/ray/core_worker/tests/core_worker_test
```

```
[==========] 5 tests from 1 test suite ran. (3 ms total)
[  PASSED  ] 5 tests.
[==========] 45 tests from 4 test suites ran. (6 ms total)
[  PASSED  ] 45 tests.
[==========] 37 tests from 7 test suites ran. (41 ms total)
[  PASSED  ] 37 tests.
```

The generated header confirms protoc saw the change: `FREED` no longer appears in it and `ObjectStatus_MAX` is 1. Nothing in the tree reads `ObjectStatus_MAX`, `_IsValid` or `_Name`. macOS 15.5 / arm64, Apple clang 21; the two extra flags work around a deprecated builtin in the pinned absl on that toolchain, not this change. `pre-commit run clang-format` and `pre-commit run cpplint` pass on the four C++ files.

## AI assistance

AI assistance was used for this change and for reviewing it. I have read every changed line and run the commands above locally.

