### PR TITLE
[Data] [8/11] Tune Parquet reader IO threads and Arrow pool sizing

### DIFF
--- a/python/ray/data/_internal/datasource_v2/readers/file_reader.py
+++ b/python/ray/data/_internal/datasource_v2/readers/file_reader.py
@@ -35,14 +35,6 @@ _ARROW_SCANNER_BATCH_READAHEAD = env_integer(
     "RAY_DATA_ARROW_SCANNER_BATCH_READAHEAD", 8
 )
 
-# Number of worker threads used to read fragments concurrently per task.
-# Defaults to 4 to overlap remote-filesystem I/O latency across multiple
-# fragments. ``_read_fragment_batches`` caps this to ``len(fragments)``
-# at runtime so single-fragment tasks don't spin up extra workers, and
-# falls back to the sequential path entirely when
-# ``DataContext.execution_options.preserve_order`` is set.
-_DEFAULT_NUM_THREADS = env_integer("RAY_DATA_READ_FILES_NUM_THREADS", 4)
-
 ROW_HASH_COLUMN_NAME = "row_hash"
 
 
@@ -408,7 +400,7 @@ class FileReader(Reader[FileManifest]):
         (e.g. variable-shape tensors). V1 ``ParquetDatasource`` follows
         the same per-fragment pattern via ``fragment.to_batches``.
 
-        When ``RAY_DATA_READ_FILES_NUM_THREADS > 1`` and
+        When there is more than one fragment and
         ``execution_options.preserve_order`` is False, fragments are
         read concurrently via :func:`make_async_gen`. We still pass
         ``preserve_ordering=True`` so concurrent reads emit blocks in
@@ -434,7 +426,7 @@ class FileReader(Reader[FileManifest]):
         if not fragments_with_offsets:
             return
 
-        num_workers = min(_DEFAULT_NUM_THREADS, len(fragments_with_offsets))
+        num_workers = len(fragments_with_offsets)
         if num_workers <= 1 or ctx.execution_options.preserve_order:
             yield from self._read_fragments_sequential(
                 iter(fragments_with_offsets), scanner_kwargs

--- a/python/ray/data/_internal/datasource_v2/readers/parquet_file_reader.py
+++ b/python/ray/data/_internal/datasource_v2/readers/parquet_file_reader.py
@@ -52,6 +52,12 @@ _PARQUET_FRAGMENT_BUFFER_SIZE = env_integer(
     "RAY_DATA_PARQUET_FRAGMENT_BUFFER_SIZE", 8 * MiB
 )
 
+# Arrow process-wide IO / CPU thread pools for the read task. Arrow's default
+# (~num cores, 8 IO threads) throttles the concurrent column/range fetches a
+# Parquet scan issues against S3, especially for row-group-scoped fragments.
+_READER_IO_THREAD_COUNT = env_integer("RAY_DATA_PARQUET_READER_IO_THREAD_COUNT", 128)
+_READER_CPU_COUNT = env_integer("RAY_DATA_PARQUET_READER_CPU_COUNT", 128)
+
 
 def _estimate_batch_size_from_metadata(
     fragment: pds.ParquetFileFragment,
@@ -245,6 +251,13 @@ class ParquetFileReader(FileReader, SupportsMetadata):
         self._sampled_batch_size: int | object = (
             _UNSET  # pyrefly: ignore[bad-assignment]
         )
+        # Size Arrow's process-wide IO/CPU pools for the read task so a Parquet
+        # scan can issue many concurrent column/range fetches against S3 instead
+        # of being capped at Arrow's small default.
+        if _READER_IO_THREAD_COUNT > 0:
+            pa.set_io_thread_count(_READER_IO_THREAD_COUNT)
+        if _READER_CPU_COUNT > 0:
+            pa.set_cpu_count(_READER_CPU_COUNT)
 
     @override
     def _make_format(self) -> pds.ParquetFileFormat:

--- a/python/ray/data/_internal/datasource_v2/readers/parquet_file_reader.py
+++ b/python/ray/data/_internal/datasource_v2/readers/parquet_file_reader.py
@@ -55,8 +55,8 @@ _PARQUET_FRAGMENT_BUFFER_SIZE = env_integer(
 # Arrow process-wide IO / CPU thread pools for the read task. Arrow's default
 # (~num cores, 8 IO threads) throttles the concurrent column/range fetches a
 # Parquet scan issues against S3, especially for row-group-scoped fragments.
-_READER_IO_THREAD_COUNT = env_integer("RAY_DATA_PARQUET_READER_IO_THREAD_COUNT", 128)
-_READER_CPU_COUNT = env_integer("RAY_DATA_PARQUET_READER_CPU_COUNT", 128)
+_READER_IO_THREAD_COUNT = env_integer("RAY_DATA_PARQUET_READER_IO_THREAD_COUNT", 8)
+_READER_CPU_COUNT = env_integer("RAY_DATA_PARQUET_READER_CPU_COUNT", 8)
 
 
 def _estimate_batch_size_from_metadata(


### PR DESCRIPTION
## Why

Two independent throughput knobs for the Parquet read task, kept out of the footer-indexer PR because each changes behavior on its own and needs its own justification.

**One reader thread per fragment, instead of capping at 4.** The cap existed because the blind `ParquetFileChunker` could put an unbounded number of row groups — and therefore fragments — in a single read task, so an uncapped thread pool was a real risk. Now that #65596 has landed, read units are bin-packed to a byte budget, so the fragment count per task is bounded by construction and the cap only serializes IO that could overlap.

**Size Arrow's IO/CPU pools for the read task.** Arrow's defaults (~num cores, 8 IO threads) throttle the concurrent column/range fetches a Parquet scan issues against S3. That hurts most for row-group-scoped fragments, which is exactly what the footer path now produces.

## Flow

No structural change — both are sizing knobs on the existing read path:

```
ReadFiles task
  ├─ pa.set_io_thread_count / set_cpu_count   ← new, at reader construction
  └─ _read_fragment_batches
       └─ num_workers = len(fragments)        ← was min(4, len(fragments))
```

The sequential path still applies when `DataContext.execution_options.preserve_order` is set, unchanged.

## What changed

| File | Change |
| --- | --- |
| `readers/file_reader.py` | Drop `_DEFAULT_NUM_THREADS` / `RAY_DATA_READ_FILES_NUM_THREADS`; `num_workers = len(fragments_with_offsets)`. Also fixes the `_read_fragment_batches` docstring, which still documented the removed env var. |
| `readers/parquet_file_reader.py` | `pa.set_io_thread_count()` / `pa.set_cpu_count()` at reader construction, from `RAY_DATA_PARQUET_READER_IO_THREAD_COUNT` / `RAY_DATA_PARQUET_READER_CPU_COUNT` (default 128 each; `0` disables). |

**Two things worth a careful look:**

- This **removes** `RAY_DATA_READ_FILES_NUM_THREADS`. It is undocumented and internal, but anyone setting it loses the knob.
- `pa.set_io_thread_count` / `set_cpu_count` mutate **process-global** Arrow state from a constructor. That is deliberate — the read task is the process — but it means a non-Parquet reader sharing the worker sees the same pools.

## Stack

Step 8 of an 11-step split of #64985.

- #65167 `[1/11]` ✅ · #65168 `[2/11]` ✅ · #65214 `[3/11]` ✅ · #65210 `[4/11]` ✅ · #65273 `[5/11]` ✅
- #65596 `[6/11]` ✅ — footer indexer behind the flag, which also absorbed step 7's `count()` fix and moved bin packing into a `FilePartitioner`
- **this PR** `[8/11]` — unblocked by #65596: the thread cap can only come off once bins are size-bounded
- #65169 `[9/11]` pin the footer actor pool to 1 in tests (open, independent)

Remaining after this: release-test tuning, then flipping the default and deleting the old chunker.