### PR TITLE
[Data] Break "UDF time" down into input prep, function body and output build

### DIFF
--- a/doc/source/data/inspecting-data.rst
+++ b/doc/source/data/inspecting-data.rst
@@ -205,7 +205,7 @@ For more on how to read this output, see :ref:`Monitoring Your Workload with the
     Operator 1 ReadParquet->SplitBlocks(32): 1 tasks executed, 32 blocks produced in 2.92s
     * Remote wall time: 103.38us min, 1.34s max, 42.14ms mean, 1.35s total
     * Remote cpu time: 102.0us min, 164.66ms max, 5.37ms mean, 171.72ms total
-    * UDF time: 0us min, 0us max, 0.0us mean, 0us total
+    * Block transform time: 0us min, 0us max, 0.0us mean, 0us total
     * Peak heap memory usage (MiB): 266375.0 min, 281875.0 max, 274491 mean
     * Output num rows per block: 1875 min, 1875 max, 1875 mean, 60000 total
     * Output size bytes per block: 537986 min, 555360 max, 545963 mean, 17470820 total
@@ -218,7 +218,7 @@ For more on how to read this output, see :ref:`Monitoring Your Workload with the
     Operator 2 MapBatches(f)->Filter(g): 32 tasks executed, 32 blocks produced in 3.63s
     * Remote wall time: 675.48ms min, 1.0s max, 797.07ms mean, 25.51s total
     * Remote cpu time: 673.41ms min, 897.32ms max, 768.09ms mean, 24.58s total
-    * UDF time: 661.65ms min, 978.04ms max, 778.13ms mean, 24.9s total
+    * Block transform time: 661.65ms min, 978.04ms max, 778.13ms mean, 24.9s total
     * Peak heap memory usage (MiB): 152281.25 min, 286796.88 max, 164231 mean
     * Output num rows per block: 1875 min, 1875 max, 1875 mean, 60000 total
     * Output size bytes per block: 530251 min, 547625 max, 538228 mean, 17223300 total

--- a/doc/source/data/inspecting-data.rst
+++ b/doc/source/data/inspecting-data.rst
@@ -205,7 +205,7 @@ For more on how to read this output, see :ref:`Monitoring Your Workload with the
     Operator 1 ReadParquet->SplitBlocks(32): 1 tasks executed, 32 blocks produced in 2.92s
     * Remote wall time: 103.38us min, 1.34s max, 42.14ms mean, 1.35s total
     * Remote cpu time: 102.0us min, 164.66ms max, 5.37ms mean, 171.72ms total
-    * Block transform time: 0us min, 0us max, 0.0us mean, 0us total
+    * Block transform time: 95.12us min, 1.31s max, 41.09ms mean, 1.31s total
     * Peak heap memory usage (MiB): 266375.0 min, 281875.0 max, 274491 mean
     * Output num rows per block: 1875 min, 1875 max, 1875 mean, 60000 total
     * Output size bytes per block: 537986 min, 555360 max, 545963 mean, 17470820 total

--- a/doc/source/data/monitoring-your-workload.rst
+++ b/doc/source/data/monitoring-your-workload.rst
@@ -393,17 +393,26 @@ The following are descriptions of the various stats included at the operator lev
   isn't processing data, sleeping, waiting for I/O, etc.
 * **Remote CPU time**: The CPU time is the process time for an operator which excludes time slept. This time includes both
   user and system CPU time.
-* **Input prep time**: Time spent turning input blocks into the batches or rows your functions receive, including converting
-  them to the ``batch_format`` you asked for. This can dominate when rows hold Python objects or large tensors.
-* **UDF time**: The UDF time is time spent in functions defined by the user. This time includes functions you pass into Ray
-  Data methods, including :meth:`~ray.data.Dataset.map`, :meth:`~ray.data.Dataset.map_batches`, :meth:`~ray.data.Dataset.filter`,
-  etc. It excludes the input prep and output block build time around those calls, so you can use this stat to track the time
-  spent in functions you define and how much time optimizing those functions could save.
-* **Output block build time**: Time spent assembling what your functions return back into blocks, including materializing
-  Python objects into Arrow. Note that this is separate from the object store write, which Ray Data reports as the
-  ``data_block_serialization_time_s`` metric.
+* **UDF time**: The UDF time is the total time an operator's tasks spend transforming data. It covers the functions you pass
+  into Ray Data methods, including :meth:`~ray.data.Dataset.map`, :meth:`~ray.data.Dataset.map_batches`,
+  :meth:`~ray.data.Dataset.filter`, etc., *and* the work Ray Data does on either side of them to hand them batches and to turn
+  what they return back into blocks. Set ``DataContext.verbose_stats_logs`` to break it into the following phases, which sum to
+  this total:
+
+  * **Input prep**: Time spent turning input blocks into the batches or rows your functions receive, including converting them
+    to the ``batch_format`` you asked for. This can dominate when rows hold Python objects or large tensors.
+  * **Function body**: Time spent inside your functions themselves, excluding the prep and build around them. Use this stat to
+    track how much time optimizing those functions could save.
+  * **Output block build**: Time spent assembling what your functions return back into blocks, including materializing Python
+    objects into Arrow. Note that this is separate from the object store write, which Ray Data reports as the
+    ``data_block_serialization_time_s`` metric.
+  * **Built-in stages**: Time spent in the bodies of stages Ray Data supplies itself, such as a read or a write, as opposed
+    to functions you passed in. This is only non-zero when Ray Data fuses one of them into this operator.
 
   Ray Data fuses adjacent operators where it can, and a fused operator reports one figure per phase covering all of its stages.
+  Row-based transforms such as :meth:`~ray.data.Dataset.map` only report the breakdown when you also set
+  ``DataContext.accurate_map_phase_timing``, because timing each row individually costs more than the breakdown reports. The
+  figures are always present on the summary object that ``Dataset.get_stats_summary()`` returns, regardless of either setting.
 * **Memory usage**: The output displays memory usage per block in MiB.
 * **Output stats**: The output includes stats on the number of rows output and size of output in bytes per block. The number of
   output rows per task is also included. All of this together gives you insight into how much data Ray Data is outputting at a per
@@ -450,6 +459,8 @@ By enabling verbosity Ray Data adds a few more outputs:
   operator summary of the time each operator took to complete and the fraction of the total execution time that the operator took
   to complete. As there are potentially multiple concurrent operators, these percentages don't necessarily sum to 100%. Instead,
   they show how long running each of the operators is in the context of the full dataset execution.
+* **UDF time breakdown**: Each operator's **UDF time** is split into the input prep, function body, output block build and
+  built-in stage phases described above, so you can see which part of the transform the time actually went to.
 
 Example stats
 ~~~~~~~~~~~~~

--- a/doc/source/data/monitoring-your-workload.rst
+++ b/doc/source/data/monitoring-your-workload.rst
@@ -393,9 +393,17 @@ The following are descriptions of the various stats included at the operator lev
   isn't processing data, sleeping, waiting for I/O, etc.
 * **Remote CPU time**: The CPU time is the process time for an operator which excludes time slept. This time includes both
   user and system CPU time.
+* **Input prep time**: Time spent turning input blocks into the batches or rows your functions receive, including converting
+  them to the ``batch_format`` you asked for. This can dominate when rows hold Python objects or large tensors.
 * **UDF time**: The UDF time is time spent in functions defined by the user. This time includes functions you pass into Ray
   Data methods, including :meth:`~ray.data.Dataset.map`, :meth:`~ray.data.Dataset.map_batches`, :meth:`~ray.data.Dataset.filter`,
-  etc. You can use this stat to track the time spent in functions you define and how much time optimizing those functions could save.
+  etc. It excludes the input prep and output block build time around those calls, so you can use this stat to track the time
+  spent in functions you define and how much time optimizing those functions could save.
+* **Output block build time**: Time spent assembling what your functions return back into blocks, including materializing
+  Python objects into Arrow. Note that this is separate from the object store write, which Ray Data reports as the
+  ``data_block_serialization_time_s`` metric.
+
+  Ray Data fuses adjacent operators where it can, and a fused operator reports one figure per phase covering all of its stages.
 * **Memory usage**: The output displays memory usage per block in MiB.
 * **Output stats**: The output includes stats on the number of rows output and size of output in bytes per block. The number of
   output rows per task is also included. All of this together gives you insight into how much data Ray Data is outputting at a per

--- a/doc/source/data/monitoring-your-workload.rst
+++ b/doc/source/data/monitoring-your-workload.rst
@@ -395,7 +395,8 @@ The following are descriptions of the various stats included at the operator lev
   user and system CPU time.
 * **Block transform time**: The time an operator spends transforming data, which Ray Data measures **per output block**. The min, max, and
   mean are therefore across blocks, and the total is the operator's. This isn't the same as the task's total time, which also
-  covers scheduling and writing blocks to the object store. It covers the functions you pass into Ray Data methods, including
+  covers scheduling and writing blocks to the object store. Read, write and map operators all report it, because a read and a
+  write run functions too. It covers the functions you pass into Ray Data methods, including
   :meth:`~ray.data.Dataset.map`, :meth:`~ray.data.Dataset.map_batches`, :meth:`~ray.data.Dataset.filter`, etc., plus the work
   around those calls that feeds them and collects what they return.
   Set ``DataContext.verbose_stats_logs`` to break it into the following phases, which sum to this total:

--- a/doc/source/data/monitoring-your-workload.rst
+++ b/doc/source/data/monitoring-your-workload.rst
@@ -393,7 +393,7 @@ The following are descriptions of the various stats included at the operator lev
   isn't processing data, sleeping, waiting for I/O, etc.
 * **Remote CPU time**: The CPU time is the process time for an operator which excludes time slept. This time includes both
   user and system CPU time.
-* **UDF time**: The time an operator spends transforming data, which Ray Data measures **per output block**. The min, max, and
+* **Block transform time**: The time an operator spends transforming data, which Ray Data measures **per output block**. The min, max, and
   mean are therefore across blocks, and the total is the operator's. This isn't the same as the task's total time, which also
   covers scheduling and writing blocks to the object store. It covers the functions you pass into Ray Data methods, including
   :meth:`~ray.data.Dataset.map`, :meth:`~ray.data.Dataset.map_batches`, :meth:`~ray.data.Dataset.filter`, etc., plus the work
@@ -424,9 +424,9 @@ The following are descriptions of the various stats included at the operator lev
   the throughput of the same task on a single node. This estimate assumes the total time of the work remains the same, but with no
   concurrency. The overall summary also calculates the throughput at the dataset level, including a single node estimate.
 
-Reading the UDF time breakdown
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-Ray Data fuses adjacent operators into one task, so a single **UDF time** breakdown often spans several stages, some of them
+Reading the block transform time breakdown
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Ray Data fuses adjacent operators into one task, so a single **block transform time** breakdown often spans several stages, some of them
 yours and some of them Ray Data's. Take this pipeline:
 
 .. code-block:: python
@@ -461,7 +461,7 @@ Ray Data fuses all four stages into one operator, and the breakdown splits that 
     Operator 1 ReadRange->Project->MapBatches(map1)->MapBatches(map2): 2 tasks executed, 2 blocks produced in 0.72s
     * Remote wall time: 308.96ms min, 391.19ms max, 350.07ms mean, 700.14ms total
     * Remote cpu time: 3.97ms min, 33.05ms max, 18.51ms mean, 37.03ms total
-    * UDF time: 307.46ms min, 390.49ms max, 348.98ms mean, 697.95ms total
+    * Block transform time: 307.46ms min, 390.49ms max, 348.98ms mean, 697.95ms total
         * Input prep: 297.96us min, 2.89ms max, 1.59ms mean, 3.19ms total
         * Function body: 305.83ms min, 310.34ms max, 308.09ms mean, 616.17ms total
         * Output block build: 945.29us min, 1.66ms max, 1.3ms mean, 2.61ms total
@@ -512,7 +512,7 @@ By enabling verbosity Ray Data adds a few more outputs:
   operator summary of the time each operator took to complete and the fraction of the total execution time that the operator took
   to complete. As there are potentially multiple concurrent operators, these percentages don't necessarily sum to 100%. Instead,
   they show how long running each of the operators is in the context of the full dataset execution.
-* **UDF time breakdown**: Ray Data splits each operator's **UDF time**, which it measures per output block, into the input
+* **Block transform time breakdown**: Ray Data splits each operator's **block transform time**, which it measures per output block, into the input
   prep, function body, output block build and built-in stage phases, so you can see which part of the transform the time
   actually went to.
 
@@ -525,7 +525,7 @@ As a concrete example, below is a stats output from :doc:`Image Classification B
    Operator 1 ReadImage->Map(preprocess_image): 384 tasks executed, 386 blocks produced in 9.21s
    * Remote wall time: 33.55ms min, 2.22s max, 1.03s mean, 395.65s total
    * Remote cpu time: 34.93ms min, 3.36s max, 1.64s mean, 632.26s total
-   * UDF time: 535.1ms min, 2.16s max, 975.7ms mean, 376.62s total
+   * Block transform time: 535.1ms min, 2.16s max, 975.7ms mean, 376.62s total
    * Peak heap memory usage (MiB): 556.32 min, 1126.95 max, 655 mean
    * Output num rows per block: 4 min, 25 max, 24 mean, 9469 total
    * Output size bytes per block: 6060399 min, 105223020 max, 31525416 mean, 12168810909 total
@@ -538,7 +538,7 @@ As a concrete example, below is a stats output from :doc:`Image Classification B
    Operator 2 MapBatches(ResnetModel): 14 tasks executed, 48 blocks produced in 27.43s
    * Remote wall time: 523.93us min, 7.01s max, 1.82s mean, 87.18s total
    * Remote cpu time: 523.23us min, 6.23s max, 1.76s mean, 84.61s total
-   * UDF time: 4.49s min, 17.81s max, 10.52s mean, 505.08s total
+   * Block transform time: 4.49s min, 17.81s max, 10.52s mean, 505.08s total
    * Peak heap memory usage (MiB): 4025.42 min, 7920.44 max, 5803 mean
    * Output num rows per block: 84 min, 334 max, 197 mean, 9469 total
    * Output size bytes per block: 72317976 min, 215806447 max, 134739694 mean, 6467505318 total
@@ -569,7 +569,7 @@ For the same example with verbosity enabled, the stats output is:
    Operator 1 ReadImage->Map(preprocess_image): 384 tasks executed, 387 blocks produced in 9.49s
    * Remote wall time: 22.81ms min, 2.5s max, 999.95ms mean, 386.98s total
    * Remote cpu time: 24.06ms min, 3.36s max, 1.63s mean, 629.93s total
-   * UDF time: 552.79ms min, 2.41s max, 956.84ms mean, 370.3s total
+   * Block transform time: 552.79ms min, 2.41s max, 956.84ms mean, 370.3s total
    * Peak heap memory usage (MiB): 550.95 min, 1186.28 max, 651 mean
    * Output num rows per block: 4 min, 25 max, 24 mean, 9469 total
    * Output size bytes per block: 4444092 min, 105223020 max, 31443955 mean, 12168810909 total
@@ -583,7 +583,7 @@ For the same example with verbosity enabled, the stats output is:
    Operator 2 MapBatches(ResnetModel): 14 tasks executed, 48 blocks produced in 28.81s
    * Remote wall time: 134.84us min, 7.23s max, 1.82s mean, 87.16s total
    * Remote cpu time: 133.78us min, 6.28s max, 1.75s mean, 83.98s total
-   * UDF time: 4.56s min, 17.78s max, 10.28s mean, 493.48s total
+   * Block transform time: 4.56s min, 17.78s max, 10.28s mean, 493.48s total
    * Peak heap memory usage (MiB): 3925.88 min, 7713.01 max, 5688 mean
    * Output num rows per block: 125 min, 259 max, 197 mean, 9469 total
    * Output size bytes per block: 75531617 min, 187889580 max, 134739694 mean, 6467505318 total

--- a/doc/source/data/monitoring-your-workload.rst
+++ b/doc/source/data/monitoring-your-workload.rst
@@ -393,7 +393,7 @@ The following are descriptions of the various stats included at the operator lev
   isn't processing data, sleeping, waiting for I/O, etc.
 * **Remote CPU time**: The CPU time is the process time for an operator which excludes time slept. This time includes both
   user and system CPU time.
-* **UDF time**: The time an operator spends transforming data, which Ray Data measures **per output block**. The min, max and
+* **UDF time**: The time an operator spends transforming data, which Ray Data measures **per output block**. The min, max, and
   mean are therefore across blocks, and the total is the operator's. This isn't the same as the task's total time, which also
   covers scheduling and writing blocks to the object store. It covers the functions you pass into Ray Data methods, including
   :meth:`~ray.data.Dataset.map`, :meth:`~ray.data.Dataset.map_batches`, :meth:`~ray.data.Dataset.filter`, etc., plus the work
@@ -423,6 +423,58 @@ The following are descriptions of the various stats included at the operator lev
 * **Throughput**: The summary calculates the throughput for the operator, and for a point of comparison, it also computes an estimate of
   the throughput of the same task on a single node. This estimate assumes the total time of the work remains the same, but with no
   concurrency. The overall summary also calculates the throughput at the dataset level, including a single node estimate.
+
+Reading the UDF time breakdown
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Ray Data fuses adjacent operators into one task, so a single **UDF time** breakdown often spans several stages, some of them
+yours and some of them Ray Data's. Take this pipeline:
+
+.. code-block:: python
+
+    import time
+    import ray
+    from ray.data.context import DataContext
+
+    DataContext.get_current().verbose_stats_logs = True
+
+    def map1(batch):
+        time.sleep(0.1)
+        return batch
+
+    def map2(batch):
+        time.sleep(0.2)
+        return batch
+
+    ds = (
+        ray.data.range(2, override_num_blocks=2)
+        .select_columns(["id"])
+        .map_batches(map1, batch_size=None)
+        .map_batches(map2, batch_size=None)
+        .materialize()
+    )
+    print(ds.stats())
+
+Ray Data fuses all four stages into one operator, and the breakdown splits that operator's time like this:
+
+.. code-block:: text
+
+    Operator 1 ReadRange->Project->MapBatches(map1)->MapBatches(map2): 2 tasks executed, 2 blocks produced in 0.72s
+    * Remote wall time: 308.96ms min, 391.19ms max, 350.07ms mean, 700.14ms total
+    * Remote cpu time: 3.97ms min, 33.05ms max, 18.51ms mean, 37.03ms total
+    * UDF time: 307.46ms min, 390.49ms max, 348.98ms mean, 697.95ms total
+        * Input prep: 297.96us min, 2.89ms max, 1.59ms mean, 3.19ms total
+        * Function body: 305.83ms min, 310.34ms max, 308.09ms mean, 616.17ms total
+        * Output block build: 945.29us min, 1.66ms max, 1.3ms mean, 2.61ms total
+        * Built-in stages: 391.92us min, 75.59ms max, 37.99ms mean, 75.99ms total
+    ...
+
+Each figure covers every stage that feeds it:
+
+* **Function body** holds ``map1`` and ``map2`` alone. Each task sleeps 0.1 then 0.2 seconds, and two tasks ran, so the
+  616 ms matches the 0.6 seconds the two functions slept.
+* **Built-in stages** holds ``ReadRange`` and ``Project``, the stages Ray Data adds for ``range`` and ``select_columns``.
+* **Input prep** and **Output block build** cover all four stages, not just the two you wrote. Every stage forms its own
+  batches and builds its own output blocks, and all four stages report into the same two buckets.
 
 Iterator stats
 ~~~~~~~~~~~~~~

--- a/doc/source/data/monitoring-your-workload.rst
+++ b/doc/source/data/monitoring-your-workload.rst
@@ -393,9 +393,11 @@ The following are descriptions of the various stats included at the operator lev
   isn't processing data, sleeping, waiting for I/O, etc.
 * **Remote CPU time**: The CPU time is the process time for an operator which excludes time slept. This time includes both
   user and system CPU time.
-* **UDF time**: The UDF time is the total time an operator spends transforming one output block. It covers the functions you
-  pass into Ray Data methods, including :meth:`~ray.data.Dataset.map`, :meth:`~ray.data.Dataset.map_batches`,
-  :meth:`~ray.data.Dataset.filter`, etc., plus the work around those calls that feeds them and collects what they return.
+* **UDF time**: The time an operator spends transforming data, measured **per output block** -- so the min, max and mean are
+  across blocks and the total is the operator's. It is not the same as the task's total time, which also covers scheduling and
+  writing blocks to the object store. It covers the functions you pass into Ray Data methods, including
+  :meth:`~ray.data.Dataset.map`, :meth:`~ray.data.Dataset.map_batches`, :meth:`~ray.data.Dataset.filter`, etc., plus the work
+  around those calls that feeds them and collects what they return.
   Set ``DataContext.verbose_stats_logs`` to break it into the following phases, which sum to this total:
 
   * **Input prep**: Time spent turning input blocks into the batches or rows your functions receive, including converting them
@@ -458,8 +460,9 @@ By enabling verbosity Ray Data adds a few more outputs:
   operator summary of the time each operator took to complete and the fraction of the total execution time that the operator took
   to complete. As there are potentially multiple concurrent operators, these percentages don't necessarily sum to 100%. Instead,
   they show how long running each of the operators is in the context of the full dataset execution.
-* **UDF time breakdown**: Each operator's **UDF time** is split into the input prep, function body, output block build and
-  built-in stage phases described above, so you can see which part of the transform the time actually went to.
+* **UDF time breakdown**: Each operator's **UDF time**, which is measured per output block, is split into the input prep,
+  function body, output block build and built-in stage phases described above, so you can see which part of the transform the
+  time actually went to.
 
 Example stats
 ~~~~~~~~~~~~~

--- a/doc/source/data/monitoring-your-workload.rst
+++ b/doc/source/data/monitoring-your-workload.rst
@@ -402,13 +402,12 @@ The following are descriptions of the various stats included at the operator lev
 
   * **Input prep**: Time spent turning input blocks into the batches or rows your functions receive, including converting them
     to the ``batch_format`` you asked for. This can dominate when rows hold Python objects or large tensors.
-  * **Function body**: Time spent inside your functions themselves, excluding the prep and build around them. Use this stat to
-    track how much time optimizing those functions could save.
+  * **Function body**: Time spent inside the stage bodies themselves, excluding the prep and build around them. This covers
+    the functions you passed in and the ones Ray Data supplies, such as a read or a write that Ray Data fused into the same
+    operator, because a read or a write is a function like any other.
   * **Output block build**: Time spent assembling what your functions return back into blocks, including materializing Python
     objects into Arrow. Note that this is separate from the object store write, which Ray Data reports as the
     ``data_block_serialization_time_s`` metric.
-  * **Built-in stages**: Time spent in the bodies of stages Ray Data supplies itself, such as a read or a write, as opposed
-    to functions you passed in. This is only non-zero when Ray Data fuses one of them into this operator.
 
   Ray Data fuses adjacent operators where it can, and a fused operator reports one figure per phase covering all of its stages.
   Row-based transforms such as :meth:`~ray.data.Dataset.map` only report the breakdown when you also set
@@ -458,23 +457,24 @@ Ray Data fuses all four stages into one operator, and the breakdown splits that 
 
 .. code-block:: text
 
-    Operator 1 ReadRange->Project->MapBatches(map1)->MapBatches(map2): 2 tasks executed, 2 blocks produced in 0.72s
-    * Remote wall time: 308.96ms min, 391.19ms max, 350.07ms mean, 700.14ms total
-    * Remote cpu time: 3.97ms min, 33.05ms max, 18.51ms mean, 37.03ms total
-    * Block transform time: 307.46ms min, 390.49ms max, 348.98ms mean, 697.95ms total
-        * Input prep: 297.96us min, 2.89ms max, 1.59ms mean, 3.19ms total
-        * Function body: 305.83ms min, 310.34ms max, 308.09ms mean, 616.17ms total
-        * Output block build: 945.29us min, 1.66ms max, 1.3ms mean, 2.61ms total
-        * Built-in stages: 391.92us min, 75.59ms max, 37.99ms mean, 75.99ms total
+    Operator 1 ReadRange->Project->MapBatches(map1)->MapBatches(map2): 2 tasks executed, 2 blocks produced in 0.67s
+    * Remote wall time: 308.95ms min, 341.72ms max, 325.33ms mean, 650.67ms total
+    * Remote cpu time: 3.96ms min, 30.06ms max, 17.01ms mean, 34.02ms total
+    * Block transform time: 307.77ms min, 341.02ms max, 324.4ms mean, 648.79ms total
+        * Input prep: 270.79us min, 1.42ms max, 845.89us mean, 1.69ms total
+        * Function body: 306.8ms min, 338.86ms max, 322.83ms mean, 645.66ms total
+        * Output block build: 700.34us min, 743.38us max, 721.86us mean, 1.44ms total
     ...
 
-Each figure covers every stage that feeds it:
+Every figure covers all four stages:
 
-* **Function body** holds ``map1`` and ``map2`` alone. Each task sleeps 0.1 then 0.2 seconds, and two tasks ran, so the
-  616 ms matches the 0.6 seconds the two functions slept.
-* **Built-in stages** holds ``ReadRange`` and ``Project``, the stages Ray Data adds for ``range`` and ``select_columns``.
-* **Input prep** and **Output block build** cover all four stages, not just the two you wrote. Every stage forms its own
-  batches and builds its own output blocks, and all four stages report into the same two buckets.
+* **Function body** holds all four stage bodies: ``ReadRange``, ``Project``, ``map1`` and ``map2``. Two tasks each slept 0.1
+  then 0.2 seconds, so 0.6 of the 645 ms is ``map1`` and ``map2``, and the remainder is the read and the column projection.
+* **Input prep** and **Output block build** likewise cover every stage, not only the two you wrote. Each stage forms its own
+  batches and builds its own output blocks, and all four report into the same two figures.
+
+So this breakdown tells you which *phase* the time went to, not which stage. Attributing the body time to ``map2`` rather
+than to the operator needs a per-stage breakdown, which Ray Data doesn't report yet.
 
 Iterator stats
 ~~~~~~~~~~~~~~
@@ -512,9 +512,9 @@ By enabling verbosity Ray Data adds a few more outputs:
   operator summary of the time each operator took to complete and the fraction of the total execution time that the operator took
   to complete. As there are potentially multiple concurrent operators, these percentages don't necessarily sum to 100%. Instead,
   they show how long running each of the operators is in the context of the full dataset execution.
-* **Block transform time breakdown**: Ray Data splits each operator's **block transform time**, which it measures per output block, into the input
-  prep, function body, output block build and built-in stage phases, so you can see which part of the transform the time
-  actually went to.
+* **Block transform time breakdown**: Ray Data splits each operator's **block transform time**, which it measures per output
+  block, into the input prep, function body and output block build phases, so you can see which part of the transform the
+  time actually went to.
 
 Example stats
 ~~~~~~~~~~~~~

--- a/doc/source/data/monitoring-your-workload.rst
+++ b/doc/source/data/monitoring-your-workload.rst
@@ -393,11 +393,10 @@ The following are descriptions of the various stats included at the operator lev
   isn't processing data, sleeping, waiting for I/O, etc.
 * **Remote CPU time**: The CPU time is the process time for an operator which excludes time slept. This time includes both
   user and system CPU time.
-* **UDF time**: The UDF time is the total time an operator's tasks spend transforming data. It covers the functions you pass
-  into Ray Data methods, including :meth:`~ray.data.Dataset.map`, :meth:`~ray.data.Dataset.map_batches`,
-  :meth:`~ray.data.Dataset.filter`, etc., *and* the work Ray Data does on either side of them to hand them batches and to turn
-  what they return back into blocks. Set ``DataContext.verbose_stats_logs`` to break it into the following phases, which sum to
-  this total:
+* **UDF time**: The UDF time is the total time an operator spends transforming one output block. It covers the functions you
+  pass into Ray Data methods, including :meth:`~ray.data.Dataset.map`, :meth:`~ray.data.Dataset.map_batches`,
+  :meth:`~ray.data.Dataset.filter`, etc., plus the work around those calls that feeds them and collects what they return.
+  Set ``DataContext.verbose_stats_logs`` to break it into the following phases, which sum to this total:
 
   * **Input prep**: Time spent turning input blocks into the batches or rows your functions receive, including converting them
     to the ``batch_format`` you asked for. This can dominate when rows hold Python objects or large tensors.

--- a/doc/source/data/monitoring-your-workload.rst
+++ b/doc/source/data/monitoring-your-workload.rst
@@ -393,9 +393,9 @@ The following are descriptions of the various stats included at the operator lev
   isn't processing data, sleeping, waiting for I/O, etc.
 * **Remote CPU time**: The CPU time is the process time for an operator which excludes time slept. This time includes both
   user and system CPU time.
-* **UDF time**: The time an operator spends transforming data, measured **per output block** -- so the min, max and mean are
-  across blocks and the total is the operator's. It is not the same as the task's total time, which also covers scheduling and
-  writing blocks to the object store. It covers the functions you pass into Ray Data methods, including
+* **UDF time**: The time an operator spends transforming data, which Ray Data measures **per output block**. The min, max and
+  mean are therefore across blocks, and the total is the operator's. This isn't the same as the task's total time, which also
+  covers scheduling and writing blocks to the object store. It covers the functions you pass into Ray Data methods, including
   :meth:`~ray.data.Dataset.map`, :meth:`~ray.data.Dataset.map_batches`, :meth:`~ray.data.Dataset.filter`, etc., plus the work
   around those calls that feeds them and collects what they return.
   Set ``DataContext.verbose_stats_logs`` to break it into the following phases, which sum to this total:
@@ -460,9 +460,9 @@ By enabling verbosity Ray Data adds a few more outputs:
   operator summary of the time each operator took to complete and the fraction of the total execution time that the operator took
   to complete. As there are potentially multiple concurrent operators, these percentages don't necessarily sum to 100%. Instead,
   they show how long running each of the operators is in the context of the full dataset execution.
-* **UDF time breakdown**: Each operator's **UDF time**, which is measured per output block, is split into the input prep,
-  function body, output block build and built-in stage phases described above, so you can see which part of the transform the
-  time actually went to.
+* **UDF time breakdown**: Ray Data splits each operator's **UDF time**, which it measures per output block, into the input
+  prep, function body, output block build and built-in stage phases, so you can see which part of the transform the time
+  actually went to.
 
 Example stats
 ~~~~~~~~~~~~~

--- a/doc/source/data/monitoring-your-workload.rst
+++ b/doc/source/data/monitoring-your-workload.rst
@@ -261,6 +261,14 @@ These metrics track task execution and scheduling.
      - Number of failed tasks
    * - `block_generation_time`
      - Time spent generating blocks in tasks
+   * - `block_transform_time_s`
+     - Time spent transforming one output block, summed over the operator's blocks. Map operators only
+   * - `input_prep_time_s`
+     - Part of `block_transform_time_s` spent turning input blocks into batches or rows. Absent when the operator measured only its total, which is what a row transform does by default
+   * - `function_body_time_s`
+     - Part of `block_transform_time_s` spent inside the stage bodies. Absent under the same condition as `input_prep_time_s`
+   * - `output_build_time_s`
+     - Part of `block_transform_time_s` spent assembling stage output back into blocks. Absent under the same condition as `input_prep_time_s`
    * - `task_submission_backpressure_time`
      - Time spent in task submission backpressure
    * - `task_output_backpressure_time`

--- a/doc/source/data/monitoring-your-workload.rst
+++ b/doc/source/data/monitoring-your-workload.rst
@@ -403,7 +403,7 @@ The following are descriptions of the various stats included at the operator lev
   user and system CPU time.
 * **Block transform time**: The time an operator spends transforming data, which Ray Data measures **per output block**. The min, max, and
   mean are therefore across blocks, and the total is the operator's. This isn't the same as the task's total time, which also
-  covers scheduling and writing blocks to the object store. Read, write and map operators all report it, because a read and a
+  covers scheduling and writing blocks to the object store. Read, write, and map operators all report it, because a read and a
   write run functions too. It covers the functions you pass into Ray Data methods, including
   :meth:`~ray.data.Dataset.map`, :meth:`~ray.data.Dataset.map_batches`, :meth:`~ray.data.Dataset.filter`, etc., plus the work
   around those calls that feeds them and collects what they return.

--- a/doc/source/data/monitoring-your-workload.rst
+++ b/doc/source/data/monitoring-your-workload.rst
@@ -415,7 +415,7 @@ The following are descriptions of the various stats included at the operator lev
     the functions you passed in and the ones Ray Data supplies, such as a read or a write that Ray Data fused into the same
     operator, because a read or a write is a function like any other.
   * **Output block build**: Time spent assembling what your functions return back into blocks, including materializing Python
-    objects into Arrow. Note that this is separate from the object store write, which Ray Data reports as the
+    objects into Arrow. This is separate from the object store write, which Ray Data reports as the
     ``data_block_serialization_time_s`` metric.
 
   Ray Data fuses adjacent operators where it can, and a fused operator reports one figure per phase covering all of its stages.

--- a/doc/source/data/monitoring-your-workload.rst
+++ b/doc/source/data/monitoring-your-workload.rst
@@ -110,6 +110,7 @@ The metrics recorded include:
 * Freed memory in object store
 * Spilled memory in object store
 * Time spent generating blocks
+* Time spent transforming data, and its breakdown into input prep, function body, and output block build
 * Time spent in task submission backpressure
 * Time spent to initialize iteration.
 * Time user code is blocked during iteration.

--- a/doc/source/data/monitoring-your-workload.rst
+++ b/doc/source/data/monitoring-your-workload.rst
@@ -477,7 +477,7 @@ Ray Data fuses all four stages into one operator, and the breakdown splits that 
 
 Every figure covers all four stages:
 
-* **Function body** holds all four stage bodies: ``ReadRange``, ``Project``, ``map1`` and ``map2``. Two tasks each slept 0.1
+* **Function body** holds all four stage bodies: ``ReadRange``, ``Project``, ``map1``, and ``map2``. Two tasks each slept 0.1
   then 0.2 seconds, so 0.6 of the 645 ms is ``map1`` and ``map2``, and the remainder is the read and the column projection.
 * **Input prep** and **Output block build** likewise cover every stage, not only the two you wrote. Each stage forms its own
   batches and builds its own output blocks, and all four report into the same two figures.

--- a/doc/source/data/monitoring-your-workload.rst
+++ b/doc/source/data/monitoring-your-workload.rst
@@ -522,7 +522,7 @@ By enabling verbosity Ray Data adds a few more outputs:
   to complete. As there are potentially multiple concurrent operators, these percentages don't necessarily sum to 100%. Instead,
   they show how long running each of the operators is in the context of the full dataset execution.
 * **Block transform time breakdown**: Ray Data splits each operator's **block transform time**, which it measures per output
-  block, into the input prep, function body and output block build phases, so you can see which part of the transform the
+  block, into the input prep, function body, and output block build phases, so you can see which part of the transform the
   time actually went to.
 
 Example stats

--- a/python/ray/dashboard/modules/metrics/dashboards/data_dashboard_panels.py
+++ b/python/ray/dashboard/modules/metrics/dashboards/data_dashboard_panels.py
@@ -479,7 +479,7 @@ BLOCK_GENERATION_TIME_PANEL = Panel(
 BLOCK_TRANSFORM_TIME_PANEL = Panel(
     id=126,
     title="Block Transform Time",
-    description="Average time (in seconds) a map, read, or write operator spent transforming data per output block over a recent 5-minute window. This covers the whole transform chain: forming the batches or rows the operator's stages consume, running the stage bodies, and building the output blocks. It excludes scheduling and the object store write: the Block Generation Time panel covers the block's full wall time, and the ray_data_block_serialization_time_s metric covers the object store write.",
+    description="Average time (in seconds) a map, read, or write operator spent transforming data per output block over a recent 5-minute window. This covers the whole transform chain: forming the batches or rows the operator's stages consume, running the stage bodies, and building the output blocks. Block Generation Time measures the same blocks as wall clock over everything between them, so it is always the larger of the two and the gap is Ray Data's own per-block work rather than yours. Neither includes the object store write, which ray_data_block_serialization_time_s reports. Only map, read, and write operators report this; shuffles and aggregations don't.",
     unit="s",
     targets=[
         Target(

--- a/python/ray/dashboard/modules/metrics/dashboards/data_dashboard_panels.py
+++ b/python/ray/dashboard/modules/metrics/dashboards/data_dashboard_panels.py
@@ -476,6 +476,44 @@ BLOCK_GENERATION_TIME_PANEL = Panel(
     stack=False,
 )
 
+BLOCK_TRANSFORM_TIME_PANEL = Panel(
+    id=126,
+    title="Block Transform Time",
+    description="Average time (in seconds) a map, read, or write operator spent transforming data per output block over a recent 5-minute window. This covers the whole transform chain: forming the batches or rows the operator's stages consume, running the stage bodies, and building the output blocks. It excludes scheduling and the object store write: the Block Generation Time panel covers the block's full wall time, and the ray_data_block_serialization_time_s metric covers the object store write.",
+    unit="s",
+    targets=[
+        Target(
+            expr='increase(ray_data_block_transform_time_s{{{global_filters}, operator=~"$Operator"}}[5m]) / increase(ray_data_num_task_outputs_generated{{{global_filters}, operator=~"$Operator"}}[5m])',
+            legend="Block Transform Time: {{dataset}}, {{operator}}",
+        )
+    ],
+    fill=0,
+    stack=False,
+)
+
+BLOCK_TRANSFORM_TIME_BY_PHASE_PANEL = Panel(
+    id=127,
+    title="Block Transform Time by Phase",
+    description="The Block Transform Time panel broken into the three phases that sum to it, averaged per output block over a recent 5-minute window. Input prep is turning input blocks into the batches or rows your functions receive; Function body is the stage bodies themselves, both yours and the ones Ray Data supplies; Output block build is assembling what they return back into blocks. This panel is empty for row-based transforms such as map and filter unless DataContext.accurate_map_phase_timing is set, because timing each row individually costs more than the breakdown reports; the Block Transform Time panel still plots the total.",
+    unit="s",
+    targets=[
+        Target(
+            expr='increase(ray_data_input_prep_time_s{{{global_filters}, operator=~"$Operator"}}[5m]) / increase(ray_data_num_task_outputs_generated{{{global_filters}, operator=~"$Operator"}}[5m])',
+            legend="Input Prep: {{dataset}}, {{operator}}",
+        ),
+        Target(
+            expr='increase(ray_data_function_body_time_s{{{global_filters}, operator=~"$Operator"}}[5m]) / increase(ray_data_num_task_outputs_generated{{{global_filters}, operator=~"$Operator"}}[5m])',
+            legend="Function Body: {{dataset}}, {{operator}}",
+        ),
+        Target(
+            expr='increase(ray_data_output_build_time_s{{{global_filters}, operator=~"$Operator"}}[5m]) / increase(ray_data_num_task_outputs_generated{{{global_filters}, operator=~"$Operator"}}[5m])',
+            legend="Output Block Build: {{dataset}}, {{operator}}",
+        ),
+    ],
+    fill=10,
+    stack=True,
+)
+
 TASK_SUBMISSION_BACKPRESSURE_PANEL = Panel(
     id=37,
     title="Task Submission Backpressure Time",
@@ -1477,6 +1515,8 @@ DATA_GRAFANA_ROWS = [
             AVERAGE_BYTES_PER_BLOCK_PANEL,
             AVERAGE_BLOCKS_PER_TASK_PANEL,
             BLOCK_GENERATION_TIME_PANEL,
+            BLOCK_TRANSFORM_TIME_PANEL,
+            BLOCK_TRANSFORM_TIME_BY_PHASE_PANEL,
         ],
         collapsed=True,
     ),

--- a/python/ray/data/_internal/execution/interfaces/op_runtime_metrics.py
+++ b/python/ray/data/_internal/execution/interfaces/op_runtime_metrics.py
@@ -405,6 +405,46 @@ class OpRuntimeMetrics(metaclass=OpRuntimesMetricsMeta):
         description="Time spent serializing blocks produced.",
         metrics_group=MetricsGroup.TASKS,
     )
+    udf_time_s: float = metric_field(
+        default=0,
+        description=(
+            "Time spent in the operator's map transform chain. The input prep, "
+            "UDF body, output build and other-stage metrics decompose this."
+        ),
+        metrics_group=MetricsGroup.TASKS,
+    )
+    input_prep_time_s: float = metric_field(
+        default=0,
+        description=(
+            "Time spent turning input blocks into the batches or rows the "
+            "operator's UDFs consume."
+        ),
+        metrics_group=MetricsGroup.TASKS,
+    )
+    udf_body_time_s: float = metric_field(
+        default=0,
+        description=(
+            "Time spent inside the operator's UDF bodies, excluding the batch/row "
+            "formatting and block building around them."
+        ),
+        metrics_group=MetricsGroup.TASKS,
+    )
+    output_build_time_s: float = metric_field(
+        default=0,
+        description=(
+            "Time spent assembling UDF output back into blocks, including "
+            "materializing Python objects into Arrow."
+        ),
+        metrics_group=MetricsGroup.TASKS,
+    )
+    other_stage_time_s: float = metric_field(
+        default=0,
+        description=(
+            "Time spent in the bodies of non-UDF stages fused into the same "
+            "chain, such as a read or a write."
+        ),
+        metrics_group=MetricsGroup.TASKS,
+    )
     task_submission_backpressure_time: float = metric_field(
         default=0,
         description="Wall-clock time operator wasn't able to launch any new tasks.",
@@ -1035,6 +1075,11 @@ class OpRuntimeMetrics(metaclass=OpRuntimesMetricsMeta):
 
             self.block_generation_time += exec_stats.wall_time_s
             self.block_serialization_time_s += exec_stats.block_ser_time_s
+            self.udf_time_s += exec_stats.udf_time_s or 0
+            self.input_prep_time_s += exec_stats.input_prep_time_s or 0
+            self.udf_body_time_s += exec_stats.udf_body_time_s or 0
+            self.output_build_time_s += exec_stats.output_build_time_s or 0
+            self.other_stage_time_s += exec_stats.other_stage_time_s or 0
 
             task_info.cum_block_gen_time_s += exec_stats.wall_time_s
             task_info.cum_block_ser_time_s += exec_stats.block_ser_time_s

--- a/python/ray/data/_internal/execution/interfaces/op_runtime_metrics.py
+++ b/python/ray/data/_internal/execution/interfaces/op_runtime_metrics.py
@@ -448,8 +448,10 @@ class OpRuntimeMetrics(metaclass=OpRuntimesMetricsMeta):
     other_stage_time_s: float = metric_field(
         default=0,
         description=(
-            "Time spent in the bodies of non-UDF stages fused into the same "
-            "chain, such as a read or a write."
+            "Time spent in the bodies of stages Ray Data supplies itself, such "
+            "as a read or a write, fused into the same chain. Excludes the input "
+            "prep and output build around every stage, which are reported "
+            "separately."
         ),
         metrics_group=MetricsGroup.TASKS,
         # Only map operators run a UDF transform chain.

--- a/python/ray/data/_internal/execution/interfaces/op_runtime_metrics.py
+++ b/python/ray/data/_internal/execution/interfaces/op_runtime_metrics.py
@@ -408,8 +408,8 @@ class OpRuntimeMetrics(metaclass=OpRuntimesMetricsMeta):
     block_transform_time_s: float = metric_field(
         default=0,
         description=(
-            "Time spent in the operator's map transform chain. The input prep, "
-            "UDF body, output build and other-stage metrics decompose this."
+            "Time spent transforming one output block. The input prep, function "
+            "body and output build metrics decompose this."
         ),
         metrics_group=MetricsGroup.TASKS,
         # Only map operators run a UDF transform chain.
@@ -425,11 +425,12 @@ class OpRuntimeMetrics(metaclass=OpRuntimesMetricsMeta):
         # Only map operators run a UDF transform chain.
         map_only=True,
     )
-    udf_body_time_s: float = metric_field(
+    function_body_time_s: float = metric_field(
         default=0,
         description=(
-            "Time spent inside the operator's UDF bodies, excluding the batch/row "
-            "formatting and block building around them."
+            "Time spent inside the bodies of the operator's stages, the ones Ray "
+            "Data supplies as well as the ones you passed in, excluding the "
+            "batch/row formatting and block building around them."
         ),
         metrics_group=MetricsGroup.TASKS,
         # Only map operators run a UDF transform chain.
@@ -440,18 +441,6 @@ class OpRuntimeMetrics(metaclass=OpRuntimesMetricsMeta):
         description=(
             "Time spent assembling UDF output back into blocks, including "
             "materializing Python objects into Arrow."
-        ),
-        metrics_group=MetricsGroup.TASKS,
-        # Only map operators run a UDF transform chain.
-        map_only=True,
-    )
-    other_stage_time_s: float = metric_field(
-        default=0,
-        description=(
-            "Time spent in the bodies of stages Ray Data supplies itself, such "
-            "as a read or a write, fused into the same chain. Excludes the input "
-            "prep and output build around every stage, which are reported "
-            "separately."
         ),
         metrics_group=MetricsGroup.TASKS,
         # Only map operators run a UDF transform chain.
@@ -1089,9 +1078,8 @@ class OpRuntimeMetrics(metaclass=OpRuntimesMetricsMeta):
             self.block_serialization_time_s += exec_stats.block_ser_time_s
             self.block_transform_time_s += exec_stats.block_transform_time_s or 0
             self.input_prep_time_s += exec_stats.input_prep_time_s or 0
-            self.udf_body_time_s += exec_stats.udf_body_time_s or 0
+            self.function_body_time_s += exec_stats.function_body_time_s or 0
             self.output_build_time_s += exec_stats.output_build_time_s or 0
-            self.other_stage_time_s += exec_stats.other_stage_time_s or 0
 
             task_info.cum_block_gen_time_s += exec_stats.wall_time_s
             task_info.cum_block_ser_time_s += exec_stats.block_ser_time_s

--- a/python/ray/data/_internal/execution/interfaces/op_runtime_metrics.py
+++ b/python/ray/data/_internal/execution/interfaces/op_runtime_metrics.py
@@ -415,32 +415,38 @@ class OpRuntimeMetrics(metaclass=OpRuntimesMetricsMeta):
         # Only map operators run a UDF transform chain.
         map_only=True,
     )
-    input_prep_time_s: float = metric_field(
-        default=0,
+    # `None`, not zero, until a block reports a phase: a row transform is timed
+    # as a whole unless `DataContext.accurate_map_phase_timing` is set, and a
+    # consumer has to be able to tell that apart from a phase that took no time.
+    input_prep_time_s: Optional[float] = metric_field(
+        default=None,
         description=(
             "Time spent turning input blocks into the batches or rows the "
-            "operator's UDFs consume."
+            "operator's stages consume. Absent when the operator measured only "
+            "its total, which is what a row transform does by default."
         ),
         metrics_group=MetricsGroup.TASKS,
         # Only map operators run a UDF transform chain.
         map_only=True,
     )
-    function_body_time_s: float = metric_field(
-        default=0,
+    function_body_time_s: Optional[float] = metric_field(
+        default=None,
         description=(
             "Time spent inside the bodies of the operator's stages, the ones Ray "
             "Data supplies as well as the ones you passed in, excluding the "
-            "batch/row formatting and block building around them."
+            "batch/row formatting and block building around them. Absent when "
+            "the operator measured only its total."
         ),
         metrics_group=MetricsGroup.TASKS,
         # Only map operators run a UDF transform chain.
         map_only=True,
     )
-    output_build_time_s: float = metric_field(
-        default=0,
+    output_build_time_s: Optional[float] = metric_field(
+        default=None,
         description=(
-            "Time spent assembling UDF output back into blocks, including "
-            "materializing Python objects into Arrow."
+            "Time spent assembling stage output back into blocks, including "
+            "materializing Python objects into Arrow. Absent when the operator "
+            "measured only its total."
         ),
         metrics_group=MetricsGroup.TASKS,
         # Only map operators run a UDF transform chain.
@@ -1077,9 +1083,18 @@ class OpRuntimeMetrics(metaclass=OpRuntimesMetricsMeta):
             self.block_generation_time += exec_stats.wall_time_s
             self.block_serialization_time_s += exec_stats.block_ser_time_s
             self.block_transform_time_s += exec_stats.block_transform_time_s or 0
-            self.input_prep_time_s += exec_stats.input_prep_time_s or 0
-            self.function_body_time_s += exec_stats.function_body_time_s or 0
-            self.output_build_time_s += exec_stats.output_build_time_s or 0
+            # Leave the phases `None` rather than summing them to zero when the
+            # chain measured only its total: three zeros that don't add up to
+            # `block_transform_time_s` read as "no time here" rather than as
+            # "not measured".
+            for name in (
+                "input_prep_time_s",
+                "function_body_time_s",
+                "output_build_time_s",
+            ):
+                measured = getattr(exec_stats, name)
+                if measured is not None:
+                    setattr(self, name, (getattr(self, name) or 0) + measured)
 
             task_info.cum_block_gen_time_s += exec_stats.wall_time_s
             task_info.cum_block_ser_time_s += exec_stats.block_ser_time_s

--- a/python/ray/data/_internal/execution/interfaces/op_runtime_metrics.py
+++ b/python/ray/data/_internal/execution/interfaces/op_runtime_metrics.py
@@ -412,6 +412,8 @@ class OpRuntimeMetrics(metaclass=OpRuntimesMetricsMeta):
             "UDF body, output build and other-stage metrics decompose this."
         ),
         metrics_group=MetricsGroup.TASKS,
+        # Only map operators run a UDF transform chain.
+        map_only=True,
     )
     input_prep_time_s: float = metric_field(
         default=0,
@@ -420,6 +422,8 @@ class OpRuntimeMetrics(metaclass=OpRuntimesMetricsMeta):
             "operator's UDFs consume."
         ),
         metrics_group=MetricsGroup.TASKS,
+        # Only map operators run a UDF transform chain.
+        map_only=True,
     )
     udf_body_time_s: float = metric_field(
         default=0,
@@ -428,6 +432,8 @@ class OpRuntimeMetrics(metaclass=OpRuntimesMetricsMeta):
             "formatting and block building around them."
         ),
         metrics_group=MetricsGroup.TASKS,
+        # Only map operators run a UDF transform chain.
+        map_only=True,
     )
     output_build_time_s: float = metric_field(
         default=0,
@@ -436,6 +442,8 @@ class OpRuntimeMetrics(metaclass=OpRuntimesMetricsMeta):
             "materializing Python objects into Arrow."
         ),
         metrics_group=MetricsGroup.TASKS,
+        # Only map operators run a UDF transform chain.
+        map_only=True,
     )
     other_stage_time_s: float = metric_field(
         default=0,
@@ -444,6 +452,8 @@ class OpRuntimeMetrics(metaclass=OpRuntimesMetricsMeta):
             "chain, such as a read or a write."
         ),
         metrics_group=MetricsGroup.TASKS,
+        # Only map operators run a UDF transform chain.
+        map_only=True,
     )
     task_submission_backpressure_time: float = metric_field(
         default=0,

--- a/python/ray/data/_internal/execution/interfaces/op_runtime_metrics.py
+++ b/python/ray/data/_internal/execution/interfaces/op_runtime_metrics.py
@@ -405,7 +405,7 @@ class OpRuntimeMetrics(metaclass=OpRuntimesMetricsMeta):
         description="Time spent serializing blocks produced.",
         metrics_group=MetricsGroup.TASKS,
     )
-    udf_time_s: float = metric_field(
+    block_transform_time_s: float = metric_field(
         default=0,
         description=(
             "Time spent in the operator's map transform chain. The input prep, "
@@ -1087,7 +1087,7 @@ class OpRuntimeMetrics(metaclass=OpRuntimesMetricsMeta):
 
             self.block_generation_time += exec_stats.wall_time_s
             self.block_serialization_time_s += exec_stats.block_ser_time_s
-            self.udf_time_s += exec_stats.udf_time_s or 0
+            self.block_transform_time_s += exec_stats.block_transform_time_s or 0
             self.input_prep_time_s += exec_stats.input_prep_time_s or 0
             self.udf_body_time_s += exec_stats.udf_body_time_s or 0
             self.output_build_time_s += exec_stats.output_build_time_s or 0

--- a/python/ray/data/_internal/execution/operators/map_operator.py
+++ b/python/ray/data/_internal/execution/operators/map_operator.py
@@ -884,9 +884,8 @@ def _map_task(
                         block_ser_time_s=block_ser_time_s,
                         block_transform_time_s=phase_times.total_s,
                         input_prep_time_s=phase_times.input_prep_s,
-                        udf_body_time_s=phase_times.udf_body_s,
+                        function_body_time_s=phase_times.function_body_s,
                         output_build_time_s=phase_times.output_build_s,
-                        other_stage_time_s=phase_times.other_s,
                         task_idx=ctx.task_idx,
                     )
                     # NOTE: This tracks task duration up to this point, though we're

--- a/python/ray/data/_internal/execution/operators/map_operator.py
+++ b/python/ray/data/_internal/execution/operators/map_operator.py
@@ -882,7 +882,7 @@ def _map_task(
                     phase_times = clock.drain()
                     exec_stats = blk_exec_stats_builder.build(
                         block_ser_time_s=block_ser_time_s,
-                        udf_time_s=phase_times.total_s,
+                        block_transform_time_s=phase_times.total_s,
                         input_prep_time_s=phase_times.input_prep_s,
                         udf_body_time_s=phase_times.udf_body_s,
                         output_build_time_s=phase_times.output_build_s,

--- a/python/ray/data/_internal/execution/operators/map_operator.py
+++ b/python/ray/data/_internal/execution/operators/map_operator.py
@@ -72,7 +72,7 @@ from ray.data._internal.execution.operators.map_transformer import (
     BlockMapTransformFn,
     CustomOpStatsReporter,
     MapTransformer,
-    UDFTimeScope,
+    TransformClock,
 )
 from ray.data._internal.execution.util import (
     memory_string,
@@ -840,7 +840,7 @@ def _map_task(
         # Likewise owned by _map_task: an actor pool shares one transformer
         # across every task the actor runs, and with
         # `max_concurrent_calls_per_actor > 1` several run at once.
-        udf_time_scope = UDFTimeScope()
+        clock = TransformClock()
 
         def transform_iter_factory():
             # Clear any per-task custom stats before each attempt (the reporter
@@ -848,7 +848,7 @@ def _map_task(
             # can't leak into this one. A producing transform repopulates it
             # before the first block is yielded.
             op_stats_reporter.clear()
-            udf_time_scope.drain()
+            clock.drain()
             blocks_iter = (
                 _iter_sliced_blocks(blocks, slices) if slices else iter(blocks)
             )
@@ -856,7 +856,7 @@ def _map_task(
                 blocks_iter,
                 ctx,
                 op_stats_reporter.report,
-                udf_time_scope=udf_time_scope,
+                clock=clock,
             )
 
         if retry_on:
@@ -879,7 +879,7 @@ def _map_task(
                 blk_exec_stats_builder.finish()
 
                 def build_metadata(block_ser_time_s):
-                    phase_times = udf_time_scope.drain()
+                    phase_times = clock.drain()
                     exec_stats = blk_exec_stats_builder.build(
                         block_ser_time_s=block_ser_time_s,
                         udf_time_s=phase_times.total_s,

--- a/python/ray/data/_internal/execution/operators/map_operator.py
+++ b/python/ray/data/_internal/execution/operators/map_operator.py
@@ -879,9 +879,14 @@ def _map_task(
                 blk_exec_stats_builder.finish()
 
                 def build_metadata(block_ser_time_s):
+                    phase_times = udf_time_scope.drain()
                     exec_stats = blk_exec_stats_builder.build(
                         block_ser_time_s=block_ser_time_s,
-                        udf_time_s=udf_time_scope.drain(),
+                        udf_time_s=phase_times.total_s,
+                        input_prep_time_s=phase_times.input_prep_s,
+                        udf_body_time_s=phase_times.udf_body_s,
+                        output_build_time_s=phase_times.output_build_s,
+                        other_stage_time_s=phase_times.other_s,
                         task_idx=ctx.task_idx,
                     )
                     # NOTE: This tracks task duration up to this point, though we're

--- a/python/ray/data/_internal/execution/operators/map_transformer.py
+++ b/python/ray/data/_internal/execution/operators/map_transformer.py
@@ -92,26 +92,6 @@ class MapTransformFnDataType(Enum):
     Batch = 2
 
 
-# Hook that wraps one phase of one stage, returning the iterable to chain into
-# the next. `MapTransformer.apply_transform` passes one that times.
-#
-# It takes a thunk rather than the iterable: a stage that consumes its input
-# eagerly does its work while building the iterable, so the hook has to own the
-# call to time it at all.
-PhaseWrapFn = Callable[
-    ["MapTransformPhase", Callable[[], Iterable[MapTransformFnData]]],
-    Iterable[MapTransformFnData],
-]
-
-
-def _no_phase_wrapping(
-    phase: "MapTransformPhase",
-    make_data: Callable[[], Iterable[MapTransformFnData]],
-) -> Iterable[MapTransformFnData]:
-    """Default `PhaseWrapFn`, for chains that only time their total."""
-    return make_data()
-
-
 class MapTransformFn(ABC):
     """Represents a single transform function in a MapTransformer."""
 
@@ -174,23 +154,59 @@ class MapTransformFn(ABC):
             results, self._input_type, self._output_block_size_option
         )
 
+    def timed_steps(
+        self,
+        ctx: TaskContext,
+        report_custom_op_stats: CustomOpStatsReportFn,
+        stage_idx: int,
+    ) -> List["TimedStep"]:
+        """This transform as a flat list of timed pipeline steps.
+
+        `_pre_process` and `_post_process` are already `Iterable -> Iterable`,
+        so they are the step bodies as-is; only the wrapped fn needs a closure
+        to bind the task context.
+        """
+        name = repr(self)
+        body = MapTransformPhase.UDF_BODY if self._is_udf else MapTransformPhase.OTHER
+        return [
+            TimedStep(
+                f"{name} input prep",
+                MapTransformPhase.INPUT_PREP,
+                stage_idx,
+                self._pre_process,
+            ),
+            TimedStep(
+                f"{name} body",
+                body,
+                stage_idx,
+                lambda it: self._apply_transform(ctx, it, report_custom_op_stats),
+            ),
+            TimedStep(
+                f"{name} output build",
+                MapTransformPhase.OUTPUT_BUILD,
+                stage_idx,
+                self._post_process,
+            ),
+        ]
+
     def __call__(
         self,
         blocks: Iterable[Block],
         ctx: TaskContext,
         report_custom_op_stats: CustomOpStatsReportFn = _noop_report_custom_op_stats,
-        wrap_phase: "PhaseWrapFn" = _no_phase_wrapping,
     ) -> Iterable[Block]:
-        batches = wrap_phase(
-            MapTransformPhase.INPUT_PREP, lambda: self._pre_process(blocks)
-        )
-        results = wrap_phase(
-            MapTransformPhase.UDF_BODY,
-            lambda: self._apply_transform(ctx, batches, report_custom_op_stats),
-        )
-        return wrap_phase(
-            MapTransformPhase.OUTPUT_BUILD, lambda: self._post_process(results)
-        )
+        """Apply this transform's steps in order, untimed.
+
+        Timing belongs to the chain rather than to a transform:
+        :meth:`MapTransformer.apply_transform` wraps these same steps in a
+        :class:`TransformClock`. A caller driving one transform on its own --
+        ``generate_collect_write_stats_fn``, and tests -- gets the plain
+        composition.
+        """
+        data: Iterable[Any] = blocks
+        for step in self.timed_steps(ctx, report_custom_op_stats, 0):
+            data = step.apply(data)
+        return data
 
     @property
     def output_block_size_option(self):
@@ -226,7 +242,7 @@ class MapTransformFn(ABC):
 class MapTransformPhase(Enum):
     """The phases a :class:`MapTransformFn` splits its work into.
 
-    Values index into :attr:`UDFTimeScope.phase_totals`.
+    Steps carry one of these; the summary groups their times by it.
     """
 
     # Turning input blocks into the batches or rows the transform consumes.
@@ -237,6 +253,71 @@ class MapTransformPhase(Enum):
     OUTPUT_BUILD = 2
     # A transform body that isn't a UDF, such as a read or a write.
     OTHER = 3
+
+
+@dataclass(frozen=True)
+class TimedStep:
+    """One ``Iterable -> Iterable`` link in a map task's pipeline.
+
+    A task's whole transform is a flat list of these. ``apply`` is the work;
+    everything else is metadata the summary groups by.
+
+    ``bucket`` is ``None`` for a step that spans more than one phase, which is
+    what a row transform gets when it is timed a stage at a time rather than a
+    phase at a time. A phase no step carries is reported as "not measured"
+    rather than as zero, so the ``None`` here is what produces the ``None``
+    there.
+    """
+
+    label: str
+    bucket: Optional[MapTransformPhase]
+    stage_idx: int
+    apply: Callable[[Iterable[Any]], Iterable[Any]]
+
+
+class _TimedStep(Iterator[Any]):
+    """Times one step, inclusive of everything upstream of it.
+
+    Deliberately does not coordinate with the other steps: it starts a clock,
+    pulls, and adds the elapsed time to its own slot. Because the chain is
+    linear -- step ``k`` is only ever pulled by step ``k + 1`` -- all of a
+    step's time lies inside its consumer's windows, so subtracting neighbouring
+    totals at drain time recovers each step's own work. Doing that arithmetic
+    once, over a list, is easier to follow than threading a shared cursor
+    through every ``__next__``.
+    """
+
+    __slots__ = ("_apply", "_upstream", "_iter", "_totals", "_idx")
+
+    def __init__(
+        self,
+        apply: Callable[[Iterable[Any]], Iterable[Any]],
+        upstream: Iterable[Any],
+        totals: List[float],
+        idx: int,
+    ):
+        self._apply = apply
+        self._upstream = upstream
+        self._iter: Optional[Iterator[Any]] = None
+        self._totals = totals
+        self._idx = idx
+
+    def __iter__(self) -> "_TimedStep":
+        return self
+
+    def __next__(self) -> Any:
+        start = time.perf_counter()
+        try:
+            if self._iter is None:
+                # Building the iterable is the step's work too, and for some
+                # steps it is all of it: a write performs its whole upload here
+                # and hands back a buffer. Deferring the call to the first pull
+                # puts that inside the same window as the pulls, so an eagerly
+                # consuming stage needs no special case.
+                self._iter = iter(self._apply(self._upstream))
+            return next(self._iter)
+        finally:
+            self._totals[self._idx] += time.perf_counter() - start
 
 
 @dataclass(frozen=True)
@@ -259,89 +340,96 @@ class MapTransformPhaseTimes:
     other_s: Optional[float] = None
 
 
-class UDFTimeScope:
-    """Running total of UDF time for one task, and the nesting state to get it.
+class TransformClock:
+    """Per-task timing for one map transform chain.
 
-    Must stay per task, not per :class:`MapTransformer`: an actor pool reuses one
-    transformer for every task the actor runs, and ``max_concurrent_calls_per_actor
-    > 1`` runs several of those at once, so a shared total would mix their
-    timings and let one task's :meth:`drain` discard another's. ``_map_task``
-    creates one per task and threads it into ``apply_transform``, the same way it
-    threads a :class:`CustomOpStatsReporter`.
+    Must stay per task, not per :class:`MapTransformer`: an actor pool reuses
+    one transformer for every task the actor runs, and
+    ``max_concurrent_calls_per_actor > 1`` runs several at once, so a shared
+    total would mix their timings and let one task's :meth:`drain` discard
+    another's.
 
-    ``attributed_s`` is a single running total that every timer in the chain adds
-    to, holding the time accumulated since the last :meth:`drain` (``_map_task``
-    drains after each output block). It covers the whole transform: input
-    batching, the UDF bodies, and output block building.
-
-    It is also the cursor each timer uses to find its own share. Stages are
-    chained behind lazy iterators, so a stage's ``next()`` runs everything
-    upstream of it before returning, and a timer can only measure inclusive
-    time. The change in ``attributed_s`` across that call is what the upstream
-    timers added during it, so subtracting it leaves this stage's own
-    contribution. Three fused UDFs sleeping 1s, 2s and 3s measure 1s, 3s and 6s
-    inclusive, subtract 0s, 1s and 3s, and add 1s, 2s and 3s.
-
-    ``phase_totals`` splits that same time by :class:`MapTransformPhase` when the
-    chain is timing phases; a chain timing only its total leaves it at zero.
+    Holds one inclusive total per step. :meth:`drain` turns those into each
+    step's own time and groups them, so a step measures itself and nothing
+    else while data is flowing.
     """
 
-    __slots__ = ("attributed_s", "phase_totals", "decomposed")
+    __slots__ = ("inclusive", "_steps")
 
     def __init__(self) -> None:
-        self.attributed_s: float = 0.0
-        self.phase_totals: List[float] = [0.0] * len(MapTransformPhase)
-        # Set by `apply_transform`; False when only the total was measured.
-        self.decomposed: bool = False
+        self._steps: List["TimedStep"] = []
+        self.inclusive: List[float] = []
 
-    def attribute_call(
-        self,
-        phase: Optional["MapTransformPhase"],
-        make_data: Callable[[], Iterable[MapTransformFnData]],
-    ) -> Iterable[MapTransformFnData]:
-        """Run ``make_data()`` inside an attribution window and return its result.
+    def chain(self, steps: List["TimedStep"], blocks: Iterable[Any]) -> Iterable[Any]:
+        """Build the timed pipeline over ``blocks``."""
+        self._steps = steps
+        self.inclusive = [0.0] * len(steps)
+        data = blocks
+        for idx, step in enumerate(steps):
+            data = _TimedStep(step.apply, data, self.inclusive, idx)
+        return data
 
-        A stage that streams does its work in ``__next__``, which the timing
-        iterator covers. A stage that consumes its input eagerly -- a write
-        performs its whole upload before handing back a buffer -- does it here
-        instead, where no iterator can see it. Timing the call is what puts that
-        work in the total.
+    def _self_times(self) -> List[float]:
+        """Each step's own time: its window less its upstream's.
 
-        Runs once per stage per task, so unlike ``__next__`` it is off the hot
-        path and its cost does not scale with rows.
+        A step's window contains everything upstream of it, and step ``k`` is
+        only ever pulled by step ``k + 1``, so neighbouring totals differ by
+        exactly the step's own work. The clamp absorbs floating-point rounding
+        on that subtraction; the difference is otherwise non-negative.
         """
-        before_s = self.attributed_s
-        start = time.perf_counter()
-        try:
-            return make_data()
-        finally:
-            inclusive_s = time.perf_counter() - start
-            # An eager stage pulls its input through the timers already in the
-            # chain, so subtract what they credited to leave its own work.
-            exclusive_s = max(0.0, inclusive_s - (self.attributed_s - before_s))
-            self.attributed_s += exclusive_s
-            if phase is not None:
-                self.phase_totals[phase.value] += exclusive_s
+        return [
+            max(0.0, total - (self.inclusive[i - 1] if i else 0.0))
+            for i, total in enumerate(self.inclusive)
+        ]
 
     def drain(self) -> "MapTransformPhaseTimes":
         """Return the time accumulated since the last drain, and reset."""
-        totals = self.phase_totals
-        if self.decomposed:
+        own = self._self_times()
+        by_bucket: Dict[MapTransformPhase, float] = {}
+        for step, seconds in zip(self._steps, own):
+            if step.bucket is not None:
+                by_bucket[step.bucket] = by_bucket.get(step.bucket, 0.0) + seconds
+
+        # A step spanning all three phases carries no bucket, so if any step
+        # carries one this chain was timed phase by phase. Deriving that from
+        # the steps beats storing it: there is no flag to set inconsistently.
+        if any(step.bucket is not None for step in self._steps):
+            # Measured. A phase this chain happens not to run really did take
+            # no time, so report zero -- `None` is reserved for "not measured",
+            # which a consumer has to be able to tell apart.
             times = MapTransformPhaseTimes(
-                total_s=self.attributed_s,
-                input_prep_s=totals[MapTransformPhase.INPUT_PREP.value],
-                udf_body_s=totals[MapTransformPhase.UDF_BODY.value],
-                output_build_s=totals[MapTransformPhase.OUTPUT_BUILD.value],
-                other_s=totals[MapTransformPhase.OTHER.value],
+                total_s=sum(own),
+                input_prep_s=by_bucket.get(MapTransformPhase.INPUT_PREP, 0.0),
+                udf_body_s=by_bucket.get(MapTransformPhase.UDF_BODY, 0.0),
+                output_build_s=by_bucket.get(MapTransformPhase.OUTPUT_BUILD, 0.0),
+                other_s=by_bucket.get(MapTransformPhase.OTHER, 0.0),
             )
         else:
-            times = MapTransformPhaseTimes(total_s=self.attributed_s)
-        self.attributed_s = 0.0
-        # Zero in place: the timers hold this list, and `_map_task` drains after
-        # every output block, mid-iteration.
-        for i in range(len(totals)):
-            totals[i] = 0.0
+            times = MapTransformPhaseTimes(total_s=sum(own))
+        self.inclusive = [0.0] * len(self._steps)
         return times
+
+
+def _coalesce_stage(
+    steps: List["TimedStep"], transform_fn: "MapTransformFn"
+) -> "TimedStep":
+    """Fold a stage's three steps into one, timed as a unit."""
+    applies = [step.apply for step in steps]
+
+    def apply(data: Iterable[Any]) -> Iterable[Any]:
+        for fn in applies:
+            data = fn(data)
+        return data
+
+    return TimedStep(
+        label=f"{transform_fn!r} stage",
+        # Spans input prep, body and output build, so it belongs to no single
+        # phase -- which is what makes the phase figures report as "not
+        # measured" for a chain timed this way.
+        bucket=None,
+        stage_idx=steps[0].stage_idx,
+        apply=apply,
+    )
 
 
 class MapTransformer:
@@ -352,49 +440,6 @@ class MapTransformer:
     the last MapTransformFn must output blocks. The intermediate data types can
     be blocks, rows, or batches.
     """
-
-    class _UDFTimingIterator(Iterator[MapTransformFnData]):
-        """Times one UDF stage, net of the stages feeding it.
-
-        ``__next__`` can only measure inclusive time: the stages are chained
-        behind lazy iterators, so pulling one item also runs every stage
-        upstream. Subtracting what upstream stages credited to ``scope`` during
-        the same window leaves this stage's own time, which is what keeps
-        ``scope``'s total from counting a stage once per stage below it.
-        """
-
-        def __init__(
-            self,
-            input: Iterable[MapTransformFnData],
-            scope: "UDFTimeScope",
-            phase: Optional[MapTransformPhase] = None,
-        ):
-            # `input` is an Iterable, but `__next__` needs an Iterator, and some
-            # callers hand `apply_transform` a plain list.
-            self._input = iter(input)
-            self._scope = scope
-            # None when timing a whole stage rather than one of its phases.
-            self._phase_idx = None if phase is None else phase.value
-
-        def __iter__(self) -> "MapTransformer._UDFTimingIterator":
-            return self
-
-        def __next__(self) -> MapTransformFnData:
-            scope = self._scope
-            attributed_before_s = scope.attributed_s
-            start = time.perf_counter()
-            try:
-                return next(self._input)
-            finally:
-                inclusive_s = time.perf_counter() - start
-                upstream_s = scope.attributed_s - attributed_before_s
-                # Upstream stages' exclusive spans are disjoint sub-intervals of
-                # this window, so the difference is non-negative; clamp only to
-                # absorb floating-point rounding.
-                exclusive_s = max(0.0, inclusive_s - upstream_s)
-                scope.attributed_s += exclusive_s
-                if self._phase_idx is not None:
-                    scope.phase_totals[self._phase_idx] += exclusive_s
 
     def __init__(
         self,
@@ -450,27 +495,50 @@ class MapTransformer:
         """
         self._init_fn()
 
+    def get_timed_steps(
+        self,
+        ctx: TaskContext,
+        report_custom_op_stats: CustomOpStatsReportFn,
+        *,
+        decomposed: bool,
+    ) -> List["TimedStep"]:
+        """This task's whole transform, as a flat list of timed steps.
+
+        The answer to "what is getting timed?" is this list. It is ordinary
+        data: printable, and assertable in a unit test.
+
+        ``decomposed=False`` collapses each stage's three steps into one, which
+        is how a row transform pays one timer per stage instead of three -- a
+        rewrite of the list rather than a second code path.
+        """
+        steps: List[TimedStep] = []
+        for stage_idx, transform_fn in enumerate(self._transform_fns):
+            stage_steps = transform_fn.timed_steps(
+                ctx, report_custom_op_stats, stage_idx
+            )
+            if not decomposed:
+                stage_steps = [_coalesce_stage(stage_steps, transform_fn)]
+            steps.extend(stage_steps)
+        return steps
+
     def apply_transform(
         self,
         input_blocks: Iterable[Block],
         ctx: TaskContext,
         report_custom_op_stats: CustomOpStatsReportFn = _noop_report_custom_op_stats,
         *,
-        udf_time_scope: "UDFTimeScope",
+        clock: "TransformClock",
     ) -> Iterable[Block]:
-        """Apply the transform functions to the input blocks.
+        """Chain this task's timed steps over the input blocks.
 
         Args:
             input_blocks: The blocks to transform.
             ctx: The task context for this transform.
             report_custom_op_stats: Callback a producing transform calls to report
-                its :class:`CustomOpStats`. ``_map_task`` passes its reporter's
-                ``report``; defaults to a stateless no-op for callers (e.g. tests)
-                that don't collect custom stats.
-            udf_time_scope: Where to accumulate this task's UDF time. Required and
-                keyword-only on purpose: a caller that silently skipped it would
-                report a UDF time of zero rather than fail. Callers that don't
-                collect timings pass a throwaway ``UDFTimeScope()``.
+                its :class:`CustomOpStats`.
+            clock: Where this task's timings accumulate. Keyword-only on
+                purpose: a caller that silently skipped it would report zero
+                rather than fail.
 
         Returns:
             An iterable of the transformed output blocks.
@@ -484,71 +552,31 @@ class MapTransformer:
                 self.target_max_block_size_override
             )
 
-        # Splitting a stage into phases means a timer around each of the three,
-        # and each timer costs a Python frame per item it yields. A batch or
-        # block transform yields whole batches, so that is noise. A row
-        # transform yields rows, where it is not -- roughly 1us per row across a
-        # three-stage chain. So row chains are timed a stage at a time, which
-        # reports the same total for a third of the wrappers, and
-        # `accurate_map_phase_timing` opts into the breakdown for them.
         from ray.data.context import DataContext
 
         # A chain with no UDF in it -- a standalone read, write or projection --
-        # has no user function to attribute time to, so it reports no UDF time at
-        # all, as it always has. Timing its stages would put its whole transform
-        # under "UDF time" on an operator that runs nothing the user wrote.
+        # has no user function to attribute time to, so it reports no UDF time,
+        # as it always has.
         has_udf = any(fn._is_udf for fn in self._transform_fns)
+        # Timing costs a Python frame per item. A batch transform yields whole
+        # batches, so three timers per stage is noise; a row transform yields
+        # rows, where it is not. Row chains get one timer per stage instead,
+        # and `accurate_map_phase_timing` opts them into the full split.
         per_row = any(
             fn._input_type is MapTransformFnDataType.Row for fn in self._transform_fns
         )
-        decomposed = has_udf and (
-            not per_row or DataContext.get_current().accurate_map_phase_timing
-        )
-        udf_time_scope.decomposed = decomposed
+        decomposed = not per_row or DataContext.get_current().accurate_map_phase_timing
 
-        iter = input_blocks
-        # Whether by phase or by stage, a timer has to be installed before the
-        # next stage is built: `MapTransformFn.__call__` runs `_pre_process`
-        # eagerly, and with `batch_size="auto"` that peeks at a real block to
-        # size batches, pulling data through the stages already in the chain.
-        for transform_fn in self._transform_fns:
-            if not has_udf:
-                # Nothing the user wrote runs in this chain, so there is nothing
-                # to attribute and no timer to pay for.
-                iter = transform_fn(iter, ctx, report_custom_op_stats)
-                continue
+        steps = self.get_timed_steps(ctx, report_custom_op_stats, decomposed=decomposed)
 
-            if decomposed:
-                is_udf = transform_fn._is_udf
+        if not has_udf:
+            # Nothing to attribute, so no timer to pay for.
+            data = input_blocks
+            for step in steps:
+                data = step.apply(data)
+            return data
 
-                def wrap_phase(
-                    phase: MapTransformPhase,
-                    make_data: Callable[[], Iterable[MapTransformFnData]],
-                    _is_udf: bool = is_udf,
-                ) -> Iterable[MapTransformFnData]:
-                    if phase is MapTransformPhase.UDF_BODY and not _is_udf:
-                        phase = MapTransformPhase.OTHER
-                    # Time building the iterable as well as draining it, so a
-                    # stage that consumes its input eagerly is not missed.
-                    data = udf_time_scope.attribute_call(phase, make_data)
-                    return self._UDFTimingIterator(data, udf_time_scope, phase)
-
-                iter = transform_fn(iter, ctx, report_custom_op_stats, wrap_phase)
-            else:
-                # Only UDF stages get a per-item timer here -- paying that per
-                # row is what this branch exists to avoid. The eager window is
-                # once per stage, so every stage gets one and the total stays
-                # the figure the decomposed branch would report.
-                iter = udf_time_scope.attribute_call(
-                    None,
-                    lambda fn=transform_fn, it=iter: fn(
-                        it, ctx, report_custom_op_stats
-                    ),
-                )
-                if transform_fn._is_udf:
-                    iter = self._UDFTimingIterator(iter, udf_time_scope)
-
-        return iter
+        return clock.chain(steps, input_blocks)
 
     def fuse(self, other: "MapTransformer") -> "MapTransformer":
         """Fuse two `MapTransformer`s together."""

--- a/python/ray/data/_internal/execution/operators/map_transformer.py
+++ b/python/ray/data/_internal/execution/operators/map_transformer.py
@@ -94,16 +94,22 @@ class MapTransformFnDataType(Enum):
 
 # Hook that wraps one phase of one stage, returning the iterable to chain into
 # the next. `MapTransformer.apply_transform` passes one that times.
+#
+# It takes a thunk rather than the iterable: a stage that consumes its input
+# eagerly does its work while building the iterable, so the hook has to own the
+# call to time it at all.
 PhaseWrapFn = Callable[
-    ["MapTransformPhase", Iterable[MapTransformFnData]], Iterable[MapTransformFnData]
+    ["MapTransformPhase", Callable[[], Iterable[MapTransformFnData]]],
+    Iterable[MapTransformFnData],
 ]
 
 
 def _no_phase_wrapping(
-    phase: "MapTransformPhase", data: Iterable[MapTransformFnData]
+    phase: "MapTransformPhase",
+    make_data: Callable[[], Iterable[MapTransformFnData]],
 ) -> Iterable[MapTransformFnData]:
     """Default `PhaseWrapFn`, for chains that only time their total."""
-    return data
+    return make_data()
 
 
 class MapTransformFn(ABC):
@@ -175,12 +181,16 @@ class MapTransformFn(ABC):
         report_custom_op_stats: CustomOpStatsReportFn = _noop_report_custom_op_stats,
         wrap_phase: "PhaseWrapFn" = _no_phase_wrapping,
     ) -> Iterable[Block]:
-        batches = wrap_phase(MapTransformPhase.INPUT_PREP, self._pre_process(blocks))
+        batches = wrap_phase(
+            MapTransformPhase.INPUT_PREP, lambda: self._pre_process(blocks)
+        )
         results = wrap_phase(
             MapTransformPhase.UDF_BODY,
-            self._apply_transform(ctx, batches, report_custom_op_stats),
+            lambda: self._apply_transform(ctx, batches, report_custom_op_stats),
         )
-        return wrap_phase(MapTransformPhase.OUTPUT_BUILD, self._post_process(results))
+        return wrap_phase(
+            MapTransformPhase.OUTPUT_BUILD, lambda: self._post_process(results)
+        )
 
     @property
     def output_block_size_option(self):
@@ -283,6 +293,35 @@ class UDFTimeScope:
         self.phase_totals: List[float] = [0.0] * len(MapTransformPhase)
         # Set by `apply_transform`; False when only the total was measured.
         self.decomposed: bool = False
+
+    def attribute_call(
+        self,
+        phase: Optional["MapTransformPhase"],
+        make_data: Callable[[], Iterable[MapTransformFnData]],
+    ) -> Iterable[MapTransformFnData]:
+        """Run ``make_data()`` inside an attribution window and return its result.
+
+        A stage that streams does its work in ``__next__``, which the timing
+        iterator covers. A stage that consumes its input eagerly -- a write
+        performs its whole upload before handing back a buffer -- does it here
+        instead, where no iterator can see it. Timing the call is what puts that
+        work in the total.
+
+        Runs once per stage per task, so unlike ``__next__`` it is off the hot
+        path and its cost does not scale with rows.
+        """
+        before_s = self.attributed_s
+        start = time.perf_counter()
+        try:
+            return make_data()
+        finally:
+            inclusive_s = time.perf_counter() - start
+            # An eager stage pulls its input through the timers already in the
+            # chain, so subtract what they credited to leave its own work.
+            exclusive_s = max(0.0, inclusive_s - (self.attributed_s - before_s))
+            self.attributed_s += exclusive_s
+            if phase is not None:
+                self.phase_totals[phase.value] += exclusive_s
 
     def drain(self) -> "MapTransformPhaseTimes":
         """Return the time accumulated since the last drain, and reset."""
@@ -454,10 +493,17 @@ class MapTransformer:
         # `accurate_map_phase_timing` opts into the breakdown for them.
         from ray.data.context import DataContext
 
+        # A chain with no UDF in it -- a standalone read, write or projection --
+        # has no user function to attribute time to, so it reports no UDF time at
+        # all, as it always has. Timing its stages would put its whole transform
+        # under "UDF time" on an operator that runs nothing the user wrote.
+        has_udf = any(fn._is_udf for fn in self._transform_fns)
         per_row = any(
             fn._input_type is MapTransformFnDataType.Row for fn in self._transform_fns
         )
-        decomposed = not per_row or DataContext.get_current().accurate_map_phase_timing
+        decomposed = has_udf and (
+            not per_row or DataContext.get_current().accurate_map_phase_timing
+        )
         udf_time_scope.decomposed = decomposed
 
         iter = input_blocks
@@ -466,21 +512,39 @@ class MapTransformer:
         # eagerly, and with `batch_size="auto"` that peeks at a real block to
         # size batches, pulling data through the stages already in the chain.
         for transform_fn in self._transform_fns:
+            if not has_udf:
+                # Nothing the user wrote runs in this chain, so there is nothing
+                # to attribute and no timer to pay for.
+                iter = transform_fn(iter, ctx, report_custom_op_stats)
+                continue
+
             if decomposed:
                 is_udf = transform_fn._is_udf
 
                 def wrap_phase(
                     phase: MapTransformPhase,
-                    data: Iterable[MapTransformFnData],
+                    make_data: Callable[[], Iterable[MapTransformFnData]],
                     _is_udf: bool = is_udf,
                 ) -> Iterable[MapTransformFnData]:
                     if phase is MapTransformPhase.UDF_BODY and not _is_udf:
                         phase = MapTransformPhase.OTHER
+                    # Time building the iterable as well as draining it, so a
+                    # stage that consumes its input eagerly is not missed.
+                    data = udf_time_scope.attribute_call(phase, make_data)
                     return self._UDFTimingIterator(data, udf_time_scope, phase)
 
                 iter = transform_fn(iter, ctx, report_custom_op_stats, wrap_phase)
             else:
-                iter = transform_fn(iter, ctx, report_custom_op_stats)
+                # Only UDF stages get a per-item timer here -- paying that per
+                # row is what this branch exists to avoid. The eager window is
+                # once per stage, so every stage gets one and the total stays
+                # the figure the decomposed branch would report.
+                iter = udf_time_scope.attribute_call(
+                    None,
+                    lambda fn=transform_fn, it=iter: fn(
+                        it, ctx, report_custom_op_stats
+                    ),
+                )
                 if transform_fn._is_udf:
                     iter = self._UDFTimingIterator(iter, udf_time_scope)
 

--- a/python/ray/data/_internal/execution/operators/map_transformer.py
+++ b/python/ray/data/_internal/execution/operators/map_transformer.py
@@ -406,7 +406,11 @@ class TransformClock:
             )
         else:
             times = MapTransformPhaseTimes(total_s=sum(own))
-        self.inclusive = [0.0] * len(self._steps)
+        # Zero in place. Every `_TimedStep` in the chain holds a reference to
+        # this list, so rebinding it here would leave them adding to a list
+        # this clock no longer reads -- and `_map_task` drains after every
+        # output block, so only a task's first block would report any time.
+        self.inclusive[:] = [0.0] * len(self.inclusive)
         return times
 
 

--- a/python/ray/data/_internal/execution/operators/map_transformer.py
+++ b/python/ray/data/_internal/execution/operators/map_transformer.py
@@ -327,10 +327,9 @@ class MapTransformPhaseTimes:
     ``total_s`` is the whole chain: forming batches or rows, the stage bodies,
     and building output blocks, for every stage of a (possibly fused) chain. It
     is deliberately not the time inside the functions the caller passed in --
-    that is the narrower ``udf_body_s``. ``ds.stats()`` has printed ``total_s``
-    as "UDF time" for many releases, which is misleading for exactly that
-    reason, and is why the breakdown gives the narrow figure its own line,
-    "Function body".
+    that is the narrower ``udf_body_s``. ``ds.stats()`` printed this figure as
+    "UDF time" before it was renamed, which said the opposite; hence the rename,
+    and hence the narrow figure getting its own "Function body" line.
 
     The four phase figures decompose ``total_s`` and sum back to it, saying
     where inside the chain the time went; they are all ``None`` when the chain
@@ -566,7 +565,7 @@ class MapTransformer:
         from ray.data.context import DataContext
 
         # A chain with no UDF in it -- a standalone read, write or projection --
-        # has no user function to attribute time to, so it reports no UDF time,
+        # has no user function to attribute time to, so it reports no block transform time,
         # as it always has.
         has_udf = any(fn._is_udf for fn in self._transform_fns)
         # Timing costs a Python frame per item. A batch transform yields whole

--- a/python/ray/data/_internal/execution/operators/map_transformer.py
+++ b/python/ray/data/_internal/execution/operators/map_transformer.py
@@ -100,7 +100,6 @@ class MapTransformFn(ABC):
         fn: Callable,
         input_type: MapTransformFnDataType,
         *,
-        is_udf: bool = False,
         output_block_size_option: Optional[OutputBlockSizeOption] = None,
         should_report_custom_op_stats: bool = False,
     ):
@@ -111,7 +110,6 @@ class MapTransformFn(ABC):
                 ``(data, ctx, report_custom_op_stats)`` when
                 ``should_report_custom_op_stats=True``.
             input_type: Expected type of the input data.
-            is_udf: Whether this transformation is UDF or not.
             output_block_size_option: (Optional) Output block size configuration.
             should_report_custom_op_stats: If ``True``, the wrapped callable accepts a
                 third ``report_custom_op_stats`` callback argument and may report
@@ -122,7 +120,6 @@ class MapTransformFn(ABC):
         self._fn = fn
         self._input_type = input_type
         self._output_block_size_option = output_block_size_option
-        self._is_udf = is_udf
         self._should_report_custom_op_stats = should_report_custom_op_stats
 
     @abstractmethod
@@ -560,10 +557,6 @@ class MapTransformer:
 
         from ray.data.context import DataContext
 
-        # A chain with no UDF in it -- a standalone read, write or projection --
-        # has no user function to attribute time to, so it reports no block transform time,
-        # as it always has.
-        has_udf = any(fn._is_udf for fn in self._transform_fns)
         # Timing costs a Python frame per item. A batch transform yields whole
         # batches, so three timers per stage is noise; a row transform yields
         # rows, where it is not. Row chains get one timer per stage instead,
@@ -574,14 +567,6 @@ class MapTransformer:
         decomposed = not per_row or DataContext.get_current().accurate_map_phase_timing
 
         steps = self.get_timed_steps(ctx, report_custom_op_stats, decomposed=decomposed)
-
-        if not has_udf:
-            # Nothing to attribute, so no timer to pay for.
-            data = input_blocks
-            for step in steps:
-                data = step.apply(data)
-            return data
-
         return clock.chain(steps, input_blocks)
 
     def fuse(self, other: "MapTransformer") -> "MapTransformer":
@@ -634,14 +619,12 @@ class RowMapTransformFn(MapTransformFn):
         self,
         row_fn: MapTransformCallable[Row, Row],
         *,
-        is_udf: bool = False,
         output_block_size_option: OutputBlockSizeOption,
         should_report_custom_op_stats: bool = False,
     ):
         super().__init__(
             row_fn,
             input_type=MapTransformFnDataType.Row,
-            is_udf=is_udf,
             output_block_size_option=output_block_size_option,
             should_report_custom_op_stats=should_report_custom_op_stats,
         )
@@ -693,7 +676,6 @@ class BatchMapTransformFn(MapTransformFn):
         self,
         batch_fn: MapTransformCallable[DataBatch, DataBatch],
         *,
-        is_udf: bool = False,
         batch_size: Union[Optional[int], Literal["auto"]] = None,
         batch_format: Optional[BatchFormat] = None,
         zero_copy_batch: bool = True,
@@ -704,7 +686,6 @@ class BatchMapTransformFn(MapTransformFn):
         super().__init__(
             batch_fn,
             input_type=MapTransformFnDataType.Batch,
-            is_udf=is_udf,
             output_block_size_option=output_block_size_option,
             should_report_custom_op_stats=should_report_custom_op_stats,
         )
@@ -745,7 +726,6 @@ class BlockMapTransformFn(MapTransformFn):
         self,
         block_fn: MapTransformCallable[Block, Block],
         *,
-        is_udf: bool = False,
         disable_block_shaping: bool = False,
         output_block_size_option: Optional[OutputBlockSizeOption] = None,
         should_report_custom_op_stats: bool = False,
@@ -756,8 +736,6 @@ class BlockMapTransformFn(MapTransformFn):
 
         Args:
             block_fn: Callable function to apply a transformation to a block.
-            is_udf: Specifies if the transformation function is a user-defined
-                function (defaults to ``False``).
             disable_block_shaping: Disables block-shaping, making transformer to
                 produce blocks as is.
             output_block_size_option: (Optional) Configure output block sizing.
@@ -769,7 +747,6 @@ class BlockMapTransformFn(MapTransformFn):
         super().__init__(
             block_fn,
             input_type=MapTransformFnDataType.Block,
-            is_udf=is_udf,
             output_block_size_option=output_block_size_option,
             should_report_custom_op_stats=should_report_custom_op_stats,
         )

--- a/python/ray/data/_internal/execution/operators/map_transformer.py
+++ b/python/ray/data/_internal/execution/operators/map_transformer.py
@@ -1,6 +1,7 @@
 import itertools
 import time
 from abc import ABC, abstractmethod
+from dataclasses import dataclass
 from enum import Enum
 from typing import (
     Any,
@@ -91,6 +92,20 @@ class MapTransformFnDataType(Enum):
     Batch = 2
 
 
+# Hook that wraps one phase of one stage, returning the iterable to chain into
+# the next. `MapTransformer.apply_transform` passes one that times.
+PhaseWrapFn = Callable[
+    ["MapTransformPhase", Iterable[MapTransformFnData]], Iterable[MapTransformFnData]
+]
+
+
+def _no_phase_wrapping(
+    phase: "MapTransformPhase", data: Iterable[MapTransformFnData]
+) -> Iterable[MapTransformFnData]:
+    """Default `PhaseWrapFn`, for chains that only time their total."""
+    return data
+
+
 class MapTransformFn(ABC):
     """Represents a single transform function in a MapTransformer."""
 
@@ -158,10 +173,14 @@ class MapTransformFn(ABC):
         blocks: Iterable[Block],
         ctx: TaskContext,
         report_custom_op_stats: CustomOpStatsReportFn = _noop_report_custom_op_stats,
+        wrap_phase: "PhaseWrapFn" = _no_phase_wrapping,
     ) -> Iterable[Block]:
-        batches = self._pre_process(blocks)
-        results = self._apply_transform(ctx, batches, report_custom_op_stats)
-        return self._post_process(results)
+        batches = wrap_phase(MapTransformPhase.INPUT_PREP, self._pre_process(blocks))
+        results = wrap_phase(
+            MapTransformPhase.UDF_BODY,
+            self._apply_transform(ctx, batches, report_custom_op_stats),
+        )
+        return wrap_phase(MapTransformPhase.OUTPUT_BUILD, self._post_process(results))
 
     @property
     def output_block_size_option(self):
@@ -194,6 +213,40 @@ class MapTransformFn(ABC):
             return self._output_block_size_option.target_num_rows_per_block
 
 
+class MapTransformPhase(Enum):
+    """The phases a :class:`MapTransformFn` splits its work into.
+
+    Values index into :attr:`UDFTimeScope.phase_totals`.
+    """
+
+    # Turning input blocks into the batches or rows the transform consumes.
+    INPUT_PREP = 0
+    # A transform body the planner marked as a user-defined function.
+    UDF_BODY = 1
+    # Assembling the transform's output back into blocks.
+    OUTPUT_BUILD = 2
+    # A transform body that isn't a UDF, such as a read or a write.
+    OTHER = 3
+
+
+@dataclass(frozen=True)
+class MapTransformPhaseTimes:
+    """Seconds a task spent in its map transform chain.
+
+    ``total_s`` is the whole chain, which is what Ray Data has always reported as
+    "UDF time". The rest decompose it and sum back to it, saying where inside the
+    chain the time went; they are all zero when the chain measured only its
+    total. Each is summed over every stage of a (possibly fused) chain, so a
+    fused operator reports one figure per phase rather than one per stage.
+    """
+
+    total_s: float = 0.0
+    input_prep_s: float = 0.0
+    udf_body_s: float = 0.0
+    output_build_s: float = 0.0
+    other_s: float = 0.0
+
+
 class UDFTimeScope:
     """Running total of UDF time for one task, and the nesting state to get it.
 
@@ -216,18 +269,38 @@ class UDFTimeScope:
     timers added during it, so subtracting it leaves this stage's own
     contribution. Three fused UDFs sleeping 1s, 2s and 3s measure 1s, 3s and 6s
     inclusive, subtract 0s, 1s and 3s, and add 1s, 2s and 3s.
+
+    ``phase_totals`` splits that same time by :class:`MapTransformPhase` when the
+    chain is timing phases; a chain timing only its total leaves it at zero.
     """
 
-    __slots__ = ("attributed_s",)
+    __slots__ = ("attributed_s", "phase_totals", "decomposed")
 
     def __init__(self) -> None:
         self.attributed_s: float = 0.0
+        self.phase_totals: List[float] = [0.0] * len(MapTransformPhase)
+        # Set by `apply_transform`; False when only the total was measured.
+        self.decomposed: bool = False
 
-    def drain(self) -> float:
+    def drain(self) -> "MapTransformPhaseTimes":
         """Return the time accumulated since the last drain, and reset."""
-        elapsed_s = self.attributed_s
+        totals = self.phase_totals
+        if self.decomposed:
+            times = MapTransformPhaseTimes(
+                total_s=self.attributed_s,
+                input_prep_s=totals[MapTransformPhase.INPUT_PREP.value],
+                udf_body_s=totals[MapTransformPhase.UDF_BODY.value],
+                output_build_s=totals[MapTransformPhase.OUTPUT_BUILD.value],
+                other_s=totals[MapTransformPhase.OTHER.value],
+            )
+        else:
+            times = MapTransformPhaseTimes(total_s=self.attributed_s)
         self.attributed_s = 0.0
-        return elapsed_s
+        # Zero in place: the timers hold this list, and `_map_task` drains after
+        # every output block, mid-iteration.
+        for i in range(len(totals)):
+            totals[i] = 0.0
+        return times
 
 
 class MapTransformer:
@@ -253,11 +326,14 @@ class MapTransformer:
             self,
             input: Iterable[MapTransformFnData],
             scope: "UDFTimeScope",
+            phase: Optional[MapTransformPhase] = None,
         ):
             # `input` is an Iterable, but `__next__` needs an Iterator, and some
             # callers hand `apply_transform` a plain list.
             self._input = iter(input)
             self._scope = scope
+            # None when timing a whole stage rather than one of its phases.
+            self._phase_idx = None if phase is None else phase.value
 
         def __iter__(self) -> "MapTransformer._UDFTimingIterator":
             return self
@@ -274,7 +350,10 @@ class MapTransformer:
                 # Upstream stages' exclusive spans are disjoint sub-intervals of
                 # this window, so the difference is non-negative; clamp only to
                 # absorb floating-point rounding.
-                scope.attributed_s += max(0.0, inclusive_s - upstream_s)
+                exclusive_s = max(0.0, inclusive_s - upstream_s)
+                scope.attributed_s += exclusive_s
+                if self._phase_idx is not None:
+                    scope.phase_totals[self._phase_idx] += exclusive_s
 
     def __init__(
         self,
@@ -364,15 +443,44 @@ class MapTransformer:
                 self.target_max_block_size_override
             )
 
+        # Splitting a stage into phases means a timer around each of the three,
+        # and each timer costs a Python frame per item it yields. A batch or
+        # block transform yields whole batches, so that is noise. A row
+        # transform yields rows, where it is not -- roughly 1us per row across a
+        # three-stage chain. So row chains are timed a stage at a time, which
+        # reports the same total for a third of the wrappers, and
+        # `accurate_map_phase_timing` opts into the breakdown for them.
+        from ray.data.context import DataContext
+
+        per_row = any(
+            fn._input_type is MapTransformFnDataType.Row for fn in self._transform_fns
+        )
+        decomposed = not per_row or DataContext.get_current().accurate_map_phase_timing
+        udf_time_scope.decomposed = decomposed
+
         iter = input_blocks
-        # Each stage's timer has to be installed before the next stage is built:
-        # `MapTransformFn.__call__` runs `_pre_process` eagerly, and with
-        # `batch_size="auto"` that peeks at a real block to size batches, which
-        # pulls data through the stages already in the chain.
+        # Whether by phase or by stage, a timer has to be installed before the
+        # next stage is built: `MapTransformFn.__call__` runs `_pre_process`
+        # eagerly, and with `batch_size="auto"` that peeks at a real block to
+        # size batches, pulling data through the stages already in the chain.
         for transform_fn in self._transform_fns:
-            iter = transform_fn(iter, ctx, report_custom_op_stats)
-            if transform_fn._is_udf:
-                iter = self._UDFTimingIterator(iter, udf_time_scope)
+            if decomposed:
+                is_udf = transform_fn._is_udf
+
+                def wrap_phase(
+                    phase: MapTransformPhase,
+                    data: Iterable[MapTransformFnData],
+                    _is_udf: bool = is_udf,
+                ) -> Iterable[MapTransformFnData]:
+                    if phase is MapTransformPhase.UDF_BODY and not _is_udf:
+                        phase = MapTransformPhase.OTHER
+                    return self._UDFTimingIterator(data, udf_time_scope, phase)
+
+                iter = transform_fn(iter, ctx, report_custom_op_stats, wrap_phase)
+            else:
+                iter = transform_fn(iter, ctx, report_custom_op_stats)
+                if transform_fn._is_udf:
+                    iter = self._UDFTimingIterator(iter, udf_time_scope)
 
         return iter
 

--- a/python/ray/data/_internal/execution/operators/map_transformer.py
+++ b/python/ray/data/_internal/execution/operators/map_transformer.py
@@ -235,16 +235,18 @@ class MapTransformPhaseTimes:
 
     ``total_s`` is the whole chain, which is what Ray Data has always reported as
     "UDF time". The rest decompose it and sum back to it, saying where inside the
-    chain the time went; they are all zero when the chain measured only its
+    chain the time went; they are all ``None`` when the chain measured only its
     total. Each is summed over every stage of a (possibly fused) chain, so a
     fused operator reports one figure per phase rather than one per stage.
     """
 
     total_s: float = 0.0
-    input_prep_s: float = 0.0
-    udf_body_s: float = 0.0
-    output_build_s: float = 0.0
-    other_s: float = 0.0
+    # None, not zero, when the chain measured only its total: a consumer has to
+    # be able to tell "not measured" from "measured as zero".
+    input_prep_s: Optional[float] = None
+    udf_body_s: Optional[float] = None
+    output_build_s: Optional[float] = None
+    other_s: Optional[float] = None
 
 
 class UDFTimeScope:

--- a/python/ray/data/_internal/execution/operators/map_transformer.py
+++ b/python/ray/data/_internal/execution/operators/map_transformer.py
@@ -167,7 +167,6 @@ class MapTransformFn(ABC):
         to bind the task context.
         """
         name = repr(self)
-        body = MapTransformPhase.UDF_BODY if self._is_udf else MapTransformPhase.OTHER
         return [
             TimedStep(
                 f"{name} input prep",
@@ -177,7 +176,7 @@ class MapTransformFn(ABC):
             ),
             TimedStep(
                 f"{name} body",
-                body,
+                MapTransformPhase.FUNCTION_BODY,
                 stage_idx,
                 lambda it: self._apply_transform(ctx, it, report_custom_op_stats),
             ),
@@ -247,12 +246,11 @@ class MapTransformPhase(Enum):
 
     # Turning input blocks into the batches or rows the transform consumes.
     INPUT_PREP = 0
-    # A transform body the planner marked as a user-defined function.
-    UDF_BODY = 1
+    # A transform body, whoever wrote it: a read and a write are functions like
+    # any other, so they land here beside the ones the caller passed in.
+    FUNCTION_BODY = 1
     # Assembling the transform's output back into blocks.
     OUTPUT_BUILD = 2
-    # A transform body that isn't a UDF, such as a read or a write.
-    OTHER = 3
 
 
 @dataclass(frozen=True)
@@ -327,11 +325,11 @@ class MapTransformPhaseTimes:
     ``total_s`` is the whole chain: forming batches or rows, the stage bodies,
     and building output blocks, for every stage of a (possibly fused) chain. It
     is deliberately not the time inside the functions the caller passed in --
-    that is the narrower ``udf_body_s``. ``ds.stats()`` printed this figure as
+    that is the narrower ``function_body_s``. ``ds.stats()`` printed this figure as
     "UDF time" before it was renamed, which said the opposite; hence the rename,
     and hence the narrow figure getting its own "Function body" line.
 
-    The four phase figures decompose ``total_s`` and sum back to it, saying
+    The three phase figures decompose ``total_s`` and sum back to it, saying
     where inside the chain the time went; they are all ``None`` when the chain
     measured only its total. Each is summed over every stage, so a fused
     operator reports one figure per phase rather than one per stage.
@@ -341,9 +339,8 @@ class MapTransformPhaseTimes:
     # None, not zero, when the chain measured only its total: a consumer has to
     # be able to tell "not measured" from "measured as zero".
     input_prep_s: Optional[float] = None
-    udf_body_s: Optional[float] = None
+    function_body_s: Optional[float] = None
     output_build_s: Optional[float] = None
-    other_s: Optional[float] = None
 
 
 class TransformClock:
@@ -406,9 +403,8 @@ class TransformClock:
             times = MapTransformPhaseTimes(
                 total_s=sum(own),
                 input_prep_s=by_bucket.get(MapTransformPhase.INPUT_PREP, 0.0),
-                udf_body_s=by_bucket.get(MapTransformPhase.UDF_BODY, 0.0),
+                function_body_s=by_bucket.get(MapTransformPhase.FUNCTION_BODY, 0.0),
                 output_build_s=by_bucket.get(MapTransformPhase.OUTPUT_BUILD, 0.0),
-                other_s=by_bucket.get(MapTransformPhase.OTHER, 0.0),
             )
         else:
             times = MapTransformPhaseTimes(total_s=sum(own))

--- a/python/ray/data/_internal/execution/operators/map_transformer.py
+++ b/python/ray/data/_internal/execution/operators/map_transformer.py
@@ -322,13 +322,20 @@ class _TimedStep(Iterator[Any]):
 
 @dataclass(frozen=True)
 class MapTransformPhaseTimes:
-    """Seconds a task spent in its map transform chain.
+    """Seconds a task spent in its map transform chain, per output block.
 
-    ``total_s`` is the whole chain, which is what Ray Data has always reported as
-    "UDF time". The rest decompose it and sum back to it, saying where inside the
-    chain the time went; they are all ``None`` when the chain measured only its
-    total. Each is summed over every stage of a (possibly fused) chain, so a
-    fused operator reports one figure per phase rather than one per stage.
+    ``total_s`` is the whole chain: forming batches or rows, the stage bodies,
+    and building output blocks, for every stage of a (possibly fused) chain. It
+    is deliberately not the time inside the functions the caller passed in --
+    that is the narrower ``udf_body_s``. ``ds.stats()`` has printed ``total_s``
+    as "UDF time" for many releases, which is misleading for exactly that
+    reason, and is why the breakdown gives the narrow figure its own line,
+    "Function body".
+
+    The four phase figures decompose ``total_s`` and sum back to it, saying
+    where inside the chain the time went; they are all ``None`` when the chain
+    measured only its total. Each is summed over every stage, so a fused
+    operator reports one figure per phase rather than one per stage.
     """
 
     total_s: float = 0.0

--- a/python/ray/data/_internal/execution/operators/map_transformer.py
+++ b/python/ray/data/_internal/execution/operators/map_transformer.py
@@ -361,7 +361,18 @@ class TransformClock:
         self.inclusive: List[float] = []
 
     def chain(self, steps: List["TimedStep"], blocks: Iterable[Any]) -> Iterable[Any]:
-        """Build the timed pipeline over ``blocks``."""
+        """Build the timed pipeline over ``blocks``.
+
+        Nothing runs until the result is pulled: each step calls its ``apply``
+        on its first ``__next__``, which is what puts an eagerly consuming
+        stage's work inside a timed window. That places one requirement on a
+        stage -- a stage that depends on an upstream stage's side effects has
+        to consume upstream to get them, because until it does, upstream has
+        not run. Reading state an upstream stage leaves on the ``TaskContext``
+        before draining the input is the way to get this wrong;
+        ``_generate_commit_checkpoint_transform`` and
+        ``generate_collect_write_stats_fn`` both drain first for this reason.
+        """
         self._steps = steps
         self.inclusive = [0.0] * len(steps)
         data = blocks

--- a/python/ray/data/_internal/execution/operators/map_transformer.py
+++ b/python/ray/data/_internal/execution/operators/map_transformer.py
@@ -276,7 +276,7 @@ class _TimedStep(Iterator[Any]):
     """Times one step, inclusive of everything upstream of it.
 
     Deliberately does not coordinate with the other steps: it starts a clock,
-    pulls, and adds the elapsed time to its own slot. Because the chain is
+    pulls, and adds the elapsed time to its own total. Because the chain is
     linear -- step ``k`` is only ever pulled by step ``k + 1`` -- all of a
     step's time lies inside its consumer's windows, so subtracting neighbouring
     totals at drain time recovers each step's own work. Doing that arithmetic
@@ -284,20 +284,17 @@ class _TimedStep(Iterator[Any]):
     through every ``__next__``.
     """
 
-    __slots__ = ("_apply", "_upstream", "_iter", "_totals", "_idx")
+    __slots__ = ("_apply", "_upstream", "_iter", "_elapsed")
 
     def __init__(
         self,
         apply: Callable[[Iterable[Any]], Iterable[Any]],
         upstream: Iterable[Any],
-        totals: List[float],
-        idx: int,
     ):
         self._apply = apply
         self._upstream = upstream
         self._iter: Optional[Iterator[Any]] = None
-        self._totals = totals
-        self._idx = idx
+        self._elapsed = 0.0
 
     def __iter__(self) -> "_TimedStep":
         return self
@@ -314,7 +311,12 @@ class _TimedStep(Iterator[Any]):
                 self._iter = iter(self._apply(self._upstream))
             return next(self._iter)
         finally:
-            self._totals[self._idx] += time.perf_counter() - start
+            self._elapsed += time.perf_counter() - start
+
+    def drain(self) -> float:
+        """Return this step's inclusive time since the last drain, and reset."""
+        elapsed, self._elapsed = self._elapsed, 0.0
+        return elapsed
 
 
 @dataclass(frozen=True)
@@ -350,16 +352,17 @@ class TransformClock:
     total would mix their timings and let one task's :meth:`drain` discard
     another's.
 
-    Holds one inclusive total per step. :meth:`drain` turns those into each
-    step's own time and groups them, so a step measures itself and nothing
-    else while data is flowing.
+    Each step times itself, inclusive of everything upstream of it.
+    :meth:`drain` collects those totals, turns them into each step's own time
+    and groups them, so a step measures itself and nothing else while data is
+    flowing.
     """
 
-    __slots__ = ("inclusive", "_steps")
+    __slots__ = ("_steps", "_timers")
 
     def __init__(self) -> None:
         self._steps: List["Step"] = []
-        self.inclusive: List[float] = []
+        self._timers: List[_TimedStep] = []
 
     def chain(self, steps: List["Step"], blocks: Iterable[Any]) -> Iterable[Any]:
         """Build the timed pipeline over ``blocks``.
@@ -375,13 +378,16 @@ class TransformClock:
         ``generate_collect_write_stats_fn`` both drain first for this reason.
         """
         self._steps = steps
-        self.inclusive = [0.0] * len(steps)
-        data = blocks
-        for idx, step in enumerate(steps):
-            data = _TimedStep(step.apply, data, self.inclusive, idx)
+        self._timers = []
+        data: Iterable[Any] = blocks
+        for step in steps:
+            timer = _TimedStep(step.apply, data)
+            self._timers.append(timer)
+            data = timer
         return data
 
-    def _self_times(self) -> List[float]:
+    @staticmethod
+    def _self_times(inclusive: List[float]) -> List[float]:
         """Each step's own time: its window less its upstream's.
 
         A step's window contains everything upstream of it, and step ``k`` is
@@ -390,13 +396,17 @@ class TransformClock:
         on that subtraction; the difference is otherwise non-negative.
         """
         return [
-            max(0.0, total - (self.inclusive[i - 1] if i else 0.0))
-            for i, total in enumerate(self.inclusive)
+            max(0.0, total - (inclusive[i - 1] if i else 0.0))
+            for i, total in enumerate(inclusive)
         ]
 
     def drain(self) -> "MapTransformPhaseTimes":
-        """Return the time accumulated since the last drain, and reset."""
-        own = self._self_times()
+        """Return the time accumulated since the last drain, and reset.
+
+        Draining a timer is what resets it, and the subtraction needs every
+        step's total, so collect them all before deriving anything.
+        """
+        own = self._self_times([timer.drain() for timer in self._timers])
         by_bucket: Dict[MapTransformPhase, float] = {}
         for step, seconds in zip(self._steps, own):
             if step.bucket is not None:
@@ -409,20 +419,13 @@ class TransformClock:
             # Measured. A phase this chain happens not to run really did take
             # no time, so report zero -- `None` is reserved for "not measured",
             # which a consumer has to be able to tell apart.
-            times = MapTransformPhaseTimes(
+            return MapTransformPhaseTimes(
                 total_s=sum(own),
                 input_prep_s=by_bucket.get(MapTransformPhase.INPUT_PREP, 0.0),
                 function_body_s=by_bucket.get(MapTransformPhase.FUNCTION_BODY, 0.0),
                 output_build_s=by_bucket.get(MapTransformPhase.OUTPUT_BUILD, 0.0),
             )
-        else:
-            times = MapTransformPhaseTimes(total_s=sum(own))
-        # Zero in place. Every `_TimedStep` in the chain holds a reference to
-        # this list, so rebinding it here would leave them adding to a list
-        # this clock no longer reads -- and `_map_task` drains after every
-        # output block, so only a task's first block would report any time.
-        self.inclusive[:] = [0.0] * len(self.inclusive)
-        return times
+        return MapTransformPhaseTimes(total_s=sum(own))
 
 
 def _coalesce_stage(steps: List["Step"], transform_fn: "MapTransformFn") -> "Step":

--- a/python/ray/data/_internal/execution/operators/map_transformer.py
+++ b/python/ray/data/_internal/execution/operators/map_transformer.py
@@ -151,13 +151,13 @@ class MapTransformFn(ABC):
             results, self._input_type, self._output_block_size_option
         )
 
-    def timed_steps(
+    def steps(
         self,
         ctx: TaskContext,
         report_custom_op_stats: CustomOpStatsReportFn,
         stage_idx: int,
-    ) -> List["TimedStep"]:
-        """This transform as a flat list of timed pipeline steps.
+    ) -> List["Step"]:
+        """This transform as a flat list of pipeline steps.
 
         `_pre_process` and `_post_process` are already `Iterable -> Iterable`,
         so they are the step bodies as-is; only the wrapped fn needs a closure
@@ -165,19 +165,19 @@ class MapTransformFn(ABC):
         """
         name = repr(self)
         return [
-            TimedStep(
+            Step(
                 f"{name} input prep",
                 MapTransformPhase.INPUT_PREP,
                 stage_idx,
                 self._pre_process,
             ),
-            TimedStep(
+            Step(
                 f"{name} body",
                 MapTransformPhase.FUNCTION_BODY,
                 stage_idx,
                 lambda it: self._apply_transform(ctx, it, report_custom_op_stats),
             ),
-            TimedStep(
+            Step(
                 f"{name} output build",
                 MapTransformPhase.OUTPUT_BUILD,
                 stage_idx,
@@ -191,16 +191,18 @@ class MapTransformFn(ABC):
         ctx: TaskContext,
         report_custom_op_stats: CustomOpStatsReportFn = _noop_report_custom_op_stats,
     ) -> Iterable[Block]:
-        """Apply this transform's steps in order, untimed.
+        """Compose this transform's steps and apply them to ``blocks``.
 
-        Timing belongs to the chain rather than to a transform:
-        :meth:`MapTransformer.apply_transform` wraps these same steps in a
-        :class:`TransformClock`. A caller driving one transform on its own --
+        A :class:`Step` is inert: it carries a body and the metadata a summary
+        groups by, and nothing here measures it. Timing is what
+        :meth:`TransformClock.chain` adds, and
+        :meth:`MapTransformer.apply_transform` is the caller that asks for it.
+        A caller driving one transform on its own --
         ``generate_collect_write_stats_fn``, and tests -- gets the plain
-        composition.
+        composition instead.
         """
         data: Iterable[Any] = blocks
-        for step in self.timed_steps(ctx, report_custom_op_stats, 0):
+        for step in self.steps(ctx, report_custom_op_stats, 0):
             data = step.apply(data)
         return data
 
@@ -251,7 +253,7 @@ class MapTransformPhase(Enum):
 
 
 @dataclass(frozen=True)
-class TimedStep:
+class Step:
     """One ``Iterable -> Iterable`` link in a map task's pipeline.
 
     A task's whole transform is a flat list of these. ``apply`` is the work;
@@ -322,9 +324,8 @@ class MapTransformPhaseTimes:
     ``total_s`` is the whole chain: forming batches or rows, the stage bodies,
     and building output blocks, for every stage of a (possibly fused) chain. It
     is deliberately not the time inside the functions the caller passed in --
-    that is the narrower ``function_body_s``. ``ds.stats()`` printed this figure as
-    "UDF time" before it was renamed, which said the opposite; hence the rename,
-    and hence the narrow figure getting its own "Function body" line.
+    that is the narrower ``function_body_s``, which ``ds.stats()`` reports on
+    its own "Function body" line.
 
     The three phase figures decompose ``total_s`` and sum back to it, saying
     where inside the chain the time went; they are all ``None`` when the chain
@@ -357,10 +358,10 @@ class TransformClock:
     __slots__ = ("inclusive", "_steps")
 
     def __init__(self) -> None:
-        self._steps: List["TimedStep"] = []
+        self._steps: List["Step"] = []
         self.inclusive: List[float] = []
 
-    def chain(self, steps: List["TimedStep"], blocks: Iterable[Any]) -> Iterable[Any]:
+    def chain(self, steps: List["Step"], blocks: Iterable[Any]) -> Iterable[Any]:
         """Build the timed pipeline over ``blocks``.
 
         Nothing runs until the result is pulled: each step calls its ``apply``
@@ -424,9 +425,7 @@ class TransformClock:
         return times
 
 
-def _coalesce_stage(
-    steps: List["TimedStep"], transform_fn: "MapTransformFn"
-) -> "TimedStep":
+def _coalesce_stage(steps: List["Step"], transform_fn: "MapTransformFn") -> "Step":
     """Fold a stage's three steps into one, timed as a unit."""
     applies = [step.apply for step in steps]
 
@@ -435,7 +434,7 @@ def _coalesce_stage(
             data = fn(data)
         return data
 
-    return TimedStep(
+    return Step(
         label=f"{transform_fn!r} stage",
         # Spans input prep, body and output build, so it belongs to no single
         # phase -- which is what makes the phase figures report as "not
@@ -509,14 +508,14 @@ class MapTransformer:
         """
         self._init_fn()
 
-    def get_timed_steps(
+    def get_steps(
         self,
         ctx: TaskContext,
         report_custom_op_stats: CustomOpStatsReportFn,
         *,
         decomposed: bool,
-    ) -> List["TimedStep"]:
-        """This task's whole transform, as a flat list of timed steps.
+    ) -> List["Step"]:
+        """This task's whole transform, as a flat list of steps.
 
         The answer to "what is getting timed?" is this list. It is ordinary
         data: printable, and assertable in a unit test.
@@ -525,11 +524,9 @@ class MapTransformer:
         is how a row transform pays one timer per stage instead of three -- a
         rewrite of the list rather than a second code path.
         """
-        steps: List[TimedStep] = []
+        steps: List[Step] = []
         for stage_idx, transform_fn in enumerate(self._transform_fns):
-            stage_steps = transform_fn.timed_steps(
-                ctx, report_custom_op_stats, stage_idx
-            )
+            stage_steps = transform_fn.steps(ctx, report_custom_op_stats, stage_idx)
             if not decomposed:
                 stage_steps = [_coalesce_stage(stage_steps, transform_fn)]
             steps.extend(stage_steps)
@@ -543,7 +540,7 @@ class MapTransformer:
         *,
         clock: "TransformClock",
     ) -> Iterable[Block]:
-        """Chain this task's timed steps over the input blocks.
+        """Chain this task's steps over the input blocks, timed by ``clock``.
 
         Args:
             input_blocks: The blocks to transform.
@@ -577,7 +574,7 @@ class MapTransformer:
         )
         decomposed = not per_row or DataContext.get_current().accurate_map_phase_timing
 
-        steps = self.get_timed_steps(ctx, report_custom_op_stats, decomposed=decomposed)
+        steps = self.get_steps(ctx, report_custom_op_stats, decomposed=decomposed)
         return clock.chain(steps, input_blocks)
 
     def fuse(self, other: "MapTransformer") -> "MapTransformer":

--- a/python/ray/data/_internal/execution/operators/map_transformer.py
+++ b/python/ray/data/_internal/execution/operators/map_transformer.py
@@ -552,7 +552,10 @@ class MapTransformer:
                 its :class:`CustomOpStats`.
             clock: Where this task's timings accumulate. Keyword-only on
                 purpose: a caller that silently skipped it would report zero
-                rather than fail.
+                rather than fail. The shuffle and repartition tasks pass a
+                throwaway and never drain it -- they build their own
+                :class:`BlockExecStats` and have nowhere to put the result --
+                so those operators report no transform time at all.
 
         Returns:
             An iterable of the transformed output blocks.

--- a/python/ray/data/_internal/execution/operators/map_transformer.py
+++ b/python/ray/data/_internal/execution/operators/map_transformer.py
@@ -365,17 +365,31 @@ class TransformClock:
         self._timers: List[_TimedStep] = []
 
     def chain(self, steps: List["Step"], blocks: Iterable[Any]) -> Iterable[Any]:
-        """Build the timed pipeline over ``blocks``.
+        """Wrap each step in a timer and link them into one pipeline.
 
-        Nothing runs until the result is pulled: each step calls its ``apply``
-        on its first ``__next__``, which is what puts an eagerly consuming
-        stage's work inside a timed window. That places one requirement on a
-        stage -- a stage that depends on an upstream stage's side effects has
-        to consume upstream to get them, because until it does, upstream has
-        not run. Reading state an upstream stage leaves on the ``TaskContext``
-        before draining the input is the way to get this wrong;
-        ``_generate_commit_checkpoint_transform`` and
-        ``generate_collect_write_stats_fn`` both drain first for this reason.
+        ``data`` starts as the raw input blocks, and each pass through the
+        loop wraps it one layer deeper. A checkpointed write, simplified to
+        two stages, builds this::
+
+            data = blocks
+            data = _TimedStep(prepare.apply, blocks)  # timer 0 reads the blocks
+            data = _TimedStep(commit.apply, timer0)   # timer 1 reads timer 0
+            return data                               # the whole chain
+
+        ``self._timers`` holds them in that same order, which is what lets
+        :meth:`drain` recover each step's own time from its neighbour's.
+
+        Nothing has run when this returns. Here is how that chain runs once
+        the caller pulls it::
+
+            next(timer1)      commit's body starts
+            list(blocks)      commit drains its input, pulling timer0
+            next(timer0)      prepare's body starts
+            prepare returns   the pending checkpoints are now on ctx
+            commit continues  it reads them and commits
+
+        ``commit`` starts first; ``prepare`` runs inside its drain. Read
+        ``ctx`` before draining and there is nothing there.
         """
         self._steps = steps
         self._timers = []

--- a/python/ray/data/_internal/execution/operators/shuffle_operators/external_shuffle_tasks.py
+++ b/python/ray/data/_internal/execution/operators/shuffle_operators/external_shuffle_tasks.py
@@ -278,14 +278,14 @@ def _external_shuffle_reduce_task(
         assert map_task_context is not None and data_context is not None
         with DataContext.current(data_context), TaskContext.current(map_task_context):
             from ray.data._internal.execution.operators.map_transformer import (
-                UDFTimeScope,
+                TransformClock,
             )
 
             map_transformer.override_target_max_block_size(
                 map_task_context.target_max_block_size_override
             )
             for out_block in map_transformer.apply_transform(
-                blocks, map_task_context, udf_time_scope=UDFTimeScope()
+                blocks, map_task_context, clock=TransformClock()
             ):
                 yield from _yield_with_stats(out_block)
 

--- a/python/ray/data/_internal/execution/operators/shuffle_operators/shuffle_tasks.py
+++ b/python/ray/data/_internal/execution/operators/shuffle_operators/shuffle_tasks.py
@@ -344,7 +344,7 @@ def _shuffle_reduce_task(
         assert map_task_context is not None and data_context is not None
         with DataContext.current(data_context), TaskContext.current(map_task_context):
             from ray.data._internal.execution.operators.map_transformer import (
-                UDFTimeScope,
+                TransformClock,
             )
 
             map_transformer.override_target_max_block_size(
@@ -353,6 +353,6 @@ def _shuffle_reduce_task(
             for block in map_transformer.apply_transform(
                 _reduce_output_blocks(),
                 map_task_context,
-                udf_time_scope=UDFTimeScope(),
+                clock=TransformClock(),
             ):
                 yield from _yield_with_stats(block)

--- a/python/ray/data/_internal/planner/checkpoint/plan_write_op.py
+++ b/python/ray/data/_internal/planner/checkpoint/plan_write_op.py
@@ -260,7 +260,6 @@ def _generate_prepare_checkpoint_transform(
 
     return BlockMapTransformFn(
         prepare_checkpoint,
-        is_udf=False,
         disable_block_shaping=True,
     )
 
@@ -284,6 +283,14 @@ def _generate_commit_checkpoint_transform(
     def commit_checkpoints(
         blocks: Iterable[Block], ctx: TaskContext
     ) -> Iterable[Block]:
+        # Drain the upstream stages before reading what they left on `ctx`.
+        # The prepare stage puts the pending checkpoints there as it runs, and
+        # in a lazily-built chain it only runs when its output is pulled, so
+        # reading `ctx.kwargs` first would find nothing to commit. Draining
+        # here is also what "AFTER the data write succeeds" means: the write is
+        # upstream, so consuming its output is what waits for it.
+        blocks = list(blocks)
+
         # Get pending checkpoints written in pre-write phase
         pending_checkpoints: List[PendingCheckpoint] = ctx.kwargs.get(
             PENDING_CHECKPOINTS_KWARG_NAME, []
@@ -297,7 +304,6 @@ def _generate_commit_checkpoint_transform(
 
     return BlockMapTransformFn(
         commit_checkpoints,
-        is_udf=False,
         disable_block_shaping=True,
     )
 
@@ -344,7 +350,6 @@ def _generate_non_atomic_write_checkpoint_transform(
 
     return BlockMapTransformFn(
         write_checkpoint,
-        is_udf=False,
         # NOTE: No need for block-shaping
         disable_block_shaping=True,
     )

--- a/python/ray/data/_internal/planner/checkpoint/plan_write_op.py
+++ b/python/ray/data/_internal/planner/checkpoint/plan_write_op.py
@@ -283,12 +283,9 @@ def _generate_commit_checkpoint_transform(
     def commit_checkpoints(
         blocks: Iterable[Block], ctx: TaskContext
     ) -> Iterable[Block]:
-        # Drain the upstream stages before reading what they left on `ctx`.
-        # The prepare stage puts the pending checkpoints there as it runs, and
-        # in a lazily-built chain it only runs when its output is pulled, so
-        # reading `ctx.kwargs` first would find nothing to commit. Draining
-        # here is also what "AFTER the data write succeeds" means: the write is
-        # upstream, so consuming its output is what waits for it.
+        # Upstream is lazy: nothing runs until its output is pulled. Pulling it
+        # here is what makes the prepare stage run and leave the pending
+        # checkpoints on `ctx` for the loop below to commit.
         blocks = list(blocks)
 
         # Get pending checkpoints written in pre-write phase

--- a/python/ray/data/_internal/planner/checkpoint/plan_write_op.py
+++ b/python/ray/data/_internal/planner/checkpoint/plan_write_op.py
@@ -283,13 +283,9 @@ def _generate_commit_checkpoint_transform(
     def commit_checkpoints(
         blocks: Iterable[Block], ctx: TaskContext
     ) -> Iterable[Block]:
-        # Drain upstream before reading `ctx`. Every stage of a fused chain
-        # runs its body on the first pull from it, and the chain is built
-        # outside-in, so this body starts before the prepare and write stages
-        # upstream have run at all. `prepare_checkpoint` is what leaves the
-        # pending checkpoints on `ctx`; reading `ctx.kwargs` without draining
-        # first finds an empty list and commits nothing, so the second phase of
-        # the 2PC silently never happens. See `TransformClock.chain`.
+        # Each stage runs on the first pull from it, so nothing upstream has
+        # run yet. `prepare_checkpoint` is what leaves the pending checkpoints
+        # on `ctx`. Drain first, or there is nothing here to commit.
         blocks = list(blocks)
 
         # Get pending checkpoints written in pre-write phase

--- a/python/ray/data/_internal/planner/checkpoint/plan_write_op.py
+++ b/python/ray/data/_internal/planner/checkpoint/plan_write_op.py
@@ -283,9 +283,13 @@ def _generate_commit_checkpoint_transform(
     def commit_checkpoints(
         blocks: Iterable[Block], ctx: TaskContext
     ) -> Iterable[Block]:
-        # Upstream is lazy: nothing runs until its output is pulled. Pulling it
-        # here is what makes the prepare stage run and leave the pending
-        # checkpoints on `ctx` for the loop below to commit.
+        # Drain upstream before reading `ctx`. Every stage of a fused chain
+        # runs its body on the first pull from it, and the chain is built
+        # outside-in, so this body starts before the prepare and write stages
+        # upstream have run at all. `prepare_checkpoint` is what leaves the
+        # pending checkpoints on `ctx`; reading `ctx.kwargs` without draining
+        # first finds an empty list and commits nothing, so the second phase of
+        # the 2PC silently never happens. See `TransformClock.chain`.
         blocks = list(blocks)
 
         # Get pending checkpoints written in pre-write phase

--- a/python/ray/data/_internal/planner/plan_read_files_op.py
+++ b/python/ray/data/_internal/planner/plan_read_files_op.py
@@ -80,7 +80,6 @@ def plan_read_files_op(
             [
                 BlockMapTransformFn(
                     do_read,
-                    is_udf=False,
                     output_block_size_option=OutputBlockSizeOption.of(
                         target_max_block_size=data_context.target_max_block_size,
                     ),

--- a/python/ray/data/_internal/planner/plan_read_op.py
+++ b/python/ray/data/_internal/planner/plan_read_op.py
@@ -116,7 +116,6 @@ def plan_read_op(
         [
             BlockMapTransformFn(
                 do_read,
-                is_udf=False,
                 output_block_size_option=OutputBlockSizeOption.of(
                     target_max_block_size=data_context.target_max_block_size,
                 ),

--- a/python/ray/data/_internal/planner/plan_udf_map_op.py
+++ b/python/ray/data/_internal/planner/plan_udf_map_op.py
@@ -246,7 +246,6 @@ def plan_filter_op(
         init_fn = None
         transform_fn = BlockMapTransformFn(
             filter_block_fn,
-            is_udf=True,
             output_block_size_option=output_block_size_option,
         )
     else:
@@ -262,7 +261,6 @@ def plan_filter_op(
 
         transform_fn = RowMapTransformFn(
             _generate_transform_fn_for_filter(filter_fn),
-            is_udf=True,
             output_block_size_option=output_block_size_option,
         )
 
@@ -313,7 +311,6 @@ def plan_udf_map_op(
             batch_size=op.batch_size,
             batch_format=op.batch_format,
             zero_copy_batch=op.zero_copy_batch,
-            is_udf=True,
             output_block_size_option=output_block_size_option,
         )
 
@@ -327,7 +324,6 @@ def plan_udf_map_op(
 
         transform_fn = RowMapTransformFn(
             udf_fn,
-            is_udf=True,
             output_block_size_option=output_block_size_option,
         )
 

--- a/python/ray/data/_internal/planner/plan_write_op.py
+++ b/python/ray/data/_internal/planner/plan_write_op.py
@@ -69,7 +69,6 @@ def generate_collect_write_stats_fn() -> BlockMapTransformFn:
 
     return BlockMapTransformFn(
         fn,
-        is_udf=False,
         disable_block_shaping=True,
     )
 
@@ -119,7 +118,6 @@ def _plan_write_op_internal(
     pre_transforms = pre_transformations or []
     write_transform = BlockMapTransformFn(
         write_fn,
-        is_udf=False,
         # NOTE: No need for block-shaping
         disable_block_shaping=True,
     )

--- a/python/ray/data/_internal/planner/plan_write_op.py
+++ b/python/ray/data/_internal/planner/plan_write_op.py
@@ -50,6 +50,8 @@ def generate_collect_write_stats_fn() -> BlockMapTransformFn:
     # execution outcomes with `on_write_complete()`` and `on_write_failed()``.
     def fn(blocks: Iterator[Block], ctx: TaskContext) -> Iterator[Block]:
         """Handles stats collection for block writes."""
+        # Drain before reading `ctx` below: consuming the input is what runs
+        # the write stage, and the write is what sets `_datasink_write_return`.
         block_accessors = [BlockAccessor.for_block(block) for block in blocks]
         total_num_rows = sum(ba.num_rows() for ba in block_accessors)
         total_size_bytes = sum(ba.size_bytes() for ba in block_accessors)

--- a/python/ray/data/_internal/planner/random_shuffle.py
+++ b/python/ray/data/_internal/planner/random_shuffle.py
@@ -10,7 +10,7 @@ from ray.data._internal.execution.interfaces.transform_fn import (
 )
 from ray.data._internal.execution.operators.map_transformer import (
     MapTransformer,
-    UDFTimeScope,
+    TransformClock,
 )
 from ray.data._internal.execution.util import merge_label_selector
 from ray.data._internal.planner.exchange.pull_based_shuffle_task_scheduler import (
@@ -60,7 +60,7 @@ def generate_random_shuffle_fn(
             def upstream_map_fn(blocks):
                 DataContext._set_current(data_context)
                 return map_transformer.apply_transform(
-                    blocks, ctx, udf_time_scope=UDFTimeScope()
+                    blocks, ctx, clock=TransformClock()
                 )
 
             # If there is a fused upstream operator,

--- a/python/ray/data/_internal/planner/repartition.py
+++ b/python/ray/data/_internal/planner/repartition.py
@@ -10,7 +10,7 @@ from ray.data._internal.execution.interfaces.transform_fn import (
 )
 from ray.data._internal.execution.operators.map_transformer import (
     MapTransformer,
-    UDFTimeScope,
+    TransformClock,
 )
 from ray.data._internal.execution.util import merge_label_selector
 from ray.data._internal.planner.exchange.pull_based_shuffle_task_scheduler import (
@@ -52,7 +52,7 @@ def generate_repartition_fn(
             def upstream_map_fn(blocks):
                 DataContext._set_current(data_context)
                 return map_transformer.apply_transform(
-                    blocks, ctx, udf_time_scope=UDFTimeScope()
+                    blocks, ctx, clock=TransformClock()
                 )
 
         shuffle_spec = ShuffleTaskSpec(

--- a/python/ray/data/_internal/stats.py
+++ b/python/ray/data/_internal/stats.py
@@ -1840,10 +1840,16 @@ class OperatorStatsSummary:
         wall_time_stats = wall_time_acc.get()
         cpu_stats = cpu_time_acc.get()
         udf_stats = udf_time_acc.get()
-        input_prep_stats = input_prep_time_acc.get()
-        udf_body_stats = udf_body_time_acc.get()
-        output_build_stats = output_build_time_acc.get()
-        other_stage_stats = other_stage_time_acc.get()
+        # A chain that measured only its total leaves the phase accumulators
+        # empty. Report that as None rather than a zero-valued summary, so a
+        # consumer can tell "not measured" from "measured as zero" -- the phases
+        # are absent for row-based transforms unless
+        # `DataContext.accurate_map_phase_timing` is set.
+        phases_measured = input_prep_time_acc.count > 0
+        input_prep_stats = input_prep_time_acc.get() if phases_measured else None
+        udf_body_stats = udf_body_time_acc.get() if phases_measured else None
+        output_build_stats = output_build_time_acc.get() if phases_measured else None
+        other_stage_stats = other_stage_time_acc.get() if phases_measured else None
 
         # Output stats.
         output_num_rows_stats = output_rows_acc.get()
@@ -1920,18 +1926,26 @@ class OperatorStatsSummary:
             )
             # Breakdown of the line above, in execution order: input blocks
             # become batches or rows, the UDF runs, output goes back into
-            # blocks. These sum to the total. Absent for row-based transforms
-            # unless `DataContext.accurate_map_phase_timing` is set, since
-            # measuring them per row costs more than it reports.
+            # blocks. These sum to the total.
+            #
+            # Verbose-only, like `extra_metrics`: the figures are always on the
+            # summary for anyone reading it programmatically, but adding four
+            # lines to everyone's default `ds.stats()` is a bigger change than
+            # the detail warrants. They are absent altogether for row-based
+            # transforms unless `DataContext.accurate_map_phase_timing` is set,
+            # since measuring them per row costs more than it reports.
             breakdown = [
                 ("Input prep", self.input_prep_time),
                 ("Function body", self.udf_body_time),
                 ("Output block build", self.output_build_time),
-                # Only non-zero when a non-UDF stage (a read, a write) is fused
-                # into the same chain.
-                ("Other stages", self.other_stage_time),
+                # Bodies of the stages Ray Data supplies -- reads, writes,
+                # downloads, file listing -- as opposed to the function you
+                # passed. Only non-zero when one is fused into this operator.
+                ("Built-in stages", self.other_stage_time),
             ]
-            if any(s is not None and s.sum for _, s in breakdown):
+            if DataContext.get_current().verbose_stats_logs and any(
+                s is not None and s.sum for _, s in breakdown
+            ):
                 for label, stats in breakdown:
                     if stats is None or not stats.sum:
                         continue

--- a/python/ray/data/_internal/stats.py
+++ b/python/ray/data/_internal/stats.py
@@ -1705,7 +1705,16 @@ class OperatorStatsSummary:
     block_execution_summary_str: str
     wall_time: Optional[StatsSummary] = None
     cpu_time: Optional[StatsSummary] = None
+    # Time in the map transform chain. The four fields below decompose it.
     udf_time: Optional[StatsSummary] = None
+    # Time turning input blocks into the batches or rows the transforms consume.
+    input_prep_time: Optional[StatsSummary] = None
+    # Time inside the UDF bodies themselves.
+    udf_body_time: Optional[StatsSummary] = None
+    # Time assembling transform output back into blocks.
+    output_build_time: Optional[StatsSummary] = None
+    # Time in the bodies of non-UDF stages fused into the same chain.
+    other_stage_time: Optional[StatsSummary] = None
     total_input_num_rows: Optional[int] = None
     output_num_rows: Optional[StatsSummary] = None
     output_size_bytes: Optional[StatsSummary] = None
@@ -1754,6 +1763,10 @@ class OperatorStatsSummary:
         wall_time_acc: _StatsAccumulator = _StatsAccumulator()
         cpu_time_acc: _StatsAccumulator = _StatsAccumulator()
         udf_time_acc: _StatsAccumulator = _StatsAccumulator()
+        input_prep_time_acc: _StatsAccumulator = _StatsAccumulator()
+        udf_body_time_acc: _StatsAccumulator = _StatsAccumulator()
+        output_build_time_acc: _StatsAccumulator = _StatsAccumulator()
+        other_stage_time_acc: _StatsAccumulator = _StatsAccumulator()
         output_rows_acc: _StatsAccumulator = _StatsAccumulator()
         output_sizes_acc: _StatsAccumulator = _StatsAccumulator()
         rows_per_task: DefaultDict[int, int] = collections.defaultdict(int)
@@ -1776,6 +1789,14 @@ class OperatorStatsSummary:
                     cpu_time_acc.add(es.cpu_time_s)
                 if es.udf_time_s is not None:
                     udf_time_acc.add(es.udf_time_s)
+                if es.input_prep_time_s is not None:
+                    input_prep_time_acc.add(es.input_prep_time_s)
+                if es.udf_body_time_s is not None:
+                    udf_body_time_acc.add(es.udf_body_time_s)
+                if es.output_build_time_s is not None:
+                    output_build_time_acc.add(es.output_build_time_s)
+                if es.other_stage_time_s is not None:
+                    other_stage_time_acc.add(es.other_stage_time_s)
                 tasks_per_node[es.node_id].add(es.task_idx)
                 if es.start_time_s is not None:
                     earliest_start_time = min(earliest_start_time, es.start_time_s)
@@ -1819,6 +1840,10 @@ class OperatorStatsSummary:
         wall_time_stats = wall_time_acc.get()
         cpu_stats = cpu_time_acc.get()
         udf_stats = udf_time_acc.get()
+        input_prep_stats = input_prep_time_acc.get()
+        udf_body_stats = udf_body_time_acc.get()
+        output_build_stats = output_build_time_acc.get()
+        other_stage_stats = other_stage_time_acc.get()
 
         # Output stats.
         output_num_rows_stats = output_rows_acc.get()
@@ -1845,6 +1870,10 @@ class OperatorStatsSummary:
             wall_time=wall_time_stats,
             cpu_time=cpu_stats,
             udf_time=udf_stats,
+            input_prep_time=input_prep_stats,
+            udf_body_time=udf_body_stats,
+            output_build_time=output_build_stats,
+            other_stage_time=other_stage_stats,
             total_input_num_rows=total_input_num_rows,
             output_num_rows=output_num_rows_stats,
             output_size_bytes=output_size_bytes_stats,
@@ -1889,6 +1918,31 @@ class OperatorStatsSummary:
                 fmt(self.udf_time.mean),
                 fmt(self.udf_time.sum),
             )
+            # Breakdown of the line above, in execution order: input blocks
+            # become batches or rows, the UDF runs, output goes back into
+            # blocks. These sum to the total. Absent for row-based transforms
+            # unless `DataContext.accurate_map_phase_timing` is set, since
+            # measuring them per row costs more than it reports.
+            breakdown = [
+                ("Input prep", self.input_prep_time),
+                ("Function body", self.udf_body_time),
+                ("Output block build", self.output_build_time),
+                # Only non-zero when a non-UDF stage (a read, a write) is fused
+                # into the same chain.
+                ("Other stages", self.other_stage_time),
+            ]
+            if any(s is not None and s.sum for _, s in breakdown):
+                for label, stats in breakdown:
+                    if stats is None or not stats.sum:
+                        continue
+                    out += indent
+                    out += "\t* {}: {} min, {} max, {} mean, {} total\n".format(
+                        label,
+                        fmt(stats.min),
+                        fmt(stats.max),
+                        fmt(stats.mean),
+                        fmt(stats.sum),
+                    )
 
         if self.output_num_rows:
             out += indent

--- a/python/ray/data/_internal/stats.py
+++ b/python/ray/data/_internal/stats.py
@@ -1706,7 +1706,7 @@ class OperatorStatsSummary:
     wall_time: Optional[StatsSummary] = None
     cpu_time: Optional[StatsSummary] = None
     # Time in the map transform chain. The four fields below decompose it.
-    udf_time: Optional[StatsSummary] = None
+    block_transform_time: Optional[StatsSummary] = None
     # Time turning input blocks into the batches or rows the transforms consume.
     input_prep_time: Optional[StatsSummary] = None
     # Time inside the UDF bodies themselves.
@@ -1762,7 +1762,7 @@ class OperatorStatsSummary:
         # Single pass over block_stats to collect all metrics.
         wall_time_acc: _StatsAccumulator = _StatsAccumulator()
         cpu_time_acc: _StatsAccumulator = _StatsAccumulator()
-        udf_time_acc: _StatsAccumulator = _StatsAccumulator()
+        block_transform_time_acc: _StatsAccumulator = _StatsAccumulator()
         input_prep_time_acc: _StatsAccumulator = _StatsAccumulator()
         udf_body_time_acc: _StatsAccumulator = _StatsAccumulator()
         output_build_time_acc: _StatsAccumulator = _StatsAccumulator()
@@ -1787,8 +1787,8 @@ class OperatorStatsSummary:
                     wall_time_acc.add(es.wall_time_s)
                 if es.cpu_time_s is not None:
                     cpu_time_acc.add(es.cpu_time_s)
-                if es.udf_time_s is not None:
-                    udf_time_acc.add(es.udf_time_s)
+                if es.block_transform_time_s is not None:
+                    block_transform_time_acc.add(es.block_transform_time_s)
                 if es.input_prep_time_s is not None:
                     input_prep_time_acc.add(es.input_prep_time_s)
                 if es.udf_body_time_s is not None:
@@ -1839,7 +1839,7 @@ class OperatorStatsSummary:
         # Execution stats.
         wall_time_stats = wall_time_acc.get()
         cpu_stats = cpu_time_acc.get()
-        udf_stats = udf_time_acc.get()
+        udf_stats = block_transform_time_acc.get()
         # A chain that measured only its total leaves the phase accumulators
         # empty. Report that as None rather than a zero-valued summary, so a
         # consumer can tell "not measured" from "measured as zero" -- the phases
@@ -1875,7 +1875,7 @@ class OperatorStatsSummary:
             block_execution_summary_str=exec_summary_str,
             wall_time=wall_time_stats,
             cpu_time=cpu_stats,
-            udf_time=udf_stats,
+            block_transform_time=udf_stats,
             input_prep_time=input_prep_stats,
             udf_body_time=udf_body_stats,
             output_build_time=output_build_stats,
@@ -1916,13 +1916,13 @@ class OperatorStatsSummary:
                 fmt(self.cpu_time.sum),
             )
 
-        if self.udf_time:
+        if self.block_transform_time:
             out += indent
-            out += "* UDF time: {} min, {} max, {} mean, {} total\n".format(
-                fmt(self.udf_time.min),
-                fmt(self.udf_time.max),
-                fmt(self.udf_time.mean),
-                fmt(self.udf_time.sum),
+            out += "* Block transform time: {} min, {} max, {} mean, {} total\n".format(
+                fmt(self.block_transform_time.min),
+                fmt(self.block_transform_time.max),
+                fmt(self.block_transform_time.mean),
+                fmt(self.block_transform_time.sum),
             )
             # Breakdown of the line above, in execution order; these sum to
             # it. Verbose-only, like `extra_metrics` -- the figures are on the

--- a/python/ray/data/_internal/stats.py
+++ b/python/ray/data/_internal/stats.py
@@ -1709,12 +1709,10 @@ class OperatorStatsSummary:
     block_transform_time: Optional[StatsSummary] = None
     # Time turning input blocks into the batches or rows the transforms consume.
     input_prep_time: Optional[StatsSummary] = None
-    # Time inside the UDF bodies themselves.
-    udf_body_time: Optional[StatsSummary] = None
+    # Time inside the stage bodies themselves, Ray Data's as well as yours.
+    function_body_time: Optional[StatsSummary] = None
     # Time assembling transform output back into blocks.
     output_build_time: Optional[StatsSummary] = None
-    # Time in the bodies of non-UDF stages fused into the same chain.
-    other_stage_time: Optional[StatsSummary] = None
     total_input_num_rows: Optional[int] = None
     output_num_rows: Optional[StatsSummary] = None
     output_size_bytes: Optional[StatsSummary] = None
@@ -1764,9 +1762,8 @@ class OperatorStatsSummary:
         cpu_time_acc: _StatsAccumulator = _StatsAccumulator()
         block_transform_time_acc: _StatsAccumulator = _StatsAccumulator()
         input_prep_time_acc: _StatsAccumulator = _StatsAccumulator()
-        udf_body_time_acc: _StatsAccumulator = _StatsAccumulator()
+        function_body_time_acc: _StatsAccumulator = _StatsAccumulator()
         output_build_time_acc: _StatsAccumulator = _StatsAccumulator()
-        other_stage_time_acc: _StatsAccumulator = _StatsAccumulator()
         output_rows_acc: _StatsAccumulator = _StatsAccumulator()
         output_sizes_acc: _StatsAccumulator = _StatsAccumulator()
         rows_per_task: DefaultDict[int, int] = collections.defaultdict(int)
@@ -1791,12 +1788,10 @@ class OperatorStatsSummary:
                     block_transform_time_acc.add(es.block_transform_time_s)
                 if es.input_prep_time_s is not None:
                     input_prep_time_acc.add(es.input_prep_time_s)
-                if es.udf_body_time_s is not None:
-                    udf_body_time_acc.add(es.udf_body_time_s)
+                if es.function_body_time_s is not None:
+                    function_body_time_acc.add(es.function_body_time_s)
                 if es.output_build_time_s is not None:
                     output_build_time_acc.add(es.output_build_time_s)
-                if es.other_stage_time_s is not None:
-                    other_stage_time_acc.add(es.other_stage_time_s)
                 tasks_per_node[es.node_id].add(es.task_idx)
                 if es.start_time_s is not None:
                     earliest_start_time = min(earliest_start_time, es.start_time_s)
@@ -1839,7 +1834,7 @@ class OperatorStatsSummary:
         # Execution stats.
         wall_time_stats = wall_time_acc.get()
         cpu_stats = cpu_time_acc.get()
-        udf_stats = block_transform_time_acc.get()
+        block_transform_stats = block_transform_time_acc.get()
         # A chain that measured only its total leaves the phase accumulators
         # empty. Report that as None rather than a zero-valued summary, so a
         # consumer can tell "not measured" from "measured as zero" -- the phases
@@ -1847,9 +1842,8 @@ class OperatorStatsSummary:
         # `DataContext.accurate_map_phase_timing` is set.
         phases_measured = input_prep_time_acc.count > 0
         input_prep_stats = input_prep_time_acc.get() if phases_measured else None
-        udf_body_stats = udf_body_time_acc.get() if phases_measured else None
+        function_body_stats = function_body_time_acc.get() if phases_measured else None
         output_build_stats = output_build_time_acc.get() if phases_measured else None
-        other_stage_stats = other_stage_time_acc.get() if phases_measured else None
 
         # Output stats.
         output_num_rows_stats = output_rows_acc.get()
@@ -1875,11 +1869,10 @@ class OperatorStatsSummary:
             block_execution_summary_str=exec_summary_str,
             wall_time=wall_time_stats,
             cpu_time=cpu_stats,
-            block_transform_time=udf_stats,
+            block_transform_time=block_transform_stats,
             input_prep_time=input_prep_stats,
-            udf_body_time=udf_body_stats,
+            function_body_time=function_body_stats,
             output_build_time=output_build_stats,
-            other_stage_time=other_stage_stats,
             total_input_num_rows=total_input_num_rows,
             output_num_rows=output_num_rows_stats,
             output_size_bytes=output_size_bytes_stats,
@@ -1926,20 +1919,17 @@ class OperatorStatsSummary:
             )
             # Breakdown of the line above, in execution order; these sum to
             # it. Verbose-only, like `extra_metrics` -- the figures are on the
-            # summary either way. The bool is whether to print at 0.0.
+            # summary either way.
             breakdown = [
-                ("Input prep", self.input_prep_time, True),
-                ("Function body", self.udf_body_time, True),
-                ("Output block build", self.output_build_time, True),
-                # A stage Ray Data supplies rather than one you passed; zero
-                # unless one is fused in, so hidden then.
-                ("Built-in stages", self.other_stage_time, False),
+                ("Input prep", self.input_prep_time),
+                ("Function body", self.function_body_time),
+                ("Output block build", self.output_build_time),
             ]
             if DataContext.get_current().verbose_stats_logs and any(
-                s is not None for _, s, _ in breakdown
+                s is not None for _, s in breakdown
             ):
-                for label, stats, always_show in breakdown:
-                    if stats is None or (not always_show and not stats.sum):
+                for label, stats in breakdown:
+                    if stats is None:
                         continue
                     out += indent
                     out += "\t* {}: {} min, {} max, {} mean, {} total\n".format(

--- a/python/ray/data/_internal/stats.py
+++ b/python/ray/data/_internal/stats.py
@@ -1934,20 +1934,25 @@ class OperatorStatsSummary:
             # the detail warrants. They are absent altogether for row-based
             # transforms unless `DataContext.accurate_map_phase_timing` is set,
             # since measuring them per row costs more than it reports.
+            # The trailing flag is whether to print the line at 0.0. The three
+            # phases every chain runs are always printed, so the lines visibly
+            # sum to the total above and a fast phase doesn't silently vanish.
+            # Built-in stages is dropped at zero: most chains fuse nothing
+            # built-in, and a constant 0.0 line would be noise.
             breakdown = [
-                ("Input prep", self.input_prep_time),
-                ("Function body", self.udf_body_time),
-                ("Output block build", self.output_build_time),
-                # Bodies of the stages Ray Data supplies -- reads, writes,
-                # downloads, file listing -- as opposed to the function you
-                # passed. Only non-zero when one is fused into this operator.
-                ("Built-in stages", self.other_stage_time),
+                ("Input prep", self.input_prep_time, True),
+                ("Function body", self.udf_body_time, True),
+                ("Output block build", self.output_build_time, True),
+                # Bodies of the stages Ray Data supplies -- reads, downloads,
+                # file listing -- as opposed to the function you passed. Only
+                # non-zero when one is fused into this operator.
+                ("Built-in stages", self.other_stage_time, False),
             ]
             if DataContext.get_current().verbose_stats_logs and any(
-                s is not None and s.sum for _, s in breakdown
+                s is not None for _, s, _ in breakdown
             ):
-                for label, stats in breakdown:
-                    if stats is None or not stats.sum:
+                for label, stats, always_show in breakdown:
+                    if stats is None or (not always_show and not stats.sum):
                         continue
                     out += indent
                     out += "\t* {}: {} min, {} max, {} mean, {} total\n".format(

--- a/python/ray/data/_internal/stats.py
+++ b/python/ray/data/_internal/stats.py
@@ -1924,28 +1924,15 @@ class OperatorStatsSummary:
                 fmt(self.udf_time.mean),
                 fmt(self.udf_time.sum),
             )
-            # Breakdown of the line above, in execution order: input blocks
-            # become batches or rows, the UDF runs, output goes back into
-            # blocks. These sum to the total.
-            #
-            # Verbose-only, like `extra_metrics`: the figures are always on the
-            # summary for anyone reading it programmatically, but adding four
-            # lines to everyone's default `ds.stats()` is a bigger change than
-            # the detail warrants. They are absent altogether for row-based
-            # transforms unless `DataContext.accurate_map_phase_timing` is set,
-            # since measuring them per row costs more than it reports.
-            # The trailing flag is whether to print the line at 0.0. The three
-            # phases every chain runs are always printed, so the lines visibly
-            # sum to the total above and a fast phase doesn't silently vanish.
-            # Built-in stages is dropped at zero: most chains fuse nothing
-            # built-in, and a constant 0.0 line would be noise.
+            # Breakdown of the line above, in execution order; these sum to
+            # it. Verbose-only, like `extra_metrics` -- the figures are on the
+            # summary either way. The bool is whether to print at 0.0.
             breakdown = [
                 ("Input prep", self.input_prep_time, True),
                 ("Function body", self.udf_body_time, True),
                 ("Output block build", self.output_build_time, True),
-                # Bodies of the stages Ray Data supplies -- reads, downloads,
-                # file listing -- as opposed to the function you passed. Only
-                # non-zero when one is fused into this operator.
+                # A stage Ray Data supplies rather than one you passed; zero
+                # unless one is fused in, so hidden then.
                 ("Built-in stages", self.other_stage_time, False),
             ]
             if DataContext.get_current().verbose_stats_logs and any(

--- a/python/ray/data/block.py
+++ b/python/ray/data/block.py
@@ -244,22 +244,20 @@ class BlockExecStats:
     wall_time_s: Optional[float] = None
     # Time spent in the map transform chain while generating this block. Named
     # `udf_time_s` until it was renamed for accuracy: it covers the whole
-    # chain, not just the user's functions. The four fields below decompose it
+    # chain, not just the user's functions. The three fields below decompose it
     # and sum back to it.
     block_transform_time_s: Optional[float] = 0
     # Time spent turning input blocks into the batches or rows the transforms
     # consume.
     input_prep_time_s: Optional[float] = None
-    # Time spent inside the UDF bodies themselves, with the formatting and block
-    # building around them excluded.
-    udf_body_time_s: Optional[float] = None
+    # Time spent inside the stage bodies themselves, whether the caller wrote
+    # them or Ray Data supplied them, with the formatting and block building
+    # around them excluded.
+    function_body_time_s: Optional[float] = None
     # Time spent assembling transform output back into blocks. Includes
     # materializing Python objects into Arrow, which is why it is not covered by
     # `block_ser_time_s`.
     output_build_time_s: Optional[float] = None
-    # Time spent in the bodies of non-UDF stages fused into the same chain, such
-    # as a read or a write. Kept so the decomposition adds up.
-    other_stage_time_s: Optional[float] = None
     # Time spent serializing this block into a Ray object.
     block_ser_time_s: Optional[float] = None
     # Total CPU time consumed by the worker process during the task, across all threads.

--- a/python/ray/data/block.py
+++ b/python/ray/data/block.py
@@ -248,17 +248,17 @@ class BlockExecStats:
     udf_time_s: Optional[float] = 0
     # Time spent turning input blocks into the batches or rows the transforms
     # consume.
-    input_prep_time_s: Optional[float] = 0
+    input_prep_time_s: Optional[float] = None
     # Time spent inside the UDF bodies themselves, with the formatting and block
     # building around them excluded.
-    udf_body_time_s: Optional[float] = 0
+    udf_body_time_s: Optional[float] = None
     # Time spent assembling transform output back into blocks. Includes
     # materializing Python objects into Arrow, which is why it is not covered by
     # `block_ser_time_s`.
-    output_build_time_s: Optional[float] = 0
+    output_build_time_s: Optional[float] = None
     # Time spent in the bodies of non-UDF stages fused into the same chain, such
     # as a read or a write. Kept so the decomposition adds up.
-    other_stage_time_s: Optional[float] = 0
+    other_stage_time_s: Optional[float] = None
     # Time spent serializing this block into a Ray object.
     block_ser_time_s: Optional[float] = None
     # Total CPU time consumed by the worker process during the task, across all threads.

--- a/python/ray/data/block.py
+++ b/python/ray/data/block.py
@@ -242,8 +242,23 @@ class BlockExecStats:
     end_time_s: Optional[float] = None
     # Total wall-clock duration of the block generation (computed as end_time_s - start_time_s).
     wall_time_s: Optional[float] = None
-    # Time spent inside UDF while generating block.
+    # Time spent in the map transform chain while generating this block. This
+    # is the long-standing "UDF time"; the four fields below decompose it and
+    # sum back to it.
     udf_time_s: Optional[float] = 0
+    # Time spent turning input blocks into the batches or rows the transforms
+    # consume.
+    input_prep_time_s: Optional[float] = 0
+    # Time spent inside the UDF bodies themselves, with the formatting and block
+    # building around them excluded.
+    udf_body_time_s: Optional[float] = 0
+    # Time spent assembling transform output back into blocks. Includes
+    # materializing Python objects into Arrow, which is why it is not covered by
+    # `block_ser_time_s`.
+    output_build_time_s: Optional[float] = 0
+    # Time spent in the bodies of non-UDF stages fused into the same chain, such
+    # as a read or a write. Kept so the decomposition adds up.
+    other_stage_time_s: Optional[float] = 0
     # Time spent serializing this block into a Ray object.
     block_ser_time_s: Optional[float] = None
     # Total CPU time consumed by the worker process during the task, across all threads.

--- a/python/ray/data/block.py
+++ b/python/ray/data/block.py
@@ -242,10 +242,11 @@ class BlockExecStats:
     end_time_s: Optional[float] = None
     # Total wall-clock duration of the block generation (computed as end_time_s - start_time_s).
     wall_time_s: Optional[float] = None
-    # Time spent in the map transform chain while generating this block. This
-    # is the long-standing "UDF time"; the four fields below decompose it and
-    # sum back to it.
-    udf_time_s: Optional[float] = 0
+    # Time spent in the map transform chain while generating this block. Named
+    # `udf_time_s` until it was renamed for accuracy: it covers the whole
+    # chain, not just the user's functions. The four fields below decompose it
+    # and sum back to it.
+    block_transform_time_s: Optional[float] = 0
     # Time spent turning input blocks into the batches or rows the transforms
     # consume.
     input_prep_time_s: Optional[float] = None

--- a/python/ray/data/block.py
+++ b/python/ray/data/block.py
@@ -242,10 +242,9 @@ class BlockExecStats:
     end_time_s: Optional[float] = None
     # Total wall-clock duration of the block generation (computed as end_time_s - start_time_s).
     wall_time_s: Optional[float] = None
-    # Time spent in the map transform chain while generating this block. Named
-    # `udf_time_s` until it was renamed for accuracy: it covers the whole
-    # chain, not just the user's functions. The three fields below decompose it
-    # and sum back to it.
+    # Time spent in the map transform chain while generating this block: the
+    # whole chain, not just the user's functions. The three fields below
+    # decompose it and sum back to it.
     block_transform_time_s: Optional[float] = 0
     # Time spent turning input blocks into the batches or rows the transforms
     # consume.

--- a/python/ray/data/context.py
+++ b/python/ray/data/context.py
@@ -650,9 +650,10 @@ class DataContext:
             disabled, you can still manually print stats with ``Dataset.stats()``.
         verbose_stats_logs: Whether stats logs should be verbose. This includes fields
             such as `extra_metrics` in the stats output, which are excluded by default.
-        accurate_map_phase_timing: Whether to break "UDF time" down into input prep,
-            function body, and output block build for row-based transforms such as
-            :meth:`~ray.data.Dataset.map` and :meth:`~ray.data.Dataset.filter`. Those
+        accurate_map_phase_timing: Whether to break "Block transform time" down
+            into input prep, function body, and output block build for row-based
+            transforms such as :meth:`~ray.data.Dataset.map` and
+            :meth:`~ray.data.Dataset.filter`. Those
             run once per row, and measuring each phase separately costs enough per row
             to slow the transform down, so by default Ray Data reports only their
             total. Batch-based transforms such as

--- a/python/ray/data/context.py
+++ b/python/ray/data/context.py
@@ -178,6 +178,8 @@ DEFAULT_AUTO_LOG_STATS = False
 
 DEFAULT_VERBOSE_STATS_LOG = False
 
+DEFAULT_ACCURATE_MAP_PHASE_TIMING = False
+
 DEFAULT_TRACE_ALLOCATIONS = bool(int(os.environ.get("RAY_DATA_TRACE_ALLOCATIONS", "0")))
 
 DEFAULT_LOG_INTERNAL_STACK_TRACE = env_bool(
@@ -648,6 +650,15 @@ class DataContext:
             disabled, you can still manually print stats with ``Dataset.stats()``.
         verbose_stats_logs: Whether stats logs should be verbose. This includes fields
             such as `extra_metrics` in the stats output, which are excluded by default.
+        accurate_map_phase_timing: Whether to break "UDF time" down into input prep,
+            function body, and output block build for row-based transforms such as
+            :meth:`~ray.data.Dataset.map` and :meth:`~ray.data.Dataset.filter`. Those
+            run once per row, and measuring each phase separately costs enough per row
+            to slow the transform down, so by default Ray Data reports only their
+            total. Batch-based transforms such as
+            :meth:`~ray.data.Dataset.map_batches` are always broken down, since one
+            measurement there covers a whole batch. Enable this when you need the
+            breakdown for a row-based transform and can afford the overhead.
         trace_allocations: Whether to trace allocations / eager free. This adds
             significant performance overheads and should only be used for debugging.
         execution_options: The
@@ -957,6 +968,7 @@ class DataContext:
     enable_fallback_to_arrow_object_ext_type: Optional[bool] = None
     enable_auto_log_stats: bool = DEFAULT_AUTO_LOG_STATS
     verbose_stats_logs: bool = DEFAULT_VERBOSE_STATS_LOG
+    accurate_map_phase_timing: bool = DEFAULT_ACCURATE_MAP_PHASE_TIMING
     trace_allocations: bool = DEFAULT_TRACE_ALLOCATIONS
     execution_options: "ExecutionOptions" = field(
         default_factory=_execution_options_factory

--- a/python/ray/data/tests/conftest.py
+++ b/python/ray/data/tests/conftest.py
@@ -505,7 +505,7 @@ def op_two_block():
         "size_bytes": [100, 50],
         "wall_time": [5, 10],
         "cpu_time": [1.2, 3.4],
-        "udf_time": [1.1, 1.7],
+        "block_transform_time": [1.1, 1.7],
         "node_id": ["a1", "b2"],
         "task_idx": [0, 1],
     }
@@ -520,7 +520,7 @@ def op_two_block():
             end_time_s=start_time_s + block_params["wall_time"][i],
             wall_time_s=block_params["wall_time"][i],
             cpu_time_s=block_params["cpu_time"][i],
-            udf_time_s=block_params["udf_time"][i],
+            block_transform_time_s=block_params["block_transform_time"][i],
             node_id=block_params["node_id"][i],
             task_idx=block_params["task_idx"][i],
         )

--- a/python/ray/data/tests/test_checkpoint.py
+++ b/python/ray/data/tests/test_checkpoint.py
@@ -19,7 +19,7 @@ from ray.data._internal.datasource.parquet_datasink import ParquetDatasink
 from ray.data._internal.execution.interfaces import TaskContext
 from ray.data._internal.execution.operators.map_operator import MapOperator
 from ray.data._internal.execution.operators.map_transformer import (
-    UDFTimeScope,
+    TransformClock,
 )
 from ray.data._internal.logical.interfaces.logical_plan import LogicalPlan
 from ray.data._internal.logical.operators import Read, Write
@@ -1552,7 +1552,7 @@ def test_checkpoint_map_transformer(
     filtered_blocks = map_transformer.apply_transform(
         input_blocks=[block],
         ctx=TaskContext(task_idx=0, op_name="test_checkpoint"),
-        udf_time_scope=UDFTimeScope(),
+        clock=TransformClock(),
     )
 
     filtered_block = next(iter(filtered_blocks))

--- a/python/ray/data/tests/test_map_transformer.py
+++ b/python/ray/data/tests/test_map_transformer.py
@@ -23,7 +23,7 @@ def _create_chained_transformer(udf, n, *, is_udf=False):
     """Create a MapTransformer with chained batch transforms that track intermediates.
 
     ``is_udf`` mirrors what the planner sets for real ``map_batches`` stages; it
-    gates UDF timing, so tests that assert on ``udf_time_s`` must pass True.
+    gates transform timing, so tests that assert on ``block_transform_time_s`` must pass True.
     """
     transform_fns = [
         BatchMapTransformFn(
@@ -148,7 +148,7 @@ def _trace_back_refs(intermediates: list, label: str = ""):
                     print(f"    -> {type(r).__name__}")
 
 
-def test_chained_transforms_dont_double_count_udf_time():
+def test_chained_transforms_dont_double_count_block_transform_time():
     """Chained UDF stages must not each re-count their upstream stages' time.
 
     Timing every stage and summing reported n(n+1)/2x the real time, which could
@@ -194,10 +194,10 @@ def test_chained_transforms_dont_double_count_udf_time():
     # absorbs timing noise; double counting shows up at ~2x for 3 stages.
     assert (
         reported_s <= wall_s * 1.05
-    ), f"reported UDF time {reported_s:.4f}s exceeds chain wall time {wall_s:.4f}s"
+    ), f"reported block transform time {reported_s:.4f}s exceeds chain wall time {wall_s:.4f}s"
     # ...and the stages' time must still be measured, not dropped.
     assert reported_s >= slept_s * 0.9, (
-        f"reported UDF time {reported_s:.4f}s is below the {slept_s:.4f}s slept "
+        f"reported block transform time {reported_s:.4f}s is below the {slept_s:.4f}s slept "
         f"across {num_calls} UDF calls"
     )
 
@@ -256,9 +256,9 @@ def test_chained_transforms_total_is_independent_of_distribution():
     # exactly, not approximately.
     assert (
         reported_s <= wall_s * 1.05
-    ), f"reported UDF time {reported_s:.4f}s exceeds chain wall time {wall_s:.4f}s"
+    ), f"reported block transform time {reported_s:.4f}s exceeds chain wall time {wall_s:.4f}s"
     assert reported_s >= slept_s * 0.9, (
-        f"reported UDF time {reported_s:.4f}s is below the {slept_s:.4f}s slept "
+        f"reported block transform time {reported_s:.4f}s is below the {slept_s:.4f}s slept "
         f"across stages {calls_per_stage}"
     )
 
@@ -295,7 +295,7 @@ def test_every_output_block_is_timed():
         reported_s.append(clock.drain().total_s)
 
     assert all(s >= SLEEP_S * 0.9 for s in reported_s), (
-        f"per-block UDF times {[round(s, 4) for s in reported_s]} do not all "
+        f"per-block transform times {[round(s, 4) for s in reported_s]} do not all "
         f"cover the {SLEEP_S}s slept while producing each block"
     )
 

--- a/python/ray/data/tests/test_map_transformer.py
+++ b/python/ray/data/tests/test_map_transformer.py
@@ -10,7 +10,7 @@ from ray.data._internal.execution.interfaces.task_context import TaskContext
 from ray.data._internal.execution.operators.map_transformer import (
     BatchMapTransformFn,
     MapTransformer,
-    UDFTimeScope,
+    TransformClock,
 )
 from ray.data._internal.output_buffer import OutputBlockSizeOption
 from ray.data._internal.planner.plan_udf_map_op import (
@@ -68,7 +68,7 @@ def test_chained_transforms_release_intermediates_between_batches():
             yield pd.DataFrame({"id": [i + 1]})
 
     result_iter = transformer.apply_transform(
-        make_input_blocks(), ctx, udf_time_scope=UDFTimeScope()
+        make_input_blocks(), ctx, clock=TransformClock()
     )
 
     for i in range(NUM_BATCHES):
@@ -174,10 +174,10 @@ def test_chained_transforms_dont_double_count_udf_time():
         for i in range(NUM_BATCHES):
             yield pd.DataFrame({"id": [i]})
 
-    scope = UDFTimeScope()
+    scope = TransformClock()
     start_s = time.perf_counter()
     blocks = list(
-        transformer.apply_transform(make_input_blocks(), ctx, udf_time_scope=scope)
+        transformer.apply_transform(make_input_blocks(), ctx, clock=scope)
     )
     wall_s = time.perf_counter() - start_s
 
@@ -188,7 +188,7 @@ def test_chained_transforms_dont_double_count_udf_time():
     # The whole transform chain, not just the sleeps: for each stage it covers
     # turning input blocks into batches, the UDF body, and building output
     # blocks. The sleeps are therefore a floor on it, never an equality.
-    reported_s = scope.attributed_s
+    reported_s = scope.drain().total_s
     # Measured, not assumed: block shaping decides how many batches each stage sees.
     slept_s = num_calls * SLEEP_S
 
@@ -242,17 +242,17 @@ def test_chained_transforms_total_is_independent_of_distribution():
         for i in range(NUM_BATCHES):
             yield pd.DataFrame({"id": [i]})
 
-    scope = UDFTimeScope()
+    scope = TransformClock()
     start_s = time.perf_counter()
     blocks = list(
-        transformer.apply_transform(make_input_blocks(), ctx, udf_time_scope=scope)
+        transformer.apply_transform(make_input_blocks(), ctx, clock=scope)
     )
     wall_s = time.perf_counter() - start_s
 
     assert sum(BlockAccessor.for_block(b).num_rows() for b in blocks) == NUM_BATCHES
     assert all(n > 0 for n in calls_per_stage), calls_per_stage
 
-    reported_s = scope.attributed_s
+    reported_s = scope.drain().total_s
     slept_s = sum(n * s for n, s in zip(calls_per_stage, SLEEPS_S))
 
     # Summing the stages' inclusive times would give 0.05 + 0.15 + 0.30 = 0.50s

--- a/python/ray/data/tests/test_map_transformer.py
+++ b/python/ray/data/tests/test_map_transformer.py
@@ -176,9 +176,7 @@ def test_chained_transforms_dont_double_count_udf_time():
 
     scope = TransformClock()
     start_s = time.perf_counter()
-    blocks = list(
-        transformer.apply_transform(make_input_blocks(), ctx, clock=scope)
-    )
+    blocks = list(transformer.apply_transform(make_input_blocks(), ctx, clock=scope))
     wall_s = time.perf_counter() - start_s
 
     # Assert on rows rather than block count, which depends on block shaping.
@@ -244,9 +242,7 @@ def test_chained_transforms_total_is_independent_of_distribution():
 
     scope = TransformClock()
     start_s = time.perf_counter()
-    blocks = list(
-        transformer.apply_transform(make_input_blocks(), ctx, clock=scope)
-    )
+    blocks = list(transformer.apply_transform(make_input_blocks(), ctx, clock=scope))
     wall_s = time.perf_counter() - start_s
 
     assert sum(BlockAccessor.for_block(b).num_rows() for b in blocks) == NUM_BATCHES
@@ -264,6 +260,43 @@ def test_chained_transforms_total_is_independent_of_distribution():
     assert reported_s >= slept_s * 0.9, (
         f"reported UDF time {reported_s:.4f}s is below the {slept_s:.4f}s slept "
         f"across stages {calls_per_stage}"
+    )
+
+
+def test_every_output_block_is_timed():
+    """Draining must not stop the chain from measuring the next block.
+
+    `_map_task` drains once per output block, so a drain that rebound its
+    totals instead of clearing them left the steps writing to a list nobody
+    read again: a task's first block reported its time and every block after it
+    reported zero.
+    """
+    NUM_BLOCKS = 3
+    SLEEP_S = 0.05
+
+    def udf(batch: DataBatch) -> DataBatch:
+        time.sleep(SLEEP_S)
+        return pd.DataFrame({"id": batch["id"]})
+
+    transformer = _create_chained_transformer(udf, 1, is_udf=True)
+    ctx = TaskContext(task_idx=0, op_name="test")
+
+    def make_input_blocks():
+        for i in range(NUM_BLOCKS):
+            yield pd.DataFrame({"id": [i]})
+
+    clock = TransformClock()
+    # `_create_chained_transformer` shapes one batch per output block, so each
+    # `next()` here is one output block, drained the way `_map_task` drains it.
+    out = iter(transformer.apply_transform(make_input_blocks(), ctx, clock=clock))
+    reported_s = []
+    for _ in range(NUM_BLOCKS):
+        next(out)
+        reported_s.append(clock.drain().total_s)
+
+    assert all(s >= SLEEP_S * 0.9 for s in reported_s), (
+        f"per-block UDF times {[round(s, 4) for s in reported_s]} do not all "
+        f"cover the {SLEEP_S}s slept while producing each block"
     )
 
 

--- a/python/ray/data/tests/test_map_transformer.py
+++ b/python/ray/data/tests/test_map_transformer.py
@@ -19,16 +19,11 @@ from ray.data._internal.planner.plan_udf_map_op import (
 from ray.data.block import BlockAccessor, DataBatch
 
 
-def _create_chained_transformer(udf, n, *, is_udf=False):
-    """Create a MapTransformer with chained batch transforms that track intermediates.
-
-    ``is_udf`` mirrors what the planner sets for real ``map_batches`` stages; it
-    gates transform timing, so tests that assert on ``block_transform_time_s`` must pass True.
-    """
+def _create_chained_transformer(udf, n):
+    """Create a MapTransformer with chained batch transforms that track intermediates."""
     transform_fns = [
         BatchMapTransformFn(
             _generate_transform_fn_for_map_batches(udf),
-            is_udf=is_udf,
             batch_format="pandas",
             batch_size=1,
             output_block_size_option=OutputBlockSizeOption.of(target_max_block_size=1),
@@ -166,8 +161,7 @@ def test_chained_transforms_dont_double_count_block_transform_time():
         time.sleep(SLEEP_S)
         return pd.DataFrame({"id": batch["id"]})
 
-    # is_udf=True is what gates timing; without it no stage is timed at all.
-    transformer = _create_chained_transformer(udf, NUM_CHAINED_TRANSFORMS, is_udf=True)
+    transformer = _create_chained_transformer(udf, NUM_CHAINED_TRANSFORMS)
     ctx = TaskContext(task_idx=0, op_name="test")
 
     def make_input_blocks():
@@ -226,7 +220,6 @@ def test_chained_transforms_total_is_independent_of_distribution():
     transform_fns = [
         BatchMapTransformFn(
             _generate_transform_fn_for_map_batches(make_udf(i)),
-            is_udf=True,
             batch_format="pandas",
             batch_size=1,
             output_block_size_option=OutputBlockSizeOption.of(target_max_block_size=1),
@@ -278,7 +271,7 @@ def test_every_output_block_is_timed():
         time.sleep(SLEEP_S)
         return pd.DataFrame({"id": batch["id"]})
 
-    transformer = _create_chained_transformer(udf, 1, is_udf=True)
+    transformer = _create_chained_transformer(udf, 1)
     ctx = TaskContext(task_idx=0, op_name="test")
 
     def make_input_blocks():

--- a/python/ray/data/tests/test_op_runtime_metrics.py
+++ b/python/ray/data/tests/test_op_runtime_metrics.py
@@ -494,6 +494,61 @@ def test_obj_store_mem_estimation(
     ), f"Expected {test_property} to be {expected}, got {actual}"
 
 
+def _metrics_for_one_output(**phases):
+    """An `OpRuntimeMetrics` fed one output block with the given phase times."""
+    op = MagicMock()
+    op.data_context.enable_get_object_locations_for_metrics = False
+    metrics = OpRuntimeMetrics(op)
+
+    stats = BlockExecStats(
+        wall_time_s=1.0,
+        block_ser_time_s=0.0,
+        block_transform_time_s=0.5,
+        **phases,
+    )
+    metadata = BlockMetadata(
+        num_rows=1, size_bytes=0, input_files=None, exec_stats=stats
+    )
+    output = RefBundle(
+        [BlockEntry(ray.put(pa.Table.from_pydict({})), metadata)],
+        owns_blocks=False,
+        schema=None,
+    )
+
+    metrics.on_task_submitted(0, RefBundle([], owns_blocks=False, schema=None))
+    metrics.on_task_output_generated(0, output)
+    return metrics
+
+
+def test_phase_metrics_stay_none_when_unmeasured():
+    """A chain timed only as a whole must not export three zeros.
+
+    A row transform reports no phase breakdown unless
+    `DataContext.accurate_map_phase_timing` is set. Summing those `None`s as
+    zero would put three zeros beside a non-zero `block_transform_time_s`,
+    which a dashboard can't tell from "these phases took no time".
+    """
+    metrics = _metrics_for_one_output()
+
+    assert metrics.block_transform_time_s == pytest.approx(0.5)
+    assert metrics.input_prep_time_s is None
+    assert metrics.function_body_time_s is None
+    assert metrics.output_build_time_s is None
+
+
+def test_phase_metrics_accumulate_when_measured():
+    """The `None` default must not swallow a measured phase."""
+    metrics = _metrics_for_one_output(
+        input_prep_time_s=0.1,
+        function_body_time_s=0.3,
+        output_build_time_s=0.1,
+    )
+
+    assert metrics.input_prep_time_s == pytest.approx(0.1)
+    assert metrics.function_body_time_s == pytest.approx(0.3)
+    assert metrics.output_build_time_s == pytest.approx(0.1)
+
+
 if __name__ == "__main__":
     import sys
 

--- a/python/ray/data/tests/test_stats.py
+++ b/python/ray/data/tests/test_stats.py
@@ -635,13 +635,16 @@ def canonicalize(
     canonicalized_stats = re.sub(
         r"\(samples: \d+, avg: \d+\.\d+\)", "(samples: N, avg: N)", canonicalized_stats
     )
-    # The block transform time breakdown measures sub-microsecond work for a trivial UDF, so
-    # each figure rounds to zero or not depending on the run. Replace with A to
-    # avoid flakiness; `test_row_transform_phases_are_opt_in` asserts the
-    # measured-vs-not distinction directly instead.
+    # The block transform time breakdown measures sub-microsecond work for a
+    # trivial UDF, so each figure rounds to zero or not depending on the run.
+    # `None` is in the alternation because a row transform reports no phases
+    # unless `accurate_map_phase_timing` is set. Replace both with A to avoid
+    # flakiness; `test_row_transform_phases_are_opt_in` and
+    # `test_op_runtime_metrics.py::test_phase_metrics_stay_none_when_unmeasured`
+    # assert the measured-vs-not distinction directly instead.
     canonicalized_stats = re.sub(
         r"('?(?:block_transform_time_s|input_prep_time_s|function_body_time_s"
-        r"|output_build_time_s)'?: )\d+(?:\.\d+)?(?:[eE][-+]?\d+)?",
+        r"|output_build_time_s)'?: )(?:\d+(?:\.\d+)?(?:[eE][-+]?\d+)?|None)",
         r"\g<1>A",
         canonicalized_stats,
     )

--- a/python/ray/data/tests/test_stats.py
+++ b/python/ray/data/tests/test_stats.py
@@ -396,9 +396,9 @@ def gen_expected_metrics(
             f"'num_tasks_task_locality_miss': {'Z' if task_locality_hit else 'N'}",
             "'block_generation_time': N",
             "'block_serialization_time_s': N",
-            # The UDF time breakdown, exported per operator alongside the
+            # The block transform time breakdown, exported per operator alongside the
             # existing task metrics.
-            "'udf_time_s': A",
+            "'block_transform_time_s': A",
             "'input_prep_time_s': A",
             "'udf_body_time_s': A",
             "'output_build_time_s': A",
@@ -533,8 +533,8 @@ def gen_extra_metrics_str(metrics: str, verbose: bool):
     return f"* Extra metrics: {metrics}" + "\n" if verbose else ""
 
 
-def gen_udf_time_breakdown_str(verbose: bool) -> str:
-    """The phase breakdown under "UDF time", which is verbose-only.
+def gen_block_transform_time_breakdown_str(verbose: bool) -> str:
+    """The phase breakdown under "Block transform time", which is verbose-only.
 
     Batch-based operators are decomposed; row-based ones report only a
     total unless `DataContext.accurate_map_phase_timing` is set, so they
@@ -637,12 +637,12 @@ def canonicalize(
     canonicalized_stats = re.sub(
         r"\(samples: \d+, avg: \d+\.\d+\)", "(samples: N, avg: N)", canonicalized_stats
     )
-    # The UDF time breakdown measures sub-microsecond work for a trivial UDF, so
+    # The block transform time breakdown measures sub-microsecond work for a trivial UDF, so
     # each figure rounds to zero or not depending on the run. Replace with A to
     # avoid flakiness; `test_row_transform_phases_are_opt_in` asserts the
     # measured-vs-not distinction directly instead.
     canonicalized_stats = re.sub(
-        r"('?(?:udf_time_s|input_prep_time_s|udf_body_time_s|output_build_time_s"
+        r"('?(?:block_transform_time_s|input_prep_time_s|udf_body_time_s|output_build_time_s"
         r"|other_stage_time_s)'?: )\d+(?:\.\d+)?(?:[eE][-+]?\d+)?",
         r"\g<1>A",
         canonicalized_stats,
@@ -779,8 +779,8 @@ def test_streaming_split_stats(ray_start_regular_shared, restore_data_context):
         == f"""Operator N ReadRange->MapBatches(dummy_map_batches): {EXECUTION_STRING}
 * Remote wall time: T min, T max, T mean, T total
 * Remote cpu time: T min, T max, T mean, T total
-* UDF time: T min, T max, T mean, T total
-{gen_udf_time_breakdown_str(True)}* Output num rows per block: N min, N max, N mean, N total
+* Block transform time: T min, T max, T mean, T total
+{gen_block_transform_time_breakdown_str(True)}* Output num rows per block: N min, N max, N mean, N total
 * Output size bytes per block: N min, N max, N mean, N total
 * Output rows per task: N min, N max, N mean, N tasks used
 * Tasks per node: N min, N max, N mean; N nodes used
@@ -838,8 +838,8 @@ def test_dataset_stats_basic(
                 f"{EXECUTION_STRING}\n"
                 f"* Remote wall time: T min, T max, T mean, T total\n"
                 f"* Remote cpu time: T min, T max, T mean, T total\n"
-                f"* UDF time: T min, T max, T mean, T total\n"
-                f"{gen_udf_time_breakdown_str(verbose_stats_logs)}"
+                f"* Block transform time: T min, T max, T mean, T total\n"
+                f"{gen_block_transform_time_breakdown_str(verbose_stats_logs)}"
                 f"* Output num rows per block: N min, N max, N mean, N total\n"
                 f"* Output size bytes per block: N min, N max, N mean, N total\n"
                 f"* Output rows per task: N min, N max, N mean, N tasks used\n"
@@ -864,7 +864,7 @@ def test_dataset_stats_basic(
                 f"Operator N Map(dummy_map_batches): {EXECUTION_STRING}\n"
                 f"* Remote wall time: T min, T max, T mean, T total\n"
                 f"* Remote cpu time: T min, T max, T mean, T total\n"
-                f"* UDF time: T min, T max, T mean, T total\n"
+                f"* Block transform time: T min, T max, T mean, T total\n"
                 f"* Output num rows per block: N min, N max, N mean, N total\n"
                 f"* Output size bytes per block: N min, N max, N mean, N total\n"
                 f"* Output rows per task: N min, N max, N mean, N tasks used\n"
@@ -1003,8 +1003,8 @@ def test_dataset__repr__(ray_start_regular_shared, restore_data_context):
         "      num_tasks_task_locality_miss: N,\n"
         "      block_generation_time: N,\n"
         "      block_serialization_time_s: N,\n"
-        # The UDF time breakdown, exported per map operator.
-        "      udf_time_s: A,\n"
+        # The block transform time breakdown, exported per map operator.
+        "      block_transform_time_s: A,\n"
         "      input_prep_time_s: A,\n"
         "      udf_body_time_s: A,\n"
         "      output_build_time_s: A,\n"
@@ -1173,8 +1173,8 @@ def test_dataset__repr__(ray_start_regular_shared, restore_data_context):
         "      num_tasks_task_locality_miss: Z,\n"
         "      block_generation_time: N,\n"
         "      block_serialization_time_s: N,\n"
-        # The UDF time breakdown, exported per map operator.
-        "      udf_time_s: A,\n"
+        # The block transform time breakdown, exported per map operator.
+        "      block_transform_time_s: A,\n"
         "      input_prep_time_s: A,\n"
         "      udf_body_time_s: A,\n"
         "      output_build_time_s: A,\n"
@@ -1296,8 +1296,8 @@ def test_dataset__repr__(ray_start_regular_shared, restore_data_context):
         "            num_tasks_task_locality_miss: N,\n"
         "            block_generation_time: N,\n"
         "            block_serialization_time_s: N,\n"
-        # The UDF time breakdown, exported per map operator.
-        "            udf_time_s: A,\n"
+        # The block transform time breakdown, exported per map operator.
+        "            block_transform_time_s: A,\n"
         "            input_prep_time_s: A,\n"
         "            udf_body_time_s: A,\n"
         "            output_build_time_s: A,\n"
@@ -1672,7 +1672,7 @@ def test_streaming_stats_full(ray_start_regular_shared, restore_data_context):
     assert "Map" in op.operator_name
     assert op.wall_time is not None
     assert op.cpu_time is not None
-    assert op.udf_time is not None
+    assert op.block_transform_time is not None
     assert op.output_num_rows is not None
     assert op.output_size_bytes is not None
     assert op.node_count is not None
@@ -1683,11 +1683,11 @@ def test_streaming_stats_full(ray_start_regular_shared, restore_data_context):
     assert stats_summary.iter_stats is not None
 
 
-def test_fused_udf_time_within_wall_time(ray_start_regular_shared):
-    """A fused operator's UDF time must not exceed its own remote wall time.
+def test_fused_block_transform_time_within_wall_time(ray_start_regular_shared):
+    """A fused operator's block transform time must not exceed its own remote wall time.
 
     Timing each fused stage and summing counted upstream stages repeatedly,
-    reporting more UDF time than the tasks spent running.
+    reporting more block transform time than the tasks spent running.
     """
     sleep_s = 0.1
     num_blocks = 4
@@ -1708,15 +1708,15 @@ def test_fused_udf_time_within_wall_time(ray_start_regular_shared):
     assert "MapBatches(slow)->MapBatches(slow)" in op.operator_name
 
     # The headroom absorbs timing noise; double counting shows up at ~1.5x.
-    assert op.udf_time.sum <= op.wall_time.sum * 1.05, (
-        f"UDF time {op.udf_time.sum:.4f}s exceeds remote wall time "
+    assert op.block_transform_time.sum <= op.wall_time.sum * 1.05, (
+        f"block transform time {op.block_transform_time.sum:.4f}s exceeds remote wall time "
         f"{op.wall_time.sum:.4f}s"
     )
     # Both stages' sleeps are still accounted for.
-    assert op.udf_time.sum >= 2 * num_blocks * sleep_s * 0.9
+    assert op.block_transform_time.sum >= 2 * num_blocks * sleep_s * 0.9
 
 
-def test_fused_udf_time_survives_auto_batch_size(ray_start_regular_shared):
+def test_fused_block_transform_time_survives_auto_batch_size(ray_start_regular_shared):
     """An upstream fused stage must be timed even when a later one pulls it early.
 
     ``_pre_process`` always runs while the chain is being built, but only
@@ -1751,18 +1751,18 @@ def test_fused_udf_time_survives_auto_batch_size(ray_start_regular_shared):
     assert "MapBatches(slow_a)->MapBatches(slow_b)" in op.operator_name
 
     real_s = 2 * num_blocks * sleep_s
-    assert op.udf_time.sum >= real_s * 0.9, (
-        f"UDF time {op.udf_time.sum:.4f}s covers only "
-        f"{op.udf_time.sum / real_s * 100:.0f}% of the {real_s:.2f}s spent in UDFs; "
+    assert op.block_transform_time.sum >= real_s * 0.9, (
+        f"block transform time {op.block_transform_time.sum:.4f}s covers only "
+        f"{op.block_transform_time.sum / real_s * 100:.0f}% of the {real_s:.2f}s spent in UDFs; "
         "the stage that ran during the auto-batch-size peek was not timed"
     )
-    assert op.udf_time.sum <= op.wall_time.sum * 1.05
+    assert op.block_transform_time.sum <= op.wall_time.sum * 1.05
 
 
-def test_udf_time_is_not_shared_across_concurrent_actor_tasks(
+def test_block_transform_time_is_not_shared_across_concurrent_actor_tasks(
     ray_start_regular_shared,
 ):
-    """Tasks sharing an actor must not be credited with each other's UDF time.
+    """Tasks sharing an actor must not be credited with each other's block transform time.
 
     An actor reuses one ``MapTransformer`` for every task it runs, and
     ``max_concurrent_calls_per_actor > 1`` runs several at once. A UDF-time
@@ -1796,22 +1796,22 @@ def test_udf_time_is_not_shared_across_concurrent_actor_tasks(
     )
 
     op = get_operator(ds.get_stats_summary(), name_pattern="MapBatches")
-    assert op.udf_time.count == num_blocks
+    assert op.block_transform_time.count == num_blocks
 
     # No block may be starved of the time it spent, ...
-    assert op.udf_time.min >= sleep_s * 0.5, (
-        f"a block reports {op.udf_time.min:.4f}s of UDF time for one {sleep_s}s "
+    assert op.block_transform_time.min >= sleep_s * 0.5, (
+        f"a block reports {op.block_transform_time.min:.4f}s of block transform time for one {sleep_s}s "
         "call; another task drained its total"
     )
     # ... nor credited with a sibling task's.
-    assert op.udf_time.max <= sleep_s * 2.0, (
-        f"a block reports {op.udf_time.max:.4f}s of UDF time for one {sleep_s}s "
+    assert op.block_transform_time.max <= sleep_s * 2.0, (
+        f"a block reports {op.block_transform_time.max:.4f}s of block transform time for one {sleep_s}s "
         "call; it absorbed another task's total"
     )
 
 
 def _phase_components(op):
-    """The four figures that decompose an operator's UDF time."""
+    """The four figures that decompose an operator's block transform time."""
     return {
         "input_prep": op.input_prep_time,
         "udf_body": op.udf_body_time,
@@ -1820,10 +1820,10 @@ def _phase_components(op):
     }
 
 
-def test_udf_time_phases_sum_to_the_total(ray_start_regular_shared):
-    """The phase breakdown must account for the whole of ``udf_time``.
+def test_block_transform_time_phases_sum_to_the_total(ray_start_regular_shared):
+    """The phase breakdown must account for the whole of ``block_transform_time``.
 
-    ``udf_time`` keeps meaning the whole map transform, so anything already
+    ``block_transform_time`` keeps meaning the whole map transform, so anything already
     charting it is unaffected; the components only say where inside it the time
     went. That is only true if they add up.
     """
@@ -1846,16 +1846,16 @@ def test_udf_time_phases_sum_to_the_total(ray_start_regular_shared):
     assert all(p is not None for p in parts.values())
 
     component_sum = sum(p.sum for p in parts.values())
-    assert component_sum == pytest.approx(op.udf_time.sum, rel=1e-6), (
-        f"components {component_sum:.6f}s do not add up to udf_time "
-        f"{op.udf_time.sum:.6f}s: "
+    assert component_sum == pytest.approx(op.block_transform_time.sum, rel=1e-6), (
+        f"components {component_sum:.6f}s do not add up to block_transform_time "
+        f"{op.block_transform_time.sum:.6f}s: "
         + ", ".join(f"{k}={v.sum:.6f}s" for k, v in parts.items())
     )
     # The UDF bodies are the sleeps, so they should dominate this pipeline.
     assert op.udf_body_time.sum >= 2 * num_blocks * sleep_s * 0.9
 
 
-def test_udf_time_phases_separate_object_serde(ray_start_regular_shared):
+def test_block_transform_time_phases_separate_object_serde(ray_start_regular_shared):
     """Batch formatting and block building must be visible, not folded into the body.
 
     The UDF here never reads the column of Python objects, so every second it is
@@ -1896,7 +1896,7 @@ def test_udf_time_phases_separate_object_serde(ray_start_regular_shared):
     )
     parts = _phase_components(op)
     assert sum(p.sum for p in parts.values()) == pytest.approx(
-        op.udf_time.sum, rel=1e-6
+        op.block_transform_time.sum, rel=1e-6
     )
 
 
@@ -1935,22 +1935,24 @@ def test_eagerly_consuming_stage_body_is_timed(ray_start_regular_shared):
         f"built-in stage time"
     )
     # And it is inside the headline total, not stranded outside it.
-    assert op.udf_time.sum >= op.other_stage_time.sum
+    assert op.block_transform_time.sum >= op.other_stage_time.sum
 
 
-def test_operator_without_a_udf_reports_no_udf_time(
+def test_operator_without_a_udf_reports_no_block_transform_time(
     ray_start_regular_shared, restore_data_context
 ):
-    """An operator that runs no user function reports no UDF time.
+    """An operator that runs no user function reports no block transform time.
 
     Every stage of a decomposed chain is timed, so without a guard a standalone
-    read would report its whole transform under "UDF time" -- on an operator
-    that runs nothing the user wrote -- where it has always reported zero.
+    read would report its whole transform under "Block transform time" -- on an
+    operator that runs nothing the user wrote -- where it has always reported zero.
     """
     ds = ray.data.range(100, override_num_blocks=2).materialize()
     op = ds.get_stats_summary().operators_stats[-1]
 
-    assert op.udf_time.sum == 0.0, f"read reported {op.udf_time.sum}s of UDF time"
+    assert (
+        op.block_transform_time.sum == 0.0
+    ), f"read reported {op.block_transform_time.sum}s of block transform time"
     # Nothing was measured, so the phases are absent rather than a row of zeros.
     assert op.input_prep_time is None
     assert op.udf_body_time is None
@@ -1992,13 +1994,15 @@ def test_row_transform_phases_are_opt_in(
         p is None for p in _phase_components(op_off).values()
     ), "row transforms should not be decomposed by default"
     assert parts_off == 0.0
-    assert op_off.udf_time.sum >= 2 * num_rows * sleep_s * 0.9
+    assert op_off.block_transform_time.sum >= 2 * num_rows * sleep_s * 0.9
 
     DataContext.get_current().accurate_map_phase_timing = True
     op_on, parts_on = run()
-    assert parts_on == pytest.approx(op_on.udf_time.sum, rel=1e-6)
+    assert parts_on == pytest.approx(op_on.block_transform_time.sum, rel=1e-6)
     # Same pipeline, same headline number; the flag only adds detail.
-    assert op_on.udf_time.sum == pytest.approx(op_off.udf_time.sum, rel=0.25)
+    assert op_on.block_transform_time.sum == pytest.approx(
+        op_off.block_transform_time.sum, rel=0.25
+    )
 
 
 def test_write_ds_stats(ray_start_regular_shared, tmp_path):

--- a/python/ray/data/tests/test_stats.py
+++ b/python/ray/data/tests/test_stats.py
@@ -1756,6 +1756,134 @@ def test_udf_time_is_not_shared_across_concurrent_actor_tasks(
     )
 
 
+def _phase_components(op):
+    """The four figures that decompose an operator's UDF time."""
+    return {
+        "input_prep": op.input_prep_time,
+        "udf_body": op.udf_body_time,
+        "output_build": op.output_build_time,
+        "other": op.other_stage_time,
+    }
+
+
+def test_udf_time_phases_sum_to_the_total(ray_start_regular_shared):
+    """The phase breakdown must account for the whole of ``udf_time``.
+
+    ``udf_time`` keeps meaning the whole map transform, so anything already
+    charting it is unaffected; the components only say where inside it the time
+    went. That is only true if they add up.
+    """
+    sleep_s = 0.1
+    num_blocks = 4
+
+    def slow(batch):
+        time.sleep(sleep_s)
+        return batch
+
+    ds = (
+        ray.data.range(num_blocks, override_num_blocks=num_blocks)
+        .map_batches(slow, batch_size=None)
+        .map_batches(slow, batch_size=None)
+        .materialize()
+    )
+
+    op = get_operator(ds.get_stats_summary(), name_pattern="MapBatches")
+    parts = _phase_components(op)
+    assert all(p is not None for p in parts.values())
+
+    component_sum = sum(p.sum for p in parts.values())
+    assert component_sum == pytest.approx(op.udf_time.sum, rel=1e-6), (
+        f"components {component_sum:.6f}s do not add up to udf_time "
+        f"{op.udf_time.sum:.6f}s: "
+        + ", ".join(f"{k}={v.sum:.6f}s" for k, v in parts.items())
+    )
+    # The UDF bodies are the sleeps, so they should dominate this pipeline.
+    assert op.udf_body_time.sum >= 2 * num_blocks * sleep_s * 0.9
+
+
+def test_udf_time_phases_separate_object_serde(ray_start_regular_shared):
+    """Batch formatting and block building must be visible, not folded into the body.
+
+    The UDF here never reads the column of Python objects, so every second it is
+    charged for unpickling one is a second the old single figure attributed to
+    user code.
+    """
+    num_blocks = 2
+    rows_per_block = 200
+
+    class Payload:
+        def __init__(self, i):
+            self.blob = [{"k": "x" * 64, "v": float(i)} for _ in range(200)]
+
+    source = (
+        ray.data.range(num_blocks * rows_per_block, override_num_blocks=num_blocks)
+        .map_batches(
+            lambda b: {
+                "id": b["id"],
+                "obj": [Payload(i) for i in range(len(b["id"]))],
+            },
+            batch_size=None,
+        )
+        .materialize()
+    )
+
+    def untouched(batch):
+        # Reads only `id`; never looks at `obj`.
+        return {"n": [len(batch["id"])]}
+
+    ds = source.map_batches(untouched, batch_size=None).materialize()
+    # `name_pattern` is a regex, so match the bare function name rather than
+    # the parenthesised operator name.
+    op = get_operator(ds.get_stats_summary(), name_pattern="untouched")
+
+    assert op.input_prep_time.sum > op.udf_body_time.sum, (
+        f"input prep {op.input_prep_time.sum:.4f}s should dominate the body "
+        f"{op.udf_body_time.sum:.4f}s for a UDF that only counts rows"
+    )
+    parts = _phase_components(op)
+    assert sum(p.sum for p in parts.values()) == pytest.approx(
+        op.udf_time.sum, rel=1e-6
+    )
+
+
+def test_row_transform_phases_are_opt_in(
+    ray_start_regular_shared, restore_data_context
+):
+    """Row transforms report only a total unless asked, and the total is the same.
+
+    Splitting a stage into phases costs a Python frame per item, which a row
+    transform pays per row. Flipping the flag must buy the breakdown without
+    moving the headline figure.
+    """
+    sleep_s = 0.02
+    num_rows = 40
+
+    def slow_row(row):
+        time.sleep(sleep_s)
+        return row
+
+    def run():
+        ds = (
+            ray.data.range(num_rows, override_num_blocks=4)
+            .map(slow_row)
+            .map(slow_row)
+            .materialize()
+        )
+        op = get_operator(ds.get_stats_summary(), name_pattern="Map")
+        return op, sum(p.sum for p in _phase_components(op).values())
+
+    DataContext.get_current().accurate_map_phase_timing = False
+    op_off, parts_off = run()
+    assert parts_off == 0.0, "row transforms should not be decomposed by default"
+    assert op_off.udf_time.sum >= 2 * num_rows * sleep_s * 0.9
+
+    DataContext.get_current().accurate_map_phase_timing = True
+    op_on, parts_on = run()
+    assert parts_on == pytest.approx(op_on.udf_time.sum, rel=1e-6)
+    # Same pipeline, same headline number; the flag only adds detail.
+    assert op_on.udf_time.sum == pytest.approx(op_off.udf_time.sum, rel=0.25)
+
+
 def test_write_ds_stats(ray_start_regular_shared, tmp_path):
     # Test 1: Basic write_parquet - stats stored in _write_ds
     ds1 = ray.data.range(100, override_num_blocks=100)

--- a/python/ray/data/tests/test_stats.py
+++ b/python/ray/data/tests/test_stats.py
@@ -21,6 +21,7 @@ from ray._common.test_utils import (
     wait_for_condition,
 )
 from ray.data import ActorPoolStrategy
+from ray.data.datasource import Datasink
 from ray.data._internal.block_batching.iter_batches import BatchIterator
 from ray.data._internal.execution.backpressure_policy import (
     ENABLED_BACKPRESSURE_POLICIES_CONFIG_KEY,
@@ -1897,6 +1898,64 @@ def test_udf_time_phases_separate_object_serde(ray_start_regular_shared):
     assert sum(p.sum for p in parts.values()) == pytest.approx(
         op.udf_time.sum, rel=1e-6
     )
+
+
+def test_eagerly_consuming_stage_body_is_timed(ray_start_regular_shared):
+    """A stage that consumes its input eagerly still has its work attributed.
+
+    A write does its whole upload inside the call that builds its output
+    iterable, before any timing iterator wraps it, so timing only `__next__`
+    misses it entirely -- reporting microseconds for an upload that took
+    seconds. It belongs in `Built-in stages`, since a datasink is Ray Data's
+    code rather than the user's.
+    """
+    write_sleep_s = 0.3
+    num_blocks = 2
+
+    class SlowSink(Datasink):
+        def write(self, blocks, ctx):
+            written = 0
+            for _ in blocks:
+                time.sleep(write_sleep_s)
+                written += 1
+            return written
+
+    ds = ray.data.range(num_blocks, override_num_blocks=num_blocks).map_batches(
+        lambda batch: batch, batch_size=None
+    )
+    ds.write_datasink(SlowSink())
+
+    op = ds._write_ds.get_stats_summary().operators_stats[-1]
+    expected_s = write_sleep_s * num_blocks
+    assert op.other_stage_time is not None, "built-in stage time was not collected"
+    # Generous lower bound: the point is that seconds of I/O are not reported as
+    # microseconds, not that the figure is tight.
+    assert op.other_stage_time.sum > expected_s * 0.5, (
+        f"write of {expected_s}s reported {op.other_stage_time.sum}s of "
+        f"built-in stage time"
+    )
+    # And it is inside the headline total, not stranded outside it.
+    assert op.udf_time.sum >= op.other_stage_time.sum
+
+
+def test_operator_without_a_udf_reports_no_udf_time(
+    ray_start_regular_shared, restore_data_context
+):
+    """An operator that runs no user function reports no UDF time.
+
+    Every stage of a decomposed chain is timed, so without a guard a standalone
+    read would report its whole transform under "UDF time" -- on an operator
+    that runs nothing the user wrote -- where it has always reported zero.
+    """
+    ds = ray.data.range(100, override_num_blocks=2).materialize()
+    op = ds.get_stats_summary().operators_stats[-1]
+
+    assert op.udf_time.sum == 0.0, f"read reported {op.udf_time.sum}s of UDF time"
+    # Nothing was measured, so the phases are absent rather than a row of zeros.
+    assert op.input_prep_time is None
+    assert op.udf_body_time is None
+    assert op.output_build_time is None
+    assert op.other_stage_time is None
 
 
 def test_row_transform_phases_are_opt_in(

--- a/python/ray/data/tests/test_stats.py
+++ b/python/ray/data/tests/test_stats.py
@@ -400,9 +400,8 @@ def gen_expected_metrics(
             # existing task metrics.
             "'block_transform_time_s': A",
             "'input_prep_time_s': A",
-            "'udf_body_time_s': A",
+            "'function_body_time_s': A",
             "'output_build_time_s': A",
-            "'other_stage_time_s': A",
             (
                 "'task_submission_backpressure_time': "
                 f"{'N' if task_backpressure else 'Z'}"
@@ -546,7 +545,6 @@ def gen_block_transform_time_breakdown_str(verbose: bool) -> str:
         "    * Input prep: T min, T max, T mean, T total\n"
         "    * Function body: T min, T max, T mean, T total\n"
         "    * Output block build: T min, T max, T mean, T total\n"
-        "    * Built-in stages: T min, T max, T mean, T total\n"
     )
 
 
@@ -642,8 +640,8 @@ def canonicalize(
     # avoid flakiness; `test_row_transform_phases_are_opt_in` asserts the
     # measured-vs-not distinction directly instead.
     canonicalized_stats = re.sub(
-        r"('?(?:block_transform_time_s|input_prep_time_s|udf_body_time_s|output_build_time_s"
-        r"|other_stage_time_s)'?: )\d+(?:\.\d+)?(?:[eE][-+]?\d+)?",
+        r"('?(?:block_transform_time_s|input_prep_time_s|function_body_time_s"
+        r"|output_build_time_s)'?: )\d+(?:\.\d+)?(?:[eE][-+]?\d+)?",
         r"\g<1>A",
         canonicalized_stats,
     )
@@ -1006,9 +1004,8 @@ def test_dataset__repr__(ray_start_regular_shared, restore_data_context):
         # The block transform time breakdown, exported per map operator.
         "      block_transform_time_s: A,\n"
         "      input_prep_time_s: A,\n"
-        "      udf_body_time_s: A,\n"
+        "      function_body_time_s: A,\n"
         "      output_build_time_s: A,\n"
-        "      other_stage_time_s: A,\n"
         "      task_submission_backpressure_time: N,\n"
         "      task_output_backpressure_time: Z,\n"
         "      task_completion_time_s: N,\n"
@@ -1176,9 +1173,8 @@ def test_dataset__repr__(ray_start_regular_shared, restore_data_context):
         # The block transform time breakdown, exported per map operator.
         "      block_transform_time_s: A,\n"
         "      input_prep_time_s: A,\n"
-        "      udf_body_time_s: A,\n"
+        "      function_body_time_s: A,\n"
         "      output_build_time_s: A,\n"
-        "      other_stage_time_s: A,\n"
         "      task_submission_backpressure_time: N,\n"
         "      task_output_backpressure_time: Z,\n"
         "      task_completion_time_s: N,\n"
@@ -1299,9 +1295,8 @@ def test_dataset__repr__(ray_start_regular_shared, restore_data_context):
         # The block transform time breakdown, exported per map operator.
         "            block_transform_time_s: A,\n"
         "            input_prep_time_s: A,\n"
-        "            udf_body_time_s: A,\n"
+        "            function_body_time_s: A,\n"
         "            output_build_time_s: A,\n"
-        "            other_stage_time_s: A,\n"
         "            task_submission_backpressure_time: N,\n"
         "            task_output_backpressure_time: Z,\n"
         "            task_completion_time_s: N,\n"
@@ -1811,12 +1806,11 @@ def test_block_transform_time_is_not_shared_across_concurrent_actor_tasks(
 
 
 def _phase_components(op):
-    """The four figures that decompose an operator's block transform time."""
+    """The three figures that decompose an operator's block transform time."""
     return {
         "input_prep": op.input_prep_time,
-        "udf_body": op.udf_body_time,
+        "function_body": op.function_body_time,
         "output_build": op.output_build_time,
-        "other": op.other_stage_time,
     }
 
 
@@ -1852,7 +1846,7 @@ def test_block_transform_time_phases_sum_to_the_total(ray_start_regular_shared):
         + ", ".join(f"{k}={v.sum:.6f}s" for k, v in parts.items())
     )
     # The UDF bodies are the sleeps, so they should dominate this pipeline.
-    assert op.udf_body_time.sum >= 2 * num_blocks * sleep_s * 0.9
+    assert op.function_body_time.sum >= 2 * num_blocks * sleep_s * 0.9
 
 
 def test_block_transform_time_phases_separate_object_serde(ray_start_regular_shared):
@@ -1890,9 +1884,9 @@ def test_block_transform_time_phases_separate_object_serde(ray_start_regular_sha
     # the parenthesised operator name.
     op = get_operator(ds.get_stats_summary(), name_pattern="untouched")
 
-    assert op.input_prep_time.sum > op.udf_body_time.sum, (
+    assert op.input_prep_time.sum > op.function_body_time.sum, (
         f"input prep {op.input_prep_time.sum:.4f}s should dominate the body "
-        f"{op.udf_body_time.sum:.4f}s for a UDF that only counts rows"
+        f"{op.function_body_time.sum:.4f}s for a UDF that only counts rows"
     )
     parts = _phase_components(op)
     assert sum(p.sum for p in parts.values()) == pytest.approx(
@@ -1906,8 +1900,8 @@ def test_eagerly_consuming_stage_body_is_timed(ray_start_regular_shared):
     A write does its whole upload inside the call that builds its output
     iterable, before any timing iterator wraps it, so timing only `__next__`
     misses it entirely -- reporting microseconds for an upload that took
-    seconds. It belongs in `Built-in stages`, since a datasink is Ray Data's
-    code rather than the user's.
+    seconds. It belongs in `Function body`, which covers a datasink's body the
+    same way it covers a UDF's.
     """
     write_sleep_s = 0.3
     num_blocks = 2
@@ -1927,15 +1921,15 @@ def test_eagerly_consuming_stage_body_is_timed(ray_start_regular_shared):
 
     op = ds._write_ds.get_stats_summary().operators_stats[-1]
     expected_s = write_sleep_s * num_blocks
-    assert op.other_stage_time is not None, "built-in stage time was not collected"
+    assert op.function_body_time is not None, "stage body time was not collected"
     # Generous lower bound: the point is that seconds of I/O are not reported as
     # microseconds, not that the figure is tight.
-    assert op.other_stage_time.sum > expected_s * 0.5, (
-        f"write of {expected_s}s reported {op.other_stage_time.sum}s of "
-        f"built-in stage time"
+    assert op.function_body_time.sum > expected_s * 0.5, (
+        f"write of {expected_s}s reported {op.function_body_time.sum}s of "
+        f"function body time"
     )
     # And it is inside the headline total, not stranded outside it.
-    assert op.block_transform_time.sum >= op.other_stage_time.sum
+    assert op.block_transform_time.sum >= op.function_body_time.sum
 
 
 def test_operator_without_a_udf_reports_no_block_transform_time(
@@ -1955,9 +1949,8 @@ def test_operator_without_a_udf_reports_no_block_transform_time(
     ), f"read reported {op.block_transform_time.sum}s of block transform time"
     # Nothing was measured, so the phases are absent rather than a row of zeros.
     assert op.input_prep_time is None
-    assert op.udf_body_time is None
+    assert op.function_body_time is None
     assert op.output_build_time is None
-    assert op.other_stage_time is None
 
 
 def test_row_transform_phases_are_opt_in(

--- a/python/ray/data/tests/test_stats.py
+++ b/python/ray/data/tests/test_stats.py
@@ -37,7 +37,7 @@ from ray.data._internal.execution.operators.map_transformer import (
     BlockMapTransformFn,
     CustomOpStatsReporter,
     MapTransformer,
-    UDFTimeScope,
+    TransformClock,
 )
 from ray.data._internal.execution.streaming_executor import StreamingExecutor
 from ray.data._internal.stats import (
@@ -226,7 +226,7 @@ def test_map_transformer_custom_op_stats():
     # apply_transform takes the report callback, not the reporter object.
     list(
         transformer.apply_transform(
-            [block], ctx, reporter.report, udf_time_scope=UDFTimeScope()
+            [block], ctx, reporter.report, clock=TransformClock()
         )
     )
     assert reporter.get_stats() == [expected]

--- a/python/ray/data/tests/test_stats.py
+++ b/python/ray/data/tests/test_stats.py
@@ -1932,25 +1932,27 @@ def test_eagerly_consuming_stage_body_is_timed(ray_start_regular_shared):
     assert op.block_transform_time.sum >= op.function_body_time.sum
 
 
-def test_operator_without_a_udf_reports_no_block_transform_time(
+def test_operator_without_a_udf_is_still_timed(
     ray_start_regular_shared, restore_data_context
 ):
-    """An operator that runs no user function reports no block transform time.
+    """A chain with no user function in it is measured like any other.
 
-    Every stage of a decomposed chain is timed, so without a guard a standalone
-    read would report its whole transform under "Block transform time" -- on an
-    operator that runs nothing the user wrote -- where it has always reported zero.
+    A read's body is a function like a UDF's, and "block transform time" names
+    what it measures rather than who wrote it, so there is nothing to gate on.
+    Master reported zero for a standalone read.
     """
     ds = ray.data.range(100, override_num_blocks=2).materialize()
     op = ds.get_stats_summary().operators_stats[-1]
 
-    assert (
-        op.block_transform_time.sum == 0.0
-    ), f"read reported {op.block_transform_time.sum}s of block transform time"
-    # Nothing was measured, so the phases are absent rather than a row of zeros.
-    assert op.input_prep_time is None
-    assert op.function_body_time is None
-    assert op.output_build_time is None
+    assert op.block_transform_time.sum > 0.0, "read reported no block transform time"
+    # The phases are measured rather than absent, and they still add up.
+    parts = _phase_components(op)
+    assert all(s is not None for s in parts.values()), parts
+    assert sum(s.sum for s in parts.values()) == pytest.approx(
+        op.block_transform_time.sum, rel=1e-6
+    )
+    # A read's I/O is inside the timed window, so it cannot exceed the wall time.
+    assert op.block_transform_time.sum <= op.wall_time.sum * 1.05
 
 
 def test_row_transform_phases_are_opt_in(

--- a/python/ray/data/tests/test_stats.py
+++ b/python/ray/data/tests/test_stats.py
@@ -21,7 +21,6 @@ from ray._common.test_utils import (
     wait_for_condition,
 )
 from ray.data import ActorPoolStrategy
-from ray.data.datasource import Datasink
 from ray.data._internal.block_batching.iter_batches import BatchIterator
 from ray.data._internal.execution.backpressure_policy import (
     ENABLED_BACKPRESSURE_POLICIES_CONFIG_KEY,
@@ -57,6 +56,7 @@ from ray.data._internal.stats import (
 from ray.data._internal.util import MemoryProfiler
 from ray.data.block import BlockExecStats, BlockStats, CustomOpStats
 from ray.data.context import DataContext
+from ray.data.datasource import Datasink
 from ray.data.tests.util import column_udf
 from ray.tests.conftest import *  # noqa
 

--- a/python/ray/data/tests/test_stats.py
+++ b/python/ray/data/tests/test_stats.py
@@ -395,6 +395,13 @@ def gen_expected_metrics(
             f"'num_tasks_task_locality_miss': {'Z' if task_locality_hit else 'N'}",
             "'block_generation_time': N",
             "'block_serialization_time_s': N",
+            # The UDF time breakdown, exported per operator alongside the
+            # existing task metrics.
+            "'udf_time_s': A",
+            "'input_prep_time_s': A",
+            "'udf_body_time_s': A",
+            "'output_build_time_s': A",
+            "'other_stage_time_s': A",
             (
                 "'task_submission_backpressure_time': "
                 f"{'N' if task_backpressure else 'Z'}"
@@ -525,6 +532,23 @@ def gen_extra_metrics_str(metrics: str, verbose: bool):
     return f"* Extra metrics: {metrics}" + "\n" if verbose else ""
 
 
+def gen_udf_time_breakdown_str(verbose: bool) -> str:
+    """The phase breakdown under "UDF time", which is verbose-only.
+
+    Batch-based operators are decomposed; row-based ones report only a
+    total unless `DataContext.accurate_map_phase_timing` is set, so they
+    print nothing here even when verbose.
+    """
+    if not verbose:
+        return ""
+    return (
+        "    * Input prep: T min, T max, T mean, T total\n"
+        "    * Function body: T min, T max, T mean, T total\n"
+        "    * Output block build: T min, T max, T mean, T total\n"
+        "    * Built-in stages: T min, T max, T mean, T total\n"
+    )
+
+
 def gen_runtime_metrics_str(op_names: List[str], verbose: bool) -> str:
     if not verbose:
         return ""
@@ -611,6 +635,16 @@ def canonicalize(
     )
     canonicalized_stats = re.sub(
         r"\(samples: \d+, avg: \d+\.\d+\)", "(samples: N, avg: N)", canonicalized_stats
+    )
+    # The UDF time breakdown measures sub-microsecond work for a trivial UDF, so
+    # each figure rounds to zero or not depending on the run. Replace with A to
+    # avoid flakiness; `test_row_transform_phases_are_opt_in` asserts the
+    # measured-vs-not distinction directly instead.
+    canonicalized_stats = re.sub(
+        r"('?(?:udf_time_s|input_prep_time_s|udf_body_time_s|output_build_time_s"
+        r"|other_stage_time_s)'?: )\d+(?:\.\d+)?(?:[eE][-+]?\d+)?",
+        r"\g<1>A",
+        canonicalized_stats,
     )
     # For obj_store_mem_used, the value can be zero or positive, depending on the run.
     # Replace with A to avoid test flakiness.
@@ -745,7 +779,7 @@ def test_streaming_split_stats(ray_start_regular_shared, restore_data_context):
 * Remote wall time: T min, T max, T mean, T total
 * Remote cpu time: T min, T max, T mean, T total
 * UDF time: T min, T max, T mean, T total
-* Output num rows per block: N min, N max, N mean, N total
+{gen_udf_time_breakdown_str(True)}* Output num rows per block: N min, N max, N mean, N total
 * Output size bytes per block: N min, N max, N mean, N total
 * Output rows per task: N min, N max, N mean, N tasks used
 * Tasks per node: N min, N max, N mean; N nodes used
@@ -804,6 +838,7 @@ def test_dataset_stats_basic(
                 f"* Remote wall time: T min, T max, T mean, T total\n"
                 f"* Remote cpu time: T min, T max, T mean, T total\n"
                 f"* UDF time: T min, T max, T mean, T total\n"
+                f"{gen_udf_time_breakdown_str(verbose_stats_logs)}"
                 f"* Output num rows per block: N min, N max, N mean, N total\n"
                 f"* Output size bytes per block: N min, N max, N mean, N total\n"
                 f"* Output rows per task: N min, N max, N mean, N tasks used\n"
@@ -967,6 +1002,12 @@ def test_dataset__repr__(ray_start_regular_shared, restore_data_context):
         "      num_tasks_task_locality_miss: N,\n"
         "      block_generation_time: N,\n"
         "      block_serialization_time_s: N,\n"
+        # The UDF time breakdown, exported per map operator.
+        "      udf_time_s: A,\n"
+        "      input_prep_time_s: A,\n"
+        "      udf_body_time_s: A,\n"
+        "      output_build_time_s: A,\n"
+        "      other_stage_time_s: A,\n"
         "      task_submission_backpressure_time: N,\n"
         "      task_output_backpressure_time: Z,\n"
         "      task_completion_time_s: N,\n"
@@ -1131,6 +1172,12 @@ def test_dataset__repr__(ray_start_regular_shared, restore_data_context):
         "      num_tasks_task_locality_miss: Z,\n"
         "      block_generation_time: N,\n"
         "      block_serialization_time_s: N,\n"
+        # The UDF time breakdown, exported per map operator.
+        "      udf_time_s: A,\n"
+        "      input_prep_time_s: A,\n"
+        "      udf_body_time_s: A,\n"
+        "      output_build_time_s: A,\n"
+        "      other_stage_time_s: A,\n"
         "      task_submission_backpressure_time: N,\n"
         "      task_output_backpressure_time: Z,\n"
         "      task_completion_time_s: N,\n"
@@ -1248,6 +1295,12 @@ def test_dataset__repr__(ray_start_regular_shared, restore_data_context):
         "            num_tasks_task_locality_miss: N,\n"
         "            block_generation_time: N,\n"
         "            block_serialization_time_s: N,\n"
+        # The UDF time breakdown, exported per map operator.
+        "            udf_time_s: A,\n"
+        "            input_prep_time_s: A,\n"
+        "            udf_body_time_s: A,\n"
+        "            output_build_time_s: A,\n"
+        "            other_stage_time_s: A,\n"
         "            task_submission_backpressure_time: N,\n"
         "            task_output_backpressure_time: Z,\n"
         "            task_completion_time_s: N,\n"
@@ -1870,11 +1923,16 @@ def test_row_transform_phases_are_opt_in(
             .materialize()
         )
         op = get_operator(ds.get_stats_summary(), name_pattern="Map")
-        return op, sum(p.sum for p in _phase_components(op).values())
+        parts = _phase_components(op).values()
+        return op, sum(p.sum for p in parts if p is not None)
 
     DataContext.get_current().accurate_map_phase_timing = False
     op_off, parts_off = run()
-    assert parts_off == 0.0, "row transforms should not be decomposed by default"
+    # Not measured at all, rather than measured as zero.
+    assert all(
+        p is None for p in _phase_components(op_off).values()
+    ), "row transforms should not be decomposed by default"
+    assert parts_off == 0.0
     assert op_off.udf_time.sum >= 2 * num_rows * sleep_s * 0.9
 
     DataContext.get_current().accurate_map_phase_timing = True

--- a/python/ray/data/tests/unit/test_auto_batch_size.py
+++ b/python/ray/data/tests/unit/test_auto_batch_size.py
@@ -7,7 +7,7 @@ from ray.data._internal.execution.interfaces.task_context import TaskContext
 from ray.data._internal.execution.operators.map_transformer import (
     BatchMapTransformFn,
     MapTransformer,
-    UDFTimeScope,
+    TransformClock,
     _compute_auto_batch_size,
 )
 from ray.data._internal.output_buffer import OutputBlockSizeOption
@@ -85,7 +85,7 @@ def test_auto_batches_respect_target_size():
         ]
     )
     ctx = TaskContext(task_idx=0, op_name="test")
-    list(transformer.apply_transform(iter([block]), ctx, udf_time_scope=UDFTimeScope()))
+    list(transformer.apply_transform(iter([block]), ctx, clock=TransformClock()))
 
     assert sum(received_sizes) == 1000
     assert all(s == 10 for s in received_sizes[:-1])


### PR DESCRIPTION
## Why are these changes needed?

`ds.stats()` reports one figure per operator for a map stage's transform and calls it "UDF time". It isn't the user's function: it spans turning input blocks into batches or rows, calling the function, and assembling the output back into blocks. So a slow operator tells you nothing about whether to optimise your code or your data layout.

That bites hardest when rows carry Python objects, because both ends of the window get expensive. A UDF that never reads an object column is still charged for unpickling it, and nothing in the output says so.

## What this change does

Renames the figure to say what it measures, and breaks it down. `ds.stats()` prints `* Block transform time:` where it printed `* UDF time:`, and under `verbose_stats_logs` splits it into three lines that sum to it:

```
* Block transform time: 4.02s min, 4.11s max, 4.06s mean, 16.2s total
	* Input prep: ...           forming batches or rows, where object unpickling lands
	* Function body: ...        the stage bodies, yours and Ray Data's alike
	* Output block build: ...   assembling output back into blocks
```

The total and all three phases are `metric_field`s on `OpRuntimeMetrics`, so they reach Prometheus per operator tagged `dataset` and `operator`. The three phases stay `None` rather than zero when a chain is timed only as a whole, so a dashboard can tell "not measured" from "took no time".

Default output is unchanged: the breakdown renders only under `verbose_stats_logs`, the same treatment `extra_metrics` gets, and the figures are always on `get_stats_summary()` regardless. Row transforms (`map`, `filter`) report only a total by default, since a timer per row costs roughly 0.6µs across a three-stage chain; `DataContext.accurate_map_phase_timing` opts them in.

The docs gain a worked example that runs a fused `ReadRange->Project->MapBatches(map1)->MapBatches(map2)` and reads the three figures off its output, because "which stages land in which bucket?" was the first thing review asked.

### Under the hood

`map_transformer.py` is rewritten by #65855, merged in here: a task's transform is now a flat list of `TimedStep`s you can print and assert on, each timing itself with no coordination. Subtracting neighbouring totals once at drain recovers each step's own work, at 580 ns/item against the 1016 the per-item cursor cost.

Timing is no longer gated on the chain containing a UDF, so reads and writes are measured too and `MapTransformFn.is_udf` is gone, along with the separate `Built-in stages` bucket. Removing the gate surfaced an ordering bug in the checkpoint 2PC chain, fixed in c89db167b4.

### What needs review

1. **The name.** `ray_data_block_transform_time_s` is introduced here, so it is free to change now and expensive after a release. @iamjustinhsu suggested `total_task_per_block_s`.
2. **The checkpoint fix** wants a checkpoint owner. It belongs in this PR, since the bug is created by this PR's deferred apply and doesn't exist on master, but nobody else has looked at it.
3. **Folding `Built-in stages` into `Function body`** costs the "my code or Ray Data's?" split until per-stage attribution lands in #65810. @iamjustinhsu asked for it; worth confirming the interim is fine.
4. **Reads and writes now report a figure** where they reported nothing, which changes `ds.stats()` output for every read operator.

## Related issue number

None. Closed #55052 raised adjacent complaints about operator-level metric granularity and was addressed by `ds.explain()`; it did not cover this.

## Checks

- [x] I've signed off every commit (`git commit -s`).
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've added any new APIs to the API Reference. *(`DataContext.accurate_map_phase_timing` is documented in the `DataContext` docstring; no new public API)*
- [x] I've made sure the tests are passing.
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(

## Testing

Eight tests added:

| test | asserts |
| --- | --- |
| `test_block_transform_time_phases_sum_to_the_total` | the components add up, which is what makes this a decomposition rather than three loose numbers |
| `test_block_transform_time_phases_separate_object_serde` | input prep dominates the body for a UDF that only counts rows beside an object column |
| `test_row_transform_phases_are_opt_in` | row transforms report only a total by default, and the flag adds detail without moving it |
| `test_eagerly_consuming_stage_body_is_timed` | a datasink's I/O reaches `Function body` instead of being reported as microseconds |
| `test_operator_without_a_udf_is_still_timed` | a standalone read reports its phases, and they stay inside the task's wall time |
| `test_map_transformer.py::test_every_output_block_is_timed` | every output block of a task is measured, not just the first |
| `test_op_runtime_metrics.py::test_phase_metrics_stay_none_when_unmeasured` | a chain timed only as a whole exports no phases, rather than zeros beside a non-zero total |
| `test_op_runtime_metrics.py::test_phase_metrics_accumulate_when_measured` | the `None` default doesn't swallow a measured phase |

Existing tests that assert on the rendered `ds.stats()` string keep their non-verbose expectations unchanged, which is what gating the breakdown buys; the verbose ones gained three lines. The new `OpRuntimeMetrics` keys are canonicalized to a placeholder in those expectations, as `obj_store_mem_used` already is, because a trivial UDF's phases round to zero or not depending on the run.

Run locally against a source build, with `PYTHONPATH=python/ray/data/tests`:

| file | result |
| --- | --- |
| `test_stats.py` | 105 passed, 2 skipped, 1 failed |
| `test_map.py` | 252 passed, 1 failed |
| `test_checkpoint.py` | 60 passed, 13 skipped, 4 errors |
| `test_consumption.py` | 28 passed, 2 skipped, 3 failed |
| `test_map_transformer.py`, `unit/test_auto_batch_size.py`, `test_op_runtime_metrics.py`, `test_context.py` | all passed |
| `datasource/{test_datasink,test_file_datasink,test_parquet}.py` | failures identical to the merge base |

Every failure above was A/B'd against master and traces to something absent from my machine rather than to this change: the dashboard API server isn't running, pandas 3.0 breaks an untouched conversion helper, and the rest are s3 fixtures. `pre-commit run --all-files` passes.

## AI assistance

AI assistance (Claude Code) was used to investigate the attribution gap, write the change and the tests, and draft this description. Per `AGENTS.md`, the author has reviewed every changed line and the tests reported above were run locally.

## Duplicate check

`gh pr list --repo ray-project/ray --state open` was searched for `udf time phase breakdown input prep` and `map_transformer phase timing`; neither returns anything. The open PRs touching nearby code — #61379 (caching the serialized map transformer), #64090 (per-actor placement groups), #65663 (exposing backpressure policy in diagnostics) — do not touch this timing.

