### PR TITLE
[serve] Exclude system gRPC traffic from Serve dashboard panels

### DIFF
--- a/python/ray/dashboard/modules/metrics/dashboards/serve_dashboard_panels.py
+++ b/python/ray/dashboard/modules/metrics/dashboards/serve_dashboard_panels.py
@@ -60,7 +60,7 @@ SERVE_GRAFANA_PANELS = [
                 legend="{{application, route}}",
             ),
             Target(
-                expr='sum(rate(ray_serve_num_grpc_requests_total{{application=~"$Application",application!~"",method=~"$gRPC_Method",{global_filters}}}[5m])) by (application, method)',
+                expr='sum(rate(ray_serve_num_grpc_requests_total{{application=~"$Application",application!~"",method=~"$gRPC_Method",method!~"/ray\\\\.serve\\\\.RayServeAPIService/.*",{global_filters}}}[5m])) by (application, method)',
                 legend="{{application, method}}",
             ),
         ],
@@ -77,7 +77,7 @@ SERVE_GRAFANA_PANELS = [
                 legend="{{application, route}}",
             ),
             Target(
-                expr='sum(rate(ray_serve_num_grpc_error_requests_total{{application=~"$Application",application!~"",method=~"$gRPC_Method",{global_filters}}}[5m])) by (application, method)',
+                expr='sum(rate(ray_serve_num_grpc_error_requests_total{{application=~"$Application",application!~"",method=~"$gRPC_Method",method!~"/ray\\\\.serve\\\\.RayServeAPIService/.*",{global_filters}}}[5m])) by (application, method)',
                 legend="{{application, method}}",
             ),
         ],
@@ -94,7 +94,7 @@ SERVE_GRAFANA_PANELS = [
                 legend="{{application, route, error_code}}",
             ),
             Target(
-                expr='sum(rate(ray_serve_num_grpc_error_requests_total{{application=~"$Application",application!~"",method=~"$gRPC_Method",{global_filters}}}[5m])) by (application, method, error_code)',
+                expr='sum(rate(ray_serve_num_grpc_error_requests_total{{application=~"$Application",application!~"",method=~"$gRPC_Method",method!~"/ray\\\\.serve\\\\.RayServeAPIService/.*",{global_filters}}}[5m])) by (application, method, error_code)',
                 legend="{{application, method, error_code}}",
             ),
         ],
@@ -111,11 +111,11 @@ SERVE_GRAFANA_PANELS = [
                 legend="{{application, route}}",
             ),
             Target(
-                expr='histogram_quantile(0.5, sum(rate(ray_serve_grpc_request_latency_ms_bucket{{application=~"$Application",application!~"",method=~"$gRPC_Method",{global_filters}}}[5m])) by (application, method, le))',
+                expr='histogram_quantile(0.5, sum(rate(ray_serve_grpc_request_latency_ms_bucket{{application=~"$Application",application!~"",method=~"$gRPC_Method",method!~"/ray\\\\.serve\\\\.RayServeAPIService/.*",{global_filters}}}[5m])) by (application, method, le))',
                 legend="{{application, method}}",
             ),
             Target(
-                expr='histogram_quantile(0.5, sum(rate({{__name__=~ "ray_serve_(http|grpc)_request_latency_ms_bucket",application=~"$Application",application!~"",{global_filters}}}[5m])) by (le))',
+                expr='histogram_quantile(0.5, sum(rate({{__name__=~ "ray_serve_(http|grpc)_request_latency_ms_bucket",application=~"$Application",application!~"",route!~"/-/.*",method!~"/ray\\\\.serve\\\\.RayServeAPIService/.*",{global_filters}}}[5m])) by (le))',
                 legend="Total",
             ),
         ],
@@ -134,11 +134,11 @@ SERVE_GRAFANA_PANELS = [
                 legend="{{application, route}}",
             ),
             Target(
-                expr='histogram_quantile(0.9, sum(rate(ray_serve_grpc_request_latency_ms_bucket{{application=~"$Application",application!~"",method=~"$gRPC_Method",{global_filters}}}[5m])) by (application, method, le))',
+                expr='histogram_quantile(0.9, sum(rate(ray_serve_grpc_request_latency_ms_bucket{{application=~"$Application",application!~"",method=~"$gRPC_Method",method!~"/ray\\\\.serve\\\\.RayServeAPIService/.*",{global_filters}}}[5m])) by (application, method, le))',
                 legend="{{application, method}}",
             ),
             Target(
-                expr='histogram_quantile(0.9, sum(rate({{__name__=~ "ray_serve_(http|grpc)_request_latency_ms_bucket|ray_serve_grpc_request_latency_ms_bucket",application=~"$Application",application!~"",{global_filters}}}[5m])) by (le))',
+                expr='histogram_quantile(0.9, sum(rate({{__name__=~ "ray_serve_(http|grpc)_request_latency_ms_bucket",application=~"$Application",application!~"",route!~"/-/.*",method!~"/ray\\\\.serve\\\\.RayServeAPIService/.*",{global_filters}}}[5m])) by (le))',
                 legend="Total",
             ),
         ],
@@ -157,11 +157,11 @@ SERVE_GRAFANA_PANELS = [
                 legend="{{application, route}}",
             ),
             Target(
-                expr='histogram_quantile(0.99, sum(rate(ray_serve_grpc_request_latency_ms_bucket{{application=~"$Application",application!~"",method=~"$gRPC_Method",{global_filters}}}[5m])) by (application, method, le))',
+                expr='histogram_quantile(0.99, sum(rate(ray_serve_grpc_request_latency_ms_bucket{{application=~"$Application",application!~"",method=~"$gRPC_Method",method!~"/ray\\\\.serve\\\\.RayServeAPIService/.*",{global_filters}}}[5m])) by (application, method, le))',
                 legend="{{application, method}}",
             ),
             Target(
-                expr='histogram_quantile(0.99, sum(rate({{__name__=~ "ray_serve_(http|grpc)_request_latency_ms_bucket|ray_serve_grpc_request_latency_ms_bucket",application=~"$Application",application!~"",{global_filters}}}[5m])) by (le))',
+                expr='histogram_quantile(0.99, sum(rate({{__name__=~ "ray_serve_(http|grpc)_request_latency_ms_bucket",application=~"$Application",application!~"",route!~"/-/.*",method!~"/ray\\\\.serve\\\\.RayServeAPIService/.*",{global_filters}}}[5m])) by (le))',
                 legend="Total",
             ),
         ],

--- a/python/ray/tests/test_metrics_head.py
+++ b/python/ray/tests/test_metrics_head.py
@@ -2,6 +2,7 @@
 import json
 import logging
 import os
+import re
 import sys
 import tempfile
 
@@ -244,6 +245,22 @@ def test_serve_dashboard_utilizes_global_filters():
                 # We skip expressions that are constant value targets serving as visual aids
                 continue
             assert "{global_filters}" in target.expr
+
+
+def test_serve_dashboard_excludes_system_traffic():
+    for panel in SERVE_GRAFANA_PANELS:
+        for target in panel.targets:
+            expr = target.expr
+            # Combined targets select by __name__ and carry neither selector, so both apply.
+            combined = bool(
+                re.search(r'__name__\s*=~\s*["\']ray_serve_\(http\|grpc\)', expr)
+            )
+            if combined or re.search(r"ray_serve_(num_)?http_\w*request", expr):
+                assert 'route!~"/-/.*"' in expr, f"{panel.title}: {expr}"
+            if combined or re.search(r"ray_serve_(num_)?grpc_\w*request", expr):
+                assert (
+                    r'method!~"/ray\\.serve\\.RayServeAPIService/.*"' in expr
+                ), f"{panel.title}: {expr}"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Why

The gRPC panels aggregate every method recorded by the proxy, including the internal `ray.serve.RayServeAPIService` methods (`Healthz`, `ListApplications`). It inflates QPS with requests the user never sent and skews the latency percentiles.

The HTTP selectors already exclude the analogous system routes via `route!~"/-/.*"`; the gRPC side never got the equivalent.

## What

- Add a `RayServeAPIService` method exclusion to every gRPC request, error, and latency selector in `serve_dashboard_panels.py`.

Note the four backslashes: the expression passes through Python string parsing, JSON encoding, and PromQL string unescaping before reaching the regex engine. PromQL rejects a bare `\.` as an unknown escape sequence, so the source needs `\\\\.` to land `\.` in the regex.

## Testing

- Added init test asserting every HTTP/gRPC/combined selector carries its exclusion.
- Rendered the dashboard via `generate_serve_grafana_dashboard()` and confirmed all 9 gRPC targets reach Prometheus as `method!~"/ray\\.serve\\.RayServeAPIService/.*"`, the form PromQL accepts.
- Verified against live metrics on a staging cluster: with a gRPC Serve app under load, `Healthz`/`ListApplications` drop out of the gRPC panels while the user-defined methods remain

Not a duplicate: no open PR touches `serve_dashboard_panels.py`, and no open issue tracks gRPC health-check traffic on the Serve dashboard.

AI assistance (Claude Code) was used for this change.
