### PR TITLE
[docs] remove apple silicon install instructions

### DIFF
--- a/doc/source/ray-overview/installation.md
+++ b/doc/source/ray-overview/installation.md
@@ -188,23 +188,11 @@ There are minor variations to the format of the wheel filename; it's best to mat
 
 Ray supports machines running Apple Silicon (such as M1 macs). Multi-node clusters are untested. To get started with local Ray development:
 
-1. Install [miniforge](https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-MacOSX-arm64.sh).
+Install Ray the same way described above, for example:
 
-   * `wget https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-MacOSX-arm64.sh`
-
-   * `bash Miniforge3-MacOSX-arm64.sh`
-
-   * `rm Miniforge3-MacOSX-arm64.sh # Cleanup.`
-
-2. Ensure you're using the miniforge environment (you should see (base) in your terminal).
-
-   * `source ~/.bash_profile`
-
-   * `conda activate`
-
-3. Install Ray as you normally would.
-
-   * `pip install ray`
+```shell
+pip install -U "ray[default]"
+```
 
 (windows-support)=
 

--- a/doc/source/ray-overview/installation.md
+++ b/doc/source/ray-overview/installation.md
@@ -188,7 +188,7 @@ There are minor variations to the format of the wheel filename; it's best to mat
 
 Ray supports machines running Apple Silicon (such as M1 macs). Multi-node clusters are untested. To get started with local Ray development:
 
-Install Ray the same way described above, for example:
+Install Ray the same way as described above, for example:
 
 ```shell
 pip install -U "ray[default]"

--- a/doc/source/ray-overview/installation.md
+++ b/doc/source/ray-overview/installation.md
@@ -182,18 +182,6 @@ There are minor variations to the format of the wheel filename; it's best to mat
 * For MacOS x86_64, commits predating August 7, 2021 will have `macosx_10_13` in the filename instead of `macosx_10_15`.
 * For MacOS x86_64, commits predating June 1, 2025 will have `macosx_10_15` in the filename instead of `macosx_12_0`.
 
-(apple-silicon-support)=
-
-## M1 Mac (Apple Silicon) Support
-
-Ray supports machines running Apple Silicon (such as M1 macs). Multi-node clusters are untested. To get started with local Ray development:
-
-Install Ray the same way as described above, for example:
-
-```shell
-pip install -U "ray[default]"
-```
-
 (windows-support)=
 
 ## Windows Support

--- a/doc/source/rllib/index.rst
+++ b/doc/source/rllib/index.rst
@@ -93,11 +93,6 @@ Install RLlib and `PyTorch <https://pytorch.org>`__, as shown below:
 
 .. note::
 
-    For installation on computers running Apple Silicon, such as M1,
-    `follow instructions here. <https://docs.ray.io/en/latest/ray-overview/installation.html#m1-mac-apple-silicon-support>`_
-
-.. note::
-
     To be able to run the Atari or MuJoCo examples, you also need to do:
 
     .. code-block:: bash


### PR DESCRIPTION
## Description

I was getting setup with Ray and noticed the [installation](https://docs.ray.io/en/latest/ray-overview/installation.html#m1-mac-apple-silicon-support) docs recommended installing miniforge and activating conda. Claude Code flagged that this wasn't necessary anymore and I could just do `pip install -U "ray[default]"`, which I tested and does indeed work on my Mac M5.

~This PR removes the extra setup steps for apple silicon macs. I could also see dropping this section of the docs entirely now that installation is the same, but I will leave that decision to the maintainers (it would break anchors to `#m1-mac-apple-silicon-support`).~

This PR removes apple silicon specific instructions.

It looks like https://github.com/ray-project/ray/issues/35472 tracked the changes to actually make the default installation work on apple silicon macs but I am not deeply familiar with Ray.

## Related issues

None.

## Additional information

**AI assistance disclosure:** This change was drafted with the help of Claude Code (an AI coding agent). I (the submitter) reviewed the full diff and the reasoning below, and can defend/discuss it.

**Duplicate-work check:** Searched open PRs on ray-project/ray for `miniforge`, `apple silicon`, `installation.md`, `M1 Mac`, and `arm64 grpcio wheels` — found no other open PR touching this section. Related historical PRs (#57745, #45142, #35932, #25157) are all closed/merged and address different aspects (build-from-source, image bases, unpinning grpcio) rather than this doc section.

**Test commands run and results:**
- `pip install -U "ray[default]"` in a clean virtual environment on an Apple Silicon Mac (macOS, arm64, Python 3.14) — installed prebuilt `arm64`/`universal2` wheels for `ray` and `grpcio` with no source builds and no Conda/Miniforge involved.
- `python -c "import ray; ray.init(); print(ray.cluster_resources()); ray.shutdown()"` — ran successfully, correctly reported local CPU/GPU/memory resources.
- This is a docs-only change (no code), so no unit/release tests apply.