### PR TITLE
[Core] Implement ray.batch() API for batched actor scheduling

### DIFF
--- a/python/ray/__init__.py
+++ b/python/ray/__init__.py
@@ -116,6 +116,7 @@ from ray._private.worker import (  # noqa: E402,F401
     WORKER_MODE,
     RESTORE_WORKER_MODE,
     SPILL_WORKER_MODE,
+    batch,
     cancel,
     get,
     get_actor,
@@ -178,6 +179,7 @@ __all__ = [
     "get_runtime_context",
     "autoscaler",
     "available_resources",
+    "batch",
     "cancel",
     "client",
     "ClientBuilder",
@@ -206,6 +208,7 @@ __all__ = [
 
 # Public APIs that should automatically trigger ray.init().
 AUTO_INIT_APIS = {
+    "batch",
     "cancel",
     "get",
     "get_actor",

--- a/python/ray/_private/worker.py
+++ b/python/ray/_private/worker.py
@@ -3578,6 +3578,22 @@ def cancel(
     return worker.core_worker.cancel_task(ray_waitable, force, recursive)
 
 
+@contextmanager
+def batch():
+    """A context manager for batching actor creation requests.
+
+    When creating actors within this context, actor creation requests are buffered
+    and registered with the GCS in a single batch RPC upon exiting the context.
+    """
+    worker = ray._private.worker.global_worker
+    worker.check_connected()
+    worker.core_worker.enter_actor_batch()
+    try:
+        yield
+    finally:
+        worker.core_worker.exit_actor_batch()
+
+
 def _mode(worker=global_worker):
     """This is a wrapper around worker.mode.
 

--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -4136,6 +4136,14 @@ cdef class CoreWorker:
 
             return ActorID(c_actor_id.Binary())
 
+    def enter_actor_batch(self):
+        with nogil:
+            CCoreWorkerProcess.GetCoreWorker().EnterActorBatch()
+
+    def exit_actor_batch(self):
+        with nogil:
+            CCoreWorkerProcess.GetCoreWorker().ExitActorBatch()
+
     def create_placement_group(
                             self,
                             c_string name,

--- a/python/ray/includes/libcoreworker.pxd
+++ b/python/ray/includes/libcoreworker.pxd
@@ -155,6 +155,8 @@ cdef extern from "ray/core_worker/core_worker.h" nogil:
             const c_string &extension_data,
             c_string call_site,
             CActorID *actor_id)
+        void EnterActorBatch()
+        void ExitActorBatch()
         CRayStatus CreatePlacementGroup(
             const CPlacementGroupCreationOptions &options,
             CPlacementGroupID *placement_group_id)

--- a/python/ray/tests/BUILD.bazel
+++ b/python/ray/tests/BUILD.bazel
@@ -51,6 +51,7 @@ py_test_module_list(
         "test_async.py",
         "test_asyncio.py",
         "test_autoscaler_drain_node_api.py",
+        "test_batch.py",
         "test_component_failures_2.py",
         "test_component_failures_3.py",
         "test_dashboard_profiler.py",

--- a/python/ray/tests/test_batch.py
+++ b/python/ray/tests/test_batch.py
@@ -1,0 +1,307 @@
+import sys
+
+import pytest
+
+import ray
+
+
+def test_basic_batch_actor_creation(shutdown_only):
+    ray.init(num_cpus=4)
+
+    @ray.remote
+    class Counter:
+        def __init__(self, start=0):
+            self.val = start
+
+        def inc(self, step=1):
+            self.val += step
+            return self.val
+
+        def get(self):
+            return self.val
+
+    # Create batch of actors
+    with ray.batch():
+        c1 = Counter.remote(10)
+        c2 = Counter.remote(20)
+        c3 = Counter.remote(30)
+
+    # Verify tasks can be scheduled and executed on each actor
+    res = ray.get([c1.inc.remote(5), c2.inc.remote(10), c3.inc.remote(15)])
+    assert res == [15, 30, 45]
+
+
+def test_heterogeneous_actors_in_batch(shutdown_only):
+    ray.init(num_cpus=4)
+
+    @ray.remote
+    class Adder:
+        def add(self, a, b):
+            return a + b
+
+    @ray.remote
+    class Multiplier:
+        def mul(self, a, b):
+            return a * b
+
+    with ray.batch():
+        adder = Adder.remote()
+        multiplier = Multiplier.remote()
+
+    res = ray.get([adder.add.remote(2, 3), multiplier.mul.remote(4, 5)])
+    assert res == [5, 20]
+
+
+def test_nested_batch(shutdown_only):
+    ray.init(num_cpus=4)
+
+    @ray.remote
+    class Echo:
+        def echo(self, msg):
+            return msg
+
+    with ray.batch():
+        e1 = Echo.remote()
+        with ray.batch():
+            e2 = Echo.remote()
+            with ray.batch():
+                e3 = Echo.remote()
+        e4 = Echo.remote()
+
+    res = ray.get(
+        [
+            e1.echo.remote("a"),
+            e2.echo.remote("b"),
+            e3.echo.remote("c"),
+            e4.echo.remote("d"),
+        ]
+    )
+    assert res == ["a", "b", "c", "d"]
+
+
+def test_empty_batch(shutdown_only):
+    ray.init(num_cpus=2)
+
+    with ray.batch():
+        pass
+
+    @ray.remote
+    class Foo:
+        def ping(self):
+            return "pong"
+
+    f = Foo.remote()
+    assert ray.get(f.ping.remote()) == "pong"
+
+
+def test_batch_with_exception(shutdown_only):
+    ray.init(num_cpus=2)
+
+    @ray.remote
+    class Worker:
+        def ping(self):
+            return "ok"
+
+    with pytest.raises(ValueError, match="intentional error"):
+        with ray.batch():
+            Worker.remote()
+            raise ValueError("intentional error")
+
+    # Ensure system is still in a healthy state for normal actor creation
+    w2 = Worker.remote()
+    assert ray.get(w2.ping.remote()) == "ok"
+
+
+def test_large_batch(shutdown_only):
+    ray.init(num_cpus=4)
+
+    @ray.remote
+    class SimpleActor:
+        def __init__(self, idx):
+            self.idx = idx
+
+        def get_idx(self):
+            return self.idx
+
+    count = 50
+    with ray.batch():
+        actors = [SimpleActor.remote(i) for i in range(count)]
+
+    results = ray.get([a.get_idx.remote() for a in actors])
+    assert results == list(range(count))
+
+
+def test_batch_calls_inside_context(shutdown_only):
+    ray.init(num_cpus=4)
+
+    @ray.remote
+    class Worker:
+        def __init__(self, val):
+            self.val = val
+
+        def get(self):
+            return self.val
+
+    with ray.batch():
+        a1 = Worker.remote(100)
+        ref1 = a1.get.remote()
+        a2 = Worker.remote(200)
+        ref2 = a2.get.remote()
+
+    assert ray.get([ref1, ref2]) == [100, 200]
+
+
+def test_batch_named_and_detached_actors(shutdown_only):
+    ray.init(num_cpus=4)
+
+    @ray.remote
+    class NamedActor:
+        def ping(self):
+            return "pong"
+
+    with ray.batch():
+        a1 = NamedActor.options(name="actor_one").remote()
+        a2 = NamedActor.options(name="actor_two", lifetime="detached").remote()
+
+    assert ray.get(a1.ping.remote()) == "pong"
+    assert ray.get(a2.ping.remote()) == "pong"
+
+    # Verify retrieval by name
+    h1 = ray.get_actor("actor_one")
+    h2 = ray.get_actor("actor_two")
+    assert ray.get(h1.ping.remote()) == "pong"
+    assert ray.get(h2.ping.remote()) == "pong"
+
+
+def test_batch_concurrent_threads(shutdown_only):
+    import threading
+
+    ray.init(num_cpus=8)
+
+    @ray.remote(num_cpus=0.1)
+    class Worker:
+        def __init__(self, tid, idx):
+            self.tid = tid
+            self.idx = idx
+
+        def get(self):
+            return (self.tid, self.idx)
+
+    results = {}
+
+    def thread_worker(tid):
+        with ray.batch():
+            actors = [Worker.remote(tid, i) for i in range(10)]
+        res = ray.get([a.get.remote() for a in actors])
+        results[tid] = res
+
+    threads = [threading.Thread(target=thread_worker, args=(i,)) for i in range(4)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    for tid in range(4):
+        assert results[tid] == [(tid, i) for i in range(10)]
+
+
+def test_batch_placement_group(shutdown_only):
+    ray.init(num_cpus=4)
+    pg = ray.util.placement_group([{"CPU": 1}, {"CPU": 1}])
+    ray.get(pg.ready())
+
+    @ray.remote(num_cpus=1)
+    class PGActor:
+        def get_id(self, idx):
+            return idx
+
+    with ray.batch():
+        a1 = PGActor.options(
+            scheduling_strategy=ray.util.scheduling_strategies.PlacementGroupSchedulingStrategy(
+                placement_group=pg, placement_group_bundle_index=0
+            )
+        ).remote()
+        a2 = PGActor.options(
+            scheduling_strategy=ray.util.scheduling_strategies.PlacementGroupSchedulingStrategy(
+                placement_group=pg, placement_group_bundle_index=1
+            )
+        ).remote()
+
+    assert ray.get([a1.get_id.remote(1), a2.get_id.remote(2)]) == [1, 2]
+
+
+def test_batch_performance_comparison(shutdown_only):
+    import time
+
+    ray.init(num_cpus=4)
+
+    @ray.remote(num_cpus=0)
+    class BenchActor:
+        def ping(self):
+            return 1
+
+    num_actors = 100
+
+    start_seq = time.time()
+    seq_actors = [BenchActor.remote() for _ in range(num_actors)]
+    ray.get([a.ping.remote() for a in seq_actors])
+    seq_duration = time.time() - start_seq
+
+    start_batch = time.time()
+    with ray.batch():
+        batch_actors = [BenchActor.remote() for _ in range(num_actors)]
+    ray.get([a.ping.remote() for a in batch_actors])
+    batch_duration = time.time() - start_batch
+
+    print(
+        f"Sequential: {seq_duration:.3f}s, Batch: {batch_duration:.3f}s for {num_actors} actors"
+    )
+    assert len(batch_actors) == num_actors
+
+
+def test_batch_auto_init(shutdown_only):
+    # Ensure ray is shut down
+    if ray.is_initialized():
+        ray.shutdown()
+
+    @ray.remote
+    class InitTestActor:
+        def ping(self):
+            return "pong"
+
+    # with ray.batch() should auto-init ray
+    with ray.batch():
+        a = InitTestActor.remote()
+
+    assert ray.is_initialized()
+    assert ray.get(a.ping.remote()) == "pong"
+
+
+if __name__ == "__main__":
+    if len(sys.argv) > 1 and sys.argv[1] == "run_all":
+        for test_fn in [
+            test_basic_batch_actor_creation,
+            test_heterogeneous_actors_in_batch,
+            test_nested_batch,
+            test_empty_batch,
+            test_batch_with_exception,
+            test_large_batch,
+            test_batch_calls_inside_context,
+            test_batch_named_and_detached_actors,
+            test_batch_concurrent_threads,
+            test_batch_placement_group,
+            test_batch_performance_comparison,
+            test_batch_auto_init,
+        ]:
+            print(f"Running {test_fn.__name__}...")
+            if ray.is_initialized():
+                ray.shutdown()
+            try:
+                test_fn(None)
+                print(f"  {test_fn.__name__} PASSED")
+            finally:
+                if ray.is_initialized():
+                    ray.shutdown()
+        print("All tests PASSED!")
+    else:
+        sys.exit(pytest.main(["-v", __file__]))

--- a/python/ray/tests/test_top_level_api.py
+++ b/python/ray/tests/test_top_level_api.py
@@ -33,6 +33,7 @@ def test_api_functions():
         "java_function",
         "java_actor_class",
         "client",
+        "batch",
     ]
 
     OTHER_ALLOWED_FUNCTIONS = [

--- a/src/mock/ray/gcs_client/accessors/actor_info_accessor.h
+++ b/src/mock/ray/gcs_client/accessors/actor_info_accessor.h
@@ -63,6 +63,11 @@ class FakeActorInfoAccessor : public gcs::ActorInfoAccessorInterface {
                           int64_t = -1) override {
     async_register_actor_callback_ = callback;
   }
+  void AsyncRegisterActorBatch(const std::vector<TaskSpecification> &task_specs,
+                               const rpc::StatusCallback &callback,
+                               int64_t = -1) override {
+    async_register_actor_batch_callback_ = callback;
+  }
   void AsyncRestartActorForLineageReconstruction(const ActorID &,
                                                  uint64_t,
                                                  const rpc::StatusCallback &,
@@ -134,6 +139,7 @@ class FakeActorInfoAccessor : public gcs::ActorInfoAccessorInterface {
   // Callbacks for AsyncCreateActor and AsyncRegisterActor
   rpc::ClientCallback<rpc::CreateActorReply> async_create_actor_callback_;
   rpc::StatusCallback async_register_actor_callback_;
+  rpc::StatusCallback async_register_actor_batch_callback_;
   Status sync_register_actor_status_ = Status::OK();
 };
 

--- a/src/ray/core_worker/actor_management/actor_creator.cc
+++ b/src/ray/core_worker/actor_management/actor_creator.cc
@@ -49,6 +49,38 @@ void ActorCreator::AsyncRegisterActor(const TaskSpecification &task_spec,
   });
 }
 
+void ActorCreator::AsyncRegisterActorBatch(
+    const std::vector<TaskSpecification> &task_specs, rpc::StatusCallback callback) {
+  if (task_specs.empty()) {
+    if (callback != nullptr) {
+      callback(Status::OK());
+    }
+    return;
+  }
+  for (const auto &task_spec : task_specs) {
+    auto actor_id = task_spec.ActorCreationId();
+    (*registering_actors_)[actor_id] = {};
+  }
+  actor_client_.AsyncRegisterActorBatch(
+      task_specs, [task_specs, callback = std::move(callback), this](Status status) {
+        for (const auto &task_spec : task_specs) {
+          auto actor_id = task_spec.ActorCreationId();
+          std::vector<rpc::StatusCallback> cbs;
+          auto it = registering_actors_->find(actor_id);
+          if (it != registering_actors_->end()) {
+            cbs = std::move(it->second);
+            registering_actors_->erase(it);
+          }
+          for (auto &cb : cbs) {
+            cb(status);
+          }
+        }
+        if (callback != nullptr) {
+          callback(status);
+        }
+      });
+}
+
 void ActorCreator::AsyncRestartActorForLineageReconstruction(
     const ActorID &actor_id,
     uint64_t num_restarts_due_to_lineage_reconstructions,

--- a/src/ray/core_worker/actor_management/actor_creator.h
+++ b/src/ray/core_worker/actor_management/actor_creator.h
@@ -40,6 +40,13 @@ class ActorCreatorInterface {
   virtual void AsyncRegisterActor(const TaskSpecification &task_spec,
                                   rpc::StatusCallback callback) = 0;
 
+  /// Asynchronously request GCS to register a batch of actors.
+  /// \param task_specs The specifications for the actor creation tasks.
+  /// \param callback Callback that will be called after all actors in the batch are
+  /// registered
+  virtual void AsyncRegisterActorBatch(const std::vector<TaskSpecification> &task_specs,
+                                       rpc::StatusCallback callback) = 0;
+
   virtual void AsyncRestartActorForLineageReconstruction(
       const ActorID &actor_id,
       uint64_t num_restarts_due_to_lineage_reconstructions,
@@ -81,6 +88,9 @@ class ActorCreator : public ActorCreatorInterface {
 
   void AsyncRegisterActor(const TaskSpecification &task_spec,
                           rpc::StatusCallback callback) override;
+
+  void AsyncRegisterActorBatch(const std::vector<TaskSpecification> &task_specs,
+                               rpc::StatusCallback callback) override;
 
   void AsyncRestartActorForLineageReconstruction(
       const ActorID &actor_id,

--- a/src/ray/core_worker/actor_management/fake_actor_creator.h
+++ b/src/ray/core_worker/actor_management/fake_actor_creator.h
@@ -33,6 +33,13 @@ class FakeActorCreator : public ActorCreatorInterface {
   void AsyncRegisterActor(const TaskSpecification &task_spec,
                           rpc::StatusCallback callback) override {}
 
+  void AsyncRegisterActorBatch(const std::vector<TaskSpecification> &task_specs,
+                               rpc::StatusCallback callback) override {
+    if (callback) {
+      callbacks.push_back(callback);
+    }
+  }
+
   void AsyncRestartActorForLineageReconstruction(
       const ActorID &actor_id,
       uint64_t num_restarts_due_to_lineage_reconstructions,

--- a/src/ray/core_worker/actor_management/tests/actor_creator_test.cc
+++ b/src/ray/core_worker/actor_management/tests/actor_creator_test.cc
@@ -73,5 +73,108 @@ TEST_F(ActorCreatorTest, AsyncWaitForFinish) {
   ASSERT_EQ(11, count);
 }
 
+TEST_F(ActorCreatorTest, AsyncRegisterActorBatch) {
+  auto actor_id1 = ActorID::FromHex("f4ce02420592ca68c1738a0d01000000");
+  auto actor_id2 = ActorID::FromHex("f4ce02420592ca68c1738a0d02000000");
+  auto task_spec1 = GetTaskSpec(actor_id1);
+  auto task_spec2 = GetTaskSpec(actor_id2);
+
+  ASSERT_FALSE(actor_creator->IsActorInRegistering(actor_id1));
+  ASSERT_FALSE(actor_creator->IsActorInRegistering(actor_id2));
+
+  int batch_cb_count = 0;
+  actor_creator->AsyncRegisterActorBatch({task_spec1, task_spec2},
+                                         [&batch_cb_count](Status status) {
+                                           ASSERT_TRUE(status.ok());
+                                           batch_cb_count++;
+                                         });
+
+  ASSERT_TRUE(actor_creator->IsActorInRegistering(actor_id1));
+  ASSERT_TRUE(actor_creator->IsActorInRegistering(actor_id2));
+
+  ASSERT_TRUE(gcs_client->mock_actor_accessor->async_register_actor_batch_callback_ !=
+              nullptr);
+  gcs_client->mock_actor_accessor->async_register_actor_batch_callback_(Status::OK());
+
+  ASSERT_FALSE(actor_creator->IsActorInRegistering(actor_id1));
+  ASSERT_FALSE(actor_creator->IsActorInRegistering(actor_id2));
+  ASSERT_EQ(1, batch_cb_count);
+}
+
+TEST_F(ActorCreatorTest, AsyncRegisterActorBatchEmpty) {
+  int batch_cb_count = 0;
+  actor_creator->AsyncRegisterActorBatch({}, [&batch_cb_count](Status status) {
+    ASSERT_TRUE(status.ok());
+    batch_cb_count++;
+  });
+  ASSERT_EQ(1, batch_cb_count);
+}
+
+TEST_F(ActorCreatorTest, AsyncRegisterActorBatchWithWaiters) {
+  auto actor_id1 = ActorID::FromHex("f4ce02420592ca68c1738a0d01000000");
+  auto actor_id2 = ActorID::FromHex("f4ce02420592ca68c1738a0d02000000");
+  auto task_spec1 = GetTaskSpec(actor_id1);
+  auto task_spec2 = GetTaskSpec(actor_id2);
+
+  int batch_cb_count = 0;
+  int waiter1_cb_count = 0;
+  int waiter2_cb_count = 0;
+
+  actor_creator->AsyncRegisterActorBatch({task_spec1, task_spec2},
+                                         [&batch_cb_count](Status status) {
+                                           ASSERT_TRUE(status.ok());
+                                           batch_cb_count++;
+                                         });
+
+  actor_creator->AsyncWaitForActorRegisterFinish(actor_id1,
+                                                 [&waiter1_cb_count](Status status) {
+                                                   ASSERT_TRUE(status.ok());
+                                                   waiter1_cb_count++;
+                                                 });
+  actor_creator->AsyncWaitForActorRegisterFinish(actor_id2,
+                                                 [&waiter2_cb_count](Status status) {
+                                                   ASSERT_TRUE(status.ok());
+                                                   waiter2_cb_count++;
+                                                 });
+
+  ASSERT_TRUE(gcs_client->mock_actor_accessor->async_register_actor_batch_callback_ !=
+              nullptr);
+  gcs_client->mock_actor_accessor->async_register_actor_batch_callback_(Status::OK());
+
+  ASSERT_EQ(1, batch_cb_count);
+  ASSERT_EQ(1, waiter1_cb_count);
+  ASSERT_EQ(1, waiter2_cb_count);
+  ASSERT_FALSE(actor_creator->IsActorInRegistering(actor_id1));
+  ASSERT_FALSE(actor_creator->IsActorInRegistering(actor_id2));
+}
+
+TEST_F(ActorCreatorTest, AsyncRegisterActorBatchFailure) {
+  auto actor_id1 = ActorID::FromHex("f4ce02420592ca68c1738a0d01000000");
+  auto task_spec1 = GetTaskSpec(actor_id1);
+
+  int batch_cb_count = 0;
+  int waiter_cb_count = 0;
+
+  actor_creator->AsyncRegisterActorBatch({task_spec1}, [&batch_cb_count](Status status) {
+    ASSERT_TRUE(status.IsIOError());
+    batch_cb_count++;
+  });
+
+  actor_creator->AsyncWaitForActorRegisterFinish(actor_id1,
+                                                 [&waiter_cb_count](Status status) {
+                                                   ASSERT_TRUE(status.IsIOError());
+                                                   waiter_cb_count++;
+                                                 });
+
+  ASSERT_TRUE(gcs_client->mock_actor_accessor->async_register_actor_batch_callback_ !=
+              nullptr);
+  gcs_client->mock_actor_accessor->async_register_actor_batch_callback_(
+      Status::IOError("GCS error"));
+
+  ASSERT_EQ(1, batch_cb_count);
+  ASSERT_EQ(1, waiter_cb_count);
+  ASSERT_FALSE(actor_creator->IsActorInRegistering(actor_id1));
+}
+
 }  // namespace core
 }  // namespace ray

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -57,6 +57,9 @@ using MessageType = ray::protocol::MessageType;
 namespace ray::core {
 
 namespace {
+thread_local int64_t actor_batch_depth = 0;
+thread_local std::vector<TaskSpecification> actor_batch_buffer;
+
 // Default capacity for serialization caches.
 constexpr size_t kDefaultSerializationCacheCap = 500;
 
@@ -2312,6 +2315,11 @@ Status CoreWorker::CreateActor(const RayFunction &function,
       // Actor creation task retry happens on GCS not on core worker.
       /*max_retries=*/0);
 
+  if (actor_batch_depth > 0) {
+    actor_batch_buffer.push_back(std::move(task_spec));
+    return Status::OK();
+  }
+
   if (actor_name.empty()) {
     io_service_.post(
         [this, task_spec = std::move(task_spec)]() {
@@ -2348,6 +2356,38 @@ Status CoreWorker::CreateActor(const RayFunction &function,
         "CoreWorker.SubmitTask");
   }
   return Status::OK();
+}
+
+void CoreWorker::EnterActorBatch() { ++actor_batch_depth; }
+
+void CoreWorker::ExitActorBatch() {
+  if (actor_batch_depth > 0) {
+    --actor_batch_depth;
+  }
+  if (actor_batch_depth > 0) {
+    return;
+  }
+  if (actor_batch_buffer.empty()) {
+    return;
+  }
+  auto batch = std::move(actor_batch_buffer);
+  actor_batch_buffer.clear();
+  io_service_.post(
+      [this, batch = std::move(batch)]() {
+        actor_creator_->AsyncRegisterActorBatch(batch, [this, batch](Status status) {
+          for (const auto &task_spec : batch) {
+            if (!status.ok()) {
+              RAY_LOG(ERROR).WithField(task_spec.ActorCreationId())
+                  << "Failed to register actor in batch. Error message: " << status;
+              task_manager_->FailPendingTask(
+                  task_spec.TaskId(), rpc::ErrorType::ACTOR_CREATION_FAILED, &status);
+            } else {
+              actor_task_submitter_->SubmitActorCreationTask(task_spec);
+            }
+          }
+        });
+      },
+      "ActorCreator.AsyncRegisterActorBatch");
 }
 
 Status CoreWorker::CreatePlacementGroup(

--- a/src/ray/core_worker/core_worker.h
+++ b/src/ray/core_worker/core_worker.h
@@ -1038,6 +1038,12 @@ class CoreWorker : public std::enable_shared_from_this<CoreWorker> {
                      const std::string &call_site,
                      ActorID *actor_id);
 
+  /// Enter actor batch mode for the current thread.
+  void EnterActorBatch();
+
+  /// Exit actor batch mode for the current thread and flush buffered actor creations.
+  void ExitActorBatch();
+
   /// Create a placement group.
   ///
   /// \param[in] function The remote function that generates the placement group object.

--- a/src/ray/gcs/actor/gcs_actor_manager.cc
+++ b/src/ray/gcs/actor/gcs_actor_manager.cc
@@ -337,6 +337,54 @@ void GcsActorManager::HandleRegisterActor(rpc::RegisterActorRequest request,
   ++counts_[CountType::REGISTER_ACTOR_REQUEST];
 }
 
+void GcsActorManager::HandleRegisterActorBatch(
+    rpc::RegisterActorBatchRequest request,
+    rpc::RegisterActorBatchReply *reply,
+    rpc::SendReplyCallback send_reply_callback) {
+  const int total_tasks = request.task_specs_size();
+  RAY_LOG(INFO) << "Registering actor batch of size " << total_tasks;
+  if (total_tasks == 0) {
+    GCS_RPC_SEND_REPLY(send_reply_callback, reply, Status::OK());
+    return;
+  }
+
+  auto pending_count = std::make_shared<size_t>(total_tasks);
+  auto first_error = std::make_shared<Status>(Status::OK());
+
+  for (int i = 0; i < total_tasks; ++i) {
+    rpc::RegisterActorRequest single_request;
+    single_request.mutable_task_spec()->Swap(request.mutable_task_specs(i));
+    RAY_CHECK(single_request.task_spec().type() == TaskType::ACTOR_CREATION_TASK);
+    auto actor_id = ActorID::FromBinary(
+        single_request.task_spec().actor_creation_task_spec().actor_id());
+
+    auto on_done = [reply, send_reply_callback, pending_count, first_error, actor_id](
+                       const Status &status) {
+      if (!status.ok()) {
+        RAY_LOG(WARNING).WithField(actor_id.JobId()).WithField(actor_id)
+            << "Failed to register actor in batch: " << status.ToString();
+        if (first_error->ok()) {
+          *first_error = status;
+        }
+      } else {
+        RAY_LOG(INFO).WithField(actor_id.JobId()).WithField(actor_id)
+            << "Registered actor in batch";
+      }
+      (*pending_count)--;
+      if (*pending_count == 0) {
+        const auto &reply_status = *first_error;
+        GCS_RPC_SEND_REPLY(send_reply_callback, reply, reply_status);
+      }
+    };
+
+    Status status = RegisterActor(single_request, on_done);
+    if (!status.ok()) {
+      on_done(status);
+    }
+  }
+  counts_[CountType::REGISTER_ACTOR_REQUEST] += total_tasks;
+}
+
 void GcsActorManager::HandleRestartActorForLineageReconstruction(
     rpc::RestartActorForLineageReconstructionRequest request,
     rpc::RestartActorForLineageReconstructionReply *reply,

--- a/src/ray/gcs/actor/gcs_actor_manager.h
+++ b/src/ray/gcs/actor/gcs_actor_manager.h
@@ -123,6 +123,10 @@ class GcsActorManager : public rpc::ActorInfoGcsServiceHandler,
                            rpc::RegisterActorReply *reply,
                            rpc::SendReplyCallback send_reply_callback) override;
 
+  void HandleRegisterActorBatch(rpc::RegisterActorBatchRequest request,
+                                rpc::RegisterActorBatchReply *reply,
+                                rpc::SendReplyCallback send_reply_callback) override;
+
   void HandleRestartActorForLineageReconstruction(
       rpc::RestartActorForLineageReconstructionRequest request,
       rpc::RestartActorForLineageReconstructionReply *reply,

--- a/src/ray/gcs/actor/tests/gcs_actor_manager_test.cc
+++ b/src/ray/gcs/actor/tests/gcs_actor_manager_test.cc
@@ -2622,6 +2622,88 @@ TEST_F(GcsActorManagerTest, TestInitializeRestoresLocalRayletAddressForAliveActo
   ASSERT_EQ(local_raylet_address->port(), 9999);
 }
 
+TEST_F(GcsActorManagerTest, TestHandleRegisterActorBatch) {
+  // Test 1: Empty batch
+  {
+    rpc::RegisterActorBatchRequest empty_request;
+    rpc::RegisterActorBatchReply empty_reply;
+    bool callback_invoked = false;
+    gcs_actor_manager_->HandleRegisterActorBatch(
+        empty_request,
+        &empty_reply,
+        [&callback_invoked](
+            Status status, std::function<void()> success, std::function<void()> failure) {
+          callback_invoked = true;
+          ASSERT_TRUE(status.ok());
+        });
+    ASSERT_TRUE(callback_invoked);
+  }
+
+  // Test 2: Valid batch with multiple actors
+  auto job_id = JobID::FromInt(1);
+  auto register_request1 =
+      GenRegisterActorRequest(job_id, /*max_restarts=*/-1, /*detached=*/false);
+  auto register_request2 =
+      GenRegisterActorRequest(job_id, /*max_restarts=*/-1, /*detached=*/false);
+  auto actor_id1 = ActorID::FromBinary(
+      register_request1.task_spec().actor_creation_task_spec().actor_id());
+  auto actor_id2 = ActorID::FromBinary(
+      register_request2.task_spec().actor_creation_task_spec().actor_id());
+
+  rpc::RegisterActorBatchRequest batch_request;
+  batch_request.add_task_specs()->CopyFrom(register_request1.task_spec());
+  batch_request.add_task_specs()->CopyFrom(register_request2.task_spec());
+
+  rpc::RegisterActorBatchReply batch_reply;
+  bool callback_invoked = false;
+  gcs_actor_manager_->HandleRegisterActorBatch(
+      batch_request,
+      &batch_reply,
+      [&callback_invoked](
+          Status status, std::function<void()> success, std::function<void()> failure) {
+        callback_invoked = true;
+        ASSERT_TRUE(status.ok());
+      });
+  drain_io_context();
+  ASSERT_TRUE(callback_invoked);
+  ASSERT_EQ(RegisteredActorCount(*gcs_actor_manager_), 2u);
+  auto actor1 = GetRegisteredActor(*gcs_actor_manager_, actor_id1);
+  auto actor2 = GetRegisteredActor(*gcs_actor_manager_, actor_id2);
+  ASSERT_NE(actor1, nullptr);
+  ASSERT_NE(actor2, nullptr);
+  ASSERT_EQ(actor1->GetState(), rpc::ActorTableData::DEPENDENCIES_UNREADY);
+  ASSERT_EQ(actor2->GetState(), rpc::ActorTableData::DEPENDENCIES_UNREADY);
+
+  // Test 3: Batch with duplicate named actors should report error
+  {
+    std::string name = "duplicated_actor";
+    std::string ray_ns = "test_ns";
+    auto req_dup1 = GenRegisterActorRequest(job_id, 0, false, name, ray_ns);
+    auto req_dup2 = GenRegisterActorRequest(job_id, 0, false, name, ray_ns);
+
+    rpc::RegisterActorBatchRequest dup_batch_request;
+    dup_batch_request.add_task_specs()->CopyFrom(req_dup1.task_spec());
+    dup_batch_request.add_task_specs()->CopyFrom(req_dup2.task_spec());
+
+    rpc::RegisterActorBatchReply dup_batch_reply;
+    bool dup_callback_invoked = false;
+    Status dup_status = Status::OK();
+    gcs_actor_manager_->HandleRegisterActorBatch(
+        dup_batch_request,
+        &dup_batch_reply,
+        [&dup_callback_invoked, &dup_status](
+            Status status, std::function<void()> success, std::function<void()> failure) {
+          dup_callback_invoked = true;
+          dup_status = status;
+        });
+    drain_io_context();
+    ASSERT_TRUE(dup_callback_invoked);
+    ASSERT_TRUE(dup_status.ok());
+    ASSERT_EQ(dup_batch_reply.status().code(),
+              static_cast<int>(StatusCode::AlreadyExists));
+  }
+}
+
 }  // namespace gcs
 
 }  // namespace ray

--- a/src/ray/gcs/grpc_service_interfaces.h
+++ b/src/ray/gcs/grpc_service_interfaces.h
@@ -29,9 +29,9 @@
 namespace ray {
 namespace rpc {
 
-#define GCS_RPC_SEND_REPLY(send_reply_callback, reply, status)        \
-  reply->mutable_status()->set_code(static_cast<int>(status.code())); \
-  reply->mutable_status()->set_message(status.message());             \
+#define GCS_RPC_SEND_REPLY(send_reply_callback, reply, status)          \
+  reply->mutable_status()->set_code(static_cast<int>((status).code())); \
+  reply->mutable_status()->set_message((status).message());             \
   send_reply_callback(ray::Status::OK(), nullptr, nullptr)
 
 class ActorInfoGcsServiceHandler {
@@ -41,6 +41,10 @@ class ActorInfoGcsServiceHandler {
   virtual void HandleRegisterActor(RegisterActorRequest request,
                                    RegisterActorReply *reply,
                                    SendReplyCallback send_reply_callback) = 0;
+
+  virtual void HandleRegisterActorBatch(RegisterActorBatchRequest request,
+                                        RegisterActorBatchReply *reply,
+                                        SendReplyCallback send_reply_callback) = 0;
 
   virtual void HandleRestartActorForLineageReconstruction(
       RestartActorForLineageReconstructionRequest request,

--- a/src/ray/gcs/grpc_services.cc
+++ b/src/ray/gcs/grpc_services.cc
@@ -28,6 +28,7 @@ void ActorInfoGrpcService::InitServerCallFactories(
   /// The register & create actor RPCs take a long time, so we shouldn't limit their
   /// concurrency to avoid distributed deadlock.
   RPC_SERVICE_HANDLER(ActorInfoGcsService, RegisterActor, -1)
+  RPC_SERVICE_HANDLER(ActorInfoGcsService, RegisterActorBatch, -1)
   RPC_SERVICE_HANDLER(ActorInfoGcsService, CreateActor, -1)
   RPC_SERVICE_HANDLER(ActorInfoGcsService, RestartActorForLineageReconstruction, -1)
 

--- a/src/ray/gcs_rpc_client/accessors/actor_info_accessor.cc
+++ b/src/ray/gcs_rpc_client/accessors/actor_info_accessor.cc
@@ -194,6 +194,24 @@ void ActorInfoAccessor::AsyncRegisterActor(const ray::TaskSpecification &task_sp
       timeout_ms);
 }
 
+void ActorInfoAccessor::AsyncRegisterActorBatch(
+    const std::vector<TaskSpecification> &task_specs,
+    const rpc::StatusCallback &callback,
+    int64_t timeout_ms) {
+  RAY_CHECK(callback);
+  rpc::RegisterActorBatchRequest request;
+  for (const auto &task_spec : task_specs) {
+    RAY_CHECK(task_spec.IsActorCreationTask());
+    request.add_task_specs()->CopyFrom(task_spec.GetMessage());
+  }
+  context_->GetGcsRpcClient().RegisterActorBatch(
+      std::move(request),
+      [callback](const Status &status, rpc::RegisterActorBatchReply &&reply) {
+        callback(ComputeGcsStatus(status, reply.status()));
+      },
+      timeout_ms);
+}
+
 Status ActorInfoAccessor::SyncRegisterActor(const ray::TaskSpecification &task_spec) {
   RAY_CHECK(task_spec.IsActorCreationTask());
   rpc::RegisterActorRequest request;

--- a/src/ray/gcs_rpc_client/accessors/actor_info_accessor.h
+++ b/src/ray/gcs_rpc_client/accessors/actor_info_accessor.h
@@ -134,6 +134,10 @@ class ActorInfoAccessor : public ActorInfoAccessorInterface {
                           const rpc::StatusCallback &callback,
                           int64_t timeout_ms = -1) override;
 
+  void AsyncRegisterActorBatch(const std::vector<TaskSpecification> &task_specs,
+                               const rpc::StatusCallback &callback,
+                               int64_t timeout_ms = -1) override;
+
   /**
     Restart actor for lineage reconstruction asynchronously.
 

--- a/src/ray/gcs_rpc_client/accessors/actor_info_accessor_interface.h
+++ b/src/ray/gcs_rpc_client/accessors/actor_info_accessor_interface.h
@@ -130,6 +130,17 @@ class ActorInfoAccessorInterface {
                                   int64_t timeout_ms = -1) = 0;
 
   /**
+    Register actor batch asynchronously.
+
+    @param task_specs The specifications for the actor creation tasks.
+    @param callback Callback that will be called after the actors are registered.
+    @param timeout_ms Timeout ms. -1 means there's no timeout.
+   */
+  virtual void AsyncRegisterActorBatch(const std::vector<TaskSpecification> &task_specs,
+                                       const rpc::StatusCallback &callback,
+                                       int64_t timeout_ms = -1) = 0;
+
+  /**
   Restart actor for lineage reconstruction asynchronously.
 
   @param actor_id The ID of the actor.

--- a/src/ray/gcs_rpc_client/rpc_client.h
+++ b/src/ray/gcs_rpc_client/rpc_client.h
@@ -280,6 +280,12 @@ class GcsRpcClient {
                              actor_info_grpc_client_,
                              /*method_timeout_ms*/ -1, )
 
+  /// Register actor batch via GCS Service.
+  VOID_GCS_RPC_CLIENT_METHOD(ActorInfoGcsService,
+                             RegisterActorBatch,
+                             actor_info_grpc_client_,
+                             /*method_timeout_ms*/ -1, )
+
   VOID_GCS_RPC_CLIENT_METHOD(ActorInfoGcsService,
                              ReportActorOutOfScope,
                              actor_info_grpc_client_,

--- a/src/ray/gcs_rpc_client/tests/gcs_client_injectable_test.cc
+++ b/src/ray/gcs_rpc_client/tests/gcs_client_injectable_test.cc
@@ -131,6 +131,9 @@ class TestActorInfoAccessor : public ActorInfoAccessorInterface {
   void AsyncRegisterActor(const TaskSpecification &task_spec,
                           const rpc::StatusCallback &callback,
                           int64_t timeout_ms = -1) override {}
+  void AsyncRegisterActorBatch(const std::vector<TaskSpecification> &task_specs,
+                               const rpc::StatusCallback &callback,
+                               int64_t timeout_ms = -1) override {}
   void AsyncRestartActorForLineageReconstruction(
       const ActorID &actor_id,
       uint64_t num_restarts_due_to_lineage_reconstructions,

--- a/src/ray/protobuf/gcs_service.proto
+++ b/src/ray/protobuf/gcs_service.proto
@@ -179,6 +179,8 @@ message ReportActorOutOfScopeReply {
 service ActorInfoGcsService {
   // Register actor to gcs service.
   rpc RegisterActor(RegisterActorRequest) returns (RegisterActorReply);
+  // Register actor batch to gcs service.
+  rpc RegisterActorBatch(RegisterActorBatchRequest) returns (RegisterActorBatchReply);
   rpc RestartActorForLineageReconstruction(RestartActorForLineageReconstructionRequest)
       returns (RestartActorForLineageReconstructionReply);
   // Create actor which local dependencies are resolved.
@@ -419,6 +421,14 @@ message RegisterActorRequest {
 }
 
 message RegisterActorReply {
+  GcsStatus status = 1;
+}
+
+message RegisterActorBatchRequest {
+  repeated TaskSpec task_specs = 1;
+}
+
+message RegisterActorBatchReply {
   GcsStatus status = 1;
 }
 


### PR DESCRIPTION
Introduces the ray.batch() context manager API for scheduling Ray actors in batches, reducing GCS RPC overhead by registering actor creation requests in a single batch RPC rather than one-by-one.

- Protobuf: Added RegisterActorBatch RPC, RegisterActorBatchRequest, and RegisterActorBatchReply in ActorInfoGcsService.
- GCS Service: Implemented HandleRegisterActorBatch in GcsActorManager to process and register batches of actors atomically.
- GCS Client & Accessors: Added AsyncRegisterActorBatch to ActorInfoAccessor and ActorCreator.
- CoreWorker: Added EnterActorBatch() and ExitActorBatch() with thread-local buffering to defer registration until batch context exit, followed by submitting creation tasks upon registration completion.
- Python API: Exposed CCoreWorker bindings in Cython and added ray.batch() context manager in worker.py and public ray namespace.
- Unit Tests: Added C++ unit tests in gcs_actor_manager_test and actor_creator_test, and Python unit tests in test_batch.py.

## Description
> Briefly describe what this PR accomplishes and why it's needed.

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
