### PR TITLE
[serve] Deflake test_metrics_2 metric waits

### DIFF
--- a/python/ray/serve/tests/test_metrics_2.py
+++ b/python/ray/serve/tests/test_metrics_2.py
@@ -143,9 +143,22 @@ class TestRequestContextMetrics:
             timeout=PROMETHEUS_METRICS_TIMEOUT_S,
         )
 
+    def _wait_for_exports(self, metric_names, timeseries):
+        """One debut budget covering every series; a first export is the slow
+        step, and gating each name separately would take one budget apiece."""
+
+        def check():
+            samples = self._scrape(timeseries)
+            for name in metric_names:
+                assert samples[name], f"Metric {name} not exported yet"
+            return True
+
+        wait_for_metric(check, budget_s=METRICS_FIRST_EXPORT_TIMEOUT_S)
+
     def _wait_for_metric_summary(self, metric_names, expected, timeseries):
         """Deployments export independently, so wait for all of them rather than
         asserting on whichever happen to have reported already."""
+        self._wait_for_exports(metric_names, timeseries)
 
         def check():
             samples = self._scrape(timeseries)
@@ -188,6 +201,7 @@ class TestRequestContextMetrics:
     def _wait_for_proxy_routes(self, metric_names, expected_routes, timeseries):
         """Proxy metrics export on their own cycle, so they can still be missing
         once the deployment metrics waited on above have arrived."""
+        self._wait_for_exports(metric_names, timeseries)
 
         def check():
             samples = self._scrape(timeseries)
@@ -684,6 +698,7 @@ class TestHandleMetrics:
             # call.remote("WaitForSignal", "app1")
             # c.call.remote()
             caller.call.remote()
+            wait_for_metric_export("ray_serve_deployment_queued_queries", timeseries)
             wait_for_metric(
                 check_sum_metric_eq,
                 metric_name="ray_serve_deployment_queued_queries",
@@ -919,6 +934,9 @@ class TestHandleMetrics:
             print(f"Sending request to d{index}")
             call.remote("Router", "app1", index)
             requests_sent[index] += 1
+            wait_for_metric_export(
+                "ray_serve_num_ongoing_requests_at_replicas", timeseries
+            )
 
             wait_for_metric(
                 check_sum_metric_eq,

--- a/python/ray/serve/tests/test_metrics_2.py
+++ b/python/ray/serve/tests/test_metrics_2.py
@@ -104,18 +104,25 @@ class TestRequestContextMetrics:
         for key in expected_output:
             assert metric[key] == expected_output[key]
 
-    def _wait_for_metric_summary(self, metric_name, expected, timeseries):
+    def _scrape(self, timeseries):
+        return fetch_prometheus_metric_timeseries(
+            ["localhost:9999"], timeseries, timeout=PROMETHEUS_METRICS_TIMEOUT_S
+        )
+
+    def _wait_for_metric_summary(self, metric_names, expected, timeseries):
         """Deployments export independently, so wait for all of them rather than
         asserting on whichever happen to have reported already."""
 
         def check():
-            routes, apps = self._generate_metrics_summary(
-                get_metric_dictionaries(metric_name, timeseries=timeseries, wait=False)
-            )
-            msg = f"Incorrect metrics for {metric_name}"
-            for deployment, (route, app) in expected.items():
-                assert routes[deployment] == route, msg
-                assert apps[deployment] == app, msg
+            samples = self._scrape(timeseries)
+            for name in metric_names:
+                routes, apps = self._generate_metrics_summary(
+                    [sample.labels for sample in samples[name]]
+                )
+                msg = f"Incorrect metrics for {name}"
+                for deployment, (route, app) in expected.items():
+                    assert routes[deployment] == route, msg
+                    assert apps[deployment] == app, msg
             return True
 
         wait_for_metric(check)
@@ -125,7 +132,7 @@ class TestRequestContextMetrics:
     ):
         """Waits for app name and route to appear in deployment's metric."""
         self._wait_for_metric_summary(
-            metric_name, {deployment_name: ({route}, app_name)}, timeseries
+            [metric_name], {deployment_name: ({route}, app_name)}, timeseries
         )
 
     def _wait_for_labeled_metric(self, metric_name, expected_labels, timeseries):
@@ -145,29 +152,26 @@ class TestRequestContextMetrics:
     def _wait_for_proxy_routes(self, metric_names, expected_routes, timeseries):
         """Proxy metrics export on their own cycle, so they can still be missing
         once the deployment metrics waited on above have arrived."""
-        for metric_name in metric_names:
 
-            def check(name=metric_name):
-                routes = {
-                    sample.labels["route"]
-                    for sample in fetch_prometheus_metric_timeseries(
-                        ["localhost:9999"],
-                        timeseries,
-                        timeout=PROMETHEUS_METRICS_TIMEOUT_S,
-                    )[name]
-                }
+        def check():
+            samples = self._scrape(timeseries)
+            for name in metric_names:
+                routes = {sample.labels["route"] for sample in samples[name]}
                 assert routes == expected_routes, f"Incorrect routes for {name}"
-                return True
+            return True
 
-            wait_for_metric(check)
+        wait_for_metric(check)
 
     def _wait_for_handle_metrics(self, expected, timeseries):
-        for metric_name in [
-            "ray_serve_handle_request_counter_total",
-            "ray_serve_num_router_requests_total",
-            "ray_serve_deployment_processing_latency_ms_sum",
-        ]:
-            self._wait_for_metric_summary(metric_name, expected, timeseries)
+        self._wait_for_metric_summary(
+            [
+                "ray_serve_handle_request_counter_total",
+                "ray_serve_num_router_requests_total",
+                "ray_serve_deployment_processing_latency_ms_sum",
+            ],
+            expected,
+            timeseries,
+        )
 
     @skip_if_haproxy(
         "direct ingress invokes the ingress deployment without a handle or router "
@@ -393,7 +397,7 @@ class TestRequestContextMetrics:
             timeout=40,
         )
         self._wait_for_metric_summary(
-            "ray_serve_deployment_request_counter_total",
+            ["ray_serve_deployment_request_counter_total"],
             {
                 "G": ({"/api", "/api2"}, "app"),
                 "g1": ({"/api"}, "app"),

--- a/python/ray/serve/tests/test_metrics_2.py
+++ b/python/ray/serve/tests/test_metrics_2.py
@@ -18,6 +18,7 @@ from ray._common.test_utils import (
 from ray.serve._private.constants import DEFAULT_LATENCY_BUCKET_MS
 from ray.serve._private.test_utils import (
     PROMETHEUS_METRICS_TIMEOUT_S,
+    TEST_METRICS_EXPORT_PORT,
     get_application_url,
     ping_fruit_stand,
     ping_grpc_call_method,
@@ -33,16 +34,47 @@ from ray.serve.tests.test_metrics import (
 )
 
 # A slow scrape burns PROMETHEUS_METRICS_TIMEOUT_S and then yields nothing, so a wait
-# on an exported metric needs room for several full-length attempts.
-METRICS_WAIT_TIMEOUT_S = 90
+# needs room for several full-length attempts. A newly registered series is the slow
+# thing to surface, so its debut gets the larger budget and value checks the smaller.
+METRICS_FIRST_EXPORT_TIMEOUT_S = 90
+METRICS_WAIT_TIMEOUT_S = 45
+METRICS_RETRY_INTERVAL_MS = 1000
 
 
-def wait_for_metric(predicate, **kwargs):
+def wait_for_metric(predicate, budget_s=METRICS_WAIT_TIMEOUT_S, **kwargs):
     """Waits on a predicate that scrapes, pacing retries so a loaded dashboard
     agent is not hammered while it catches up."""
     wait_for_condition(
-        predicate, timeout=METRICS_WAIT_TIMEOUT_S, retry_interval_ms=1000, **kwargs
+        predicate,
+        timeout=budget_s,
+        retry_interval_ms=METRICS_RETRY_INTERVAL_MS,
+        **kwargs,
     )
+
+
+def wait_for_metric_export(metric_name, timeseries, count=None):
+    """Waits for a series to surface, which is the slow step; count=None accepts
+    any number of samples."""
+
+    def check():
+        metrics = get_metric_dictionaries(
+            metric_name, timeseries=timeseries, wait=False
+        )
+        if count is None:
+            assert metrics, f"Metric {metric_name} not exported yet"
+        else:
+            assert (
+                len(metrics) == count
+            ), f"Expected {count} {metric_name}, got {len(metrics)}"
+        return True
+
+    wait_for_metric(check, budget_s=METRICS_FIRST_EXPORT_TIMEOUT_S)
+
+
+def check_metric_float(**kwargs):
+    """Bounds each scrape to one PROMETHEUS_METRICS_TIMEOUT_S; the shared helper's
+    own 20s default is larger than most callers' retry budgets."""
+    return check_metric_float_eq(timeout=PROMETHEUS_METRICS_TIMEOUT_S, **kwargs)
 
 
 @serve.deployment
@@ -106,7 +138,9 @@ class TestRequestContextMetrics:
 
     def _scrape(self, timeseries):
         return fetch_prometheus_metric_timeseries(
-            ["localhost:9999"], timeseries, timeout=PROMETHEUS_METRICS_TIMEOUT_S
+            [f"localhost:{TEST_METRICS_EXPORT_PORT}"],
+            timeseries,
+            timeout=PROMETHEUS_METRICS_TIMEOUT_S,
         )
 
     def _wait_for_metric_summary(self, metric_names, expected, timeseries):
@@ -122,7 +156,8 @@ class TestRequestContextMetrics:
                 msg = f"Incorrect metrics for {name}"
                 for deployment, (route, app) in expected.items():
                     assert routes[deployment] == route, msg
-                    assert apps[deployment] == app, msg
+                    if app is not None:
+                        assert apps[deployment] == app, msg
             return True
 
         wait_for_metric(check)
@@ -136,8 +171,9 @@ class TestRequestContextMetrics:
         )
 
     def _wait_for_labeled_metric(self, metric_name, expected_labels, timeseries):
-        """The series can be mid-export, so wait for it instead of asserting on
-        whatever the first scrape happened to return."""
+        """The series can be mid-export, so wait for its debut before checking
+        labels; the label check itself must not sit on the debut budget."""
+        wait_for_metric_export(metric_name, timeseries)
 
         def check():
             metrics = get_metric_dictionaries(
@@ -206,16 +242,8 @@ class TestRequestContextMetrics:
         assert resp.status_code == 500
         timeseries = PrometheusTimeseries()
 
-        wait_for_condition(
-            lambda: len(
-                get_metric_dictionaries(
-                    "ray_serve_deployment_processing_latency_ms_sum",
-                    timeseries=timeseries,
-                    wait=False,
-                )
-            )
-            == 3,
-            timeout=40,
+        wait_for_metric_export(
+            "ray_serve_deployment_processing_latency_ms_sum", timeseries, count=3
         )
 
         # Check replica qps & latency
@@ -290,16 +318,8 @@ class TestRequestContextMetrics:
         timeseries = PrometheusTimeseries()
 
         # app1 has 1 deployment, app2 has 3 deployments, and app3 has 1 deployment.
-        wait_for_condition(
-            lambda: len(
-                get_metric_dictionaries(
-                    "ray_serve_deployment_processing_latency_ms_sum",
-                    timeseries=timeseries,
-                    wait=False,
-                )
-            )
-            == 5,
-            timeout=40,
+        wait_for_metric_export(
+            "ray_serve_deployment_processing_latency_ms_sum", timeseries, count=5
         )
 
         # Check replica qps & latency
@@ -385,16 +405,8 @@ class TestRequestContextMetrics:
         # g2 deployment metrics:
         #   {xxx, route:/api2}
         timeseries = PrometheusTimeseries()
-        wait_for_condition(
-            lambda: len(
-                get_metric_dictionaries(
-                    "ray_serve_deployment_request_counter_total",
-                    timeseries=timeseries,
-                    wait=False,
-                )
-            )
-            == 4,
-            timeout=40,
+        wait_for_metric_export(
+            "ray_serve_deployment_request_counter_total", timeseries, count=4
         )
         self._wait_for_metric_summary(
             ["ray_serve_deployment_request_counter_total"],
@@ -433,26 +445,19 @@ class TestRequestContextMetrics:
         assert resp.text == '"ok2"'
 
         timeseries = PrometheusTimeseries()
-        wait_for_condition(
-            lambda: len(
-                get_metric_dictionaries(
-                    "ray_serve_deployment_request_counter_total",
-                    timeseries=timeseries,
-                    wait=False,
+        wait_for_metric_export(
+            "ray_serve_deployment_request_counter_total", timeseries, count=2
+        )
+        self._wait_for_metric_summary(
+            ["ray_serve_deployment_request_counter_total"],
+            {
+                "A": (
+                    {route_prefix + "/api", route_prefix + "/api2/{user_id}"},
+                    None,
                 )
-            )
-            == 2,
-            timeout=40,
+            },
+            timeseries,
         )
-        (requests_metrics_route, _,) = self._generate_metrics_summary(
-            get_metric_dictionaries(
-                "ray_serve_deployment_request_counter_total", timeseries=timeseries
-            )
-        )
-        assert requests_metrics_route["A"] == {
-            route_prefix + "/api",
-            route_prefix + "/api2/{user_id}",
-        }
 
     def test_customer_metrics_with_context(self, metrics_start_shutdown):
         @serve.deployment
@@ -506,15 +511,7 @@ class TestRequestContextMetrics:
         http_url = get_application_url("HTTP", "app")
         resp = httpx.get(http_url)
         deployment_name, replica_id = resp.json()
-        wait_for_condition(
-            lambda: len(
-                get_metric_dictionaries(
-                    "ray_my_gauge", timeseries=timeseries, wait=False
-                ),
-            )
-            == 1,
-            timeout=40,
-        )
+        wait_for_metric_export("ray_my_gauge", timeseries, count=1)
 
         expected_metrics = {
             "my_static_tag": "static_value",
@@ -647,15 +644,7 @@ class TestRequestContextMetrics:
         resp = httpx.get(http_url)
         assert resp.text == "hello"
         timeseries = PrometheusTimeseries()
-        wait_for_condition(
-            lambda: len(
-                get_metric_dictionaries(
-                    "ray_my_gauge", timeseries=timeseries, wait=False
-                ),
-            )
-            == 1,
-            timeout=40,
-        )
+        wait_for_metric_export("ray_my_gauge", timeseries, count=1)
 
         expected_metrics = {
             "my_static_tag": "static_value",
@@ -705,6 +694,9 @@ class TestHandleMetrics:
 
         # Release signal
         ray.get(signal.send.remote())
+        # A retired replica leaves a stale sample that would hold the sum above 0.
+        timeseries.flush()
+        wait_for_metric_export("ray_serve_deployment_queued_queries", timeseries)
         wait_for_metric(
             check_sum_metric_eq,
             metric_name="ray_serve_deployment_queued_queries",
@@ -716,42 +708,37 @@ class TestHandleMetrics:
     def test_queued_queries_multiple_handles(self, metrics_start_shutdown):
         signal = SignalActor.options(name="signal123").remote()
         serve.run(WaitForSignal.options(max_ongoing_requests=1).bind(), name="app1")
+        timeseries = PrometheusTimeseries()
 
-        # Send first request
+        def wait_for_queued(expected):
+            wait_for_metric(
+                check_sum_metric_eq,
+                metric_name="ray_serve_deployment_queued_queries",
+                tags={"application": "app1", "deployment": "WaitForSignal"},
+                expected=expected,
+                timeseries=timeseries,
+            )
+
+        # Send first request. An absent series also sums to 0, so wait for its
+        # debut before trusting the count.
         call.remote("WaitForSignal", "app1")
-        wait_for_metric(
-            check_sum_metric_eq,
-            metric_name="ray_serve_deployment_queued_queries",
-            tags={"application": "app1", "deployment": "WaitForSignal"},
-            expected=0,
-        )
+        wait_for_metric_export("ray_serve_deployment_queued_queries", timeseries)
+        wait_for_queued(0)
 
         # Send second request (which should stay queued)
         call.remote("WaitForSignal", "app1")
-        wait_for_metric(
-            check_sum_metric_eq,
-            metric_name="ray_serve_deployment_queued_queries",
-            tags={"application": "app1", "deployment": "WaitForSignal"},
-            expected=1,
-        )
+        wait_for_queued(1)
 
         # Send third request (which should stay queued)
         call.remote("WaitForSignal", "app1")
-        wait_for_metric(
-            check_sum_metric_eq,
-            metric_name="ray_serve_deployment_queued_queries",
-            tags={"application": "app1", "deployment": "WaitForSignal"},
-            expected=2,
-        )
+        wait_for_queued(2)
 
         # Release signal
         ray.get(signal.send.remote())
-        wait_for_metric(
-            check_sum_metric_eq,
-            metric_name="ray_serve_deployment_queued_queries",
-            tags={"application": "app1", "deployment": "WaitForSignal"},
-            expected=0,
-        )
+        # A retired replica leaves a stale sample that would hold the sum above 0.
+        timeseries.flush()
+        wait_for_metric_export("ray_serve_deployment_queued_queries", timeseries)
+        wait_for_queued(0)
 
     @skip_if_haproxy(
         "asserts num_scheduling_tasks, a proxy-router metric that direct ingress "
@@ -772,9 +759,9 @@ class TestHandleMetrics:
 
         print("Deployed hang_on_first_request deployment.")
         timeseries = PrometheusTimeseries()
-        wait_for_condition(
-            check_metric_float_eq,
-            timeout=15,
+        wait_for_metric(
+            check_metric_float,
+            budget_s=METRICS_FIRST_EXPORT_TIMEOUT_S,
             metric="ray_serve_num_scheduling_tasks",
             # Router is eagerly created on HTTP proxy, so there are metrics emitted
             # from proxy router
@@ -787,9 +774,9 @@ class TestHandleMetrics:
             timeseries=timeseries,
         )
         print("ray_serve_num_scheduling_tasks updated successfully.")
-        wait_for_condition(
-            check_metric_float_eq,
-            timeout=15,
+        wait_for_metric(
+            check_metric_float,
+            budget_s=METRICS_FIRST_EXPORT_TIMEOUT_S,
             metric="ray_serve_num_scheduling_tasks_in_backoff",
             # Router is eagerly created on HTTP proxy, so there are metrics emitted
             # from proxy router
@@ -816,9 +803,9 @@ class TestHandleMetrics:
         )
 
         print("First request is executing.")
-        wait_for_condition(
+        wait_for_metric(
             check_sum_metric_eq,
-            timeout=15,
+            budget_s=METRICS_FIRST_EXPORT_TIMEOUT_S,
             metric_name="ray_serve_num_ongoing_http_requests",
             expected=1,
             timeseries=timeseries,
@@ -830,17 +817,16 @@ class TestHandleMetrics:
         print(f"{num_queued_requests} more requests now queued.")
 
         # First request should be processing. All others should be queued.
-        wait_for_condition(
+        wait_for_metric(
             check_sum_metric_eq,
-            timeout=15,
+            budget_s=METRICS_FIRST_EXPORT_TIMEOUT_S,
             metric_name="ray_serve_deployment_queued_queries",
             expected=num_queued_requests,
             timeseries=timeseries,
         )
         print("ray_serve_deployment_queued_queries updated successfully.")
-        wait_for_condition(
+        wait_for_metric(
             check_sum_metric_eq,
-            timeout=15,
             metric_name="ray_serve_num_ongoing_http_requests",
             expected=num_queued_requests + 1,
             timeseries=timeseries,
@@ -849,17 +835,15 @@ class TestHandleMetrics:
 
         # There should be 2 scheduling tasks (which is the max, since
         # 2 = 2 * 1 replica) that are attempting to schedule the hanging requests.
-        wait_for_condition(
+        wait_for_metric(
             check_sum_metric_eq,
-            timeout=15,
             metric_name="ray_serve_num_scheduling_tasks",
             expected=2,
             timeseries=timeseries,
         )
         print("ray_serve_num_scheduling_tasks updated successfully.")
-        wait_for_condition(
+        wait_for_metric(
             check_sum_metric_eq,
-            timeout=15,
             metric_name="ray_serve_num_scheduling_tasks_in_backoff",
             expected=2,
             timeseries=timeseries,
@@ -871,9 +855,8 @@ class TestHandleMetrics:
         timeseries.flush()
         print("Cancelled all HTTP requests.")
 
-        wait_for_condition(
+        wait_for_metric(
             check_sum_metric_eq,
-            timeout=15,
             metric_name="ray_serve_deployment_queued_queries",
             expected=0,
             timeseries=timeseries,
@@ -881,26 +864,23 @@ class TestHandleMetrics:
         print("ray_serve_deployment_queued_queries updated successfully.")
 
         # Task should get cancelled.
-        wait_for_condition(
+        wait_for_metric(
             check_sum_metric_eq,
-            timeout=15,
             metric_name="ray_serve_num_ongoing_http_requests",
             expected=0,
             timeseries=timeseries,
         )
         print("ray_serve_num_ongoing_http_requests updated successfully.")
 
-        wait_for_condition(
+        wait_for_metric(
             check_sum_metric_eq,
-            timeout=15,
             metric_name="ray_serve_num_scheduling_tasks",
             expected=0,
             timeseries=timeseries,
         )
         print("ray_serve_num_scheduling_tasks updated successfully.")
-        wait_for_condition(
+        wait_for_metric(
             check_sum_metric_eq,
-            timeout=15,
             metric_name="ray_serve_num_scheduling_tasks_in_backoff",
             expected=0,
             timeseries=timeseries,
@@ -966,6 +946,9 @@ class TestHandleMetrics:
 
         # Release signal, the number of running requests should drop to 0
         ray.get(signal.send.remote())
+        # A retired replica leaves a stale sample that would hold the sum above 0.
+        timeseries.flush()
+        wait_for_metric_export("ray_serve_num_ongoing_requests_at_replicas", timeseries)
         wait_for_metric(
             check_sum_metric_eq,
             metric_name="ray_serve_num_ongoing_requests_at_replicas",
@@ -999,7 +982,7 @@ class TestProxyStateMetrics:
                     return True
             return False
 
-        wait_for_condition(check_proxy_status, timeout=30)
+        wait_for_metric(check_proxy_status, budget_s=METRICS_FIRST_EXPORT_TIMEOUT_S)
 
         # Verify the metric has the expected tags
         metrics = get_metric_dictionaries(
@@ -1011,7 +994,7 @@ class TestProxyStateMetrics:
             assert "node_ip_address" in metric
 
         wait_for_metric(
-            check_metric_float_eq,
+            check_metric_float,
             metric="ray_serve_proxy_status",
             expected=2,
             timeseries=timeseries,
@@ -1029,13 +1012,13 @@ class TestProxyStateMetrics:
         timeseries = PrometheusTimeseries()
 
         # Wait for the proxy to become healthy first (status=2 means HEALTHY)
-        wait_for_condition(
-            check_metric_float_eq,
+        wait_for_metric(
+            check_metric_float,
+            budget_s=METRICS_FIRST_EXPORT_TIMEOUT_S,
             metric="ray_serve_proxy_status",
             expected=2,
             timeseries=timeseries,
             expected_tags={},
-            timeout=30,
         )
 
         # Shutdown serve, which will trigger proxy shutdown
@@ -1057,10 +1040,13 @@ class TestProxyStateMetrics:
                     return True
             return False
 
-        wait_for_condition(check_shutdown_duration_metric_exists, timeout=30)
+        wait_for_metric(
+            check_shutdown_duration_metric_exists,
+            budget_s=METRICS_FIRST_EXPORT_TIMEOUT_S,
+        )
 
-        # Verify the sum and _count series, which export separately from the
-        # sample the wait above observed.
+        # A histogram exports _sum and _count in one scrape, so this re-checks
+        # their tags rather than waiting for a second export.
         def check_shutdown_duration_series():
             for name in [
                 "ray_serve_proxy_shutdown_duration_ms_sum",

--- a/python/ray/serve/tests/test_metrics_2.py
+++ b/python/ray/serve/tests/test_metrics_2.py
@@ -32,6 +32,18 @@ from ray.serve.tests.test_metrics import (
     get_metric_dictionaries,
 )
 
+# A slow scrape burns PROMETHEUS_METRICS_TIMEOUT_S and then yields nothing, so a wait
+# on an exported metric needs room for several full-length attempts.
+METRICS_WAIT_TIMEOUT_S = 90
+
+
+def wait_for_metric(predicate, **kwargs):
+    """Waits on a predicate that scrapes, pacing retries so a loaded dashboard
+    agent is not hammered while it catches up."""
+    wait_for_condition(
+        predicate, timeout=METRICS_WAIT_TIMEOUT_S, retry_interval_ms=1000, **kwargs
+    )
+
 
 @serve.deployment
 class WaitForSignal:
@@ -92,6 +104,71 @@ class TestRequestContextMetrics:
         for key in expected_output:
             assert metric[key] == expected_output[key]
 
+    def _wait_for_metric_summary(self, metric_name, expected, timeseries):
+        """Deployments export independently, so wait for all of them rather than
+        asserting on whichever happen to have reported already."""
+
+        def check():
+            routes, apps = self._generate_metrics_summary(
+                get_metric_dictionaries(metric_name, timeseries=timeseries, wait=False)
+            )
+            msg = f"Incorrect metrics for {metric_name}"
+            for deployment, (route, app) in expected.items():
+                assert routes[deployment] == route, msg
+                assert apps[deployment] == app, msg
+            return True
+
+        wait_for_metric(check)
+
+    def _wait_for_route_and_name(
+        self, metric_name, deployment_name, app_name, route, timeseries
+    ):
+        """Waits for app name and route to appear in deployment's metric."""
+        self._wait_for_metric_summary(
+            metric_name, {deployment_name: ({route}, app_name)}, timeseries
+        )
+
+    def _wait_for_labeled_metric(self, metric_name, expected_labels, timeseries):
+        """The series can be mid-export, so wait for it instead of asserting on
+        whatever the first scrape happened to return."""
+
+        def check():
+            metrics = get_metric_dictionaries(
+                metric_name, timeseries=timeseries, wait=False
+            )
+            assert len(metrics) == 1, f"Expected one {metric_name}, got {len(metrics)}"
+            self.verify_metrics(metrics[0], expected_labels)
+            return True
+
+        wait_for_metric(check)
+
+    def _wait_for_proxy_routes(self, metric_names, expected_routes, timeseries):
+        """Proxy metrics export on their own cycle, so they can still be missing
+        once the deployment metrics waited on above have arrived."""
+        for metric_name in metric_names:
+
+            def check(name=metric_name):
+                routes = {
+                    sample.labels["route"]
+                    for sample in fetch_prometheus_metric_timeseries(
+                        ["localhost:9999"],
+                        timeseries,
+                        timeout=PROMETHEUS_METRICS_TIMEOUT_S,
+                    )[name]
+                }
+                assert routes == expected_routes, f"Incorrect routes for {name}"
+                return True
+
+            wait_for_metric(check)
+
+    def _wait_for_handle_metrics(self, expected, timeseries):
+        for metric_name in [
+            "ray_serve_handle_request_counter_total",
+            "ray_serve_num_router_requests_total",
+            "ray_serve_deployment_processing_latency_ms_sum",
+        ]:
+            self._wait_for_metric_summary(metric_name, expected, timeseries)
+
     @skip_if_haproxy(
         "direct ingress invokes the ingress deployment without a handle or router "
         "hop, so these metrics are not emitted"
@@ -137,81 +214,46 @@ class TestRequestContextMetrics:
             timeout=40,
         )
 
-        def wait_for_route_and_name(
-            metric_name: str,
-            deployment_name: str,
-            app_name: str,
-            route: str,
-            timeout: float = 5,
-        ):
-            """Waits for app name and route to appear in deployment's metric."""
-
-            def check():
-                # Check replica qps & latency
-                (
-                    qps_metrics_route,
-                    qps_metrics_app_name,
-                ) = self._generate_metrics_summary(
-                    get_metric_dictionaries(metric_name, timeseries=timeseries),
-                )
-                assert qps_metrics_app_name[deployment_name] == app_name
-                assert qps_metrics_route[deployment_name] == {route}
-                return True
-
-            wait_for_condition(check, timeout=timeout)
-
         # Check replica qps & latency
-        wait_for_route_and_name(
-            "ray_serve_deployment_request_counter_total", "f", "app1", "/app1"
+        self._wait_for_route_and_name(
+            "ray_serve_deployment_request_counter_total",
+            "f",
+            "app1",
+            "/app1",
+            timeseries,
         )
-        wait_for_route_and_name(
-            "ray_serve_deployment_request_counter_total", "g", "app2", "/app2"
+        self._wait_for_route_and_name(
+            "ray_serve_deployment_request_counter_total",
+            "g",
+            "app2",
+            "/app2",
+            timeseries,
         )
-        wait_for_route_and_name(
-            "ray_serve_deployment_error_counter_total", "h", "app3", "/app3"
+        self._wait_for_route_and_name(
+            "ray_serve_deployment_error_counter_total",
+            "h",
+            "app3",
+            "/app3",
+            timeseries,
         )
 
         # Check http proxy qps & latency
-        for metric_name in [
-            "ray_serve_num_http_requests_total",
-            "ray_serve_http_request_latency_ms_sum",
-        ]:
-            metrics = [
-                sample.labels
-                for sample in fetch_prometheus_metric_timeseries(
-                    ["localhost:9999"],
-                    timeseries,
-                    timeout=PROMETHEUS_METRICS_TIMEOUT_S,
-                )[metric_name]
-            ]
-            assert {metric["route"] for metric in metrics} == {
-                "/app1",
-                "/app2",
-                "/app3",
-            }
-
-        for metric_name in [
-            "ray_serve_handle_request_counter_total",
-            "ray_serve_num_router_requests_total",
-            "ray_serve_deployment_processing_latency_ms_sum",
-        ]:
-            metrics_route, metrics_app_name = self._generate_metrics_summary(
-                [
-                    sample.labels
-                    for sample in fetch_prometheus_metric_timeseries(
-                        ["localhost:9999"],
-                        timeseries,
-                        timeout=PROMETHEUS_METRICS_TIMEOUT_S,
-                    )[metric_name]
-                ]
-            )
-            msg = f"Incorrect metrics for {metric_name}"
-            assert metrics_route["f"] == {"/app1"}, msg
-            assert metrics_route["g"] == {"/app2"}, msg
-            assert metrics_route["h"] == {"/app3"}, msg
-            assert metrics_app_name["f"] == "app1", msg
-            assert metrics_app_name["g"] == "app2", msg
-            assert metrics_app_name["h"] == "app3", msg
+        self._wait_for_proxy_routes(
+            [
+                "ray_serve_num_http_requests_total",
+                "ray_serve_http_request_latency_ms_sum",
+            ],
+            {"/app1", "/app2", "/app3"},
+            timeseries,
+        )
+        self._wait_for_handle_metrics(
+            {
+                "f": ({"/app1"}, "app1"),
+                "g": ({"/app2"}, "app2"),
+                "h": ({"/app3"}, "app3"),
+            },
+            timeseries,
+        )
 
     @skip_if_haproxy(
         "direct ingress skips the handle and router hop and HAProxy counts its "
@@ -256,80 +298,46 @@ class TestRequestContextMetrics:
             timeout=40,
         )
 
-        def wait_for_route_and_name(
-            _metric_name: str,
-            deployment_name: str,
-            app_name: str,
-            route: str,
-            timeout: float = 5,
-        ):
-            """Waits for app name and route to appear in deployment's metric."""
-
-            def check():
-                # Check replica qps & latency
-                (
-                    qps_metrics_route,
-                    qps_metrics_app_name,
-                ) = self._generate_metrics_summary(
-                    get_metric_dictionaries(_metric_name, timeseries=timeseries),
-                )
-                assert qps_metrics_app_name[deployment_name] == app_name
-                assert qps_metrics_route[deployment_name] == {route}
-                return True
-
-            wait_for_condition(check, timeout=timeout)
-
         # Check replica qps & latency
-        wait_for_route_and_name(
+        self._wait_for_route_and_name(
             "ray_serve_deployment_request_counter_total",
             depl_name1,
             app_name1,
             app_name1,
+            timeseries,
         )
-        wait_for_route_and_name(
+        self._wait_for_route_and_name(
             "ray_serve_deployment_request_counter_total",
             depl_name2,
             app_name2,
             app_name2,
+            timeseries,
         )
-        wait_for_route_and_name(
-            "ray_serve_deployment_error_counter_total", depl_name3, app_name3, app_name3
+        self._wait_for_route_and_name(
+            "ray_serve_deployment_error_counter_total",
+            depl_name3,
+            app_name3,
+            app_name3,
+            timeseries,
         )
 
         # Check grpc proxy qps & latency
-        for metric_name in [
-            "ray_serve_num_grpc_requests_total",
-            "ray_serve_grpc_request_latency_ms_sum",
-        ]:
-            metrics = [
-                sample.labels
-                for sample in fetch_prometheus_metric_timeseries(
-                    ["localhost:9999"],
-                    timeseries,
-                    timeout=PROMETHEUS_METRICS_TIMEOUT_S,
-                )[metric_name]
-            ]
-            assert {metric["route"] for metric in metrics} == {
-                "app1",
-                "app2",
-                "app3",
-            }
-
-        for metric_name in [
-            "ray_serve_handle_request_counter_total",
-            "ray_serve_num_router_requests_total",
-            "ray_serve_deployment_processing_latency_ms_sum",
-        ]:
-            metrics_route, metrics_app_name = self._generate_metrics_summary(
-                get_metric_dictionaries(metric_name, timeseries=timeseries),
-            )
-            msg = f"Incorrect metrics for {metric_name}"
-            assert metrics_route[depl_name1] == {"app1"}, msg
-            assert metrics_route[depl_name2] == {"app2"}, msg
-            assert metrics_route[depl_name3] == {"app3"}, msg
-            assert metrics_app_name[depl_name1] == "app1", msg
-            assert metrics_app_name[depl_name2] == "app2", msg
-            assert metrics_app_name[depl_name3] == "app3", msg
+        self._wait_for_proxy_routes(
+            [
+                "ray_serve_num_grpc_requests_total",
+                "ray_serve_grpc_request_latency_ms_sum",
+            ],
+            {app_name1, app_name2, app_name3},
+            timeseries,
+        )
+        self._wait_for_handle_metrics(
+            {
+                depl_name1: ({app_name1}, app_name1),
+                depl_name2: ({app_name2}, app_name2),
+                depl_name3: ({app_name3}, app_name3),
+            },
+            timeseries,
+        )
 
     def test_request_context_pass_for_handle_passing(self, metrics_start_shutdown):
         """Test handle passing contexts between replicas"""
@@ -384,20 +392,15 @@ class TestRequestContextMetrics:
             == 4,
             timeout=40,
         )
-        (
-            requests_metrics_route,
-            requests_metrics_app_name,
-        ) = self._generate_metrics_summary(
-            get_metric_dictionaries(
-                "ray_serve_deployment_request_counter_total", timeseries=timeseries
-            ),
+        self._wait_for_metric_summary(
+            "ray_serve_deployment_request_counter_total",
+            {
+                "G": ({"/api", "/api2"}, "app"),
+                "g1": ({"/api"}, "app"),
+                "g2": ({"/api2"}, "app"),
+            },
+            timeseries,
         )
-        assert requests_metrics_route["G"] == {"/api", "/api2"}
-        assert requests_metrics_route["g1"] == {"/api"}
-        assert requests_metrics_route["g2"] == {"/api2"}
-        assert requests_metrics_app_name["G"] == "app"
-        assert requests_metrics_app_name["g1"] == "app"
-        assert requests_metrics_app_name["g2"] == "app"
 
     @pytest.mark.parametrize("route_prefix", ["", "/prefix"])
     def test_fastapi_route_metrics(self, metrics_start_shutdown, route_prefix: str):
@@ -509,10 +512,6 @@ class TestRequestContextMetrics:
             timeout=40,
         )
 
-        counter_metrics = get_metric_dictionaries(
-            "ray_my_counter_total", timeseries=timeseries
-        )
-        assert len(counter_metrics) == 1
         expected_metrics = {
             "my_static_tag": "static_value",
             "my_runtime_tag": "100",
@@ -521,7 +520,9 @@ class TestRequestContextMetrics:
             "application": "app",
             "route": "/app",
         }
-        self.verify_metrics(counter_metrics[0], expected_metrics)
+        self._wait_for_labeled_metric(
+            "ray_my_counter_total", expected_metrics, timeseries
+        )
 
         expected_metrics = {
             "my_static_tag": "static_value",
@@ -531,9 +532,7 @@ class TestRequestContextMetrics:
             "application": "app",
             "route": "/app",
         }
-        gauge_metrics = get_metric_dictionaries("ray_my_gauge", timeseries=timeseries)
-        assert len(gauge_metrics) == 1
-        self.verify_metrics(gauge_metrics[0], expected_metrics)
+        self._wait_for_labeled_metric("ray_my_gauge", expected_metrics, timeseries)
 
         expected_metrics = {
             "my_static_tag": "static_value",
@@ -543,11 +542,9 @@ class TestRequestContextMetrics:
             "application": "app",
             "route": "/app",
         }
-        histogram_metrics = get_metric_dictionaries(
-            "ray_my_histogram_sum", timeseries=timeseries
+        self._wait_for_labeled_metric(
+            "ray_my_histogram_sum", expected_metrics, timeseries
         )
-        assert len(histogram_metrics) == 1
-        self.verify_metrics(histogram_metrics[0], expected_metrics)
 
     @pytest.mark.parametrize("use_actor", [False, True])
     def test_serve_metrics_outside_serve(self, use_actor, metrics_start_shutdown):
@@ -656,33 +653,27 @@ class TestRequestContextMetrics:
             timeout=40,
         )
 
-        counter_metrics = get_metric_dictionaries(
-            "ray_my_counter_total", timeseries=timeseries
-        )
-        assert len(counter_metrics) == 1
         expected_metrics = {
             "my_static_tag": "static_value",
             "my_runtime_tag": "100",
         }
-        self.verify_metrics(counter_metrics[0], expected_metrics)
+        self._wait_for_labeled_metric(
+            "ray_my_counter_total", expected_metrics, timeseries
+        )
 
-        gauge_metrics = get_metric_dictionaries("ray_my_gauge", timeseries=timeseries)
-        assert len(gauge_metrics) == 1
         expected_metrics = {
             "my_static_tag": "static_value",
             "my_runtime_tag": "300",
         }
-        self.verify_metrics(gauge_metrics[0], expected_metrics)
+        self._wait_for_labeled_metric("ray_my_gauge", expected_metrics, timeseries)
 
-        histogram_metrics = get_metric_dictionaries(
-            "ray_my_histogram_sum", timeseries=timeseries
-        )
-        assert len(histogram_metrics) == 1
         expected_metrics = {
             "my_static_tag": "static_value",
             "my_runtime_tag": "200",
         }
-        self.verify_metrics(histogram_metrics[0], expected_metrics)
+        self._wait_for_labeled_metric(
+            "ray_my_histogram_sum", expected_metrics, timeseries
+        )
 
 
 class TestHandleMetrics:
@@ -700,7 +691,7 @@ class TestHandleMetrics:
             # call.remote("WaitForSignal", "app1")
             # c.call.remote()
             caller.call.remote()
-            wait_for_condition(
+            wait_for_metric(
                 check_sum_metric_eq,
                 metric_name="ray_serve_deployment_queued_queries",
                 tags={"application": "app1"},
@@ -710,7 +701,7 @@ class TestHandleMetrics:
 
         # Release signal
         ray.get(signal.send.remote())
-        wait_for_condition(
+        wait_for_metric(
             check_sum_metric_eq,
             metric_name="ray_serve_deployment_queued_queries",
             tags={"application": "app1", "deployment": "WaitForSignal"},
@@ -724,7 +715,7 @@ class TestHandleMetrics:
 
         # Send first request
         call.remote("WaitForSignal", "app1")
-        wait_for_condition(
+        wait_for_metric(
             check_sum_metric_eq,
             metric_name="ray_serve_deployment_queued_queries",
             tags={"application": "app1", "deployment": "WaitForSignal"},
@@ -733,7 +724,7 @@ class TestHandleMetrics:
 
         # Send second request (which should stay queued)
         call.remote("WaitForSignal", "app1")
-        wait_for_condition(
+        wait_for_metric(
             check_sum_metric_eq,
             metric_name="ray_serve_deployment_queued_queries",
             tags={"application": "app1", "deployment": "WaitForSignal"},
@@ -742,7 +733,7 @@ class TestHandleMetrics:
 
         # Send third request (which should stay queued)
         call.remote("WaitForSignal", "app1")
-        wait_for_condition(
+        wait_for_metric(
             check_sum_metric_eq,
             metric_name="ray_serve_deployment_queued_queries",
             tags={"application": "app1", "deployment": "WaitForSignal"},
@@ -751,7 +742,7 @@ class TestHandleMetrics:
 
         # Release signal
         ray.get(signal.send.remote())
-        wait_for_condition(
+        wait_for_metric(
             check_sum_metric_eq,
             metric_name="ray_serve_deployment_queued_queries",
             tags={"application": "app1", "deployment": "WaitForSignal"},
@@ -945,7 +936,7 @@ class TestHandleMetrics:
             call.remote("Router", "app1", index)
             requests_sent[index] += 1
 
-            wait_for_condition(
+            wait_for_metric(
                 check_sum_metric_eq,
                 metric_name="ray_serve_num_ongoing_requests_at_replicas",
                 tags={"application": "app1", "deployment": "d1"},
@@ -953,7 +944,7 @@ class TestHandleMetrics:
                 timeseries=timeseries,
             )
 
-            wait_for_condition(
+            wait_for_metric(
                 check_sum_metric_eq,
                 metric_name="ray_serve_num_ongoing_requests_at_replicas",
                 tags={"application": "app1", "deployment": "d2"},
@@ -961,7 +952,7 @@ class TestHandleMetrics:
                 timeseries=timeseries,
             )
 
-            wait_for_condition(
+            wait_for_metric(
                 check_sum_metric_eq,
                 metric_name="ray_serve_num_ongoing_requests_at_replicas",
                 tags={"application": "app1", "deployment": "Router"},
@@ -971,7 +962,7 @@ class TestHandleMetrics:
 
         # Release signal, the number of running requests should drop to 0
         ray.get(signal.send.remote())
-        wait_for_condition(
+        wait_for_metric(
             check_sum_metric_eq,
             metric_name="ray_serve_num_ongoing_requests_at_replicas",
             tags={"application": "app1"},
@@ -1015,7 +1006,7 @@ class TestProxyStateMetrics:
             assert "node_id" in metric
             assert "node_ip_address" in metric
 
-        wait_for_condition(
+        wait_for_metric(
             check_metric_float_eq,
             metric="ray_serve_proxy_status",
             expected=2,
@@ -1064,24 +1055,22 @@ class TestProxyStateMetrics:
 
         wait_for_condition(check_shutdown_duration_metric_exists, timeout=30)
 
-        # Verify the metric has the expected tags
-        metrics = get_metric_dictionaries(
-            "ray_serve_proxy_shutdown_duration_ms_sum",
-            timeseries=timeseries,
-            wait=False,
-        )
-        assert len(metrics) == 1
-        for metric in metrics:
-            assert "node_id" in metric
-            assert "node_ip_address" in metric
+        # Verify the sum and _count series, which export separately from the
+        # sample the wait above observed.
+        def check_shutdown_duration_series():
+            for name in [
+                "ray_serve_proxy_shutdown_duration_ms_sum",
+                "ray_serve_proxy_shutdown_duration_ms_count",
+            ]:
+                metrics = get_metric_dictionaries(
+                    name, timeseries=timeseries, wait=False
+                )
+                assert len(metrics) == 1, f"Expected one {name}, got {len(metrics)}"
+                assert "node_id" in metrics[0]
+                assert "node_ip_address" in metrics[0]
+            return True
 
-        # Also verify _count metric exists
-        count_metrics = get_metric_dictionaries(
-            "ray_serve_proxy_shutdown_duration_ms_count",
-            timeseries=timeseries,
-            wait=False,
-        )
-        assert len(count_metrics) == 1
+        wait_for_metric(check_shutdown_duration_series)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Every assertion in this file is backed by a Prometheus scrape that is budgeted at
`PROMETHEUS_METRICS_TIMEOUT_S` (5s) and, on timeout, is *swallowed* by
`fetch_raw_prometheus` and returns nothing. So a slow scrape does not raise, it
yields an empty result and the assertion fails. That makes every metric
assertion in the file a retry problem, and on master the retry budgets do not
account for it.

Of the 34 `wait_for_condition` calls on master:

| Budget | Count | Attempts when a scrape is slow |
|---|---|---|
| 10s default | 11 | ≤2 |
| `timeout=15` | 11 | ≤3 |
| `timeout=40` (first-export gates) | 6 | ≤8 |
| `timeout=30` | 3 | ≤6 |
| `timeout=timeout` (default 5s) | 2 | ≤1 |

Plus assertions with **no** retry at all: 8 `assert len(...) == 1` and 7 bare
`_generate_metrics_summary` blocks, which read whatever a single scrape returned.
Because a missing metric yields `[]` rather than an error, these fail instantly
and cannot recover.

Two of those budgets are inverted — smaller than the work they wrap.
`check_metric_float_eq` defaults to a **20s** per-scrape timeout, larger than the
15s and 5s budgets around it, so those waits get exactly one attempt and report a
bare `-1 != 0`. And the duplicated `wait_for_route_and_name` helpers wrapped a 5s
wait around `get_metric_dictionaries(wait=True)`, whose own internal wait is
`timeout * 4` = 80s.

### What this changes

**One helper, budgets scoped to what is being waited on.** The expensive event is
a series' *first export* — under dashboard-agent saturation a newly registered
metric can take tens of seconds to surface, and that happens once per test. Value
checks on a series that is already live are fast. So:

```python
METRICS_FIRST_EXPORT_TIMEOUT_S = 90   # a series' debut
METRICS_WAIT_TIMEOUT_S = 45           # value checks on a live series
METRICS_RETRY_INTERVAL_MS = 1000      # do not hammer a catching-up agent