### PR TITLE
[core][sandbox] Support multi-uid user namespaces for network="public" sandboxes

### DIFF
--- a/doc/source/ray-core/sandboxes.md
+++ b/doc/source/ray-core/sandboxes.md
@@ -38,6 +38,7 @@ Ray Sandboxes need the following on every Ray node that runs a sandbox:
 * **gVisor (`runsc`)**: Install the `runsc` binary on worker nodes and make it reachable from the system `$PATH`.
 * **Ray**: version 2.58.0 or later, which includes the `ray.experimental.sandbox` package.
 * **pasta (`network="public"` only)**: The [passt](https://passt.top) package's `pasta` binary on the `$PATH`, plus `/dev/net/tun` in the worker's environment. pasta bridges each sandbox's private network namespace to the node.
+* **uidmap (multi-uid sandboxes)**: The `uidmap` package's setuid `newuidmap`/`newgidmap` helpers plus `/etc/subuid` and `/etc/subgid` ranges for the worker user (for example `ray:100000:65536`). With them, every sandbox's user namespace maps a subordinate id range, so files inside the sandbox can be owned by distinct uids and images that spread ownership across users (postfix, mailman) behave as under Docker. Without them, sandboxes run single-uid: every file reads as root and `chown` to other users fails. `RAY_SANDBOX_SINGLE_UID=1` on workers forces single-uid.
 
 To install `runsc` on a Linux worker node, see the [gVisor installation guide](https://gvisor.dev/docs/user_guide/install/). `pasta` ships as the `passt` package on Debian 12+/Ubuntu 23.04+ and Fedora, or as a [static build](https://passt.top/builds/latest/) (x86_64 only; on arm64 use the distro package or build from source — passt has no build dependencies).
 
@@ -244,7 +245,7 @@ Sandboxes boot from OCI container images. The image manager pulls an image strai
 
 ### Bound the image cache
 
-The cache is bounded so that a node that runs many distinct images doesn't fill its disk. Before each pull, Ray evicts the least recently extracted images until the cache fits under the cap. Images that a running sandbox uses are never evicted. The cap defaults to half of the filesystem that holds the cache. Set `RAY_SANDBOX_IMAGE_CACHE_MAX_BYTES` on worker nodes to choose a cap in bytes, or set it to `0` to disable eviction.
+The cache is bounded so that a node that runs many distinct images doesn't fill its disk. Before each pull, Ray evicts the least recently extracted images until the cache fits under the cap. Images that a running sandbox uses are never evicted. The cap defaults to half of the filesystem that holds the cache. Set `RAY_SANDBOX_IMAGE_CACHE_MAX_BYTES` on worker nodes to choose a cap in bytes, or set it to `0` to disable eviction. On a multi-uid node (see Requirements) the cached files carry the image's real owners, mapped to the node's subordinate id range; a node that switches between single-uid and multi-uid re-extracts its cache once.
 
 ### Route Docker Hub pulls through a mirror
 
@@ -368,6 +369,7 @@ For detailed signatures, parameters, and return types, see {ref}`ray-sandbox-ref
 * **Image pull failures**: Verify that the node can reach the container registry, such as Docker Hub or GHCR, or pre-populate the image cache directory at `/tmp/ray/sandbox/images`. When many nodes pull large images at once, Docker Hub's anonymous rate limits are a likely cause; see [Route Docker Hub pulls through a mirror](#route-docker-hub-pulls-through-a-mirror).
 * **`pasta` not found for `network="public"`**: Install the passt package (or a [static build](https://passt.top/builds/latest/)) on worker nodes.
 * **`public` sandboxes fail to start with a tap or namespace error**: pasta needs `/dev/net/tun` in the worker's environment and a seccomp policy that allows unprivileged user+network namespace creation (`unshare -Un true` must succeed as the Ray user). The pasta error appears in the sandbox's `runsc.stderr.log` and in the creation error message.
+* **Files all appear owned by root, or `chown` fails with "Invalid argument"**: The node lacks multi-uid prerequisites (uidmap package, `/etc/subuid`/`/etc/subgid` ranges), the pod runs with `allowPrivilegeEscalation: false` (disables the setuid `newuidmap`/`newgidmap` helpers), or the pod itself runs under a sandboxed runtime such as gVisor (GKE Sandbox), whose kernel accepts only single-entry self-maps — even privileged writes to a child `uid_map` fail there, so multi-uid needs regular runc-backed nodes. Ray probes the node once per process, logs the fallback reason, and runs single-uid. Also note gVisor's own `runsc spec` capability default is far narrower than Docker's: traversing another user's `0700` directory as root needs `CAP_DAC_OVERRIDE`, so pass `DOCKER_DEFAULT_CAPABILITIES` for Docker-like behavior. `RAY_SANDBOX_SINGLE_UID=1` on workers forces the single-uid behavior fleet-wide.
 
 ## Next steps
 

--- a/python/ray/experimental/sandbox/_internal/idmap.py
+++ b/python/ray/experimental/sandbox/_internal/idmap.py
@@ -1,0 +1,271 @@
+"""Multi-uid user-namespace mapping for sandboxes.
+
+A single-uid user namespace (``unshare --map-root-user``) can express no
+identity but its own: every in-sandbox file reads as root, and a chown to any
+other uid fails because the id has no host representation. Mapping a subuid
+range (``/etc/subuid`` + the setuid ``newuidmap``/``newgidmap`` helpers, the
+rootless-Podman model) gives container uids 1..count host-side existence, so
+images and workloads that spread ownership across users (postfix/mailman
+style) behave as under Docker.
+
+A node is either multi-uid (the helpers and ranges are usable) or single-uid;
+``detect_idmap`` decides once per process. Image extraction and sandbox
+creation both follow that decision, so the cached root filesystems on a node
+always match the mapping its sandboxes run with.
+"""
+
+import logging
+import os
+import shutil
+import subprocess
+import time
+from contextlib import contextmanager
+from dataclasses import dataclass
+from functools import lru_cache
+from pathlib import Path
+from typing import Iterator, List, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+# Set to "1" on workers to force single-uid namespaces even where the node
+# could map a subordinate range.
+SINGLE_UID_ENV = "RAY_SANDBOX_SINGLE_UID"
+
+# A usable subordinate range must cover the uids images realistically ship
+# (distro system users plus nobody at 65534).
+_MIN_RANGE = 65536
+
+
+@dataclass(frozen=True)
+class IdMap:
+    """One node-canonical uid/gid mapping for sandbox user namespaces.
+
+    Container root maps to the worker's own ids (so the bundle and cache
+    files it already owns stay accessible); container 1..count map onto the
+    subordinate range, giving every other uid a host representation.
+    """
+
+    euid: int
+    egid: int
+    subuid_base: int
+    subuid_count: int
+    subgid_base: int
+    subgid_count: int
+
+
+def parse_subid_file(
+    path: str, user_name: Optional[str], uid: int
+) -> Optional[Tuple[int, int]]:
+    """First usable ``(base, count)`` range for the user in a subid file.
+
+    Entries may be keyed by user name or numeric uid; malformed lines and
+    ranges below the usable floor are skipped.
+    """
+    keys = {str(uid)}
+    if user_name:
+        keys.add(user_name)
+    try:
+        text = Path(path).read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return None
+    for line in text.splitlines():
+        parts = line.strip().split(":")
+        if len(parts) != 3 or parts[0] not in keys:
+            continue
+        try:
+            base, count = int(parts[1]), int(parts[2])
+        except ValueError:
+            continue
+        if count >= _MIN_RANGE:
+            return base, count
+    return None
+
+
+def _user_name() -> Optional[str]:
+    try:
+        import pwd
+
+        return pwd.getpwuid(os.geteuid()).pw_name
+    except (ImportError, KeyError, OSError):
+        return None
+
+
+def _no_new_privs() -> bool:
+    """Whether this process runs with no_new_privs (setuid helpers no-op)."""
+    try:
+        status = Path("/proc/self/status").read_text(encoding="utf-8")
+    except OSError:
+        return False
+    for line in status.splitlines():
+        if line.startswith("NoNewPrivs:"):
+            return line.split(":", 1)[1].strip() == "1"
+    return False
+
+
+def wait_for_userns(pid: int, timeout: float = 5.0) -> None:
+    """Wait until *pid* has entered a user namespace different from ours."""
+    own = os.readlink("/proc/self/ns/user")
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            if os.readlink(f"/proc/{pid}/ns/user") != own:
+                return
+        except OSError:
+            pass
+        time.sleep(0.02)
+    raise RuntimeError(
+        f"user-namespace holder (pid {pid}) never left the initial namespace"
+    )
+
+
+def map_ids_into(pid: int, idmap: IdMap) -> None:
+    """Write the canonical uid/gid maps into *pid*'s fresh user namespace.
+
+    Runs the setuid ``newuidmap``/``newgidmap`` helpers, which shadow-utils
+    authorizes against ``/etc/subuid`` and ``/etc/subgid``. Raises
+    RuntimeError on failure.
+    """
+    for helper, own, base, count in (
+        ("newuidmap", idmap.euid, idmap.subuid_base, idmap.subuid_count),
+        ("newgidmap", idmap.egid, idmap.subgid_base, idmap.subgid_count),
+    ):
+        res = subprocess.run(
+            [helper, str(pid), "0", str(own), "1", "1", str(base), str(count)],
+            capture_output=True,
+        )
+        if res.returncode != 0:
+            raise RuntimeError(
+                f"{helper} failed: " + res.stderr.decode(errors="replace").strip()
+            )
+
+
+@contextmanager
+def mapped_userns(idmap: IdMap, timeout: float = 60.0) -> Iterator[int]:
+    """Yield the pid of a throwaway process in a user namespace mapped with ``idmap``.
+
+    Raises RuntimeError when the namespace cannot be created or mapped.
+    """
+    try:
+        holder = subprocess.Popen(
+            ["unshare", "--user", "sleep", str(timeout)],
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+    except OSError as err:
+        raise RuntimeError(f"cannot start a user-namespace holder: {err}") from err
+    try:
+        wait_for_userns(holder.pid)
+        map_ids_into(holder.pid, idmap)
+        yield holder.pid
+    finally:
+        holder.kill()
+        holder.communicate()
+
+
+def run_as_mapped_root(
+    pid: int, argv: List[str], timeout: Optional[float] = None
+) -> subprocess.CompletedProcess:
+    """Run ``argv`` as root inside the user namespace of ``pid``."""
+    return subprocess.run(
+        ["nsenter", "--preserve-credentials", "-U", "-t", str(pid), "--", *argv],
+        capture_output=True,
+        timeout=timeout,
+    )
+
+
+def remove_tree_as_mapped_root(path: str, idmap: IdMap) -> None:
+    """Remove a tree with subordinate-owned entries, which only mapped root can."""
+    try:
+        with mapped_userns(idmap) as pid:
+            res = run_as_mapped_root(pid, ["rm", "-rf", "--", path], timeout=120)
+    except (RuntimeError, subprocess.TimeoutExpired) as err:
+        logger.warning("Could not remove %s as mapped root: %s", path, err)
+        return
+    if res.returncode != 0:
+        logger.warning(
+            "Could not remove %s as mapped root: %s",
+            path,
+            res.stderr.decode(errors="replace").strip(),
+        )
+
+
+def _probe_mapping(idmap: IdMap) -> bool:
+    """Whether the setuid helpers actually write ``idmap`` on this node.
+
+    A passing NoNewPrivs check does not guarantee the helpers elevate: image
+    build pipelines can strip their setuid bits, and sandboxed runtimes such
+    as gVisor only accept single-entry self-maps.
+    """
+    try:
+        with mapped_userns(idmap, timeout=5.0):
+            return True
+    except (RuntimeError, OSError):
+        return False
+
+
+@lru_cache(maxsize=1)
+def detect_idmap() -> Optional[IdMap]:
+    """The node's multi-uid mapping, or None to run single-uid.
+
+    Cached per process; each fallback reason is logged once. The setuid
+    newuidmap/newgidmap helpers silently become no-ops under no_new_privs
+    (``allowPrivilegeEscalation: false``-style pod contexts), so that is
+    detected here rather than discovered as a boot failure.
+    """
+    if os.environ.get(SINGLE_UID_ENV) == "1":
+        logger.info("%s=1: sandboxes use single-uid user namespaces", SINGLE_UID_ENV)
+        return None
+    missing = [b for b in ("newuidmap", "newgidmap") if not shutil.which(b)]
+    if missing:
+        logger.warning(
+            "%s not found in PATH; sandboxes use single-uid user namespaces "
+            "(in-sandbox files cannot be owned by distinct uids). Install the "
+            "uidmap package on the node image.",
+            ", ".join(missing),
+        )
+        return None
+    if _no_new_privs():
+        logger.warning(
+            "This process runs with no_new_privs, which disables the setuid "
+            "newuidmap/newgidmap helpers; sandboxes use single-uid user "
+            "namespaces. Remove allowPrivilegeEscalation=false (or equivalent) "
+            "from the pod securityContext to enable multi-uid."
+        )
+        return None
+    euid, egid = os.geteuid(), os.getegid()
+    name = _user_name()
+    # Both /etc/subuid and /etc/subgid are keyed by the login name or the
+    # numeric *uid* (the shadow-utils convention), so the numeric lookup key
+    # is euid for both files.
+    uid_range = parse_subid_file("/etc/subuid", name, euid)
+    gid_range = parse_subid_file("/etc/subgid", name, euid)
+    if uid_range is None or gid_range is None:
+        logger.warning(
+            "/etc/subuid or /etc/subgid has no range of at least %d ids for "
+            "user %s (uid %d); sandboxes use single-uid user namespaces. Add "
+            "e.g. '%s:100000:65536' to both files.",
+            _MIN_RANGE,
+            name or "<unknown>",
+            euid,
+            name or euid,
+        )
+        return None
+    idmap = IdMap(
+        euid=euid,
+        egid=egid,
+        subuid_base=uid_range[0],
+        subuid_count=uid_range[1],
+        subgid_base=gid_range[0],
+        subgid_count=gid_range[1],
+    )
+    if not _probe_mapping(idmap):
+        logger.warning(
+            "newuidmap/newgidmap could not write a subordinate mapping here "
+            "(stripped setuid bits, a restricted pod securityContext, or the "
+            "pod itself running under a sandboxed runtime such as gVisor, "
+            "whose kernel only supports self-maps); sandboxes use single-uid "
+            "user namespaces."
+        )
+        return None
+    return idmap

--- a/python/ray/experimental/sandbox/_internal/idmap_extract.py
+++ b/python/ray/experimental/sandbox/_internal/idmap_extract.py
@@ -1,0 +1,53 @@
+"""Apply an image's recorded ownership to a freshly extracted rootfs.
+
+Invoked as ``python -m ray.experimental.sandbox._internal.idmap_extract ROOTFS
+OWNERSHIP_JSON`` by :func:`ray.experimental.sandbox._internal.image_utils.pull_and_extract_container_image`
+through ``nsenter`` into a user namespace mapped with the node's subordinate
+ranges; only there can ``lchown`` give files their true owners. The rootfs is
+extracted worker-owned first, which is what root inside the sandbox maps to,
+so only the entries the image ships with a non-root owner need changing.
+"""
+
+import argparse
+import json
+import os
+import stat
+import sys
+from typing import Dict, Tuple
+
+
+def apply_ownership(rootfs: str, ownership: Dict[str, Tuple[int, int]]) -> None:
+    """Chown ``rootfs`` entries per ``ownership``, restoring the modes chown clears."""
+    from ray.experimental.sandbox._internal.image_utils import _lchown_preserving
+
+    for rel, (uid, gid) in ownership.items():
+        path = os.path.join(rootfs, rel)
+        try:
+            st = os.lstat(path)
+        except OSError:
+            continue
+        _lchown_preserving(path, uid, gid)
+        if not stat.S_ISLNK(st.st_mode):
+            # chown clears setuid/setgid on files; put the mode back.
+            try:
+                os.chmod(path, stat.S_IMODE(st.st_mode))
+            except OSError:
+                pass
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("rootfs", help="extracted rootfs to chown in place")
+    parser.add_argument(
+        "ownership", help="JSON {path: [uid, gid]} recorded at extraction"
+    )
+    args = parser.parse_args()
+
+    with open(args.ownership, encoding="utf-8") as f:
+        ownership = {p: (int(ids[0]), int(ids[1])) for p, ids in json.load(f).items()}
+    apply_ownership(args.rootfs, ownership)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/python/ray/experimental/sandbox/_internal/image_utils.py
+++ b/python/ray/experimental/sandbox/_internal/image_utils.py
@@ -6,6 +6,8 @@ import os
 import platform
 import re
 import shutil
+import subprocess
+import sys
 import tarfile
 import tempfile
 import urllib.error
@@ -14,12 +16,27 @@ import urllib.request
 import uuid
 from typing import BinaryIO, Dict, Optional, Tuple, Union
 
+from ray.experimental.sandbox._internal.idmap import (
+    IdMap,
+    detect_idmap,
+    mapped_userns,
+    remove_tree_as_mapped_root,
+    run_as_mapped_root,
+)
 from ray.experimental.sandbox.exceptions import SandboxCreationError
 
 logger = logging.getLogger(__name__)
 
 DEFAULT_IMAGES_DIR = "/tmp/ray/sandbox/images"
 _USER_AGENT = "ray-sandbox/1.0 (python-urllib)"
+
+# Cache layout version recorded in each image's ``.extracted`` marker, next
+# to the uid/gid mapping the rootfs was extracted for. A cache written under
+# another version or mapping is re-extracted once.
+_EXTRACT_FORMAT = 2
+
+# Warn once per process about uids the node's subordinate range cannot map.
+_UNMAPPED_ID_WARNED = False
 
 
 def _registry_request(
@@ -225,16 +242,59 @@ def get_registry_auth_headers(
     return {}
 
 
+def _drop_ownership_subtree(ownership: Dict[str, Tuple[int, int]], name: str) -> None:
+    """Forget recorded owners for a deleted path and everything under it."""
+    ownership.pop(name, None)
+    prefix = name + "/"
+    for key in [k for k in ownership if k.startswith(prefix)]:
+        del ownership[key]
+
+
+def _lchown_preserving(target_path: str, uid: int, gid: int) -> None:
+    """lchown that tolerates ids outside the mapped subordinate range."""
+    global _UNMAPPED_ID_WARNED
+    try:
+        os.lchown(target_path, uid, gid)
+    except OSError as err:
+        if not _UNMAPPED_ID_WARNED:
+            _UNMAPPED_ID_WARNED = True
+            logger.warning(
+                "Could not chown '%s' to %d:%d (%s); ids outside the mapped "
+                "subordinate range keep the extracting user's ownership "
+                "(warning once).",
+                target_path,
+                uid,
+                gid,
+                err,
+            )
+
+
 def extract_tar_layer(
-    tar_input: Union[bytes, io.IOBase, BinaryIO], dest_dir: str
+    tar_input: Union[bytes, io.IOBase, BinaryIO],
+    dest_dir: str,
+    ownership: Optional[Dict[str, Tuple[int, int]]] = None,
 ) -> None:
-    """Extract a tar archive layer onto dest_dir with OCI whiteout handling."""
+    """Extract a tar archive layer onto dest_dir with OCI whiteout handling.
+
+    ``ownership`` (shared by the caller across an image's layers) records the
+    final {path: (uid, gid)} for members shipped with a non-root owner;
+    whiteouts drop entries. The extracted files themselves stay owned by the
+    extracting user; the idmapped-rootfs build applies the recorded owners.
+    Directory modes are applied children-first after the loop, since a
+    restrictive parent written mid-extraction could block its own children.
+    """
     if isinstance(tar_input, bytes):
         tar_fileobj = io.BytesIO(tar_input)
     else:
         tar_fileobj = tar_input
 
-    dir_mtimes = []
+    # {dir target_path: (mode, mtime)} in final (last-layer-wins) state,
+    # applied children-first after the loop. The mtime matters: apt inside
+    # the sandbox revalidates package lists with If-Modified-Since from the
+    # directory mtime, so a reset-to-now mtime makes mirrors answer 304 for
+    # stale baked lists.
+    deferred_dirs: Dict[str, Tuple[int, int]] = {}
+
     with tarfile.open(fileobj=tar_fileobj, mode="r:*") as tar:
         for member in tar.getmembers():
             name = member.name.lstrip("/")
@@ -274,6 +334,9 @@ def extract_tar_layer(
                                 os.remove(item_path)
                             except OSError:
                                 pass
+                if ownership is not None and dirname:
+                    for key in [k for k in ownership if k.startswith(dirname + "/")]:
+                        del ownership[key]
                 continue
 
             # Handle OCI deletion whiteout (.wh.<filename>)
@@ -287,6 +350,11 @@ def extract_tar_layer(
                         os.remove(del_path)
                     except OSError:
                         pass
+                if ownership is not None:
+                    _drop_ownership_subtree(
+                        ownership,
+                        os.path.join(dirname, del_name) if dirname else del_name,
+                    )
                 continue
 
             # Remove conflicting existing file/dir if member type differs
@@ -327,12 +395,12 @@ def extract_tar_layer(
                     pass
             elif member.isdir():
                 os.makedirs(target_path, exist_ok=True)
-                # Deferred to the post-loop pass: tar lists a directory
-                # before its contents, so a restrictive archived mode (0500)
-                # applied here would break extracting the children. Preserved
-                # symlinks (UsrMerge) are skipped: chmod/utime follow them.
+                # Deferred to the post-loop pass: tar lists a directory before
+                # its contents, so a restrictive archived mode (0500) applied
+                # here would break extracting the children. Preserved symlinks
+                # (UsrMerge) are skipped: chmod/utime follow them.
                 if not os.path.islink(target_path):
-                    dir_mtimes.append((target_path, member.mode, member.mtime))
+                    deferred_dirs[target_path] = (member.mode, member.mtime)
             elif member.issym():
                 os.makedirs(parent_dir, exist_ok=True)
                 try:
@@ -349,15 +417,102 @@ def extract_tar_layer(
                         os.link(link_target, target_path)
                     except OSError:
                         pass
+                # Hardlinks share the target's inode: no chown, and the
+                # ownership record comes from the link target's own member.
 
-    # Children first, so a parent's restrictive mode cannot block them.
-    for dir_path, mode, mtime in reversed(dir_mtimes):
+            if ownership is not None and not member.islnk():
+                if member.uid or member.gid:
+                    ownership[name] = (member.uid, member.gid)
+                else:
+                    # A later layer re-shipping the path as root wins.
+                    ownership.pop(name, None)
+
+    if deferred_dirs:
+        # Children first: a restrictive parent mode (0500) applied before its
+        # children would block extracting them.
+        for target_path in sorted(
+            deferred_dirs, key=lambda p: p.count(os.sep), reverse=True
+        ):
+            mode, mtime = deferred_dirs[target_path]
+            try:
+                if mode:
+                    os.chmod(target_path, mode)
+                os.utime(target_path, (mtime, mtime))
+            except OSError:
+                pass
+
+
+def expected_extract_marker(idmap: Optional[IdMap]) -> str:
+    """The ``.extracted`` content a cache built for ``idmap`` must carry."""
+    mapping = None
+    if idmap is not None:
+        mapping = [
+            idmap.subuid_base,
+            idmap.subuid_count,
+            idmap.subgid_base,
+            idmap.subgid_count,
+        ]
+    return json.dumps({"format": _EXTRACT_FORMAT, "idmap": mapping}, sort_keys=True)
+
+
+def _apply_ownership_in_namespace(
+    rootfs: str,
+    ownership: Dict[str, Tuple[int, int]],
+    idmap: IdMap,
+    timeout_seconds: float,
+) -> None:
+    """Give a freshly extracted rootfs the image's real owners.
+
+    Runs ``idmap_extract`` as root inside a user namespace mapped with
+    ``idmap``: only there can ``lchown`` produce the subordinate host ids
+    that read as the image's uids from inside a sandbox.
+    """
+    if not ownership:
+        return
+    ownership_path = f"{rootfs}.ownership.json"
+    with open(ownership_path, "w", encoding="utf-8") as f:
+        json.dump({p: list(ids) for p, ids in ownership.items()}, f)
+    try:
+        with mapped_userns(idmap, timeout=max(timeout_seconds, 60.0)) as pid:
+            res = run_as_mapped_root(
+                pid,
+                [
+                    sys.executable,
+                    "-m",
+                    "ray.experimental.sandbox._internal.idmap_extract",
+                    rootfs,
+                    ownership_path,
+                ],
+                timeout=timeout_seconds,
+            )
+    except (RuntimeError, subprocess.TimeoutExpired) as err:
+        raise SandboxCreationError(f"applying image ownership failed: {err}") from err
+    finally:
         try:
-            if mode:
-                os.chmod(dir_path, mode)
-            os.utime(dir_path, (mtime, mtime))
+            os.remove(ownership_path)
         except OSError:
             pass
+    if res.returncode != 0:
+        raise SandboxCreationError(
+            "applying image ownership failed: "
+            + res.stderr.decode(errors="replace").strip()
+        )
+
+
+def _remove_image_tree(path: str) -> None:
+    """Remove a cached image tree; multi-uid caches need the node's mapping."""
+    shutil.rmtree(path, ignore_errors=True)
+    if not os.path.lexists(path):
+        return
+    idmap = detect_idmap()
+    if idmap is not None:
+        remove_tree_as_mapped_root(path, idmap)
+    if os.path.lexists(path):
+        logger.warning(
+            "Could not fully remove %s; it holds files owned by subordinate ids "
+            "and the node's id mapping is unavailable.",
+            path,
+        )
 
 
 _IMAGE_CACHE_MAX_BYTES_ENV = "RAY_SANDBOX_IMAGE_CACHE_MAX_BYTES"
@@ -447,11 +602,11 @@ def evict_least_recently_used_images(
 
     Nodes cache every image they ever ran, so without a cap a long-lived
     node eventually fills its disk. Candidates are fully extracted images
-    (``.extracted`` marker present) and ``<name>.tar`` archives left behind
-    by earlier Ray versions, oldest first. An image is skipped when a live sandbox uses it, when its
-    per-image lock is held (a pull in progress), or when it is ``keep``. The
-    in-use check is repeated under the lock, which is also where pulls
-    register their users, so a marked image is never removed.
+    (``.extracted`` marker present) and stray ``<name>.tar`` archives left by
+    earlier Ray versions, oldest first. An image is skipped when a live
+    sandbox uses it, when its per-image lock is held (a pull in progress), or
+    when it is ``keep``. The in-use check is repeated under the lock, which is
+    also where pulls register their users, so a marked image is never removed.
 
     Args:
         images_dir: Root image cache directory.
@@ -490,6 +645,8 @@ def evict_least_recently_used_images(
         except OSError:
             continue  # Concurrently deleted; keep going.
         tar_path = os.path.join(images_dir, f"{name}.tar")
+        # Subordinate-owned subtrees of a multi-uid cache are unreadable
+        # here, so this is a lower bound for them.
         size = _dir_size_bytes(path) + _file_size_bytes(tar_path)
         entries.append((mtime, name, path, tar_path, size))
 
@@ -507,7 +664,7 @@ def evict_least_recently_used_images(
                 if img_dir is not None and _has_users(img_dir):
                     continue
                 if img_dir is not None:
-                    shutil.rmtree(img_dir, ignore_errors=True)
+                    _remove_image_tree(img_dir)
                 try:
                     os.remove(tar_path)
                 except OSError:
@@ -552,6 +709,12 @@ def pull_and_extract_container_image(
     if max_cache > 0:
         evict_least_recently_used_images(images_dir, max_cache, keep=safe_name)
 
+    # The node's mapping decides the cache's ownership layout: multi-uid nodes
+    # store the image's real owners (at subordinate host ids), single-uid
+    # nodes store everything worker-owned.
+    idmap = detect_idmap()
+    expected_marker = expected_extract_marker(idmap)
+
     def _finish() -> str:
         if instance_id is not None:
             _mark_image_in_use(target_dir, instance_id)
@@ -562,11 +725,19 @@ def pull_and_extract_container_image(
             fcntl.flock(f_lock, fcntl.LOCK_EX)
             marker_path = os.path.join(target_dir, ".extracted")
             if os.path.isdir(target_dir) and os.path.exists(marker_path):
-                if os.path.isfile(image):
-                    if os.path.getmtime(marker_path) >= os.path.getmtime(image):
+                try:
+                    with open(marker_path, "r", encoding="utf-8") as f_mark:
+                        marker_current = f_mark.read() == expected_marker
+                except OSError:
+                    marker_current = False
+                # A cache from another layout version or id mapping falls
+                # through to a one-time re-pull.
+                if marker_current:
+                    if os.path.isfile(image):
+                        if os.path.getmtime(marker_path) >= os.path.getmtime(image):
+                            return _finish()
+                    else:
                         return _finish()
-                else:
-                    return _finish()
 
             tmp_extract_dir = os.path.join(
                 images_dir, f"{safe_name}.tmp.{uuid.uuid4().hex}"
@@ -576,12 +747,14 @@ def pull_and_extract_container_image(
             tmp_rootfs_dir = os.path.join(tmp_extract_dir, "rootfs")
             os.makedirs(tmp_rootfs_dir, mode=0o755, exist_ok=True)
 
+            ownership: Dict[str, Tuple[int, int]] = {}
+
             if os.path.isfile(image):
                 try:
                     with open(image, "rb") as f:
-                        extract_tar_layer(f, tmp_rootfs_dir)
+                        extract_tar_layer(f, tmp_rootfs_dir, ownership=ownership)
                 except Exception as err:
-                    shutil.rmtree(tmp_extract_dir, ignore_errors=True)
+                    _remove_image_tree(tmp_extract_dir)
                     raise SandboxCreationError(
                         f"Failed to extract local image archive '{image}': {err}"
                     ) from err
@@ -592,7 +765,7 @@ def pull_and_extract_container_image(
                     or image.startswith("./")
                     or image.startswith("../")
                 ):
-                    shutil.rmtree(tmp_extract_dir, ignore_errors=True)
+                    _remove_image_tree(tmp_extract_dir)
                     raise SandboxCreationError(
                         f"Local image archive '{image}' not found."
                     )
@@ -689,24 +862,45 @@ def pull_and_extract_container_image(
                                     blob_resp, tmp_blob_file, length=64 * 1024
                                 )
                                 tmp_blob_file.seek(0)
-                                extract_tar_layer(tmp_blob_file, tmp_rootfs_dir)
+                                extract_tar_layer(
+                                    tmp_blob_file,
+                                    tmp_rootfs_dir,
+                                    ownership=ownership,
+                                )
 
                 except Exception as err:
-                    shutil.rmtree(tmp_extract_dir, ignore_errors=True)
+                    _remove_image_tree(tmp_extract_dir)
                     if isinstance(err, SandboxCreationError):
                         raise
                     raise SandboxCreationError(
                         f"Failed to pull and extract container image '{image}': {err}"
                     ) from err
 
+            if idmap is not None:
+                try:
+                    _apply_ownership_in_namespace(
+                        tmp_rootfs_dir, ownership, idmap, timeout_seconds
+                    )
+                except Exception:
+                    _remove_image_tree(tmp_extract_dir)
+                    raise
+
             with open(
                 os.path.join(tmp_extract_dir, ".extracted"), "w", encoding="utf-8"
             ) as f_mark:
-                f_mark.write("ok")
+                f_mark.write(expected_marker)
 
+            # A re-extract (stale marker) replaces the directory; keep the
+            # pins of sandboxes already running on the old extraction.
+            try:
+                users = os.listdir(os.path.join(target_dir, _USERS_SUBDIR))
+            except OSError:
+                users = []
             if os.path.exists(target_dir):
-                shutil.rmtree(target_dir, ignore_errors=True)
+                _remove_image_tree(target_dir)
             os.replace(tmp_extract_dir, target_dir)
+            for user in users:
+                _mark_image_in_use(target_dir, user)
 
             return _finish()
         finally:

--- a/python/ray/experimental/sandbox/backend/gvisor.py
+++ b/python/ray/experimental/sandbox/backend/gvisor.py
@@ -9,6 +9,11 @@ import time
 import uuid
 from typing import Callable, Dict, List, Optional, Union
 
+from ray.experimental.sandbox._internal.idmap import (
+    IdMap,
+    detect_idmap,
+    remove_tree_as_mapped_root,
+)
 from ray.experimental.sandbox.backend.base import (
     BaseSandboxBackend,
     ExecResult,
@@ -44,6 +49,11 @@ _RAY_SANDBOX_DIR = "/tmp/ray/sandbox"
 # leaves through pasta's tap. Mount and pid namespaces stay shared, so the
 # bundle and runsc's control sockets under _RUNSC_ROOT keep working for
 # pod-side state/exec/kill/delete.
+#
+# Multi-uid nodes (see _internal/idmap.py) use the same holder + nsenter
+# shape for every rootless sandbox, network namespace or not, so that runsc
+# runs as mapped root in a user namespace carrying the node's subordinate id
+# range; single-uid nodes wrap only network="public".
 #
 # pasta relays every outbound connection through the pod's own sockets, so
 # the sandbox can reach any address the pod can reach: other Ray nodes
@@ -87,7 +97,12 @@ class GVisorSandboxBackend(BaseSandboxBackend):
                 "gVisor executable 'runsc' not found in PATH. "
                 "Please install gVisor (runsc) on the node."
             )
-        if config.network == "public":
+        use_pasta = config.network == "public"
+        # Rootless sandboxes map a subordinate id range into their user
+        # namespace when the node can (warn-once inside detect_idmap);
+        # privileged runsc needs no namespace of ours.
+        idmap = detect_idmap() if config.rootless else None
+        if use_pasta:
             missing = [b for b in ("pasta", "nsenter") if not shutil.which(b)]
             if missing:
                 raise SandboxCreationError(
@@ -162,7 +177,9 @@ class GVisorSandboxBackend(BaseSandboxBackend):
             raise
         overlay_dir = os.path.join(root_dir, "overlay")
         os.makedirs(overlay_dir, mode=0o777, exist_ok=True)
-        run_args = self._build_run_command(config, root_dir, overlay_dir, sandbox_id)
+        run_args = self._build_run_command(
+            config, root_dir, overlay_dir, sandbox_id, idmap=idmap
+        )
 
         stderr_log_path = os.path.join(root_dir, "runsc.stderr.log")
         stderr_file = open(stderr_log_path, "w+", encoding="utf-8")
@@ -222,7 +239,7 @@ class GVisorSandboxBackend(BaseSandboxBackend):
             self._delete_container_state(config, sandbox_id)
             self._terminate_tree(proc)
             stderr_file.close()
-            shutil.rmtree(root_dir, ignore_errors=True)
+            self._remove_root_dir(root_dir, idmap)
             # The sandbox never registered, so delete_sandbox will not run
             # for it: release the image here to keep it evictable.
             self._image_manager.release_image(config.image, sandbox_id)
@@ -238,6 +255,7 @@ class GVisorSandboxBackend(BaseSandboxBackend):
             "proc": proc,
             "stderr_file": stderr_file,
             "status": SandboxStatus.RUNNING,
+            "idmap": idmap,
         }
         return sandbox_id
 
@@ -271,9 +289,20 @@ class GVisorSandboxBackend(BaseSandboxBackend):
                 except Exception:
                     pass
 
-            shutil.rmtree(root_dir, ignore_errors=True)
+            self._remove_root_dir(root_dir, meta.get("idmap"))
             # Only now is the overlay's lower layer unused.
             self._image_manager.release_image(config.image, sandbox_id)
+
+    def _remove_root_dir(self, root_dir: str, idmap: Optional[IdMap]) -> None:
+        """Remove a sandbox's directory, including subordinate-owned files.
+
+        A multi-uid sandbox can chown files under its workdir bind to ids the
+        worker cannot delete from the initial namespace; those go through a
+        namespace mapped with the sandbox's ``idmap``.
+        """
+        shutil.rmtree(root_dir, ignore_errors=True)
+        if idmap is not None and os.path.lexists(root_dir):
+            remove_tree_as_mapped_root(root_dir, idmap)
 
     def exec_command(
         self,
@@ -431,49 +460,74 @@ class GVisorSandboxBackend(BaseSandboxBackend):
             pass
 
     def _build_run_command(
-        self, config: SandboxConfig, root_dir: str, overlay_dir: str, sandbox_id: str
+        self,
+        config: SandboxConfig,
+        root_dir: str,
+        overlay_dir: str,
+        sandbox_id: str,
+        idmap: Optional[IdMap] = None,
     ) -> List[str]:
-        """Build the full `runsc run` argv, pasta-wrapped for network="public".
+        """Build the full `runsc run` argv, wrapped in a user namespace when needed.
 
         Pure argv construction (no filesystem side effects) so tests can
         assert the exact command without runsc or pasta installed.
+
+        A bare ``runsc --rootless`` invocation is enough for a single-uid
+        sandbox on the worker's network. Two features need runsc to run as
+        mapped root inside a user namespace we own: ``network="public"``
+        (the namespace also carries the private network namespace pasta
+        bridges) and multi-uid ``idmap`` (the namespace maps the node's
+        subordinate id range via newuidmap/newgidmap). runsc drops
+        ``--rootless`` there because nesting a second user namespace breaks
+        the gofer's /proc magic-link derefs, and gains ``--ignore-cgroups``
+        to keep rootless mode's tolerance of cgroup permission failures.
         """
         args = self._runsc_base_args(config)
         use_pasta = config.network == "public"
-        if use_pasta and "--rootless" in args:
-            # runsc runs as mapped root inside the holder's user namespace;
-            # --rootless would nest a second user namespace whose
-            # /proc/<pid>/root magic links the gofer cannot dereference.
-            # Rootless mode also tolerates cgroup permission failures, so
-            # keep that behavior explicitly.
+        wrap = config.rootless and (use_pasta or idmap is not None)
+        if wrap:
             args = [a for a in args if a != "--rootless"]
             if "--ignore-cgroups" not in args:
                 args.insert(1, "--ignore-cgroups")
         if config.network:
             # "public" = host egress + generated resolv.conf (handled in the
-            # OCI bundle); runsc itself just sees host networking — of the
-            # per-sandbox namespace when wrapped, of the worker otherwise.
+            # OCI bundle); runsc itself just sees host networking: of the
+            # per-sandbox namespace when pasta wraps it, of the worker
+            # otherwise.
             runsc_network = "host" if config.network == "public" else config.network
             args.extend(["--network", runsc_network])
         args.append(f"--overlay2=root:dir={overlay_dir}")
         args.extend(["run", "--bundle", root_dir, sandbox_id])
+        if not wrap:
+            return args
+
+        netns_pidfile = shlex.quote(os.path.join(root_dir, "netns.pid"))
+        runsc = " ".join(shlex.quote(a) for a in args)
+        net_flag = " --net" if use_pasta else ""
+        if idmap is not None:
+            # The holder starts unmapped (DAC is kuid-based, so writing the
+            # pidfile into the 0777 root_dir and sleeping both work; ids
+            # merely read as the overflow uid until mapped). The maps are
+            # written exactly once into the fresh uid_map/gid_map: container
+            # root onto the worker's own ids, 1..count onto the subordinate
+            # range. Plain --user never writes setgroups=deny, so newgidmap
+            # works. &&-chaining surfaces a map failure through
+            # runsc.stderr.log.
+            holder = f"unshare --user{net_flag} --fork --kill-child "
+            maps = (
+                f"newuidmap $NSPID 0 {idmap.euid} 1"
+                f" 1 {idmap.subuid_base} {idmap.subuid_count} && "
+                f"newgidmap $NSPID 0 {idmap.egid} 1"
+                f" 1 {idmap.subgid_base} {idmap.subgid_count} && "
+            )
+        else:
+            holder = f"unshare --user --map-root-user{net_flag} --fork --kill-child "
+            maps = ""
+        pasta_part = ""
         if use_pasta:
-            netns_pidfile = shlex.quote(os.path.join(root_dir, "netns.pid"))
             pasta_pidfile = shlex.quote(os.path.join(root_dir, "pasta.pid"))
-            runsc = " ".join(shlex.quote(a) for a in args)
             pasta = " ".join(["pasta", *_PASTA_FLAGS])
-            script = (
-                # The holder pins the namespaces for the sandbox's lifetime;
-                # --kill-child ties it to this script's process group.
-                "unshare --user --map-root-user --net --fork --kill-child "
-                f"bash -c 'echo $$ > {netns_pidfile}; exec sleep infinity' & "
-                "HOLDER=$!; "
-                # Stop waiting as soon as the holder dies, and refuse an
-                # empty NSPID (which would resolve to /proc//ns/net).
-                f"for i in $(seq 1 100); do [ -s {netns_pidfile} ] && break; "
-                "kill -0 $HOLDER 2>/dev/null || break; sleep 0.1; done; "
-                f"NSPID=$(cat {netns_pidfile} 2>/dev/null); "
-                '[ -n "$NSPID" ] || { echo "netns holder failed to start" >&2; exit 1; }; '
+            pasta_part = (
                 # pasta attaches from the pod side and stays in the
                 # foreground, so it lives and dies with this process group.
                 # It writes --pid once initialised: that is the go signal.
@@ -483,10 +537,25 @@ class GVisorSandboxBackend(BaseSandboxBackend):
                 f"for i in $(seq 1 100); do [ -s {pasta_pidfile} ] && break; "
                 "kill -0 $PASTA 2>/dev/null || break; sleep 0.1; done; "
                 f'[ -s {pasta_pidfile} ] || {{ echo "pasta failed to start" >&2; exit 1; }}; '
-                f"exec nsenter --preserve-credentials -U -n -t $NSPID -- {runsc}"
             )
-            return ["bash", "-c", script]
-        return args
+        enter = "-U -n" if use_pasta else "-U"
+        script = (
+            # The holder pins the namespaces for the sandbox's lifetime;
+            # --kill-child ties it to this script's process group.
+            f"{holder}"
+            f"bash -c 'echo $$ > {netns_pidfile}; exec sleep infinity' & "
+            "HOLDER=$!; "
+            # Stop waiting as soon as the holder dies, and refuse an empty
+            # NSPID (which would resolve to /proc//ns/net).
+            f"for i in $(seq 1 100); do [ -s {netns_pidfile} ] && break; "
+            "kill -0 $HOLDER 2>/dev/null || break; sleep 0.1; done; "
+            f"NSPID=$(cat {netns_pidfile} 2>/dev/null); "
+            '[ -n "$NSPID" ] || { echo "netns holder failed to start" >&2; exit 1; }; '
+            f"{maps}"
+            f"{pasta_part}"
+            f"exec nsenter --preserve-credentials {enter} -t $NSPID -- {runsc}"
+        )
+        return ["bash", "-c", script]
 
     def _terminate_tree(self, proc: subprocess.Popen) -> None:
         """SIGKILL the sandbox process group and reap the Popen.

--- a/python/ray/experimental/sandbox/tests/conftest.py
+++ b/python/ray/experimental/sandbox/tests/conftest.py
@@ -97,3 +97,22 @@ def ensure_pasta(ensure_runsc):
             'network="public" needs a per-sandbox user+network namespace this '
             "environment forbids (nested user namespace denied at sandbox boot)"
         )
+
+
+@pytest.fixture(scope="session")
+def ensure_idmap_node():
+    """The node's multi-uid mapping; skips when the node cannot map one.
+
+    Multi-uid tests need the setuid newuidmap/newgidmap helpers (uidmap
+    package) and /etc/subuid + /etc/subgid ranges for the test user.
+    """
+    from ray.experimental.sandbox._internal.idmap import detect_idmap
+
+    detect_idmap.cache_clear()
+    idmap = detect_idmap()
+    if idmap is None:
+        pytest.skip(
+            "node lacks newuidmap/newgidmap or usable /etc/subuid ranges; "
+            "multi-uid tests skipped"
+        )
+    return idmap

--- a/python/ray/experimental/sandbox/tests/test_gvisor_backend.py
+++ b/python/ray/experimental/sandbox/tests/test_gvisor_backend.py
@@ -393,11 +393,84 @@ def test_build_run_command_public_keeps_rootless_cgroup_tolerance(monkeypatch):
     assert "--ignore-cgroups" not in _run_argv("none")
 
 
+def test_build_run_command_public_multiuid_script():
+    """With an IdMap, the holder is mapped via newuidmap/newgidmap.
+
+    Pin the whole chain: unmapped holder (no --map-root-user), both map
+    lines with the exact ranges (container root onto the worker's ids,
+    1..count onto the subordinate range), maps written before pasta
+    attaches, runsc still entered as mapped root without --rootless.
+    """
+    from ray.experimental.sandbox._internal.idmap import IdMap
+
+    backend = GVisorSandboxBackend()
+    cfg = GVisorSandboxConfig(image="busybox:latest", network="public")
+    idmap = IdMap(
+        euid=1000,
+        egid=1001,
+        subuid_base=100000,
+        subuid_count=65536,
+        subgid_base=200000,
+        subgid_count=65536,
+    )
+    cmd = backend._build_run_command(
+        cfg, "/tmp/rd", "/tmp/rd/overlay", "sb-1", idmap=idmap
+    )
+
+    assert cmd[:2] == ["bash", "-c"]
+    script = cmd[2]
+    assert script.startswith("unshare --user --net --fork --kill-child ")
+    assert "--map-root-user" not in script
+    assert (
+        "newuidmap $NSPID 0 1000 1 1 100000 65536 && "
+        "newgidmap $NSPID 0 1001 1 1 200000 65536 && "
+        "pasta " in script
+    )
+    assert "exec nsenter --preserve-credentials -U -n -t $NSPID -- runsc" in script
+    assert "--rootless" not in script
+    assert script.endswith("run --bundle /tmp/rd sb-1")
+
+
+@pytest.mark.parametrize("network", ["none", "host"])
+def test_build_run_command_multiuid_wraps_without_pasta(network):
+    """Multi-uid is independent of the network mode: a mapped user namespace
+    wraps every rootless sandbox, with no network namespace and no pasta."""
+    from ray.experimental.sandbox._internal.idmap import IdMap
+
+    backend = GVisorSandboxBackend()
+    cfg = GVisorSandboxConfig(image="busybox:latest", network=network)
+    idmap = IdMap(1000, 1001, 100000, 65536, 200000, 65536)
+    cmd = backend._build_run_command(
+        cfg, "/tmp/rd", "/tmp/rd/overlay", "sb-1", idmap=idmap
+    )
+
+    assert cmd[:2] == ["bash", "-c"]
+    script = cmd[2]
+    assert script.startswith("unshare --user --fork --kill-child ")
+    assert "--net" not in script.split("bash -c")[0]
+    assert "pasta" not in script
+    assert "newuidmap $NSPID 0 1000 1 1 100000 65536 && " in script
+    assert "exec nsenter --preserve-credentials -U -t $NSPID -- runsc" in script
+    assert f"--network {network}" in script
+    assert "--ignore-cgroups" in script
+    assert "--rootless" not in script
+
+    # Privileged runsc (rootless=False) never gets a namespace of ours.
+    privileged = backend._build_run_command(
+        GVisorSandboxConfig(image="busybox:latest", network="sandbox", rootless=False),
+        "/tmp/rd",
+        "/tmp/rd/overlay",
+        "sb-1",
+        idmap=idmap,
+    )
+    assert privileged[0] == "runsc"
+
+
 @pytest.mark.parametrize(
     "network,rootless", [("none", True), ("host", True), ("sandbox", False)]
 )
 def test_build_run_command_other_modes_unwrapped(network, rootless):
-    """Every mode but "public" keeps today's bare runsc invocation."""
+    """On a single-uid node, every mode but "public" keeps the bare runsc invocation."""
     cmd = _run_argv(network, rootless=rootless)
     assert cmd[0] == "runsc"
     assert "pasta" not in cmd
@@ -491,6 +564,197 @@ def test_netns_teardown_reaps_pasta(ensure_pasta):
     assert _pasta_pids() == before
     assert not os.path.exists(meta["root_dir"])
     assert sb not in backend._sandbox_metadata
+
+
+def test_multiuid_runtime_chown(ensure_pasta, ensure_idmap_node):
+    """With a mapped subordinate range, in-sandbox chown to arbitrary uids
+    works — on the overlay rootfs, and host-visibly on a workdir bind."""
+    from ray.experimental.sandbox.config import DOCKER_DEFAULT_CAPABILITIES
+
+    idmap = ensure_idmap_node
+    backend = GVisorSandboxBackend()
+
+    # Overlay rootfs path (readonly=False) plus /tmp control.
+    sb = backend.create_sandbox(
+        GVisorSandboxConfig(
+            image="busybox:latest",
+            shell="/bin/sh",
+            network="public",
+            readonly=False,
+            capabilities=list(DOCKER_DEFAULT_CAPABILITIES),
+        )
+    )
+    try:
+        res = backend.exec_command(
+            sb,
+            "touch /probe && chown 38:38 /probe && stat -c %u:%g /probe && "
+            "touch /tmp/probe && chown 101:104 /tmp/probe && "
+            "stat -c %u:%g /tmp/probe",
+            timeout=30,
+        )
+        assert res.exit_code == 0, res.stderr
+        assert res.stdout.split() == ["38:38", "101:104"]
+    finally:
+        backend.delete_sandbox(sb)
+
+    # Workdir bind: the chown must materialize host-side at the subordinate
+    # ids (the overlay upper is a sentry filestore, so the bind is the only
+    # host-visible surface).
+    sb = backend.create_sandbox(
+        GVisorSandboxConfig(
+            image="busybox:latest",
+            shell="/bin/sh",
+            network="public",
+            workdir="/data",
+            capabilities=list(DOCKER_DEFAULT_CAPABILITIES),
+        )
+    )
+    try:
+        meta = backend._sandbox_metadata[sb]
+        res = backend.exec_command(
+            sb,
+            "touch /data/f && chown 101:104 /data/f && stat -c %u:%g /data/f",
+            timeout=30,
+        )
+        assert res.exit_code == 0, res.stderr
+        assert res.stdout.strip() == "101:104"
+        host_stat = os.stat(os.path.join(meta["workdir"], "f"))
+        assert host_stat.st_uid == idmap.subuid_base + 100
+        assert host_stat.st_gid == idmap.subgid_base + 103
+    finally:
+        backend.delete_sandbox(sb)
+
+
+def _owned_busybox_tar(tar_path: str) -> None:
+    """A busybox-based local image tar shipping baked non-root ownership,
+    modeled on the mailman image (0700 uid=101 spool, 02710 setgid dir)."""
+    import io
+    import tarfile
+
+    from ray.experimental.sandbox.image_manager import ImageManager
+
+    busybox_rootfs = os.path.join(ImageManager().pull_image("busybox:latest"), "rootfs")
+
+    def _as_root(ti):
+        ti.uid = ti.gid = 0
+        ti.uname = ti.gname = ""
+        return ti
+
+    with tarfile.open(tar_path, "w") as tar:
+        tar.add(busybox_rootfs, arcname=".", filter=_as_root)
+        spool = tarfile.TarInfo("./var/spool/testq")
+        spool.type = tarfile.DIRTYPE
+        spool.uid, spool.gid, spool.mode = 101, 0, 0o700
+        tar.addfile(spool)
+        inner = tarfile.TarInfo("./var/spool/testq/inner.txt")
+        data = b"queued\n"
+        inner.size = len(data)
+        inner.uid, inner.gid, inner.mode = 101, 0, 0o600
+        tar.addfile(inner, io.BytesIO(data))
+        public = tarfile.TarInfo("./var/spool/public")
+        public.type = tarfile.DIRTYPE
+        public.uid, public.gid, public.mode = 101, 104, 0o2710
+        tar.addfile(public)
+
+
+def test_multiuid_image_baked_ownership(ensure_pasta, ensure_idmap_node, tmp_path):
+    """Ownership baked into image layers survives into the sandbox: distinct
+    uids stat correctly, root traverses 0700 dirs it doesn't own (needs
+    CAP_DAC_OVERRIDE — Docker's default set, not the far narrower
+    ``runsc spec`` default), and the setgid bit rides through extraction."""
+    from ray.experimental.sandbox.config import DOCKER_DEFAULT_CAPABILITIES
+
+    tar_path = str(tmp_path / "owned-busybox.tar")
+    _owned_busybox_tar(tar_path)
+
+    backend = GVisorSandboxBackend()
+    sb = backend.create_sandbox(
+        GVisorSandboxConfig(
+            image=tar_path,
+            shell="/bin/sh",
+            network="public",
+            capabilities=list(DOCKER_DEFAULT_CAPABILITIES),
+            # A tar-path image has no image config, hence no baked PATH.
+            env={"PATH": "/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"},
+        )
+    )
+    try:
+        res = backend.exec_command(
+            sb,
+            "stat -c %u:%g:%a /var/spool/testq && cat /var/spool/testq/inner.txt "
+            "&& stat -c %u:%g:%a /var/spool/public",
+            timeout=30,
+        )
+        assert res.exit_code == 0, res.stderr
+        lines = res.stdout.split()
+        assert lines[0] == "101:0:700"
+        assert lines[1] == "queued"
+        assert lines[2] == "101:104:2710"
+    finally:
+        backend.delete_sandbox(sb)
+
+
+def test_multiuid_mailman_mini(ensure_pasta, ensure_idmap_node):
+    """The mailman shape in miniature: create a user at runtime, chown -R a
+    tree to it, and get setgid-directory group inheritance."""
+    from ray.experimental.sandbox.config import DOCKER_DEFAULT_CAPABILITIES
+
+    backend = GVisorSandboxBackend()
+    sb = backend.create_sandbox(
+        GVisorSandboxConfig(
+            image="busybox:latest",
+            shell="/bin/sh",
+            network="public",
+            readonly=False,
+            capabilities=list(DOCKER_DEFAULT_CAPABILITIES),
+        )
+    )
+    try:
+        res = backend.exec_command(
+            sb,
+            "adduser -D -u 1234 alice && "
+            "mkdir -p /srv/lists && touch /srv/lists/cfg && "
+            "chown -R alice:alice /srv/lists && "
+            "stat -c %u:%g /srv/lists /srv/lists/cfg && "
+            "mkdir /srv/shared && chown 0:104 /srv/shared && "
+            "chmod 2770 /srv/shared && touch /srv/shared/post && "
+            "stat -c %g:%a /srv/shared /srv/shared/post | head -1",
+            timeout=60,
+        )
+        assert res.exit_code == 0, res.stderr
+        lines = res.stdout.split()
+        assert lines[0] == "1234:1234"
+        assert lines[1] == "1234:1234"
+        assert lines[2] == "104:2770"
+    finally:
+        backend.delete_sandbox(sb)
+
+
+def test_multiuid_without_network(ensure_idmap_node):
+    """Multi-uid does not depend on the network mode: a network="none"
+    sandbox on a multi-uid node can chown to arbitrary uids too."""
+    from ray.experimental.sandbox.config import DOCKER_DEFAULT_CAPABILITIES
+
+    backend = GVisorSandboxBackend()
+    sb = backend.create_sandbox(
+        GVisorSandboxConfig(
+            image="busybox:latest",
+            shell="/bin/sh",
+            network="none",
+            capabilities=list(DOCKER_DEFAULT_CAPABILITIES),
+        )
+    )
+    try:
+        res = backend.exec_command(
+            sb,
+            "stat -c %u /bin/busybox && touch /tmp/p && chown 38:38 /tmp/p && "
+            "stat -c %u:%g /tmp/p",
+            timeout=30,
+        )
+        assert res.exit_code == 0, res.stderr
+        assert res.stdout.split() == ["0", "38:38"]
+    finally:
+        backend.delete_sandbox(sb)
 
 
 def test_netns_create_failure_leaves_no_pasta(ensure_pasta):

--- a/python/ray/experimental/sandbox/tests/test_idmap.py
+++ b/python/ray/experimental/sandbox/tests/test_idmap.py
@@ -1,0 +1,155 @@
+import sys
+
+import pytest
+
+from ray.experimental.sandbox._internal import idmap as idmap_mod
+from ray.experimental.sandbox._internal.idmap import (
+    IdMap,
+    detect_idmap,
+    parse_subid_file,
+)
+
+
+@pytest.fixture(autouse=True)
+def _fresh_detect_cache():
+    detect_idmap.cache_clear()
+    yield
+    detect_idmap.cache_clear()
+
+
+def test_parse_subid_file_name_and_uid_keyed(tmp_path):
+    path = tmp_path / "subuid"
+    path.write_text(
+        "# comment\n"
+        "other:1000:65536\n"
+        "malformed line\n"
+        "ray:too:many:fields\n"
+        "1000:300000:65536\n"
+        "ray:100000:65536\n"
+    )
+    # Numeric-uid entry appears first and wins.
+    assert parse_subid_file(str(path), "ray", 1000) == (300000, 65536)
+    # Name-only match.
+    assert parse_subid_file(str(path), "ray", 4242) == (100000, 65536)
+    # No match at all.
+    assert parse_subid_file(str(path), "nobody", 4242) is None
+
+
+def test_parse_subid_file_skips_small_ranges(tmp_path):
+    path = tmp_path / "subuid"
+    path.write_text("ray:5000:1\nray:100000:65536\n")
+    assert parse_subid_file(str(path), "ray", 1000) == (100000, 65536)
+
+
+def test_parse_subid_file_missing_file(tmp_path):
+    assert parse_subid_file(str(tmp_path / "absent"), "ray", 1000) is None
+
+
+def _capable_node(monkeypatch, tmp_path):
+    """Monkeypatch an environment where multi-uid detection succeeds."""
+    subuid = tmp_path / "subuid"
+    subgid = tmp_path / "subgid"
+    subuid.write_text("ray:100000:65536\n")
+    subgid.write_text("ray:200000:65536\n")
+    monkeypatch.setattr(idmap_mod.shutil, "which", lambda name: f"/usr/bin/{name}")
+    monkeypatch.setattr(idmap_mod, "_no_new_privs", lambda: False)
+    monkeypatch.setattr(idmap_mod, "_user_name", lambda: "ray")
+    monkeypatch.setattr(idmap_mod, "_probe_mapping", lambda idmap: True)
+    monkeypatch.setattr(idmap_mod.os, "geteuid", lambda: 1000)
+    monkeypatch.setattr(idmap_mod.os, "getegid", lambda: 1001)
+
+    real_parse = parse_subid_file
+
+    def _redirected(path, user_name, uid):
+        redirect = {"/etc/subuid": str(subuid), "/etc/subgid": str(subgid)}
+        return real_parse(redirect.get(path, path), user_name, uid)
+
+    monkeypatch.setattr(idmap_mod, "parse_subid_file", _redirected)
+
+
+def test_detect_idmap_success(monkeypatch, tmp_path):
+    monkeypatch.delenv("RAY_SANDBOX_SINGLE_UID", raising=False)
+    _capable_node(monkeypatch, tmp_path)
+    assert detect_idmap() == IdMap(
+        euid=1000,
+        egid=1001,
+        subuid_base=100000,
+        subuid_count=65536,
+        subgid_base=200000,
+        subgid_count=65536,
+    )
+
+
+def test_detect_idmap_probe_failure(monkeypatch, tmp_path):
+    """Helpers that exist but cannot write the mapping degrade to single-uid."""
+    monkeypatch.delenv("RAY_SANDBOX_SINGLE_UID", raising=False)
+    _capable_node(monkeypatch, tmp_path)
+    monkeypatch.setattr(idmap_mod, "_probe_mapping", lambda idmap: False)
+    assert detect_idmap() is None
+
+
+def test_detect_idmap_kill_switch(monkeypatch, tmp_path):
+    _capable_node(monkeypatch, tmp_path)
+    monkeypatch.setenv("RAY_SANDBOX_SINGLE_UID", "1")
+    assert detect_idmap() is None
+
+
+def test_detect_idmap_missing_helpers(monkeypatch, tmp_path):
+    monkeypatch.delenv("RAY_SANDBOX_SINGLE_UID", raising=False)
+    _capable_node(monkeypatch, tmp_path)
+    monkeypatch.setattr(
+        idmap_mod.shutil,
+        "which",
+        lambda name: None if name == "newgidmap" else f"/usr/bin/{name}",
+    )
+    assert detect_idmap() is None
+
+
+def test_detect_idmap_no_new_privs(monkeypatch, tmp_path):
+    monkeypatch.delenv("RAY_SANDBOX_SINGLE_UID", raising=False)
+    _capable_node(monkeypatch, tmp_path)
+    monkeypatch.setattr(idmap_mod, "_no_new_privs", lambda: True)
+    assert detect_idmap() is None
+
+
+def test_detect_idmap_missing_range(monkeypatch, tmp_path):
+    monkeypatch.delenv("RAY_SANDBOX_SINGLE_UID", raising=False)
+    _capable_node(monkeypatch, tmp_path)
+    monkeypatch.setattr(idmap_mod, "parse_subid_file", lambda *a: None)
+    assert detect_idmap() is None
+
+
+def test_detect_idmap_numeric_keyed_subgid(monkeypatch, tmp_path):
+    """A uid-keyed /etc/subgid resolves even when euid != egid.
+
+    Regression: /etc/subgid's numeric key is the uid, not the gid, so a purely
+    uid-keyed subgid file must be found using euid. _capable_node runs with
+    euid=1000, egid=1001, so a lookup keyed by egid would miss this entry.
+    """
+    monkeypatch.delenv("RAY_SANDBOX_SINGLE_UID", raising=False)
+    _capable_node(monkeypatch, tmp_path)
+    (tmp_path / "subuid").write_text("1000:100000:65536\n")
+    (tmp_path / "subgid").write_text("1000:200000:65536\n")
+    assert detect_idmap() == IdMap(
+        euid=1000,
+        egid=1001,
+        subuid_base=100000,
+        subuid_count=65536,
+        subgid_base=200000,
+        subgid_count=65536,
+    )
+
+
+def test_probe_mapping_missing_unshare(monkeypatch):
+    """A missing/unrunnable unshare fails the probe, not the process."""
+
+    def _no_unshare(*args, **kwargs):
+        raise FileNotFoundError("unshare")
+
+    monkeypatch.setattr(idmap_mod.subprocess, "Popen", _no_unshare)
+    idmap = IdMap(1000, 1000, 100000, 65536, 200000, 65536)
+    assert idmap_mod._probe_mapping(idmap) is False
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-v", __file__]))

--- a/python/ray/experimental/sandbox/tests/test_image_utils.py
+++ b/python/ray/experimental/sandbox/tests/test_image_utils.py
@@ -1,4 +1,5 @@
 import io
+import json
 import os
 import sys
 import tarfile
@@ -7,7 +8,10 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from ray.experimental.sandbox._internal import image_utils
+from ray.experimental.sandbox._internal.idmap import IdMap
 from ray.experimental.sandbox._internal.image_utils import (
+    expected_extract_marker,
     extract_tar_layer,
     get_platform_arch,
     get_registry_auth_headers,
@@ -431,6 +435,198 @@ def test_get_registry_auth_headers_no_auth_needed():
             "localhost:5000", "my/repo", reference="latest"
         )
         assert headers == {}
+
+
+def _add_member(tar, name, data=b"", uid=0, gid=0, mode=0o644, typ=tarfile.REGTYPE):
+    ti = tarfile.TarInfo(name)
+    ti.uid = uid
+    ti.gid = gid
+    ti.mode = mode
+    ti.type = typ
+    if typ == tarfile.REGTYPE:
+        ti.size = len(data)
+        tar.addfile(ti, io.BytesIO(data))
+    else:
+        tar.addfile(ti)
+
+
+def test_extract_tar_layer_ownership_recording(tmp_path):
+    """The ownership map accumulates across layers and honors whiteouts —
+    modeled on the mailman image (uid=101 spool dirs, opaque whiteout)."""
+    dest = tmp_path / "rootfs"
+    dest.mkdir()
+    ownership = {}
+
+    buf1 = io.BytesIO()
+    with tarfile.open(fileobj=buf1, mode="w:gz") as tar:
+        _add_member(
+            tar, "var/spool/postfix/defer", uid=101, mode=0o700, typ=tarfile.DIRTYPE
+        )
+        _add_member(
+            tar,
+            "var/spool/postfix/maildrop",
+            uid=101,
+            gid=104,
+            mode=0o1730,
+            typ=tarfile.DIRTYPE,
+        )
+        _add_member(
+            tar,
+            "var/lib/mailman3/data",
+            uid=38,
+            gid=38,
+            mode=0o755,
+            typ=tarfile.DIRTYPE,
+        )
+        _add_member(tar, "var/lib/mailman3/data/gone.txt", b"x", uid=38, gid=38)
+        _add_member(tar, "etc/passwd", b"root:x:0:0::/root:/bin/sh\n")
+    extract_tar_layer(buf1.getvalue(), str(dest), ownership=ownership)
+
+    assert ownership == {
+        "var/spool/postfix/defer": (101, 0),
+        "var/spool/postfix/maildrop": (101, 104),
+        "var/lib/mailman3/data": (38, 38),
+        "var/lib/mailman3/data/gone.txt": (38, 38),
+    }
+
+    # Layer 2: deletion whiteout drops the file; opaque whiteout clears the
+    # mailman3 subtree; a root-owned replacement records nothing.
+    buf2 = io.BytesIO()
+    with tarfile.open(fileobj=buf2, mode="w:gz") as tar:
+        _add_member(tar, "var/spool/postfix/.wh.maildrop")
+        _add_member(tar, "var/lib/mailman3/.wh..wh..opq")
+        _add_member(tar, "var/lib/mailman3/fresh.txt", b"y")
+    extract_tar_layer(buf2.getvalue(), str(dest), ownership=ownership)
+
+    assert ownership == {"var/spool/postfix/defer": (101, 0)}
+
+    # Layer 3: the same path shipped root-owned again drops its record.
+    buf3 = io.BytesIO()
+    with tarfile.open(fileobj=buf3, mode="w:gz") as tar:
+        _add_member(tar, "var/spool/postfix/defer", mode=0o755, typ=tarfile.DIRTYPE)
+    extract_tar_layer(buf3.getvalue(), str(dest), ownership=ownership)
+    assert ownership == {}
+
+
+def _owned_sample_tar(path):
+    with tarfile.open(str(path), "w") as tar:
+        _add_member(tar, "opt/data", uid=38, gid=38, mode=0o750, typ=tarfile.DIRTYPE)
+        _add_member(tar, "opt/data/f.txt", b"z", uid=38, gid=38)
+        _add_member(tar, "etc/hosts", b"127.0.0.1 localhost\n")
+
+
+def test_single_uid_pull_writes_marker_and_keeps_worker_ownership(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setattr(image_utils, "detect_idmap", lambda: None)
+    local_tar = tmp_path / "sample.tar"
+    _owned_sample_tar(local_tar)
+
+    images_dir = tmp_path / "images"
+    extracted_dir = pull_and_extract_container_image(
+        str(local_tar), images_dir=str(images_dir)
+    )
+    marker = os.path.join(extracted_dir, ".extracted")
+    assert open(marker, encoding="utf-8").read() == expected_extract_marker(None)
+    assert json.loads(expected_extract_marker(None)) == {"format": 2, "idmap": None}
+    assert os.stat(os.path.join(extracted_dir, "rootfs", "opt", "data")).st_uid == (
+        os.geteuid()
+    )
+
+
+def test_multi_uid_pull_applies_recorded_ownership(tmp_path, monkeypatch):
+    """On a multi-uid node the recorded owners are applied inside the mapped
+    namespace to the freshly extracted tree, and the marker names the mapping."""
+    idmap = IdMap(1000, 1000, 100000, 65536, 200000, 65536)
+    monkeypatch.setattr(image_utils, "detect_idmap", lambda: idmap)
+    applied = []
+    monkeypatch.setattr(
+        image_utils,
+        "_apply_ownership_in_namespace",
+        lambda rootfs, ownership, m, timeout: applied.append((rootfs, ownership, m)),
+    )
+    local_tar = tmp_path / "sample.tar"
+    _owned_sample_tar(local_tar)
+
+    images_dir = tmp_path / "images"
+    extracted_dir = pull_and_extract_container_image(
+        str(local_tar), images_dir=str(images_dir)
+    )
+
+    # Ownership is applied to the staging tree before it is promoted.
+    ((rootfs, ownership, used_idmap),) = applied
+    assert rootfs.startswith(str(images_dir)) and rootfs.endswith("/rootfs")
+    assert ownership == {"opt/data": (38, 38), "opt/data/f.txt": (38, 38)}
+    assert used_idmap == idmap
+    marker = open(os.path.join(extracted_dir, ".extracted"), encoding="utf-8").read()
+    assert json.loads(marker) == {"format": 2, "idmap": [100000, 65536, 200000, 65536]}
+
+
+def test_marker_mismatch_triggers_reextract(tmp_path, monkeypatch):
+    """A legacy marker, or one written for another id mapping, re-pulls once."""
+    monkeypatch.setattr(image_utils, "detect_idmap", lambda: None)
+    local_tar = tmp_path / "sample.tar"
+    with tarfile.open(str(local_tar), "w") as tar:
+        _add_member(tar, "hello.txt", b"hi")
+
+    images_dir = tmp_path / "images"
+    extracted_dir = pull_and_extract_container_image(
+        str(local_tar), images_dir=str(images_dir)
+    )
+    marker = os.path.join(extracted_dir, ".extracted")
+    for stale in ("ok", expected_extract_marker(IdMap(1, 1, 100000, 65536, 1, 65536))):
+        with open(marker, "w", encoding="utf-8") as f:
+            f.write(stale)
+        again = pull_and_extract_container_image(
+            str(local_tar), images_dir=str(images_dir)
+        )
+        assert again == extracted_dir
+        assert open(marker, encoding="utf-8").read() == expected_extract_marker(None)
+
+
+def test_apply_ownership_chowns_then_restores_mode(tmp_path, monkeypatch):
+    """The idmapped copy applies sidecar owners and puts back the setuid/setgid
+    bits that chown clears; symlinks are lchowned without a chmod."""
+    from ray.experimental.sandbox._internal import idmap_extract
+
+    calls = []
+    monkeypatch.setattr(
+        "ray.experimental.sandbox._internal.image_utils.os.lchown",
+        lambda path, uid, gid: calls.append(("lchown", path, uid, gid)),
+    )
+    real_chmod = os.chmod
+    monkeypatch.setattr(
+        idmap_extract.os,
+        "chmod",
+        lambda path, mode: (
+            calls.append(("chmod", path, mode)),
+            real_chmod(path, mode),
+        ),
+    )
+    dest = tmp_path / "rootfs"
+    (dest / "spool").mkdir(parents=True)
+    tool = dest / "spool" / "suid-tool"
+    tool.write_bytes(b"#!")
+    real_chmod(tool, 0o4750)
+    (dest / "spool" / "link").symlink_to("suid-tool")
+
+    idmap_extract.apply_ownership(
+        str(dest),
+        {
+            "spool": (101, 0),
+            "spool/suid-tool": (101, 104),
+            "spool/link": (101, 0),
+            "gone": (1, 1),
+        },
+    )
+
+    assert calls == [
+        ("lchown", str(dest / "spool"), 101, 0),
+        ("chmod", str(dest / "spool"), 0o755),
+        ("lchown", str(tool), 101, 104),
+        ("chmod", str(tool), 0o4750),
+        ("lchown", str(dest / "spool" / "link"), 101, 0),
+    ]
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
> **On hold.** The `newuidmap` mechanism here is likely superseded: with gVisor's EROFS root filesystem (`dev.gvisor.spec.rootfs.type: erofs`) the image's uids live inside the Sentry and never need a host representation, so image-baked ownership and runtime `chown` work without subordinate ranges or a mapped user namespace. See the discussion below. The ownership-recording extraction code in this PR is what an EROFS image build needs as input, so it carries over.

## Description

Rootless sandboxes map the whole container to one host uid: every file reads as root, `chown` to any other user fails with `EINVAL`, and ownership baked into image layers (postfix's `0700` uid-101 spool, mailman's uid-38 data) flattens away, so workloads that spread ownership across users fail.

A node is now either **multi-uid** or **single-uid**, and everything follows that one decision:

- **Detection.** `detect_idmap()` runs once per process. When the `uidmap` package's setuid `newuidmap`/`newgidmap` helpers and `/etc/subuid` + `/etc/subgid` ranges for the worker user are usable (verified by writing a throwaway namespace's map), the node is multi-uid. Missing helpers, missing ranges, `no_new_privs`, a probe failure, or `RAY_SANDBOX_SINGLE_UID=1` make it single-uid, with the reason logged once. There is no `sudo` path.
- **Sandboxes.** On a multi-uid node every rootless sandbox runs as mapped root inside a user namespace that maps `0 <worker-id> 1` plus `1 <subbase> <count>` (the rootless-Podman model), whatever its network mode. The holder + `nsenter` shape that `network="public"` already uses carries the mapping; `--net` and pasta are added only for `public`. Single-uid nodes wrap only `public`, exactly as before. Privileged runsc (`rootless=False`) is untouched.
- **Image cache.** Extraction records each layer's non-root owners (whiteout-aware; a later root-owned layer drops the entry). On a multi-uid node those owners are applied to the freshly extracted tree inside a mapped namespace (chown, then the mode restored so setuid/setgid bits survive) before the tree is promoted, so the one cached rootfs carries the image's real ownership at subordinate host ids. Single-uid nodes keep the worker-owned tree. The `.extracted` marker records the layout version and the mapping, so a node that switches modes re-extracts once, and that re-pull keeps the pins of sandboxes already running on the old tree.
- **Cleanup.** Trees holding subordinate-owned files can only be deleted as mapped root, so cache eviction and sandbox teardown both fall back to `rm -rf` inside a mapped namespace when a plain `rmtree` leaves entries behind.

Traversing another user's `0700` directory as root additionally needs `CAP_DAC_OVERRIDE`, which Docker's default capability set carries and the bare `runsc spec` default does not; documented in troubleshooting. The HTTP service's best-effort `/etc/subuid` seeding at boot belongs to #65633.

## Related issues

Follow-up to #65820. Related to #65633.

## Additional information

Tested with `TEST_SANDBOX=1` in a privileged `rayproject/ray:nightly-py312` container on arm64 as the non-root `ray` user, with `uidmap` installed, `ray:100000:65536` in `/etc/subuid` and `/etc/subgid`, and pasta built from source: runtime `chown` to arbitrary uids inside a `public` sandbox and host-visibly on a workdir bind at `subuid_base + uid`; the same `chown` in a `network="none"` sandbox; image-baked ownership (`0700` uid-101 dir, `02710` setgid dir) surviving into the sandbox from a local tar image; and the mailman-shaped adduser + `chown -R` + setgid inheritance flow. The netns suite (same-port binds, egress and DNS, teardown, failed create) passes alongside, 28 tests in total. Argv-level unit tests pin the multi-uid holder script for `public`, `none`, and `host`, and the cache tests cover ownership recording across layers, the mode-specific marker, mode-switch re-extraction, owner application with mode restore, and eviction.
