### PR TITLE
[serve] Stop ingress routers from retaining proxy nodes

### DIFF
--- a/python/ray/serve/_private/deployment_state.py
+++ b/python/ray/serve/_private/deployment_state.py
@@ -6846,7 +6846,8 @@ class DeploymentStateManager:
         """
         node_ids = set()
         for deployment_state in self._deployment_states.values():
-            if deployment_state.is_ingress_request_router():
+            info = deployment_state.target_info
+            if info is not None and info.ingress_request_router:
                 continue
             node_ids.update(deployment_state.get_active_node_ids())
         return node_ids

--- a/python/ray/serve/_private/deployment_state.py
+++ b/python/ray/serve/_private/deployment_state.py
@@ -6839,11 +6839,15 @@ class DeploymentStateManager:
     def get_active_node_ids(self) -> Set[str]:
         """Return set of node ids with running replicas of any deployment.
 
-        This is used to determine which node has replicas. Only nodes with replicas and
-        head node should have active proxies.
+        This is used to determine which nodes should have active proxies. Ingress
+        request router replicas are excluded because they are created on proxy nodes;
+        counting them here would make a proxy node retain itself after all application
+        replicas on the node have stopped.
         """
         node_ids = set()
         for deployment_state in self._deployment_states.values():
+            if deployment_state.is_ingress_request_router():
+                continue
             node_ids.update(deployment_state.get_active_node_ids())
         return node_ids
 

--- a/python/ray/serve/tests/unit/test_deployment_state.py
+++ b/python/ray/serve/tests/unit/test_deployment_state.py
@@ -4424,6 +4424,34 @@ def test_get_active_node_ids_none(mock_deployment_state_manager):
     assert None not in dsm.get_active_node_ids()
 
 
+def test_get_active_node_ids_excludes_ingress_request_router(
+    mock_deployment_state_manager,
+):
+    """Ingress request routers should not keep their proxy nodes active."""
+    create_dsm, _, cluster_node_info_cache, _ = mock_deployment_state_manager
+    dsm = create_dsm()
+    application_node = NodeID.from_random().hex()
+    router_node = NodeID.from_random().hex()
+    cluster_node_info_cache.add_node(application_node)
+    cluster_node_info_cache.add_node(router_node)
+
+    assert dsm.deploy(TEST_DEPLOYMENT_ID, deployment_info(num_replicas=1)[0])
+    assert dsm.deploy(
+        TEST_DEPLOYMENT_ID_2,
+        deployment_info(ingress_request_router=True)[0],
+    )
+    dsm.update(proxy_nodes={router_node})
+
+    application_state = dsm._deployment_states[TEST_DEPLOYMENT_ID]
+    router_state = dsm._deployment_states[TEST_DEPLOYMENT_ID_2]
+    application_state._replicas.get()[0]._actor.set_node_id(application_node)
+    router_state._replicas.get()[0]._actor.set_node_id(router_node)
+
+    assert application_state.get_active_node_ids() == {application_node}
+    assert router_state.get_active_node_ids() == {router_node}
+    assert dsm.get_active_node_ids() == {application_node}
+
+
 def _pinned_target_node_ids(ds) -> set:
     return {r.target_node_id for r in ds._replicas.get(states=[ReplicaState.STARTING])}
 

--- a/python/ray/serve/tests/unit/test_deployment_state.py
+++ b/python/ray/serve/tests/unit/test_deployment_state.py
@@ -4452,6 +4452,20 @@ def test_get_active_node_ids_excludes_ingress_request_router(
     assert dsm.get_active_node_ids() == {application_node}
 
 
+def test_get_active_node_ids_handles_undeployed_state(
+    mock_deployment_state_manager,
+):
+    """An uninitialized deployment state should not break proxy reconciliation."""
+    create_dsm, _, _, _ = mock_deployment_state_manager
+    dsm = create_dsm()
+    undeployed_id = DeploymentID(name="undeployed", app_name="test_app")
+    undeployed_state = dsm._create_deployment_state(undeployed_id)
+    dsm._deployment_states[undeployed_id] = undeployed_state
+
+    assert undeployed_state.target_info is None
+    assert dsm.get_active_node_ids() == set()
+
+
 def _pinned_target_node_ids(ds) -> set:
     return {r.target_node_id for r in ds._replicas.get(states=[ReplicaState.STARTING])}
 


### PR DESCRIPTION
## Why

Ingress request-router replicas are placed on every proxy node. DeploymentStateManager currently counts those router replicas when deciding which nodes need proxies, creating a retention loop: after application replicas stop, the router keeps its proxy node active and therefore keeps itself alive.

This behavior was introduced by #64724. I could not find an existing issue or PR covering the scale-to-zero retention case.

## What changed

- Exclude ingress request-router deployments from the active application node set used for proxy placement.
- Use the non-asserting target_info accessor so a partially initialized deployment state cannot break proxy reconciliation.
- Add regression tests for both router exclusion and an undeployed state with no target info.

The head node remains included separately by the controller, and nodes with real application replicas still receive their colocated proxy and router.

## Testing

- GOTOOLCHAIN=auto pre-commit run --files python/ray/serve/_private/deployment_state.py python/ray/serve/tests/unit/test_deployment_state.py (passed)
- python -m py_compile python/ray/serve/_private/deployment_state.py python/ray/serve/tests/unit/test_deployment_state.py (passed)

## AI assistance

OpenAI Codex assisted with implementation and validation; I reviewed the changes.