### PR TITLE
[Core] Answer GetObjectStatus for an out-of-scope object whose Reference is pinned

### DIFF
--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -3908,6 +3908,15 @@ void CoreWorker::HandleGetObjectStatus(rpc::GetObjectStatusRequest request,
     return;
   }
   RAY_CHECK(owner_address.worker_id() == request.owner_worker_id());
+  if (reference_counter_->IsObjectOutOfScope(object_id)) {
+    // Same answer as above, reached when the Reference outlived the scope it was
+    // tracking: lineage pinning keeps it while a task that may be retried depends on
+    // the object. The value was deleted when the object went out of scope, so unless
+    // such a task is retried the wait below never gets a reply.
+    reply->set_status(rpc::GetObjectStatusReply::OUT_OF_SCOPE);
+    send_reply_callback(Status::OK(), nullptr, nullptr);
+    return;
+  }
   if (reference_counter_->IsPlasmaObjectFreed(object_id)) {
     reply->set_status(rpc::GetObjectStatusReply::FREED);
     send_reply_callback(Status::OK(), nullptr, nullptr);
@@ -3915,7 +3924,7 @@ void CoreWorker::HandleGetObjectStatus(rpc::GetObjectStatusRequest request,
   }
   // Send the reply once the value has become available. The value is
   // guaranteed to become available eventually because we own the object and
-  // its ref count is > 0.
+  // it is still in scope.
   memory_store_->GetAsync(object_id,
                           [this, object_id, reply, send_reply_callback](
                               const std::shared_ptr<RayObject> &obj) {

--- a/src/ray/core_worker/reference_counter.cc
+++ b/src/ray/core_worker/reference_counter.cc
@@ -988,6 +988,15 @@ bool ReferenceCounter::HasReference(const ObjectID &object_id) const {
   return object_id_refs_.find(object_id) != object_id_refs_.end();
 }
 
+bool ReferenceCounter::IsObjectOutOfScope(const ObjectID &object_id) const {
+  absl::MutexLock lock(&mutex_);
+  auto it = object_id_refs_.find(object_id);
+  if (it == object_id_refs_.end()) {
+    return false;
+  }
+  return it->second.OutOfScope(lineage_pinning_enabled_);
+}
+
 size_t ReferenceCounter::NumObjectIDsInScope() const {
   absl::MutexLock lock(&mutex_);
   return object_id_refs_.size();

--- a/src/ray/core_worker/reference_counter.h
+++ b/src/ray/core_worker/reference_counter.h
@@ -211,6 +211,9 @@ class ReferenceCounter : public ReferenceCounterInterface,
 
   bool HasReference(const ObjectID &object_id) const override ABSL_LOCKS_EXCLUDED(mutex_);
 
+  bool IsObjectOutOfScope(const ObjectID &object_id) const override
+      ABSL_LOCKS_EXCLUDED(mutex_);
+
   void AddObjectRefStats(
       const absl::flat_hash_map<ObjectID, std::pair<int64_t, std::string>>
           &pinned_objects,

--- a/src/ray/core_worker/reference_counter_interface.h
+++ b/src/ray/core_worker/reference_counter_interface.h
@@ -474,6 +474,16 @@ class ReferenceCounterInterface {
   /// \return Whether we have a reference to the object ID.
   virtual bool HasReference(const ObjectID &object_id) const = 0;
 
+  /// Whether the object has no in-scope references left, in which case its value
+  /// may already have been deleted. A Reference can outlive that point: with
+  /// lineage pinning it is kept until no task that may be retried depends on the
+  /// object, so HasReference and GetOwner keep returning true.
+  ///
+  /// \param[in] object_id The object ID to check for.
+  /// \return Whether the object is tracked and out of scope. False if it is
+  /// still in scope, or not tracked at all.
+  virtual bool IsObjectOutOfScope(const ObjectID &object_id) const = 0;
+
   /// Write the current reference table to the given proto.
   ///
   /// \param[out] stats The proto to write references to.

--- a/src/ray/core_worker/tests/core_worker_test.cc
+++ b/src/ray/core_worker/tests/core_worker_test.cc
@@ -17,6 +17,7 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <chrono>
 #include <future>
 #include <memory>
 #include <string>
@@ -66,7 +67,7 @@ using ::testing::Return;
 
 class CoreWorkerTest : public ::testing::Test {
  public:
-  CoreWorkerTest()
+  explicit CoreWorkerTest(bool lineage_pinning_enabled = false)
       : io_work_(io_service_.get_executor()),
         task_execution_service_work_(task_execution_service_.get_executor()),
         object_freed_callback_service_work_(
@@ -161,7 +162,7 @@ class CoreWorkerTest : public ::testing::Test {
         [](const ObjectID &, const absl::flat_hash_set<NodeID> &) {},
         fake_owned_object_count_gauge_,
         fake_owned_object_size_gauge_,
-        false);
+        lineage_pinning_enabled);
 
     // Mock reference counter as enabled
     memory_store_ = std::make_shared<CoreWorkerMemoryStore>(
@@ -886,6 +887,74 @@ TEST_F(CoreWorkerTest, HandleGetObjectStatusObjectOutOfScope) {
   // Not calling io_service_.run_one() because the callback is called on the main thread
   ASSERT_TRUE(future2.get().ok());
   EXPECT_EQ(reply2.status(), rpc::GetObjectStatusReply::OUT_OF_SCOPE);
+}
+
+// Lineage pinning is off in the fixture above, and with it off an object that goes out of
+// scope always takes its Reference with it, so the state the next test needs cannot be
+// built there.
+class CoreWorkerLineagePinningTest : public CoreWorkerTest {
+ public:
+  CoreWorkerLineagePinningTest() : CoreWorkerTest(/*lineage_pinning_enabled=*/true) {}
+};
+
+// A borrower asking about an object that is out of scope with its Reference still alive
+// has to get an answer: the value is gone, the borrower has no deadline, and only a retry
+// of a task that depends on the object would put a value back.
+TEST_F(CoreWorkerLineagePinningTest, HandleGetObjectStatusOutOfScopeObject) {
+  auto object_id = ObjectID::FromRandom();
+  auto consumer_return_id = ObjectID::FromRandom();
+  auto ray_object = MakeRayObject("test_data", "meta");
+
+  rpc::Address owner_address;
+  owner_address.set_worker_id(core_worker_->GetWorkerID().Binary());
+  reference_counter_->AddOwnedObject(object_id,
+                                     {},
+                                     owner_address,
+                                     "",
+                                     0,
+                                     LineageReconstructionEligibility::ELIGIBLE,
+                                     /*add_local_ref=*/true);
+  memory_store_->Put(*ray_object, object_id, reference_counter_->HasReference(object_id));
+
+  // A task took the object by reference and finished without releasing its lineage, which
+  // is what a retryable consumer leaves behind.
+  reference_counter_->UpdateSubmittedTaskReferences({consumer_return_id}, {object_id});
+  std::vector<ObjectID> deleted;
+  reference_counter_->UpdateFinishedTaskReferences({consumer_return_id},
+                                                   {object_id},
+                                                   /*release_lineage=*/false,
+                                                   rpc::Address(),
+                                                   {},
+                                                   &deleted);
+
+  // The last in-scope reference goes away. This is CoreWorker::RemoveLocalReference: the
+  // object is out of scope, so its value is deleted, but the Reference stays.
+  reference_counter_->RemoveLocalReference(object_id, &deleted);
+  memory_store_->Delete(deleted);
+  ASSERT_TRUE(reference_counter_->HasReference(object_id));
+  ASSERT_TRUE(reference_counter_->IsObjectOutOfScope(object_id));
+
+  rpc::GetObjectStatusRequest request;
+  request.set_object_id(object_id.Binary());
+  request.set_owner_worker_id(core_worker_->GetWorkerID().Binary());
+
+  std::promise<Status> promise;
+  auto future = promise.get_future();
+  rpc::GetObjectStatusReply reply;
+
+  core_worker_->HandleGetObjectStatus(
+      request,
+      &reply,
+      [&promise](Status s, std::function<void()>, std::function<void()>) {
+        promise.set_value(s);
+      });
+
+  // A bounded wait rather than get(): without the check above the handler leaves the
+  // callback in the store and never replies, and that should fail here instead of
+  // hanging.
+  ASSERT_EQ(future.wait_for(std::chrono::seconds(5)), std::future_status::ready);
+  ASSERT_TRUE(future.get().ok());
+  EXPECT_EQ(reply.status(), rpc::GetObjectStatusReply::OUT_OF_SCOPE);
 }
 
 namespace {


### PR DESCRIPTION
## Description

`HandleGetObjectStatus` decided between replying `OUT_OF_SCOPE` and waiting for the value on whether the owner still had a `Reference`. That is not the same question: `GetOwner` only checks that the entry exists and carries an owner address, and lineage pinning keeps the entry after the object goes out of scope, since `ShouldDelete` also requires the lineage ref count to be zero. `DeleteReferenceInternal` acts on `OutOfScope` for the value and on `ShouldDelete` for the entry, so between those two points the owner holds a `Reference` with no value behind it. For a task return that a retryable task consumed, that is the ordinary state after the owner's reference goes away.

The handler then waited. `GetAsync` registers the reply callback with no timeout, only a `Put` takes it back out, and nothing puts a value back unless a task that depends on the object is retried. The borrower has no deadline either, `GetObjectStatus` being declared with `method_timeout_ms` of -1, so its `ray.get` blocked instead of raising. The reply the protocol already has for this case is `OUT_OF_SCOPE`, which is what the borrower turns into `ObjectDeletedError`, so the fix is to ask the question the branch meant to ask: a new `IsObjectOutOfScope` on the reference counter, reusing the same predicate that decided the value could be deleted in the first place.

Two things worth noting about the shape of the fix. It is placed before the `IsPlasmaObjectFreed` branch, so an object that was both freed and is out of scope now answers `OUT_OF_SCOPE` rather than `FREED`; that is an improvement, since no borrower branches on `FREED` and it lands in the catch-all as `OBJECT_LOST` with a warning. And the predicate cannot swallow an object that is merely still being created: an owned object holds a local reference from `AddPendingTask` onwards, and a resubmission adds its reference back before the object is marked pending again, so `OutOfScope` and pending creation do not overlap.

## Related issues

Fixes #65833

Not a duplicate: no open issue or PR describes a `GetObjectStatus` reply that never arrives, and no open PR touches `HandleGetObjectStatus`.

## Additional information

`CoreWorkerTest` builds its `ReferenceCounter` with lineage pinning off, and with it off an object going out of scope always takes its `Reference` with it, so the state cannot be built in that fixture. The constructor now takes the flag, defaulting to the old value, and `CoreWorkerLineagePinningTest` passes it as true, following `ReferenceCountLineageEnabledTest` in the reference counter tests. The 36 tests on the original fixture are unchanged.

The new test builds the state the way production does, with `UpdateSubmittedTaskReferences` and `UpdateFinishedTaskReferences(release_lineage=false)` for the consumer, then `RemoveLocalReference` and the memory store delete that `CoreWorker::RemoveLocalReference` pairs with it, and asserts the state before going near the handler. It waits on the reply with a bounded `wait_for` rather than `get`, because the failure being guarded against is the absence of a reply: with the check removed the test fails in five seconds instead of hanging. Only that test fails; the other four `GetObjectStatus` tests pass either way.

I looked for tests that depend on the old behaviour and found the opposite: `test_reference_counting_2.py` and `test_reference_counting_standalone.py` both assert that a borrower does not hang in a related case. Neither goes through the new branch, since passing a ref inside a list produces a borrowed reference rather than a lineage one, so the `Reference` is erased and the existing branch answers.

```
bazel build --dynamic_mode=off \
  --copt=-Wno-error=deprecated-builtins \
  --host_copt=-Wno-error=deprecated-builtins \
  //src/ray/core_worker/tests:core_worker_test \
  //src/ray/core_worker/tests:reference_counter_test
./bazel-bin/src/ray/core_worker/tests/core_worker_test
./bazel-bin/src/ray/core_worker/tests/reference_counter_test
```

```
[==========] 37 tests from 8 test suites ran. (42 ms total)
[  PASSED  ] 37 tests.
[==========] 45 tests from 4 test suites ran. (6 ms total)
[  PASSED  ] 45 tests.
```

macOS 15.5 / arm64, Apple clang 21; the two extra flags work around a deprecated builtin in the pinned absl on that toolchain, not this change. `pre-commit run clang-format` and `pre-commit run cpplint` pass on all five files.

## AI assistance

AI assistance was used for this change and for reviewing it. I have read every changed line and run the commands above locally.
