### PR TITLE
[core] Release pinned lease arguments when a leased worker is killed after its owner dies

### DIFF
--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -1048,7 +1048,8 @@ void NodeManager::HandleUnexpectedWorkerFailure(const WorkerID &worker_id) {
     RAY_LOG(INFO)
             .WithField(worker->WorkerId())
             .WithField("owner_worker_id", owner_worker_id)
-        << "Killing leased worker because its owner died.";
+        << "Killing leased worker and cleaning up its lease because its owner died.";
+    local_lease_manager_.CleanupLease(worker);
     worker->KillAsync(io_service_);
   }
 
@@ -1551,16 +1552,18 @@ void NodeManager::DisconnectClient(const std::shared_ptr<ClientConnection> &clie
   if (is_worker) {
     const ActorID &actor_id = worker->GetActorId();
     const LeaseID &lease_id = worker->GetGrantedLeaseId();
-    // If the worker was granted a lease, clean up the lease and push an
-    // error to the driver, unless the worker is already dead.
-    if ((!lease_id.IsNil() || !actor_id.IsNil()) && !worker->IsDead()) {
+    // Clean up the lease regardless of whether the worker is already dead: a worker
+    // the raylet reaped still holds pinned lease arguments and granted-lease state
+    // that nothing else releases. Only the failure reporting below is suppressed
+    // for a worker we killed ourselves.
+    if (!lease_id.IsNil() || !actor_id.IsNil()) {
       // If the worker was an actor, it'll be cleaned by GCS.
       if (actor_id.IsNil()) {
         // Return the resources that were being used by this worker.
         local_lease_manager_.CleanupLease(worker);
       }
 
-      if (disconnect_type == rpc::WorkerExitType::SYSTEM_ERROR) {
+      if (!worker->IsDead() && disconnect_type == rpc::WorkerExitType::SYSTEM_ERROR) {
         // Push the error to driver.
         const JobID &job_id = worker->GetAssignedJobId();
         // TODO(rkn): Define this constant somewhere else.

--- a/src/ray/raylet/scheduling/local_lease_manager.h
+++ b/src/ray/raylet/scheduling/local_lease_manager.h
@@ -390,6 +390,7 @@ class LocalLeaseManager : public LocalLeaseManagerInterface {
   FRIEND_TEST(ClusterLeaseManagerTest, FeasibleToNonFeasible);
   FRIEND_TEST(LocalLeaseManagerTest, TestLeaseGrantingOrder);
   friend size_t GetPendingLeaseWorkerCount(const LocalLeaseManager &local_lease_manager);
+  friend size_t GetPinnedLeaseArgumentCount(const LocalLeaseManager &local_lease_manager);
 };
 }  // namespace raylet
 }  // namespace ray

--- a/src/ray/raylet/tests/node_manager_test.cc
+++ b/src/ray/raylet/tests/node_manager_test.cc
@@ -126,9 +126,9 @@ class FakeLocalObjectManager : public LocalObjectManagerInterface {
 };
 
 LeaseSpecification BuildLeaseSpec(
-    const std::unordered_map<std::string, double> &resources) {
+    const std::unordered_map<std::string, double> &resources,
+    const rpc::Address &caller_address = rpc::Address()) {
   TaskSpecBuilder builder;
-  rpc::Address empty_address;
   rpc::JobConfig config;
   FunctionDescriptor function_descriptor =
       FunctionDescriptorBuilder::BuildPython("x", "", "", "");
@@ -141,7 +141,7 @@ LeaseSpecification BuildLeaseSpec(
                             TaskID::Nil(),
                             0,
                             TaskID::Nil(),
-                            empty_address,
+                            caller_address,
                             1,
                             false,
                             false,
@@ -675,6 +675,206 @@ TEST_F(NodeManagerTest, TestDetachedWorkerIsKilledByFailedWorker) {
   EXPECT_FALSE(worker->IsKilled());
 }
 
+TEST_F(NodeManagerTest, TestCleanupLeaseAfterOwnerWorkerDies) {
+  EXPECT_CALL(mock_worker_pool_, GetAllRegisteredWorkers(_, _))
+      .WillRepeatedly(Return(std::vector<std::shared_ptr<WorkerInterface>>{}));
+  EXPECT_CALL(mock_worker_pool_, GetAllRegisteredDrivers(_, _))
+      .WillRepeatedly(Return(std::vector<std::shared_ptr<WorkerInterface>>{}));
+  EXPECT_CALL(mock_worker_pool_, AllAliveWorkersAreActors())
+      .WillRepeatedly(Return(false));
+  EXPECT_CALL(mock_worker_pool_, PrestartWorkers(_, _)).Times(1);
+
+  // Save the pop_worker_callback for providing a mock worker later.
+  PopWorkerCallback pop_worker_callback;
+  EXPECT_CALL(mock_worker_pool_, PopWorker(_, _))
+      .WillOnce(
+          [&](const LeaseSpecification &lease_spec, const PopWorkerCallback &callback) {
+            pop_worker_callback = callback;
+          });
+
+  // Save the publish_worker_failure_callback for publishing a worker failure event later.
+  rpc::ItemCallback<rpc::WorkerDeltaData> publish_worker_failure_callback;
+  EXPECT_CALL(*mock_gcs_client_->mock_worker_accessor,
+              AsyncSubscribeToWorkerFailures(_, _))
+      .WillOnce([&](const rpc::ItemCallback<rpc::WorkerDeltaData> &subscribe,
+                    const rpc::StatusCallback &done) {
+        publish_worker_failure_callback = subscribe;
+        return Status::OK();
+      });
+
+  // Invoke RegisterGcs and wait until publish_worker_failure_callback is set.
+  node_manager_->RegisterGcs();
+  while (!publish_worker_failure_callback) {
+    io_service_.run_one();
+  }
+
+  const auto owner_worker_id = WorkerID::FromRandom();
+  rpc::Address owner_address;
+  owner_address.set_worker_id(owner_worker_id.Binary());
+  auto lease_spec = BuildLeaseSpec({}, owner_address);
+  LeaseID lease_id = LeaseID::FromRandom();
+  lease_spec.GetMutableMessage().set_lease_id(lease_id.Binary());
+
+  ObjectID object_dep = ObjectID::FromRandom();
+  auto *dep = lease_spec.GetMutableMessage().add_dependencies();
+  dep->set_object_id(object_dep.Binary());
+
+  plasma::flatbuf::ObjectSource source = plasma::flatbuf::ObjectSource::CreatedByWorker;
+  RAY_UNUSED(mock_store_client_->TryCreateImmediately(
+      object_dep, owner_address, 1024, nullptr, 1024, nullptr, source, 0));
+
+  EXPECT_CALL(*mock_object_manager_, Pull(_, _, _)).Times(1).WillOnce(Return(1));
+
+  // Invoke RequestWorkerLease to request a leased worker for the task in the
+  // NodeManager.
+  std::promise<Status> promise;
+  rpc::RequestWorkerLeaseReply reply;
+  rpc::RequestWorkerLeaseRequest request;
+  request.mutable_lease_spec()->CopyFrom(lease_spec.GetMessage());
+  node_manager_->HandleRequestWorkerLease(
+      request,
+      &reply,
+      [&](Status status, std::function<void()> success, std::function<void()> failure) {
+        promise.set_value(status);
+      });
+
+  auto ready_lease_ids = lease_dependency_manager_->HandleObjectLocal(object_dep);
+  ASSERT_EQ(ready_lease_ids.size(), 1);
+  local_lease_manager_->LeasesUnblocked(ready_lease_ids);
+  ASSERT_TRUE(pop_worker_callback);
+
+  // Prepare a mock worker and check if it is killed later.
+  const auto worker = std::make_shared<MockWorker>(WorkerID::FromRandom(), 10, clock_);
+  // Complete the RequestWorkerLease rpc with the mock worker.
+  pop_worker_callback(worker, PopWorkerStatus::OK, "");
+  EXPECT_TRUE(promise.get_future().get().ok());
+
+  ASSERT_EQ(GetPinnedLeaseArgumentCount(*local_lease_manager_), 1);
+
+  // After RequestWorkerLease, a leased worker is ready in the NodeManager.
+  // Then use publish_worker_failure_callback to say owner_worker_id is dead.
+  // The leased worker should be killed by this.
+  rpc::WorkerDeltaData delta_data;
+  delta_data.set_worker_id(owner_worker_id.Binary());
+  publish_worker_failure_callback(std::move(delta_data));
+
+  // The worker should be dead because it should be killed by
+  // publish_worker_failure_callback.
+  EXPECT_TRUE(worker->IsKilled());
+  EXPECT_EQ(GetPinnedLeaseArgumentCount(*local_lease_manager_), 0);
+}
+
+TEST_F(NodeManagerTest, TestDisconnectClientAfterOwnerWorkerDies) {
+  EXPECT_CALL(mock_worker_pool_, GetAllRegisteredWorkers(_, _))
+      .WillRepeatedly(Return(std::vector<std::shared_ptr<WorkerInterface>>{}));
+  EXPECT_CALL(mock_worker_pool_, GetAllRegisteredDrivers(_, _))
+      .WillRepeatedly(Return(std::vector<std::shared_ptr<WorkerInterface>>{}));
+  EXPECT_CALL(mock_worker_pool_, AllAliveWorkersAreActors())
+      .WillRepeatedly(Return(false));
+  EXPECT_CALL(mock_worker_pool_, PrestartWorkers(_, _)).Times(1);
+
+  // Save the pop_worker_callback for providing a mock worker later.
+  PopWorkerCallback pop_worker_callback;
+  EXPECT_CALL(mock_worker_pool_, PopWorker(_, _))
+      .WillOnce(
+          [&](const LeaseSpecification &lease_spec, const PopWorkerCallback &callback) {
+            pop_worker_callback = callback;
+          });
+
+  const auto owner_worker_id = WorkerID::FromRandom();
+  rpc::Address owner_address;
+  owner_address.set_worker_id(owner_worker_id.Binary());
+  auto lease_spec = BuildLeaseSpec({}, owner_address);
+  LeaseID lease_id = LeaseID::FromRandom();
+  lease_spec.GetMutableMessage().set_lease_id(lease_id.Binary());
+
+  ObjectID object_dep = ObjectID::FromRandom();
+  auto *dep = lease_spec.GetMutableMessage().add_dependencies();
+  dep->set_object_id(object_dep.Binary());
+
+  plasma::flatbuf::ObjectSource source = plasma::flatbuf::ObjectSource::CreatedByWorker;
+  RAY_UNUSED(mock_store_client_->TryCreateImmediately(
+      object_dep, owner_address, 1024, nullptr, 1024, nullptr, source, 0));
+
+  EXPECT_CALL(*mock_object_manager_, Pull(_, _, _)).Times(1).WillOnce(Return(1));
+
+  // Invoke RequestWorkerLease to request a leased worker for the task in the
+  // NodeManager.
+  std::promise<Status> promise;
+  rpc::RequestWorkerLeaseReply reply;
+  rpc::RequestWorkerLeaseRequest request;
+  request.mutable_lease_spec()->CopyFrom(lease_spec.GetMessage());
+  node_manager_->HandleRequestWorkerLease(
+      request,
+      &reply,
+      [&](Status status, std::function<void()> success, std::function<void()> failure) {
+        promise.set_value(status);
+      });
+
+  auto ready_lease_ids = lease_dependency_manager_->HandleObjectLocal(object_dep);
+  ASSERT_EQ(ready_lease_ids.size(), 1);
+  local_lease_manager_->LeasesUnblocked(ready_lease_ids);
+  ASSERT_TRUE(pop_worker_callback);
+
+  // Prepare a mock worker and check if it is killed later.
+  const auto worker = std::make_shared<MockWorker>(WorkerID::FromRandom(), 10, clock_);
+  // DisconnectClient closes the worker's connection on its way out, so the mock
+  // worker needs a real (never-opened) one rather than nullptr.
+  auto noop_message_handler = [](std::shared_ptr<ClientConnection> client,
+                                 int64_t message_type,
+                                 const std::vector<uint8_t> &message) {};
+  auto connection_error_handler = [](std::shared_ptr<ClientConnection> client,
+                                     const boost::system::error_code &error) {};
+  local_stream_socket socket(io_service_);
+  worker->SetConnection(ClientConnection::Create(std::move(noop_message_handler),
+                                                 std::move(connection_error_handler),
+                                                 std::move(socket),
+                                                 "worker",
+                                                 {}));
+
+  // Complete the RequestWorkerLease rpc with the mock worker.
+  pop_worker_callback(worker, PopWorkerStatus::OK, "");
+  EXPECT_TRUE(promise.get_future().get().ok());
+
+  // Kill the worker deliberately, exactly as HandleUnexpectedWorkerFailure and
+  // NodeRemoved do. It is already dead by the time the disconnect arrives.
+  worker->KillAsync(io_service_, /*force=*/false);
+  ASSERT_TRUE(worker->IsKilled());
+  ASSERT_EQ(GetPinnedLeaseArgumentCount(*local_lease_manager_), 1);
+
+  // DisconnectClient resolves a connection to a worker via the pool. The mocked
+  // pool keeps no such map, so tell it which worker this connection belongs to.
+  EXPECT_CALL(
+      mock_worker_pool_,
+      GetRegisteredWorker(testing::An<const std::shared_ptr<ClientConnection> &>()))
+      .WillOnce(Return(worker));
+
+  // Return the lease and ask the raylet to disconnect the already-dead worker.
+  rpc::ReturnWorkerLeaseRequest return_request;
+  rpc::ReturnWorkerLeaseReply return_reply;
+  return_request.set_lease_id(worker->GetGrantedLeaseId().Binary());
+  return_request.set_disconnect_worker(true);
+  return_request.set_disconnect_worker_error_detail("test");
+  return_request.set_worker_exiting(false);
+  node_manager_->HandleReturnWorkerLease(
+      return_request,
+      &return_reply,
+      [](Status s, std::function<void()> success, std::function<void()> failure) {
+        ASSERT_TRUE(s.ok());
+      });
+
+  // The pinned lease arguments must be released even though the worker was
+  // already dead when the disconnect arrived.
+  EXPECT_EQ(GetPinnedLeaseArgumentCount(*local_lease_manager_), 0);
+
+  // A worker Ray killed on purpose must not be reported as an unexpected failure.
+  // This also guards against "fixing" the leak by deleting the IsDead() check
+  // outright rather than narrowing it: that would report every deliberate reap
+  // as a task failure and inflate Raylet.UnexpectedTaskFailure.Total.
+  EXPECT_TRUE(
+      fake_node_manager_unexpected_worker_failure_total_count_.GetTagToValue().empty());
+}
+
 TEST_F(NodeManagerTest, TestDetachedWorkerIsKilledByFailedNode) {
   EXPECT_CALL(*mock_object_directory_, HandleNodeRemoved(_)).Times(1);
   EXPECT_CALL(*mock_object_manager_, HandleNodeRemoved(_)).Times(1);
@@ -1198,6 +1398,10 @@ TEST_F(NodeManagerTest, TestHandleRequestWorkerLeaseInfeasibleIdempotent) {
 size_t GetPendingLeaseWorkerCount(const LocalLeaseManager &local_lease_manager) {
   return local_lease_manager.waiting_lease_queue_.size() +
          local_lease_manager.leases_to_grant_.size();
+}
+
+size_t GetPinnedLeaseArgumentCount(const LocalLeaseManager &local_lease_manager) {
+  return local_lease_manager.pinned_lease_arguments_.size();
 }
 
 TEST_F(NodeManagerTest, TestReschedulingLeasesDuringHandleDrainRaylet) {

--- a/src/ray/raylet/tests/util.h
+++ b/src/ray/raylet/tests/util.h
@@ -144,7 +144,13 @@ class MockWorker : public WorkerInterface {
     return lease_->GetLeaseSpecification().IsDetachedActor();
   }
 
-  const std::shared_ptr<ClientConnection> Connection() const override { return nullptr; }
+  const std::shared_ptr<ClientConnection> Connection() const override {
+    return connection_;
+  }
+  // Test-only: lets a test drive code paths that operate on the worker's connection.
+  void SetConnection(std::shared_ptr<ClientConnection> connection) {
+    connection_ = std::move(connection);
+  }
   const rpc::Address &GetOwnerAddress() const override { return address_; }
   std::optional<pid_t> GetSavedProcessGroupId() const override { return std::nullopt; }
   void SetSavedProcessGroupId(pid_t pgid) override { (void)pgid; }
@@ -202,6 +208,7 @@ class MockWorker : public WorkerInterface {
   std::unique_ptr<ProcessInterface> proc_;
   std::atomic<bool> killing_ = false;
   std::shared_ptr<rpc::CoreWorkerClientInterface> rpc_client_;
+  std::shared_ptr<ClientConnection> connection_;
   ClockInterface &clock_;
 };
 


### PR DESCRIPTION
## Problem

When a worker dies, the GCS broadcasts the failure and every raylet runs
`NodeManager::HandleUnexpectedWorkerFailure`. Any leased worker whose owner was the
dead worker is killed with a bare `worker->KillAsync(...)`.

`KillAsync` sets the worker's `killing_` flag, so `IsDead()` returns true from that
point on. When the killed process exits and its socket closes,
`NodeManager::DisconnectClient` runs, but the lease cleanup there was guarded by
`!worker->IsDead()`, so it was skipped.

`LocalLeaseManager::CleanupLease` therefore never ran for that lease, and two things
leaked:

1. The task arguments the raylet pinned in plasma for the lease. `pinned_lease_arguments_`
   keeps holding them, so plasma reports the objects as in use, they can never be evicted,
   and the node's `PullManager` budget shrinks permanently. With large arguments this drives
   the budget to zero, after which the node cannot fetch dependencies for any new lease.
   Only a raylet restart clears it.
2. The granted lease entry in `info_by_sched_cls_`, which nothing else removes.

Worker resources are *not* leaked: `DisconnectClient` calls
`local_lease_manager_.ReleaseWorkerResources(worker)` further down, outside the guard.

`NodeManager::NodeRemoved` has the same shape. It kills leased workers whose owner's node
died, also with a bare `KillAsync` and no cleanup, so node failure leaks the same way.

## Why the guard exists

`NodeManager::DestroyWorker` explains it:

    // We should disconnect the client first. Otherwise, we'll remove bundle resources
    // before actual resources are returned. Subsequent disconnect request that comes
    // due to worker dead will be ignored.

The `!worker->IsDead()` check is there so a worker Ray killed on purpose is not reported
as an unexpected failure. That is a reasonable job, but it was also gating the cleanup,
and `HandleUnexpectedWorkerFailure` kills without disconnecting first, so the guard ends
up swallowing the only disconnect that ever happens for that worker.

The Ray v2 architecture doc (Failure Model, System Model) states the contract this breaks:

> The raylets are responsible for preventing leaks in cluster resources and system state
> after individual worker process failures. For a worker process (local or remote) that has
> failed, each raylet is responsible for: [...] Freeing any distributed object store memory
> used by that worker.

Note the shape of the miss: `HandleUnexpectedWorkerFailure` already frees the objects the
dead owner *owned*, via `GetLocalObjectsOwnedBy` and `FreeLocalObjects`. What it misses are
the objects its leased workers were *borrowing* as task arguments.

## Fix

1. `HandleUnexpectedWorkerFailure` now calls `local_lease_manager_.CleanupLease(worker)`
   before killing the worker, so the lease is released immediately rather than waiting for
   the process to exit.
2. In `DisconnectClient`, `!worker->IsDead()` moves from the outer condition onto the error
   reporting branch. Cleanup now runs for any disconnect with a granted lease, while a
   worker Ray killed deliberately is still not reported as an unexpected task failure.

`CleanupLease` is idempotent, which makes running it from both places safe.
`RemoveFromGrantedLeasesIfExists` and `ReleaseLeaseArgs` both no-op when their entry is
already gone, and `ReleaseWorkerResources` returns early once the allocation is cleared.

Fixing `DisconnectClient` rather than patching each caller means `NodeRemoved` is covered
by the same change, as is any future caller that kills a worker without disconnecting it
first.

## Tests

Two new tests in `node_manager_test.cc`, both confirmed failing before the fix:

- `TestCleanupLeaseAfterOwnerWorkerDies` grants a lease with a plasma argument, publishes an
  owner-death event through the GCS worker-failure subscription, and asserts the pinned
  argument is released. Covers change 1.
- `TestDisconnectClientAfterOwnerWorkerDies` grants the same kind of lease, kills the worker
  directly, then drives a disconnect and asserts the argument is released and that no
  unexpected-failure metric was recorded. Covers change 2.

Supporting test changes: `BuildLeaseSpec` takes an optional caller address, and `MockWorker`
gained a `SetConnection` setter defaulting to null so existing tests are unaffected.

Local results: `bazel test //src/ray/raylet/...` passes, 18/18.

Related to #64627.

## AI assistance

This change was developed with AI assistance. I verified the diagnosis myself by reading the
relevant code paths, wrote and ran the tests, and confirmed each test fails without the
corresponding change and passes with it.