### PR TITLE
[serve] Deflake test_grpc: treat TaskCancelledError as cancellation

### DIFF
--- a/python/ray/serve/_private/test_utils.py
+++ b/python/ray/serve/_private/test_utils.py
@@ -26,6 +26,7 @@ from ray._common.test_utils import (
 )
 from ray._common.utils import TimerBase
 from ray.actor import ActorHandle
+from ray.exceptions import TaskCancelledError
 from ray.serve._private.client import ServeControllerClient
 from ray.serve._private.common import (
     CreatePlacementGroupRequest,
@@ -1162,7 +1163,9 @@ async def send_signal_on_cancellation(signal_actor: ActorHandle):
     try:
         yield
         await asyncio.sleep(100)
-    except asyncio.CancelledError:
+    except (asyncio.CancelledError, TaskCancelledError):
+        # A cancelled task surfaces as TaskCancelledError on an in-flight
+        # `.remote()` await, which is not an asyncio.CancelledError.
         cancelled = True
         # Clear the context var to avoid Ray recursively cancelling this method call.
         ray._raylet.async_task_id.set(None)


### PR DESCRIPTION
send_signal_on_cancellation treated only asyncio.CancelledError as a cancellation. When a replica task is cancelled while the managed block is suspended inside an in-flight Ray `.remote()` await, that await raises RayTaskError(TaskCancelledError), which derives from RayError and not from asyncio.CancelledError. The handler was skipped, the signal was never sent, and the waiting test blocked until the repo-wide pytest.ini `timeout = 180` fired -- which CI reports as an ordinary flake that goes green on retry, never a target timeout.

test_grpc_streaming_cancellation[bidi] is the case that reproduces: it signals "running" and then awaits the next request, so the test's cancel can land inside a Ray call. Its [client] sibling drains the request stream first and parks in asyncio.sleep, so it always gets a real CancelledError.

Measured on a 4-core box under 2 CPU stressors: 1 hang / 8 runs before, 0 hangs / 14 runs after, including a run that took the TaskCancelledError path and passed. The helper is shared by 9 serve test files.