### PR TITLE
[docs][train] Save custom Lightning checkpoints on all ranks

### DIFF
--- a/doc/source/train/doc_code/checkpoints.py
+++ b/doc/source/train/doc_code/checkpoints.py
@@ -249,12 +249,13 @@ class CustomRayTrainReportCallback(Callback):
 
             checkpoint = None
             global_rank = ray.train.get_context().get_world_rank() == 0
-            if global_rank == 0 and should_checkpoint:
+            if should_checkpoint:
                 # Save model checkpoint file to tmpdir
                 ckpt_path = os.path.join(tmpdir, "ckpt.pt")
                 trainer.save_checkpoint(ckpt_path, weights_only=False)
 
-                checkpoint = Checkpoint.from_directory(tmpdir)
+                if global_rank:
+                    checkpoint = Checkpoint.from_directory(tmpdir)
 
             # Report to train session
             ray.train.report(metrics=metrics, checkpoint=checkpoint)

--- a/doc/source/train/doc_code/checkpoints.py
+++ b/doc/source/train/doc_code/checkpoints.py
@@ -248,17 +248,16 @@ class CustomRayTrainReportCallback(Callback):
             metrics["custom_metric"] = 123
 
             checkpoint = None
-            global_rank = ray.train.get_context().get_world_rank() == 0
             if should_checkpoint:
                 # Save model checkpoint file to tmpdir
                 ckpt_path = os.path.join(tmpdir, "ckpt.pt")
                 trainer.save_checkpoint(ckpt_path, weights_only=False)
 
-                if global_rank:
-                    checkpoint = Checkpoint.from_directory(tmpdir)
+                checkpoint = Checkpoint.from_directory(tmpdir)
 
             # Report to train session
             ray.train.report(metrics=metrics, checkpoint=checkpoint)
+            trainer.strategy.barrier()
 # __lightning_custom_save_example_end__
 
 # __lightning_restore_example_start__

--- a/python/ray/train/tests/test_torch_lightning_train.py
+++ b/python/ray/train/tests/test_torch_lightning_train.py
@@ -1,10 +1,11 @@
 import os
+from tempfile import TemporaryDirectory
 
 import numpy as np
 import pytest
 
 import ray
-from ray.train import ScalingConfig
+from ray.train import Checkpoint, ScalingConfig
 from ray.train.lightning import (
     RayDDPStrategy,
     RayDeepSpeedStrategy,
@@ -151,6 +152,42 @@ def test_trainer_with_ray_data(ray_start_6_cpus_2_gpus, strategy_name, accelerat
     )
     assert "loss" in results.metrics
     assert "val_loss" in results.metrics
+
+
+def test_custom_checkpoint_callback(ray_start_6_cpus_2_gpus):
+    """A custom callback must save on every worker to avoid a DDP deadlock."""
+
+    class CustomCheckpointCallback(pl.Callback):
+        def on_train_epoch_end(self, trainer, pl_module):
+            with TemporaryDirectory() as tmpdir:
+                checkpoint = None
+                if trainer.current_epoch == 0:
+                    checkpoint_path = os.path.join(tmpdir, "ckpt.pt")
+                    trainer.save_checkpoint(checkpoint_path, weights_only=False)
+                    if ray.train.get_context().get_world_rank() == 0:
+                        checkpoint = Checkpoint.from_directory(tmpdir)
+                ray.train.report(
+                    {"epoch": trainer.current_epoch}, checkpoint=checkpoint
+                )
+
+    def train_loop():
+        trainer = pl.Trainer(
+            max_epochs=1,
+            devices="auto",
+            accelerator="cpu",
+            strategy=RayDDPStrategy(),
+            plugins=[RayLightningEnvironment()],
+            callbacks=[CustomCheckpointCallback()],
+        )
+        trainer.fit(LinearModule(input_dim=32, output_dim=4), DummyDataModule(8, 16))
+
+    result = TorchTrainer(
+        train_loop_per_worker=train_loop,
+        scaling_config=ScalingConfig(num_workers=2, use_gpu=False),
+    ).fit()
+
+    with result.checkpoint.as_directory() as checkpoint_dir:
+        assert os.path.exists(os.path.join(checkpoint_dir, "ckpt.pt"))
 
 
 @pytest.mark.parametrize("stage", [1, 2, 3])

--- a/python/ray/train/tests/test_torch_lightning_train.py
+++ b/python/ray/train/tests/test_torch_lightning_train.py
@@ -164,11 +164,11 @@ def test_custom_checkpoint_callback(ray_start_6_cpus_2_gpus):
                 if trainer.current_epoch == 0:
                     checkpoint_path = os.path.join(tmpdir, "ckpt.pt")
                     trainer.save_checkpoint(checkpoint_path, weights_only=False)
-                    if ray.train.get_context().get_world_rank() == 0:
-                        checkpoint = Checkpoint.from_directory(tmpdir)
+                    checkpoint = Checkpoint.from_directory(tmpdir)
                 ray.train.report(
                     {"epoch": trainer.current_epoch}, checkpoint=checkpoint
                 )
+                trainer.strategy.barrier()
 
     def train_loop():
         trainer = pl.Trainer(


### PR DESCRIPTION
## Summary

Fixes #56997.

- Update the custom Lightning checkpoint example so every train worker calls `trainer.save_checkpoint()`.
- Continue creating the Ray `Checkpoint` only on global rank 0.
- Add focused two-worker CPU coverage that verifies the custom callback produces `ckpt.pt` without a DDP deadlock.

## Duplicate-work check

There is no open PR for #56997. The prior volunteer, @TQC0103, confirmed on the issue that they are no longer working on it and that this contribution can proceed.

## Testing

- `python -m py_compile doc/source/train/doc_code/checkpoints.py python/ray/train/tests/test_torch_lightning_train.py`
- `pre-commit run ruff --files doc/source/train/doc_code/checkpoints.py python/ray/train/tests/test_torch_lightning_train.py`
- `pre-commit run pydoclint --files python/ray/train/tests/test_torch_lightning_train.py`
- `pre-commit run black --files doc/source/train/doc_code/checkpoints.py python/ray/train/tests/test_torch_lightning_train.py`
- `pre-commit run check-ast --files doc/source/train/doc_code/checkpoints.py python/ray/train/tests/test_torch_lightning_train.py`
- Local two-worker CPU `TorchTrainer` reproduction of the callback logic (exit 0; verified that `ckpt.pt` exists).

## AI assistance

AI assistance was used. The human submitter reviewed every changed line, understands the behavior and validation, and can defend this change end-to-end.
