### PR TITLE
[autoscaler] Bump Aliyun default image from Ubuntu 20.04 to 22.04

### DIFF
--- a/python/ray/autoscaler/aliyun/defaults.yaml
+++ b/python/ray/autoscaler/aliyun/defaults.yaml
@@ -56,7 +56,7 @@ available_node_types:
         # Provider-specific config for this node type, e.g. instance type. By default
         node_config:
             InstanceType: ecs.n4.large
-            ImageId: ubuntu_20_04_x64_20G_alibase_20210420.vhd
+            ImageId: ubuntu_22_04_x64_20G_alibase_20251226.vhd
             # You can provision additional disk space with a conf as follows
             BlockDeviceMappings:
                 - DeviceName: /dev/sda1
@@ -77,7 +77,7 @@ available_node_types:
         # Ray will auto-configure unspecified fields such as SubnetId and KeyName.
         node_config:
             InstanceType: ecs.n4.2xlarge
-            ImageId: ubuntu_20_04_x64_20G_alibase_20210420.vhd
+            ImageId: ubuntu_22_04_x64_20G_alibase_20251226.vhd
 #            KeyPairName: id_rsa.pub
             # Run workers on spot by default. Comment this out to use on-demand.
             InstanceMarketOptions:

--- a/python/ray/autoscaler/aliyun/example-full.yaml
+++ b/python/ray/autoscaler/aliyun/example-full.yaml
@@ -62,7 +62,7 @@ available_node_types:
         # Provider-specific config for this node type, e.g. instance type. By default
         node_config:
             InstanceType: ecs.n4.large
-            ImageId: ubuntu_20_04_x64_20G_alibase_20210420.vhd
+            ImageId: ubuntu_22_04_x64_20G_alibase_20251226.vhd
             # You can provision additional disk space with a conf as follows
             BlockDeviceMappings:
                 - DeviceName: /dev/sda1
@@ -83,7 +83,7 @@ available_node_types:
         # Ray will auto-configure unspecified fields such as SubnetId.
         node_config:
             InstanceType: ecs.n4.2xlarge
-            ImageId: ubuntu_20_04_x64_20G_alibase_20210420.vhd
+            ImageId: ubuntu_22_04_x64_20G_alibase_20251226.vhd
 #            KeyPairName: id_rsa.pub
             # Run workers on spot by default. Comment this out to use on-demand.
             InstanceMarketOptions:

--- a/python/ray/autoscaler/aliyun/example-linux.yaml
+++ b/python/ray/autoscaler/aliyun/example-linux.yaml
@@ -63,7 +63,7 @@ available_node_types:
         # Provider-specific config for this node type, e.g. instance type. By default
         node_config:
             InstanceType: ecs.n4.large
-            ImageId: ubuntu_20_04_x64_20G_alibase_20210420.vhd
+            ImageId: ubuntu_22_04_x64_20G_alibase_20251226.vhd
             # You can provision additional disk space with a conf as follows
             BlockDeviceMappings:
                 - DeviceName: /dev/sda1
@@ -86,7 +86,7 @@ available_node_types:
         # http://boto3.readthedocs.io/en/latest/reference/services/ec2.html#EC2.ServiceResource.create_instances
         node_config:
             InstanceType: ecs.n4.2xlarge
-            ImageId: ubuntu_20_04_x64_20G_alibase_20210420.vhd
+            ImageId: ubuntu_22_04_x64_20G_alibase_20251226.vhd
 #            KeyPairName: id_rsa.pub
             # Run workers on spot by default. Comment this out to use on-demand.
             InstanceMarketOptions:


### PR DESCRIPTION
## Why are these changes needed?

The Aliyun cluster launcher has pinned `ubuntu_20_04_x64_20G_alibase_20210420.vhd` as its default node image since 2021. That default is now stale in two ways:

- Alibaba Cloud marks Ubuntu 20.04 as **EOL** in its public image list, and Ubuntu 20.04 left standard support in May 2025.
- The image ships **Python 3.8** as the system interpreter, which current Ray no longer supports.

This bumps the pin to the current Alibaba Cloud Ubuntu 22.04 LTS public image, `ubuntu_22_04_x64_20G_alibase_20251226.vhd`, in the provider defaults (`aliyun/defaults.yaml`) and in both example configs so a user copying an example doesn't land back on the EOL image. It also brings the system interpreter to Python 3.10 and lines the launcher up with the Ubuntu 22.04 baseline Ray's container images already use (`docker/base-deps`, `docker/base-slim`, `ci/docker/base.test.*`).

Two notes on the approach:

- The image stays an **exact pin** rather than a date-less prefix like `ubuntu_22_04_x64`. Fuzzy image-name matching is a Resource Orchestration Service *template* feature; the ECS `RunInstances` call that `AliyunNodeProvider` makes (`utils.py` → `request.set_ImageId(...)`, fed by a hard `node_config["ImageId"]` lookup in `node_provider.py`) requires an exact `ImageId`.
- Scope is deliberately limited to the image pin. `aliyun/defaults.yaml` also still installs `Anaconda3-2020.11` (Python 3.8) in `setup_commands`; that's a separate pre-existing staleness and I've left it alone rather than widen this PR.

## Not a duplicate

- `gh pr list --repo ray-project/ray --state open --search "aliyun"` → only #65417, an unrelated dashboard NVML fix.
- `gh pr list --repo ray-project/ray --state open --search "ubuntu 20.04"` → no results.
- `gh issue list --repo ray-project/ray --state open --search "aliyun"` → only #47446, which is an `InvalidSystemDiskCategory` failure using a user-supplied custom `ImageId`, not the default image pin. Not addressed or duplicated here.

## Related issue number

Not filed against an issue.

## Checks

There is no automated coverage for this provider to extend: `aliyun` appears in no release test and no test under `python/ray/tests/`, `_private/aliyun/**` is excluded from the doctest glob in `python/ray/autoscaler/BUILD.bazel`, and `aliyun/defaults.yaml` is not in the `default_configs` filegroup. Booting an ECS instance to verify the image resolves requires Alibaba Cloud credentials, which I do not have, so the image name is sourced from Alibaba Cloud's own current Ubuntu image documentation.

What was run locally:

- All three configs parse and their `ImageId` values assert to the new pin.
- All three validate against `python/ray/autoscaler/ray-schema.json` (the schema `validate_config` uses) — `defaults.yaml`, `example-full.yaml`, `example-linux.yaml` all **SCHEMA VALID**.
- `pre-commit run --files python/ray/autoscaler/aliyun/{defaults,example-full,example-linux}.yaml` — passed.
- `git grep ubuntu_20_04` — no remaining references in the repo.

- [x] I've signed off every commit (`-s`).
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for the change (none needed — no doc references the pinned image ID).
- [x] I've made sure the tests are passing.
- Testing Strategy
   - [x] Manual/local validation as described above (no CI coverage exists for this provider)

AI assistance was used to prepare this change.