### PR TITLE
[doc] Add community connectors for Apache Doris and Kinetica

### DIFF
--- a/doc/source/data/loading-data.rst
+++ b/doc/source/data/loading-data.rst
@@ -1238,7 +1238,7 @@ datasink and pass it to :func:`~ray.data.Dataset.write_datasink`. For more detai
     ds.write_datasink(YourCustomDatasink())
 
 Community-maintained connectors
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+===============================
 
 The following connectors are maintained by the community and provide integrations
 with additional data systems:

--- a/doc/source/data/loading-data.rst
+++ b/doc/source/data/loading-data.rst
@@ -1237,6 +1237,15 @@ datasink and pass it to :func:`~ray.data.Dataset.write_datasink`. For more detai
     # Write to a custom datasink.
     ds.write_datasink(YourCustomDatasink())
 
+Community-maintained connectors
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The following connectors are maintained by the community and provide integrations
+with additional data systems:
+
+* `Apache Doris Ray Connector <https://github.com/jiangxt2/ray-doris>`_ - Read and write data between Ray Data and `Apache Doris <https://doris.apache.org/>`_.
+* `Kinetica Ray Connector <https://github.com/kineticadb/kinetica-ray>`_ - Read and write data between Ray Data and `Kinetica <https://www.kinetica.com/>`_.
+
 Performance considerations
 ==========================
 


### PR DESCRIPTION
## Summary
- Add a "Community-maintained connectors" subsection under "Loading other datasources" in the Ray Data loading data docs
- Links to [Apache Doris Ray Connector](https://github.com/jiangxt2/ray-doris) and [Kinetica Ray Connector](https://github.com/kineticadb/kinetica-ray)

## Test plan
- [ ] Docs-only change — verify rendering in PR preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)