### PR TITLE
[Data] Fix HDFS URI reads with explicit filesystems

### DIFF
--- a/python/ray/data/datasource/path_util.py
+++ b/python/ray/data/datasource/path_util.py
@@ -532,7 +532,7 @@ def _is_http_filesystem(fs: "pyarrow.fs.FileSystem") -> bool:
     )
 
 
-def _unwrap_protocol(path):
+def _unwrap_protocol(path: str) -> str:
     """
     Slice off any protocol prefixes on path.
     """
@@ -551,6 +551,9 @@ def _unwrap_protocol(path):
         netloc = parsed.netloc.split("@")[-1]
 
     parsed_path = parsed.path
+    if parsed.scheme in ("hdfs", "viewfs"):
+        return parsed_path
+
     # urlparse prepends the path with a '/'. This does not work on Windows
     # so if this is the case strip the leading slash.
     if (

--- a/python/ray/data/tests/unit/test_path_util.py
+++ b/python/ray/data/tests/unit/test_path_util.py
@@ -4,6 +4,7 @@ import pyarrow
 import pyarrow.fs
 import pytest
 from fsspec.implementations.http import HTTPFileSystem
+from fsspec.implementations.memory import MemoryFileSystem
 from pyarrow.fs import FSSpecHandler, PyFileSystem
 
 from ray.data._internal.util import RetryingPyFileSystem
@@ -14,6 +15,7 @@ from ray.data.datasource.path_util import (
     _resolve_paths_and_filesystem,
     _resolve_single_path_with_fallback,
     _rewrite_azure_blob_https_url,
+    _unwrap_protocol,
 )
 from ray.util.annotations import RayDeprecationWarning
 
@@ -53,6 +55,36 @@ def test_resolve_http_paths(filesystem):
     assert isinstance(resolve_filesystem, pyarrow.fs.PyFileSystem)
     assert isinstance(resolve_filesystem.handler, pyarrow.fs.FSSpecHandler)
     assert isinstance(resolve_filesystem.handler.fs, HTTPFileSystem)
+
+
+@pytest.mark.parametrize(
+    "path, expected",
+    [
+        ("hdfs://namenode.example/path/file", "/path/file"),
+        ("viewfs://cluster/path/file", "/path/file"),
+        ("s3://bucket/path/file", "bucket/path/file"),
+        ("gs://bucket/path/file", "bucket/path/file"),
+        ("abfs://container/path/file", "container/path/file"),
+        ("file:///path/file", "/path/file"),
+        ("https://example.com/path/file", "example.com/path/file"),
+    ],
+)
+def test_unwrap_protocol(path: str, expected: str) -> None:
+    assert _unwrap_protocol(path) == expected
+
+
+def test_resolve_hdfs_uri_with_explicit_filesystem() -> None:
+    class HdfsMemoryFileSystem(MemoryFileSystem):
+        protocol = "hdfs"
+
+    resolved_paths, resolved_filesystem = _resolve_paths_and_filesystem(
+        paths="hdfs://namenode.example/path/file",
+        filesystem=HdfsMemoryFileSystem(),
+    )
+
+    assert resolved_paths == ["/path/file"]
+    assert isinstance(resolved_filesystem, PyFileSystem)
+    assert isinstance(resolved_filesystem.handler.fs, HdfsMemoryFileSystem)
 
 
 @pytest.mark.parametrize(

--- a/python/ray/data/tests/unit/test_path_util.py
+++ b/python/ray/data/tests/unit/test_path_util.py
@@ -61,7 +61,9 @@ def test_resolve_http_paths(filesystem):
     "path, expected",
     [
         ("hdfs://namenode.example/path/file", "/path/file"),
+        ("hdfs://namenode.example/path/file;param?query=value", "/path/file;param"),
         ("viewfs://cluster/path/file", "/path/file"),
+        ("viewfs://cluster/path/file;param?query=value", "/path/file;param"),
         ("s3://bucket/path/file", "bucket/path/file"),
         ("gs://bucket/path/file", "bucket/path/file"),
         ("abfs://container/path/file", "container/path/file"),


### PR DESCRIPTION
## Description

Reading an HDFS or ViewFS URI with a caller-provided Hadoop filesystem fails because Ray Data passes the URI authority as part of the path. For `hdfs://namenode.example/path/file.json`, this produces `FileNotFoundError: namenode.example/path/file.json`. PyArrow stores the namenode in the filesystem object and expects `/path/file.json`.

This change drops the authority only for `hdfs://` and `viewfs://` paths. S3, GCS, Azure, local, and HTTP path handling stays unchanged. The existing issue was closed without a linked fix, and no open or closed PR implements one.

## Related issues

Fixes https://github.com/ray-project/ray/issues/20834

## Additional information

<details>
<summary>Reproducer and raw output</summary>

```bash
python - <<'PY'
from fsspec.implementations.memory import MemoryFileSystem
from pyarrow.fs import FSSpecHandler, PyFileSystem
import ray.data

class HdfsMemoryFileSystem(MemoryFileSystem):
    protocol = "hdfs"

    def info(self, path, **kwargs):
        if not path.startswith("/"):
            raise FileNotFoundError(path)
        return super().info(path, **kwargs)

fs = HdfsMemoryFileSystem()
fs.pipe("/path/file.json", b'{"value": 1}\n')
ds = ray.data.read_json(
    "hdfs://namenode.example/path/file.json",
    filesystem=PyFileSystem(FSSpecHandler(fs)),
)
print(ds.input_files())
PY
```

Before:

```text
FileNotFoundError: namenode.example/path/file.json
```

After:

```text
['/path/file.json']
```
</details>

With the repository Python sources loaded over a Ray nightly wheel for native extensions:

```bash
python -c 'import pathlib, pytest, ray, sys; ray.__path__.insert(0, str(pathlib.Path("python/ray").resolve())); sys.path.insert(0, str(pathlib.Path("python").resolve())); raise SystemExit(pytest.main(["-q", "python/ray/data/tests/unit/test_path_util.py", "-k", "test_unwrap_protocol or test_resolve_hdfs_uri_with_explicit_filesystem"]))'
python -c 'import pathlib, pytest, ray, sys; ray.__path__.insert(0, str(pathlib.Path("python/ray").resolve())); sys.path.insert(0, str(pathlib.Path("python").resolve())); raise SystemExit(pytest.main(["-q", "python/ray/data/tests/unit/test_path_util.py"]))'
```

```text
10 passed, 49 deselected in 0.48s
52 passed, 7 skipped in 0.67s
```
