### PR TITLE
[doc] Add a KubeRay Helm chart values reference

### DIFF
--- a/doc/source/cluster/kubernetes/references.md
+++ b/doc/source/cluster/kubernetes/references.md
@@ -1,21 +1,25 @@
 ---
 myst:
   html_meta:
-    description: "API reference for the KubeRay custom resources, plus KubeRay's API compatibility and stability guarantees."
+    description: "Reference material for running Ray on Kubernetes with KubeRay: the custom resource API reference and the Helm chart values reference."
 ---
 
 (kuberay-api-reference)=
-# API Reference
+# References
+
+Reference material for configuring Ray on Kubernetes with KubeRay:
+
+- The {ref}`KubeRay CRD API reference <kuberay-crd-api-reference>` documents every field of the `ray.io/v1` custom resources. KubeRay generates it from the CRD definitions.
+- The {ref}`Helm chart values reference <kuberay-helm-values>` explains the operator and ray-cluster chart values.
 
 ```{toctree}
 :hidden:
 
 references/api
+references/helm-values
 ```
 
-To learn about RayCluster configuration, we recommend taking a look at the {ref}`configuration guide <kuberay-config>`.
-
-For comprehensive coverage of all supported RayCluster fields, refer to the {ref}`KubeRay CRD API reference <kuberay-crd-api-reference>`. It documents every field of the `ray.io/v1` custom resources, and is generated from the KubeRay CRD definitions.
+To learn about RayCluster configuration, see the {ref}`configuration guide <kuberay-config>`.
 
 ## KubeRay API compatibility and guarantees
 

--- a/doc/source/cluster/kubernetes/references/helm-values.md
+++ b/doc/source/cluster/kubernetes/references/helm-values.md
@@ -1,0 +1,107 @@
+---
+myst:
+  html_meta:
+    description: "Reference for the KubeRay operator and ray-cluster Helm chart values, including feature gates, default container environment variables, sidecar containers, operator logging, and Argo CD installation."
+---
+
+(kuberay-helm-values)=
+# Helm chart values
+
+This page explains the KubeRay Helm chart values that need more context than a values table gives you, and points you to the complete list of values for each chart. KubeRay publishes two charts:
+
+- `kuberay-operator` installs the KubeRay operator and its custom resource definitions.
+- `ray-cluster` installs a single RayCluster custom resource.
+
+To install the operator, follow the {ref}`kuberay-operator-deploy` guide. To configure the operator's RBAC resources, see {ref}`kuberay-helm-chart-rbac`. To configure a RayCluster, see the {ref}`configuration guide <kuberay-config>`.
+
+## Where to find the complete values
+
+The complete values table for each chart lives in the chart's `README.md` in the `ray-project/kuberay` repository:
+
+- [kuberay-operator chart values](https://github.com/ray-project/kuberay/blob/master/helm-chart/kuberay-operator/README.md#values)
+- [ray-cluster chart values](https://github.com/ray-project/kuberay/blob/master/helm-chart/ray-cluster/README.md#values)
+
+Treat those tables as the source of truth. KubeRay generates them from each chart's `values.yaml` with [helm-docs](https://github.com/norwoodj/helm-docs), and a continuous integration check fails if a committed table drifts from its `values.yaml`. The tables list every key, its type, and its default. The sections below cover the values whose behavior the generated table doesn't explain.
+
+## Set chart values
+
+Override a value on the command line with `--set`, or pass a YAML file with `-f`. A file is easier to read and version-control for anything beyond a single flag:
+
+```yaml
+# operator-values.yaml
+configuration:
+  defaultContainerEnvs:
+  - name: RAY_enable_open_telemetry
+    value: "true"
+```
+
+```bash
+helm install kuberay-operator kuberay/kuberay-operator --version 1.6.0 -f operator-values.yaml
+```
+
+## Operator feature gates
+
+`featureGates` is a list of `{name, enabled}` entries that turn individual operator features on or off. Each entry controls one feature. The default state varies by feature and by chart version, and the generated values table lists each gate's name without describing what it does.
+
+Set a gate through a values file, which keeps the entry readable and stable across releases:
+
+```yaml
+# operator-values.yaml
+featureGates:
+- name: RayServiceIncrementalUpgrade
+  enabled: true
+```
+
+For the authoritative list of available gates and their defaults in a given chart version, read the [`featureGates` block in the operator's `values.yaml`](https://github.com/ray-project/kuberay/blob/master/helm-chart/kuberay-operator/values.yaml).
+
+## Inject environment variables into Ray containers
+
+`configuration.defaultContainerEnvs` sets environment variables on every Ray container in every RayCluster the operator manages. Use it to apply a Ray feature flag across all Ray pods without editing each RayCluster:
+
+```yaml
+# operator-values.yaml
+configuration:
+  defaultContainerEnvs:
+  - name: RAY_enable_open_telemetry
+    value: "true"
+  - name: RAY_metric_cardinality_level
+    value: "recommended"
+```
+
+## Add sidecar containers to Ray pods
+
+`configuration.headSidecarContainers` and `configuration.workerSidecarContainers` inject sidecar containers into every Ray head pod and every Ray worker pod the operator manages. A common use is a log-forwarding agent:
+
+```yaml
+# operator-values.yaml
+configuration:
+  headSidecarContainers:
+  - name: fluentbit
+    image: fluent/fluent-bit:1.9
+  workerSidecarContainers:
+  - name: fluentbit
+    image: fluent/fluent-bit:1.9
+```
+
+## Configure operator logging
+
+The `logging` values control how the KubeRay operator writes its own logs.
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `logging.stdoutEncoder` | `json` | Encoder for stdout logs. Set to `json` or `console`. |
+| `logging.fileEncoder` | `json` | Encoder for file logs. Set to `json` or `console`. |
+| `logging.baseDir` | `""` | Directory for the operator log file. |
+| `logging.fileName` | `""` | File name for the operator log file. |
+| `logging.sizeLimit` | `""` | Size limit for the `emptyDir` volume that holds the operator log file. |
+
+The operator writes to a file only when you set `logging.baseDir` and `logging.fileName`. Use `console` encoding when you read the logs directly and `json` when a log pipeline parses them.
+
+## Install the operator with Argo CD
+
+Argo CD can't apply the operator chart in one step, because the RayCluster, RayJob, RayService, and RayCronJob CRDs are too large for Argo CD to apply as a single resource. Split the installation into two Argo CD applications:
+
+- The first application applies the CRDs from the chart's `crds` directory with the `Replace=true` sync option.
+- The second application installs the chart with Helm's `skipCrds=true` option so it doesn't try to apply the CRDs again.
+
+For the full `Application` manifests, see [Working with Argo CD](https://github.com/ray-project/kuberay/blob/master/helm-chart/kuberay-operator/README.md#working-with-argo-cd) in the operator chart README.


### PR DESCRIPTION
## Why

The Ray Kubernetes docs have no Helm values reference for either KubeRay chart. The complete values tables live only in the chart READMEs in `ray-project/kuberay` (`helm-chart/kuberay-operator/README.md` and `helm-chart/ray-cluster/README.md`), which aren't discoverable from the Ray docs. Several values have no explanation anywhere in the Ray docs: feature gates, `configuration.defaultContainerEnvs`, head and worker sidecar containers, `logging.*`, and Argo CD installation.

## What

Add `cluster/kubernetes/references/helm-values.md`, a hand-written reference that:

- Explains the values that need more context than a generated table row gives, focused on the items above.
- Points to the chart READMEs for the exhaustive, per-key tables.

The KubeRay READMEs are generated with [helm-docs](https://github.com/norwoodj/helm-docs) from each chart's `values.yaml` and gated in CI (the `helm-docs-built` pre-commit hook), so they stay current and are the right source of truth to link to, rather than vendoring a copy into this repo that would drift.

Every value description and example is taken from the chart `values.yaml` and templates. For instance, the page states file logging activates only when both `logging.baseDir` and `logging.fileName` are set, which matches `kuberay-operator/templates/deployment.yaml` (it appends `--log-file-path` only under that condition).

## Note for reviewers

This also reframes the `references.md` landing page from **API Reference** to **References** so it parents both the CRD API reference and the new Helm values reference. The existing `kuberay-api-reference` label is preserved, so no cross-references break. Happy to revert that framing change if you'd rather keep the values reference somewhere else in the tree.
