### PR TITLE
[train][doc] Install evaluate/scikit-learn in Train examples that use evaluate metrics

### DIFF
--- a/doc/source/train/examples/deepspeed/gptj_deepspeed_fine_tuning.ipynb
+++ b/doc/source/train/examples/deepspeed/gptj_deepspeed_fine_tuning.ipynb
@@ -44,7 +44,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "! pip install -q \"datasets\" \"evaluate\" \"accelerate==0.33.0\" \"transformers==4.36.2\" \"deepspeed==0.17.2\""
+    "! pip install -q \"datasets\" \"evaluate\" \"scikit-learn\" \"accelerate==0.33.0\" \"transformers==4.36.2\" \"deepspeed==0.17.2\""
    ]
   },
   {
@@ -108,6 +108,7 @@
     "        \"pip\": [\n",
     "            \"datasets\",\n",
     "            \"evaluate\",\n",
+    "            \"scikit-learn\",\n",
     "            \"accelerate==0.33.0\",\n",
     "            \"transformers==4.36.2\",\n",
     "            \"deepspeed==0.17.2\",\n",

--- a/doc/source/train/examples/lightning/lightning_cola_advanced.ipynb
+++ b/doc/source/train/examples/lightning/lightning_cola_advanced.ipynb
@@ -51,7 +51,7 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "!pip install numpy datasets \"transformers>=4.19.1\" \"lightning>=2.0\""
+        "!pip install numpy datasets evaluate scikit-learn \"transformers>=4.19.1\" \"lightning>=2.0\""
       ]
     },
     {

--- a/doc/source/train/examples/transformers/huggingface_text_classification.ipynb
+++ b/doc/source/train/examples/transformers/huggingface_text_classification.ipynb
@@ -38,7 +38,7 @@
    },
    "outputs": [],
    "source": [
-    "#! pip install \"datasets\" \"transformers>=4.19.0\" \"torch>=1.10.0\" \"mlflow\""
+    "#! pip install \"datasets\" \"evaluate\" \"scikit-learn\" \"transformers>=4.19.0\" \"torch>=1.10.0\" \"mlflow\""
    ]
   },
   {


### PR DESCRIPTION
## Why are these changes needed?

Three Ray Train examples compute a Hugging Face `evaluate` metric whose metric script imports `scikit-learn` (and, for the `glue` metrics, `scipy`), but their dependency declarations don't install those packages. Each runs only on images that already ship the ML extras and raises `ModuleNotFoundError` on a clean environment.

- **`lightning/lightning_cola_advanced.ipynb`** — imports `from evaluate import load` and loads `glue`/`cola`, but the install cell installs neither `evaluate` nor `scikit-learn`. Added both.
- **`deepspeed/gptj_deepspeed_fine_tuning.ipynb`** — loads `evaluate.load("accuracy")`, whose script needs `scikit-learn`. `evaluate` was declared but `scikit-learn` wasn't, in both the driver `pip install` cell and the `runtime_env` pip list. Added `scikit-learn` to both, since the metric runs on the Trainer workers.
- **`transformers/huggingface_text_classification.ipynb`** — imports `from evaluate import load` and loads `glue`, but its install cell was commented out and missing `evaluate` entirely. Completed the documented line with `evaluate` and `scikit-learn`, kept commented so CI execution is unchanged.

CI is unaffected: the doc-build image already provides these packages, so executed outputs don't change. The fix makes the documented install steps correct for readers on a clean environment.

This surfaced from a downstream KubeRay change that repins its copy of the Lightning sample onto the base `rayproject/ray` image (ray-project/kuberay#5194), where the same imports fail because the base image doesn't ship the ML extras.

## Related issue number

Surfaced by ray-project/kuberay#5194.

## Checks

- [x] I've signed off every commit (`git commit --signoff`).
- [x] Changes are limited to notebook `pip install` / `runtime_env` dependency declarations; no code or API surface is affected.
- [x] The notebooks are executed in doc CI on images that already provide `evaluate`/`scikit-learn`, so their behavior there is unchanged; the fix restores the documented install steps for clean environments.
