### PR TITLE
[Data] RFC: build a map task's timing from a declared list of steps

### DIFF
--- a/python/ray/data/_internal/execution/operators/map_operator.py
+++ b/python/ray/data/_internal/execution/operators/map_operator.py
@@ -72,7 +72,7 @@ from ray.data._internal.execution.operators.map_transformer import (
     BlockMapTransformFn,
     CustomOpStatsReporter,
     MapTransformer,
-    UDFTimeScope,
+    TransformClock,
 )
 from ray.data._internal.execution.util import (
     memory_string,
@@ -840,7 +840,7 @@ def _map_task(
         # Likewise owned by _map_task: an actor pool shares one transformer
         # across every task the actor runs, and with
         # `max_concurrent_calls_per_actor > 1` several run at once.
-        udf_time_scope = UDFTimeScope()
+        clock = TransformClock()
 
         def transform_iter_factory():
             # Clear any per-task custom stats before each attempt (the reporter
@@ -848,7 +848,7 @@ def _map_task(
             # can't leak into this one. A producing transform repopulates it
             # before the first block is yielded.
             op_stats_reporter.clear()
-            udf_time_scope.drain()
+            clock.drain()
             blocks_iter = (
                 _iter_sliced_blocks(blocks, slices) if slices else iter(blocks)
             )
@@ -856,7 +856,7 @@ def _map_task(
                 blocks_iter,
                 ctx,
                 op_stats_reporter.report,
-                udf_time_scope=udf_time_scope,
+                clock=clock,
             )
 
         if retry_on:
@@ -879,7 +879,7 @@ def _map_task(
                 blk_exec_stats_builder.finish()
 
                 def build_metadata(block_ser_time_s):
-                    phase_times = udf_time_scope.drain()
+                    phase_times = clock.drain()
                     exec_stats = blk_exec_stats_builder.build(
                         block_ser_time_s=block_ser_time_s,
                         udf_time_s=phase_times.total_s,

--- a/python/ray/data/_internal/execution/operators/map_transformer.py
+++ b/python/ray/data/_internal/execution/operators/map_transformer.py
@@ -92,26 +92,6 @@ class MapTransformFnDataType(Enum):
     Batch = 2
 
 
-# Hook that wraps one phase of one stage, returning the iterable to chain into
-# the next. `MapTransformer.apply_transform` passes one that times.
-#
-# It takes a thunk rather than the iterable: a stage that consumes its input
-# eagerly does its work while building the iterable, so the hook has to own the
-# call to time it at all.
-PhaseWrapFn = Callable[
-    ["MapTransformPhase", Callable[[], Iterable[MapTransformFnData]]],
-    Iterable[MapTransformFnData],
-]
-
-
-def _no_phase_wrapping(
-    phase: "MapTransformPhase",
-    make_data: Callable[[], Iterable[MapTransformFnData]],
-) -> Iterable[MapTransformFnData]:
-    """Default `PhaseWrapFn`, for chains that only time their total."""
-    return make_data()
-
-
 class MapTransformFn(ABC):
     """Represents a single transform function in a MapTransformer."""
 
@@ -174,23 +154,59 @@ class MapTransformFn(ABC):
             results, self._input_type, self._output_block_size_option
         )
 
+    def timed_steps(
+        self,
+        ctx: TaskContext,
+        report_custom_op_stats: CustomOpStatsReportFn,
+        stage_idx: int,
+    ) -> List["TimedStep"]:
+        """This transform as a flat list of timed pipeline steps.
+
+        `_pre_process` and `_post_process` are already `Iterable -> Iterable`,
+        so they are the step bodies as-is; only the wrapped fn needs a closure
+        to bind the task context.
+        """
+        name = repr(self)
+        body = MapTransformPhase.UDF_BODY if self._is_udf else MapTransformPhase.OTHER
+        return [
+            TimedStep(
+                f"{name} input prep",
+                MapTransformPhase.INPUT_PREP,
+                stage_idx,
+                self._pre_process,
+            ),
+            TimedStep(
+                f"{name} body",
+                body,
+                stage_idx,
+                lambda it: self._apply_transform(ctx, it, report_custom_op_stats),
+            ),
+            TimedStep(
+                f"{name} output build",
+                MapTransformPhase.OUTPUT_BUILD,
+                stage_idx,
+                self._post_process,
+            ),
+        ]
+
     def __call__(
         self,
         blocks: Iterable[Block],
         ctx: TaskContext,
         report_custom_op_stats: CustomOpStatsReportFn = _noop_report_custom_op_stats,
-        wrap_phase: "PhaseWrapFn" = _no_phase_wrapping,
     ) -> Iterable[Block]:
-        batches = wrap_phase(
-            MapTransformPhase.INPUT_PREP, lambda: self._pre_process(blocks)
-        )
-        results = wrap_phase(
-            MapTransformPhase.UDF_BODY,
-            lambda: self._apply_transform(ctx, batches, report_custom_op_stats),
-        )
-        return wrap_phase(
-            MapTransformPhase.OUTPUT_BUILD, lambda: self._post_process(results)
-        )
+        """Apply this transform's steps in order, untimed.
+
+        Timing belongs to the chain rather than to a transform:
+        :meth:`MapTransformer.apply_transform` wraps these same steps in a
+        :class:`TransformClock`. A caller driving one transform on its own --
+        ``generate_collect_write_stats_fn``, and tests -- gets the plain
+        composition.
+        """
+        data: Iterable[Any] = blocks
+        for step in self.timed_steps(ctx, report_custom_op_stats, 0):
+            data = step.apply(data)
+        return data
 
     @property
     def output_block_size_option(self):
@@ -226,7 +242,7 @@ class MapTransformFn(ABC):
 class MapTransformPhase(Enum):
     """The phases a :class:`MapTransformFn` splits its work into.
 
-    Values index into :attr:`UDFTimeScope.phase_totals`.
+    Steps carry one of these; the summary groups their times by it.
     """
 
     # Turning input blocks into the batches or rows the transform consumes.
@@ -237,6 +253,71 @@ class MapTransformPhase(Enum):
     OUTPUT_BUILD = 2
     # A transform body that isn't a UDF, such as a read or a write.
     OTHER = 3
+
+
+@dataclass(frozen=True)
+class TimedStep:
+    """One ``Iterable -> Iterable`` link in a map task's pipeline.
+
+    A task's whole transform is a flat list of these. ``apply`` is the work;
+    everything else is metadata the summary groups by.
+
+    ``bucket`` is ``None`` for a step that spans more than one phase, which is
+    what a row transform gets when it is timed a stage at a time rather than a
+    phase at a time. A phase no step carries is reported as "not measured"
+    rather than as zero, so the ``None`` here is what produces the ``None``
+    there.
+    """
+
+    label: str
+    bucket: Optional[MapTransformPhase]
+    stage_idx: int
+    apply: Callable[[Iterable[Any]], Iterable[Any]]
+
+
+class _TimedStep(Iterator[Any]):
+    """Times one step, inclusive of everything upstream of it.
+
+    Deliberately does not coordinate with the other steps: it starts a clock,
+    pulls, and adds the elapsed time to its own slot. Because the chain is
+    linear -- step ``k`` is only ever pulled by step ``k + 1`` -- all of a
+    step's time lies inside its consumer's windows, so subtracting neighbouring
+    totals at drain time recovers each step's own work. Doing that arithmetic
+    once, over a list, is easier to follow than threading a shared cursor
+    through every ``__next__``.
+    """
+
+    __slots__ = ("_apply", "_upstream", "_iter", "_totals", "_idx")
+
+    def __init__(
+        self,
+        apply: Callable[[Iterable[Any]], Iterable[Any]],
+        upstream: Iterable[Any],
+        totals: List[float],
+        idx: int,
+    ):
+        self._apply = apply
+        self._upstream = upstream
+        self._iter: Optional[Iterator[Any]] = None
+        self._totals = totals
+        self._idx = idx
+
+    def __iter__(self) -> "_TimedStep":
+        return self
+
+    def __next__(self) -> Any:
+        start = time.perf_counter()
+        try:
+            if self._iter is None:
+                # Building the iterable is the step's work too, and for some
+                # steps it is all of it: a write performs its whole upload here
+                # and hands back a buffer. Deferring the call to the first pull
+                # puts that inside the same window as the pulls, so an eagerly
+                # consuming stage needs no special case.
+                self._iter = iter(self._apply(self._upstream))
+            return next(self._iter)
+        finally:
+            self._totals[self._idx] += time.perf_counter() - start
 
 
 @dataclass(frozen=True)
@@ -259,89 +340,96 @@ class MapTransformPhaseTimes:
     other_s: Optional[float] = None
 
 
-class UDFTimeScope:
-    """Running total of UDF time for one task, and the nesting state to get it.
+class TransformClock:
+    """Per-task timing for one map transform chain.
 
-    Must stay per task, not per :class:`MapTransformer`: an actor pool reuses one
-    transformer for every task the actor runs, and ``max_concurrent_calls_per_actor
-    > 1`` runs several of those at once, so a shared total would mix their
-    timings and let one task's :meth:`drain` discard another's. ``_map_task``
-    creates one per task and threads it into ``apply_transform``, the same way it
-    threads a :class:`CustomOpStatsReporter`.
+    Must stay per task, not per :class:`MapTransformer`: an actor pool reuses
+    one transformer for every task the actor runs, and
+    ``max_concurrent_calls_per_actor > 1`` runs several at once, so a shared
+    total would mix their timings and let one task's :meth:`drain` discard
+    another's.
 
-    ``attributed_s`` is a single running total that every timer in the chain adds
-    to, holding the time accumulated since the last :meth:`drain` (``_map_task``
-    drains after each output block). It covers the whole transform: input
-    batching, the UDF bodies, and output block building.
-
-    It is also the cursor each timer uses to find its own share. Stages are
-    chained behind lazy iterators, so a stage's ``next()`` runs everything
-    upstream of it before returning, and a timer can only measure inclusive
-    time. The change in ``attributed_s`` across that call is what the upstream
-    timers added during it, so subtracting it leaves this stage's own
-    contribution. Three fused UDFs sleeping 1s, 2s and 3s measure 1s, 3s and 6s
-    inclusive, subtract 0s, 1s and 3s, and add 1s, 2s and 3s.
-
-    ``phase_totals`` splits that same time by :class:`MapTransformPhase` when the
-    chain is timing phases; a chain timing only its total leaves it at zero.
+    Holds one inclusive total per step. :meth:`drain` turns those into each
+    step's own time and groups them, so a step measures itself and nothing
+    else while data is flowing.
     """
 
-    __slots__ = ("attributed_s", "phase_totals", "decomposed")
+    __slots__ = ("inclusive", "_steps")
 
     def __init__(self) -> None:
-        self.attributed_s: float = 0.0
-        self.phase_totals: List[float] = [0.0] * len(MapTransformPhase)
-        # Set by `apply_transform`; False when only the total was measured.
-        self.decomposed: bool = False
+        self._steps: List["TimedStep"] = []
+        self.inclusive: List[float] = []
 
-    def attribute_call(
-        self,
-        phase: Optional["MapTransformPhase"],
-        make_data: Callable[[], Iterable[MapTransformFnData]],
-    ) -> Iterable[MapTransformFnData]:
-        """Run ``make_data()`` inside an attribution window and return its result.
+    def chain(self, steps: List["TimedStep"], blocks: Iterable[Any]) -> Iterable[Any]:
+        """Build the timed pipeline over ``blocks``."""
+        self._steps = steps
+        self.inclusive = [0.0] * len(steps)
+        data = blocks
+        for idx, step in enumerate(steps):
+            data = _TimedStep(step.apply, data, self.inclusive, idx)
+        return data
 
-        A stage that streams does its work in ``__next__``, which the timing
-        iterator covers. A stage that consumes its input eagerly -- a write
-        performs its whole upload before handing back a buffer -- does it here
-        instead, where no iterator can see it. Timing the call is what puts that
-        work in the total.
+    def _self_times(self) -> List[float]:
+        """Each step's own time: its window less its upstream's.
 
-        Runs once per stage per task, so unlike ``__next__`` it is off the hot
-        path and its cost does not scale with rows.
+        A step's window contains everything upstream of it, and step ``k`` is
+        only ever pulled by step ``k + 1``, so neighbouring totals differ by
+        exactly the step's own work. The clamp absorbs floating-point rounding
+        on that subtraction; the difference is otherwise non-negative.
         """
-        before_s = self.attributed_s
-        start = time.perf_counter()
-        try:
-            return make_data()
-        finally:
-            inclusive_s = time.perf_counter() - start
-            # An eager stage pulls its input through the timers already in the
-            # chain, so subtract what they credited to leave its own work.
-            exclusive_s = max(0.0, inclusive_s - (self.attributed_s - before_s))
-            self.attributed_s += exclusive_s
-            if phase is not None:
-                self.phase_totals[phase.value] += exclusive_s
+        return [
+            max(0.0, total - (self.inclusive[i - 1] if i else 0.0))
+            for i, total in enumerate(self.inclusive)
+        ]
 
     def drain(self) -> "MapTransformPhaseTimes":
         """Return the time accumulated since the last drain, and reset."""
-        totals = self.phase_totals
-        if self.decomposed:
+        own = self._self_times()
+        by_bucket: Dict[MapTransformPhase, float] = {}
+        for step, seconds in zip(self._steps, own):
+            if step.bucket is not None:
+                by_bucket[step.bucket] = by_bucket.get(step.bucket, 0.0) + seconds
+
+        # A step spanning all three phases carries no bucket, so if any step
+        # carries one this chain was timed phase by phase. Deriving that from
+        # the steps beats storing it: there is no flag to set inconsistently.
+        if any(step.bucket is not None for step in self._steps):
+            # Measured. A phase this chain happens not to run really did take
+            # no time, so report zero -- `None` is reserved for "not measured",
+            # which a consumer has to be able to tell apart.
             times = MapTransformPhaseTimes(
-                total_s=self.attributed_s,
-                input_prep_s=totals[MapTransformPhase.INPUT_PREP.value],
-                udf_body_s=totals[MapTransformPhase.UDF_BODY.value],
-                output_build_s=totals[MapTransformPhase.OUTPUT_BUILD.value],
-                other_s=totals[MapTransformPhase.OTHER.value],
+                total_s=sum(own),
+                input_prep_s=by_bucket.get(MapTransformPhase.INPUT_PREP, 0.0),
+                udf_body_s=by_bucket.get(MapTransformPhase.UDF_BODY, 0.0),
+                output_build_s=by_bucket.get(MapTransformPhase.OUTPUT_BUILD, 0.0),
+                other_s=by_bucket.get(MapTransformPhase.OTHER, 0.0),
             )
         else:
-            times = MapTransformPhaseTimes(total_s=self.attributed_s)
-        self.attributed_s = 0.0
-        # Zero in place: the timers hold this list, and `_map_task` drains after
-        # every output block, mid-iteration.
-        for i in range(len(totals)):
-            totals[i] = 0.0
+            times = MapTransformPhaseTimes(total_s=sum(own))
+        self.inclusive = [0.0] * len(self._steps)
         return times
+
+
+def _coalesce_stage(
+    steps: List["TimedStep"], transform_fn: "MapTransformFn"
+) -> "TimedStep":
+    """Fold a stage's three steps into one, timed as a unit."""
+    applies = [step.apply for step in steps]
+
+    def apply(data: Iterable[Any]) -> Iterable[Any]:
+        for fn in applies:
+            data = fn(data)
+        return data
+
+    return TimedStep(
+        label=f"{transform_fn!r} stage",
+        # Spans input prep, body and output build, so it belongs to no single
+        # phase -- which is what makes the phase figures report as "not
+        # measured" for a chain timed this way.
+        bucket=None,
+        stage_idx=steps[0].stage_idx,
+        apply=apply,
+    )
 
 
 class MapTransformer:
@@ -352,49 +440,6 @@ class MapTransformer:
     the last MapTransformFn must output blocks. The intermediate data types can
     be blocks, rows, or batches.
     """
-
-    class _UDFTimingIterator(Iterator[MapTransformFnData]):
-        """Times one UDF stage, net of the stages feeding it.
-
-        ``__next__`` can only measure inclusive time: the stages are chained
-        behind lazy iterators, so pulling one item also runs every stage
-        upstream. Subtracting what upstream stages credited to ``scope`` during
-        the same window leaves this stage's own time, which is what keeps
-        ``scope``'s total from counting a stage once per stage below it.
-        """
-
-        def __init__(
-            self,
-            input: Iterable[MapTransformFnData],
-            scope: "UDFTimeScope",
-            phase: Optional[MapTransformPhase] = None,
-        ):
-            # `input` is an Iterable, but `__next__` needs an Iterator, and some
-            # callers hand `apply_transform` a plain list.
-            self._input = iter(input)
-            self._scope = scope
-            # None when timing a whole stage rather than one of its phases.
-            self._phase_idx = None if phase is None else phase.value
-
-        def __iter__(self) -> "MapTransformer._UDFTimingIterator":
-            return self
-
-        def __next__(self) -> MapTransformFnData:
-            scope = self._scope
-            attributed_before_s = scope.attributed_s
-            start = time.perf_counter()
-            try:
-                return next(self._input)
-            finally:
-                inclusive_s = time.perf_counter() - start
-                upstream_s = scope.attributed_s - attributed_before_s
-                # Upstream stages' exclusive spans are disjoint sub-intervals of
-                # this window, so the difference is non-negative; clamp only to
-                # absorb floating-point rounding.
-                exclusive_s = max(0.0, inclusive_s - upstream_s)
-                scope.attributed_s += exclusive_s
-                if self._phase_idx is not None:
-                    scope.phase_totals[self._phase_idx] += exclusive_s
 
     def __init__(
         self,
@@ -450,27 +495,50 @@ class MapTransformer:
         """
         self._init_fn()
 
+    def get_timed_steps(
+        self,
+        ctx: TaskContext,
+        report_custom_op_stats: CustomOpStatsReportFn,
+        *,
+        decomposed: bool,
+    ) -> List["TimedStep"]:
+        """This task's whole transform, as a flat list of timed steps.
+
+        The answer to "what is getting timed?" is this list. It is ordinary
+        data: printable, and assertable in a unit test.
+
+        ``decomposed=False`` collapses each stage's three steps into one, which
+        is how a row transform pays one timer per stage instead of three -- a
+        rewrite of the list rather than a second code path.
+        """
+        steps: List[TimedStep] = []
+        for stage_idx, transform_fn in enumerate(self._transform_fns):
+            stage_steps = transform_fn.timed_steps(
+                ctx, report_custom_op_stats, stage_idx
+            )
+            if not decomposed:
+                stage_steps = [_coalesce_stage(stage_steps, transform_fn)]
+            steps.extend(stage_steps)
+        return steps
+
     def apply_transform(
         self,
         input_blocks: Iterable[Block],
         ctx: TaskContext,
         report_custom_op_stats: CustomOpStatsReportFn = _noop_report_custom_op_stats,
         *,
-        udf_time_scope: "UDFTimeScope",
+        clock: "TransformClock",
     ) -> Iterable[Block]:
-        """Apply the transform functions to the input blocks.
+        """Chain this task's timed steps over the input blocks.
 
         Args:
             input_blocks: The blocks to transform.
             ctx: The task context for this transform.
             report_custom_op_stats: Callback a producing transform calls to report
-                its :class:`CustomOpStats`. ``_map_task`` passes its reporter's
-                ``report``; defaults to a stateless no-op for callers (e.g. tests)
-                that don't collect custom stats.
-            udf_time_scope: Where to accumulate this task's UDF time. Required and
-                keyword-only on purpose: a caller that silently skipped it would
-                report a UDF time of zero rather than fail. Callers that don't
-                collect timings pass a throwaway ``UDFTimeScope()``.
+                its :class:`CustomOpStats`.
+            clock: Where this task's timings accumulate. Keyword-only on
+                purpose: a caller that silently skipped it would report zero
+                rather than fail.
 
         Returns:
             An iterable of the transformed output blocks.
@@ -484,71 +552,31 @@ class MapTransformer:
                 self.target_max_block_size_override
             )
 
-        # Splitting a stage into phases means a timer around each of the three,
-        # and each timer costs a Python frame per item it yields. A batch or
-        # block transform yields whole batches, so that is noise. A row
-        # transform yields rows, where it is not -- roughly 1us per row across a
-        # three-stage chain. So row chains are timed a stage at a time, which
-        # reports the same total for a third of the wrappers, and
-        # `accurate_map_phase_timing` opts into the breakdown for them.
         from ray.data.context import DataContext
 
         # A chain with no UDF in it -- a standalone read, write or projection --
-        # has no user function to attribute time to, so it reports no UDF time at
-        # all, as it always has. Timing its stages would put its whole transform
-        # under "UDF time" on an operator that runs nothing the user wrote.
+        # has no user function to attribute time to, so it reports no UDF time,
+        # as it always has.
         has_udf = any(fn._is_udf for fn in self._transform_fns)
+        # Timing costs a Python frame per item. A batch transform yields whole
+        # batches, so three timers per stage is noise; a row transform yields
+        # rows, where it is not. Row chains get one timer per stage instead,
+        # and `accurate_map_phase_timing` opts them into the full split.
         per_row = any(
             fn._input_type is MapTransformFnDataType.Row for fn in self._transform_fns
         )
-        decomposed = has_udf and (
-            not per_row or DataContext.get_current().accurate_map_phase_timing
-        )
-        udf_time_scope.decomposed = decomposed
+        decomposed = not per_row or DataContext.get_current().accurate_map_phase_timing
 
-        iter = input_blocks
-        # Whether by phase or by stage, a timer has to be installed before the
-        # next stage is built: `MapTransformFn.__call__` runs `_pre_process`
-        # eagerly, and with `batch_size="auto"` that peeks at a real block to
-        # size batches, pulling data through the stages already in the chain.
-        for transform_fn in self._transform_fns:
-            if not has_udf:
-                # Nothing the user wrote runs in this chain, so there is nothing
-                # to attribute and no timer to pay for.
-                iter = transform_fn(iter, ctx, report_custom_op_stats)
-                continue
+        steps = self.get_timed_steps(ctx, report_custom_op_stats, decomposed=decomposed)
 
-            if decomposed:
-                is_udf = transform_fn._is_udf
+        if not has_udf:
+            # Nothing to attribute, so no timer to pay for.
+            data = input_blocks
+            for step in steps:
+                data = step.apply(data)
+            return data
 
-                def wrap_phase(
-                    phase: MapTransformPhase,
-                    make_data: Callable[[], Iterable[MapTransformFnData]],
-                    _is_udf: bool = is_udf,
-                ) -> Iterable[MapTransformFnData]:
-                    if phase is MapTransformPhase.UDF_BODY and not _is_udf:
-                        phase = MapTransformPhase.OTHER
-                    # Time building the iterable as well as draining it, so a
-                    # stage that consumes its input eagerly is not missed.
-                    data = udf_time_scope.attribute_call(phase, make_data)
-                    return self._UDFTimingIterator(data, udf_time_scope, phase)
-
-                iter = transform_fn(iter, ctx, report_custom_op_stats, wrap_phase)
-            else:
-                # Only UDF stages get a per-item timer here -- paying that per
-                # row is what this branch exists to avoid. The eager window is
-                # once per stage, so every stage gets one and the total stays
-                # the figure the decomposed branch would report.
-                iter = udf_time_scope.attribute_call(
-                    None,
-                    lambda fn=transform_fn, it=iter: fn(
-                        it, ctx, report_custom_op_stats
-                    ),
-                )
-                if transform_fn._is_udf:
-                    iter = self._UDFTimingIterator(iter, udf_time_scope)
-
-        return iter
+        return clock.chain(steps, input_blocks)
 
     def fuse(self, other: "MapTransformer") -> "MapTransformer":
         """Fuse two `MapTransformer`s together."""

--- a/python/ray/data/_internal/execution/operators/shuffle_operators/external_shuffle_tasks.py
+++ b/python/ray/data/_internal/execution/operators/shuffle_operators/external_shuffle_tasks.py
@@ -278,14 +278,14 @@ def _external_shuffle_reduce_task(
         assert map_task_context is not None and data_context is not None
         with DataContext.current(data_context), TaskContext.current(map_task_context):
             from ray.data._internal.execution.operators.map_transformer import (
-                UDFTimeScope,
+                TransformClock,
             )
 
             map_transformer.override_target_max_block_size(
                 map_task_context.target_max_block_size_override
             )
             for out_block in map_transformer.apply_transform(
-                blocks, map_task_context, udf_time_scope=UDFTimeScope()
+                blocks, map_task_context, clock=TransformClock()
             ):
                 yield from _yield_with_stats(out_block)
 

--- a/python/ray/data/_internal/execution/operators/shuffle_operators/shuffle_tasks.py
+++ b/python/ray/data/_internal/execution/operators/shuffle_operators/shuffle_tasks.py
@@ -344,7 +344,7 @@ def _shuffle_reduce_task(
         assert map_task_context is not None and data_context is not None
         with DataContext.current(data_context), TaskContext.current(map_task_context):
             from ray.data._internal.execution.operators.map_transformer import (
-                UDFTimeScope,
+                TransformClock,
             )
 
             map_transformer.override_target_max_block_size(
@@ -353,6 +353,6 @@ def _shuffle_reduce_task(
             for block in map_transformer.apply_transform(
                 _reduce_output_blocks(),
                 map_task_context,
-                udf_time_scope=UDFTimeScope(),
+                clock=TransformClock(),
             ):
                 yield from _yield_with_stats(block)

--- a/python/ray/data/_internal/planner/random_shuffle.py
+++ b/python/ray/data/_internal/planner/random_shuffle.py
@@ -10,7 +10,7 @@ from ray.data._internal.execution.interfaces.transform_fn import (
 )
 from ray.data._internal.execution.operators.map_transformer import (
     MapTransformer,
-    UDFTimeScope,
+    TransformClock,
 )
 from ray.data._internal.execution.util import merge_label_selector
 from ray.data._internal.planner.exchange.pull_based_shuffle_task_scheduler import (
@@ -60,7 +60,7 @@ def generate_random_shuffle_fn(
             def upstream_map_fn(blocks):
                 DataContext._set_current(data_context)
                 return map_transformer.apply_transform(
-                    blocks, ctx, udf_time_scope=UDFTimeScope()
+                    blocks, ctx, clock=TransformClock()
                 )
 
             # If there is a fused upstream operator,

--- a/python/ray/data/_internal/planner/repartition.py
+++ b/python/ray/data/_internal/planner/repartition.py
@@ -10,7 +10,7 @@ from ray.data._internal.execution.interfaces.transform_fn import (
 )
 from ray.data._internal.execution.operators.map_transformer import (
     MapTransformer,
-    UDFTimeScope,
+    TransformClock,
 )
 from ray.data._internal.execution.util import merge_label_selector
 from ray.data._internal.planner.exchange.pull_based_shuffle_task_scheduler import (
@@ -52,7 +52,7 @@ def generate_repartition_fn(
             def upstream_map_fn(blocks):
                 DataContext._set_current(data_context)
                 return map_transformer.apply_transform(
-                    blocks, ctx, udf_time_scope=UDFTimeScope()
+                    blocks, ctx, clock=TransformClock()
                 )
 
         shuffle_spec = ShuffleTaskSpec(

--- a/python/ray/data/tests/test_checkpoint.py
+++ b/python/ray/data/tests/test_checkpoint.py
@@ -19,7 +19,7 @@ from ray.data._internal.datasource.parquet_datasink import ParquetDatasink
 from ray.data._internal.execution.interfaces import TaskContext
 from ray.data._internal.execution.operators.map_operator import MapOperator
 from ray.data._internal.execution.operators.map_transformer import (
-    UDFTimeScope,
+    TransformClock,
 )
 from ray.data._internal.logical.interfaces.logical_plan import LogicalPlan
 from ray.data._internal.logical.operators import Read, Write
@@ -1552,7 +1552,7 @@ def test_checkpoint_map_transformer(
     filtered_blocks = map_transformer.apply_transform(
         input_blocks=[block],
         ctx=TaskContext(task_idx=0, op_name="test_checkpoint"),
-        udf_time_scope=UDFTimeScope(),
+        clock=TransformClock(),
     )
 
     filtered_block = next(iter(filtered_blocks))

--- a/python/ray/data/tests/test_map_transformer.py
+++ b/python/ray/data/tests/test_map_transformer.py
@@ -10,7 +10,7 @@ from ray.data._internal.execution.interfaces.task_context import TaskContext
 from ray.data._internal.execution.operators.map_transformer import (
     BatchMapTransformFn,
     MapTransformer,
-    UDFTimeScope,
+    TransformClock,
 )
 from ray.data._internal.output_buffer import OutputBlockSizeOption
 from ray.data._internal.planner.plan_udf_map_op import (
@@ -68,7 +68,7 @@ def test_chained_transforms_release_intermediates_between_batches():
             yield pd.DataFrame({"id": [i + 1]})
 
     result_iter = transformer.apply_transform(
-        make_input_blocks(), ctx, udf_time_scope=UDFTimeScope()
+        make_input_blocks(), ctx, clock=TransformClock()
     )
 
     for i in range(NUM_BATCHES):
@@ -174,10 +174,10 @@ def test_chained_transforms_dont_double_count_udf_time():
         for i in range(NUM_BATCHES):
             yield pd.DataFrame({"id": [i]})
 
-    scope = UDFTimeScope()
+    scope = TransformClock()
     start_s = time.perf_counter()
     blocks = list(
-        transformer.apply_transform(make_input_blocks(), ctx, udf_time_scope=scope)
+        transformer.apply_transform(make_input_blocks(), ctx, clock=scope)
     )
     wall_s = time.perf_counter() - start_s
 
@@ -188,7 +188,7 @@ def test_chained_transforms_dont_double_count_udf_time():
     # The whole transform chain, not just the sleeps: for each stage it covers
     # turning input blocks into batches, the UDF body, and building output
     # blocks. The sleeps are therefore a floor on it, never an equality.
-    reported_s = scope.attributed_s
+    reported_s = scope.drain().total_s
     # Measured, not assumed: block shaping decides how many batches each stage sees.
     slept_s = num_calls * SLEEP_S
 
@@ -242,17 +242,17 @@ def test_chained_transforms_total_is_independent_of_distribution():
         for i in range(NUM_BATCHES):
             yield pd.DataFrame({"id": [i]})
 
-    scope = UDFTimeScope()
+    scope = TransformClock()
     start_s = time.perf_counter()
     blocks = list(
-        transformer.apply_transform(make_input_blocks(), ctx, udf_time_scope=scope)
+        transformer.apply_transform(make_input_blocks(), ctx, clock=scope)
     )
     wall_s = time.perf_counter() - start_s
 
     assert sum(BlockAccessor.for_block(b).num_rows() for b in blocks) == NUM_BATCHES
     assert all(n > 0 for n in calls_per_stage), calls_per_stage
 
-    reported_s = scope.attributed_s
+    reported_s = scope.drain().total_s
     slept_s = sum(n * s for n, s in zip(calls_per_stage, SLEEPS_S))
 
     # Summing the stages' inclusive times would give 0.05 + 0.15 + 0.30 = 0.50s

--- a/python/ray/data/tests/test_stats.py
+++ b/python/ray/data/tests/test_stats.py
@@ -37,7 +37,7 @@ from ray.data._internal.execution.operators.map_transformer import (
     BlockMapTransformFn,
     CustomOpStatsReporter,
     MapTransformer,
-    UDFTimeScope,
+    TransformClock,
 )
 from ray.data._internal.execution.streaming_executor import StreamingExecutor
 from ray.data._internal.stats import (
@@ -226,7 +226,7 @@ def test_map_transformer_custom_op_stats():
     # apply_transform takes the report callback, not the reporter object.
     list(
         transformer.apply_transform(
-            [block], ctx, reporter.report, udf_time_scope=UDFTimeScope()
+            [block], ctx, reporter.report, clock=TransformClock()
         )
     )
     assert reporter.get_stats() == [expected]

--- a/python/ray/data/tests/unit/test_auto_batch_size.py
+++ b/python/ray/data/tests/unit/test_auto_batch_size.py
@@ -7,7 +7,7 @@ from ray.data._internal.execution.interfaces.task_context import TaskContext
 from ray.data._internal.execution.operators.map_transformer import (
     BatchMapTransformFn,
     MapTransformer,
-    UDFTimeScope,
+    TransformClock,
     _compute_auto_batch_size,
 )
 from ray.data._internal.output_buffer import OutputBlockSizeOption
@@ -85,7 +85,7 @@ def test_auto_batches_respect_target_size():
         ]
     )
     ctx = TaskContext(task_idx=0, op_name="test")
-    list(transformer.apply_transform(iter([block]), ctx, udf_time_scope=UDFTimeScope()))
+    list(transformer.apply_transform(iter([block]), ctx, clock=TransformClock()))
 
     assert sum(received_sizes) == 1000
     assert all(s == 10 for s in received_sizes[:-1])


### PR DESCRIPTION
> **RFC / experiment, not a merge candidate.** This answers @iamjustinhsu's [review comment on #65807](https://github.com/ray-project/ray/pull/65807#discussion_r3907044928) asking for an approach that is explicit about what gets timed. Opened as a draft so the diff is reviewable; see **Open questions** for what is deliberately unfinished.

## Why these changes are needed

The review comment:

> I think with all the lazy iterators it's getting harder to interpret what is getting timed, and what is being wrapped, since iterators don't show upstream iterators well.

That is fair, and it is the root of the subtlety in #65807: timing is *emergent* from the pull-chain rather than *declared*. You have to simulate the chain in your head to know what a number means.

## What this change does

**A task's transform becomes a flat list of steps.**

```python
@dataclass(frozen=True)
class TimedStep:
    label: str          # "MapBatches(score) body"
    bucket: MapTransformPhase
    stage_idx: int
    apply: Callable[[Iterable], Iterable]
```

`_pre_process` and `_post_process` are already `Iterable -> Iterable`, so they are the step bodies verbatim; only the wrapped fn needs a closure to bind the task context. `apply_transform` then reduces to:

```python
steps = self.get_timed_steps(ctx, report, decomposed=decomposed)
iter = input_blocks
for idx in range(len(steps)):
    iter = udf_time_scope.wrap(idx, iter)
return iter
```

**A step measures only itself, with no coordination.**

```python
def __next__(self):
    start = time.perf_counter()
    try:
        if self._iter is None:
            self._iter = iter(self._apply(self._upstream))
        return next(self._iter)
    finally:
        self._totals[self._idx] += time.perf_counter() - start
```

That total is *inclusive* of everything upstream. The chain is linear -- step `k` is only ever pulled by step `k + 1` -- so all of a step's time lies inside its consumer's windows, and subtracting neighbouring totals recovers each step's own work:

```python
def _self_times(self):
    return [max(0.0, total - (self.inclusive[i - 1] if i else 0.0))
            for i, total in enumerate(self.inclusive)]
```

#65807 does the same arithmetic, but *per item*, threading a shared cursor through every `__next__`. Doing it once over a list at drain time is easier to follow and measurably cheaper: **580 ns/item against 1016** over a three-stage chain.

**Deferring `apply` to the first pull removes the eager special case.** A write performs its whole upload while its iterable is being built, which on #65807 needed a separate timing window (`attribute_call`). Here that work happens inside the same window as the pulls, so there is one timing point rather than two.

## Two special cases dissolve

- **Eager stage bodies.** #65807 added `attribute_call` for these. Deferring `apply` into the first pull means there is nothing left to special-case -- the reviewer's second side note, satisfied by deletion rather than by handling.
- **`accurate_map_phase_timing`** stops being a second code path and becomes a rewrite of the step list -- fold a stage's three steps into one, whose `bucket` is `None` because it spans all three. A phase no step carries is then absent from the grouping, so **"not measured" falls out of the data** instead of being tracked by a flag. This is the same shape as the pre/post-process elision suggested in the follow-up comment, which would be another rewrite of the same list. **Policy becomes data.**

`UDFTimeScope` is renamed to `TransformClock`, and the `udf_time_scope=` keyword to `clock=` (41 call sites across 10 files). The old name no longer described the object: it times every step in the chain, including the ones that aren't user code, which is the same mismatch raised [here](https://github.com/ray-project/ray/pull/65807#discussion_r3906923243).

Accruing per *step* rather than per phase also unifies #65807 and #65810: per-phase and per-fused-stage are two groupings of one array. #65810's separate `stage_totals` and its parallel `+=` would disappear -- along with the bug a rebase surfaced there, where the eager window credited the phase bucket but silently skipped the stage bucket. This PR doesn't carry that grouping, since #65810 isn't in its base.

## Where the reviewer's sketch does not work, and why

The suggestion was an eager per-input-block loop. Two measurements say that cannot express what Ray Data already does.

**Batches span input blocks.** 4 input blocks of 1 row each with `batch_size=4`:

```
batch_len values: [4, 4, 4, 4]     # one batch of 4, not four of 1
```

**A single fused operator can contain several independent batching points:**

```
OPERATORS: ['MapBatches(f)->MapBatches(g)']
f sees batches of [1, 2]      g sees batches of [3]
```

`g`'s batches of 3 are re-assembled from `f`'s outputs of 2, inside one task. No unit -- not a block, not a batch -- survives the chain intact, so `for input_block in blocks:` cannot be the outer loop; it would silently turn `batch_size=4` into four batches of 1. The only eager alternative materializes at every stage, trading streaming for memory.

So laziness is structural. This PR keeps it and makes the timing declared instead.

## Measured equivalence with #65807

| case | #65807 | this PR |
| --- | --- | --- |
| `ReadRange->Project->MapBatches(map1)->MapBatches(map2)`, 0.60s of real UDF work | `Function body 614.3ms` | `611.03ms` |
| datasink sleeping 0.3s/block over 2 blocks | `Built-in stages 606ms` (via `attribute_call`) | `602.9ms`, **no special case** |
| standalone `ReadRange` (no UDF) | `0.0` | `0` |
| `UDF time` vs `Remote wall time` | 99.6% | 99.8% |

Isolated unit check of the baton -- three steps, only the middle one sleeping, 4 items x 50ms:

```
wall           = 0.2156s
total_s        = 0.2156s
  input_prep   = 0.0000s
  udf_body     = 0.2155s
  output_build = 0.0000s
```

Exact attribution, no leakage into neighbouring buckets.

Per-item cost is unchanged: over a 3-stage chain, 1019 ns/item for the baton against 1016 ns/item for the subtraction cursor in #65807 (31 ns/item with no timing at all). The 33x over baseline is inherent to per-item timing, which is why `accurate_map_phase_timing` still has to exist for row transforms.

## Testing

```bash
PYTHONPATH=python/ray/data/tests pytest python/ray/data/tests/test_stats.py
pytest -q python/ray/data/tests/test_map_transformer.py python/ray/data/tests/unit/test_auto_batch_size.py
PYTHONPATH=python/ray/data/tests pytest python/ray/data/tests/test_checkpoint.py -k "transform or checkpoint_map"
```

`test_stats.py`: 108 collected, **105 passed, 2 skipped, 1 failed** — the failure being `test_streaming_exec_schedule_percentiles_populated`, which fails identically on #65807 because the dashboard is not built locally. That matches #65807's baseline exactly, **with `test_stats.py` unmodified**: every test written for the phase breakdown there passes against this implementation untouched, which is the main evidence that this is behaviour-preserving.

`test_map_transformer.py` + `unit/test_auto_batch_size.py`: 9 passed. `test_checkpoint.py` (the cases that call `apply_transform` directly): 2 passed.

One test change was needed, and it is an API change rather than a behavioural one. `test_chained_transforms_dont_double_count_udf_time` and `test_chained_transforms_total_is_independent_of_distribution` read `scope.attributed_s`, the running total this PR removes; they now read `sum(scope.totals)`. Both are #65776's core invariant tests, and both pass with only the accessor changed.

## One behaviour change worth reviewing

A transform's body used to run when the chain was built; it now runs on the first pull:

```
#65807                              this PR
  -> calling apply_transform          -> calling apply_transform
  BODY RAN                            <- apply_transform returned
  <- apply_transform returned         -> pulling first item
  -> pulling first item               BODY RAN
```

So a transform that fails while being *set up* rather than while yielding now surfaces from the first `next()` instead of from `apply_transform`. That is safe where it matters, because `iterate_with_retry` -- which `_map_task` wraps the transform in -- puts construction and iteration inside the same `try`:

```python
try:
    iterable = iterable_factory()
    for item_index, item in enumerate(iterable):
        ...
except Exception as e:
    ...retry...
```

so `retried_map_errors` and `max_map_retries` behave identically either way.

It also removes a hazard rather than adding one. Today `_pre_process` runs eagerly at construction, so with `batch_size="auto"` a later stage peeks at a real block and pulls data through earlier stages *before their timers exist* -- the regression Cursor Bugbot caught on #65776, and the reason that PR must install each stage's timer before building the next. When nothing runs until the first pull, every timer is already in place and that class of ordering bug cannot occur.

## Open questions

- **RayTurbo's fused transform fns** collapse two `MapTransformFn`s into one (`is_udf = self._is_udf or next._is_udf`), so one step can correspond to two logical operators. `TimedStep.label` would need care there.
- **Should `Built-in stages` remain its own bucket?** The review suggests merging built-in stages into UDFs. Under this design that is a one-line change, since every step carries `is_udf`. I lean towards keeping the split -- "is this time my code or Ray Data's?" is the actionable question for the workload that motivated #65776 -- but the architecture no longer forces the answer either way.
- `TimedStep.label` would let #65810 report `MapBatches(score)` instead of `UDF stage 0`, fixing a limitation documented there.

## Related issue number

Follow-up to #65776 (merged), #65807 and #65810. No open issue or PR covers this; `gh pr list --search "map transformer timing"` returns only #65807 and #65810.

## Checks

- [x] I've signed off every commit (`git commit -s`).
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've added any new APIs to the API Reference. *(no new public API)*
- [ ] I've made sure the tests are passing. *(see Testing)*
- Testing Strategy
   - [x] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(

## AI assistance

AI assistance (Claude Code) was used to prototype this approach, run the measurements above, and draft this description. Per `AGENTS.md` the author has reviewed every changed line. This is an RFC opened for design discussion rather than a merge request.
