### PR TITLE
[Data] Reject unknown LeRobot delta timestamp feature keys

### DIFF
--- a/python/ray/data/_internal/datasource/lerobot_datasource.py
+++ b/python/ray/data/_internal/datasource/lerobot_datasource.py
@@ -587,6 +587,13 @@ def _build_root(
         zip(meta.tasks["task_index"].astype(int).tolist(), meta.tasks.index.tolist())
     )
     if delta_timestamps:
+        unknown_keys = sorted(set(delta_timestamps) - set(meta.features))
+        if unknown_keys:
+            raise ValueError(
+                f"{root_uri!r}: delta_timestamps keys {unknown_keys} are not "
+                "dataset features."
+            )
+
         # Validate offsets align to the frame grid and convert seconds -> integer
         # frame offsets; both delegated to lerobot so semantics match LeRobotDataset.
         from lerobot.datasets.feature_utils import (

--- a/python/ray/data/tests/datasource/test_lerobot.py
+++ b/python/ray/data/tests/datasource/test_lerobot.py
@@ -1496,6 +1496,13 @@ def test_read_lerobot_delta_invalid_raises(
             lerobot_dataset_no_video, delta_timestamps={"action": [0.05]}
         )
 
+    with pytest.raises(ValueError, match="not dataset features") as exc_info:
+        ray.data.read_lerobot(
+            lerobot_dataset_no_video,
+            delta_timestamps={"acton": [0.0, 0.1]},
+        )
+    assert "acton" in str(exc_info.value)
+
 
 if __name__ == "__main__":
     import sys


### PR DESCRIPTION
## Description

Validate every `delta_timestamps` key against the dataset's feature metadata before computing temporal-window indices.

Previously, an unknown key could pass timestamp-grid validation and then be silently ignored while the output schema and batches were built. A misspelled temporal-window request could therefore appear to succeed without windowing the requested feature. This change raises a `ValueError` during datasource initialization and lists the unknown feature names.

## Related issues

Follow-up to [#65165](https://github.com/ray-project/ray/pull/65165).

## Additional information

- This only changes validation for unknown `delta_timestamps` keys; valid reads are unchanged.
- Added a regression test covering a misspelled feature key.
- I searched open Ray PRs for LeRobot `delta_timestamps` feature-key validation and did not find an overlapping change.

Validation:

- `python -m pytest -q python/ray/data/tests/datasource/test_lerobot.py` — 72 passed.
- Pre-commit checks passed for both modified files.
- The repository's `docstyle` script and pinned Semgrep 1.32.0 rules were also run on Linux because their launchers are unavailable on Windows; both passed (`0 findings` from Semgrep).