### PR TITLE
[docs] Use @ray-project/kuberay team for Kubernetes docs ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -29,7 +29,7 @@
 /doc/source/cluster/ @ray-project/ray-core @ray-project/ray-docs
 /doc/source/ray-core/ @ray-project/ray-core @ray-project/ray-docs
 
-/doc/source/cluster/kubernetes/ @andrewsykim @ray-project/ray-core @ray-project/ray-docs
+/doc/source/cluster/kubernetes/ @ray-project/kuberay @ray-project/ray-core @ray-project/ray-docs
 
 # Public protobuf files.
 /src/ray/protobuf/public/ @edoakes @MengjinYan


### PR DESCRIPTION
## Why are these changes needed?

The Kubernetes cluster docs (`/doc/source/cluster/kubernetes/`) tagged `@andrewsykim` directly as a code owner, overlapping with `ray-core` and `ray-docs`. A `@ray-project/kuberay` GitHub team now exists so that both Anyscale employees and KubeRay committers can review and sign off on Kubernetes docs changes, rather than routing to a single individual.

This replaces the individual `@andrewsykim` with the `@ray-project/kuberay` team on that path. Andrew remains a code owner through team membership.

Discussed and agreed with the Ray core and KubeRay maintainers.

## Related issue number

N/A

## Checks

- [x] I've signed off every commit (Developer Certificate of Origin).
