### PR TITLE
[Tune] Fix `qrandint` and `qlograndint` to sample values uniformly

### DIFF
--- a/doc/source/tune/api/search_space.rst
+++ b/doc/source/tune/api/search_space.rst
@@ -51,20 +51,16 @@ For a high-level overview, see this example:
         # Sample a integer uniformly between -9 (inclusive) and 15 (exclusive)
         "randint": tune.randint(-9, 15),
 
-        # Sample a random uniformly between -21 (inclusive) and 12 (inclusive (!))
+        # Sample a random uniformly between -21 (inclusive) and 12 (inclusive except q=1 where it is exclusive)
         # rounding to multiples of 3 (includes 12)
-        # with q=1 the upper bound stays exclusive: the quantization grid is
-        # every integer, so nothing rounds up to it
         "qrandint": tune.qrandint(-21, 12, 3),
 
         # Sample a integer uniformly between 1 (inclusive) and 10 (exclusive),
         # while sampling in log space
         "lograndint": tune.lograndint(1, 10),
 
-        # Sample a integer uniformly between 1 (inclusive) and 10 (inclusive (!)),
+        # Sample a integer uniformly between 1 (inclusive) and 10 (inclusive except q=1 where it is exclusive),
         # while sampling in log space and rounding to multiples of 2
-        # with q=1 the upper bound stays exclusive: the quantization grid is
-        # every integer, so nothing rounds up to it
         "qlograndint": tune.qlograndint(1, 10, 2),
 
         # Sample an option uniformly from the specified choices

--- a/python/ray/tune/search/basic_variant.py
+++ b/python/ray/tune/search/basic_variant.py
@@ -11,7 +11,7 @@ import numpy as np
 from ray.air._internal.usage import tag_searcher
 from ray.tune.error import TuneError
 from ray.tune.experiment.config_parser import _create_trial_from_spec, _make_parser
-from ray.tune.search.sample import _BackwardsCompatibleNumpyRng, np_random_generator
+from ray.tune.search.sample import _BackwardsCompatibleNumpyRng
 from ray.tune.search.search_algorithm import SearchAlgorithm
 from ray.tune.search.variant_generator import (
     _count_spec_samples,
@@ -99,7 +99,7 @@ class _TrialIterator:
         lazy_eval: bool = False,
         start: int = 0,
         random_state: Optional[
-            Union[int, "np_random_generator", np.random.RandomState]
+            Union[int, np.random.Generator, np.random.RandomState]
         ] = None,
     ):
         self.parser = _make_parser()
@@ -288,7 +288,7 @@ class BasicVariantGenerator(SearchAlgorithm):
         max_concurrent: int = 0,
         constant_grid_search: bool = False,
         random_state: Optional[
-            Union[int, "np_random_generator", np.random.RandomState]
+            Union[int, np.random.Generator, np.random.RandomState]
         ] = None,
     ):
         tag_searcher(self)

--- a/python/ray/tune/search/sample.py
+++ b/python/ray/tune/search/sample.py
@@ -760,10 +760,8 @@ def lograndint(lower: int, upper: int, base: object = _MISSING):
 def qrandint(lower: int, upper: int, q: int = 1):
     """Sample an integer value uniformly between ``lower`` and ``upper``.
 
-    ``lower`` is inclusive, ``upper`` is also inclusive (!).
-
-    ``lower`` is inclusive, ``upper`` is also inclusive except for q=1 where
-    its exclusive. The value will be quantized, i.e. it will be a multiple of
+    ``lower`` is inclusive, ``upper`` is also inclusive except for ``q=1`` where
+    it's exclusive. The value will be quantized, i.e. it will be a multiple of
     ``q``. The multiples of ``q`` between ``lower`` and ``upper`` are drawn
     uniformly.
 
@@ -780,8 +778,8 @@ def qrandint(lower: int, upper: int, q: int = 1):
 def qlograndint(lower: int, upper: int, q: int, base: object = _MISSING):
     """Sample an integer value log-uniformly between ``lower`` and ``upper``.
 
-    ``lower`` is inclusive, ``upper`` is also inclusive except for q=1 where
-    its exclusive. The value will be quantized, i.e. it will be a multiple of
+    ``lower`` is inclusive, ``upper`` is also inclusive except for ``q=1`` where
+    it's exclusive. The value will be quantized, i.e. it will be a multiple of
     ``q``. The multiples of ``q`` between ``lower`` and ``upper`` are drawn
     log-uniformly.
 

--- a/python/ray/tune/search/sample.py
+++ b/python/ray/tune/search/sample.py
@@ -7,19 +7,7 @@ from typing import Any, Callable, Dict, List, Optional, Sequence, Union
 
 import numpy as np
 
-# Backwards compatibility
 from ray.util.annotations import DeveloperAPI, PublicAPI, RayDeprecationWarning
-
-try:
-    # Added in numpy>=1.17 but we require numpy>=1.16
-    np_random_generator = np.random.Generator
-    LEGACY_RNG = False
-except AttributeError:
-
-    class np_random_generator:
-        pass
-
-    LEGACY_RNG = True
 
 logger = logging.getLogger(__name__)
 
@@ -48,21 +36,19 @@ class _BackwardsCompatibleNumpyRng:
     def __init__(
         self,
         generator_or_seed: Optional[
-            Union["np_random_generator", np.random.RandomState, int]
+            Union[np.random.Generator, np.random.RandomState, int]
         ] = None,
     ):
         if generator_or_seed is None or isinstance(
-            generator_or_seed, (np.random.RandomState, np_random_generator)
+            generator_or_seed, (np.random.RandomState, np.random.Generator)
         ):
             self._rng = generator_or_seed
-        elif LEGACY_RNG:
-            self._rng = np.random.RandomState(generator_or_seed)
         else:
             self._rng = np.random.default_rng(generator_or_seed)
 
     @property
     def legacy_rng(self) -> bool:
-        return not isinstance(self._rng, np_random_generator)
+        return not isinstance(self._rng, np.random.Generator)
 
     @property
     def rng(self):
@@ -80,7 +66,7 @@ class _BackwardsCompatibleNumpyRng:
 
 
 RandomState = Union[
-    None, _BackwardsCompatibleNumpyRng, np_random_generator, np.random.RandomState, int
+    None, _BackwardsCompatibleNumpyRng, np.random.Generator, np.random.RandomState, int
 ]
 
 
@@ -570,17 +556,64 @@ class Quantized(Sampler):
         if not isinstance(random_state, _BackwardsCompatibleNumpyRng):
             random_state = _BackwardsCompatibleNumpyRng(random_state)
 
-        quantized_domain = copy(domain)
-        quantized_domain.lower = np.ceil(domain.lower / self.q) * self.q
-        quantized_domain.upper = np.floor(domain.upper / self.q) * self.q
-        values = self.sampler.sample(
-            quantized_domain, config, size, random_state=random_state
-        )
-        quantized = np.round(np.divide(values, self.q)) * self.q
+        if isinstance(domain, Integer):
+            # A quantized integer domain is the same domain over grid indices to
+            # ensure that each are uniformly sampled
+            lower_index = int(self._grid_index(domain.lower, np.ceil))
+            upper_index = int(self._grid_index(domain.upper, np.floor))
+            if upper_index < lower_index:
+                raise ValueError(
+                    f"There is no multiple of the quantization factor q={self.q} "
+                    f"between the bounds {domain.lower} and {domain.upper} of this "
+                    f"domain, so it has no values to sample."
+                )
+
+            index_domain = copy(domain)
+            index_domain.lower = lower_index
+            # Samplers are upper-exclusive except for ``q == 1``
+            index_domain.upper = upper_index + (0 if self.q == 1 else 1)
+
+            indices = self.sampler.sample(
+                index_domain, config, size, random_state=random_state
+            )
+            quantized = np.multiply(indices, self.q)
+        else:
+            # A quantized continuous (or other) domain
+            quantized_domain = copy(domain)
+            quantized_domain.lower = self._grid_index(domain.lower, np.ceil) * self.q
+            quantized_domain.upper = self._grid_index(domain.upper, np.floor) * self.q
+            values = self.sampler.sample(
+                quantized_domain, config, size, random_state=random_state
+            )
+            quantized = np.round(np.divide(values, self.q)) * self.q
 
         if not isinstance(quantized, np.ndarray):
             return domain.cast(quantized)
         return [domain.cast(x) for x in quantized]
+
+    def _grid_index(self, bound: float, round_fn: Callable[[float], float]) -> float:
+        """Return ``bound``'s index on the quantization grid, rounded inwards.
+
+        The grid is the multiples of ``q``, so index ``k`` stands for the value
+        ``k * q`` and callers scale back up. ``round_fn`` gives the direction to
+        round a bound that falls between two grid points.
+
+        Args:
+            bound: The domain's ``lower`` or ``upper``.
+            round_fn: ``np.ceil`` for a lower bound, ``np.floor`` for an upper one.
+
+        Returns:
+            The grid index, or ``bound`` unchanged when it is infinite - ``qrandn``
+            domains are unbounded, so they have no grid index to snap to.
+        """
+        if not np.isfinite(bound):
+            # ``qrandn`` domains are unbounded; there is nothing to snap.
+            return bound
+        scaled = bound / self.q
+        nearest = round(scaled)
+        if isclose(scaled, nearest):
+            return nearest
+        return round_fn(scaled)
 
 
 @PublicAPI
@@ -729,8 +762,10 @@ def qrandint(lower: int, upper: int, q: int = 1):
 
     ``lower`` is inclusive, ``upper`` is also inclusive (!).
 
-    The value will be quantized, i.e. rounded to an integer increment of ``q``.
-    Quantization makes the upper bound inclusive.
+    ``lower`` is inclusive, ``upper`` is also inclusive except for q=1 where
+    its exclusive. The value will be quantized, i.e. it will be a multiple of
+    ``q``. The multiples of ``q`` between ``lower`` and ``upper`` are drawn
+    uniformly.
 
     .. versionchanged:: 1.5.0
         When converting Ray Tune configs to searcher-specific search spaces,
@@ -745,10 +780,10 @@ def qrandint(lower: int, upper: int, q: int = 1):
 def qlograndint(lower: int, upper: int, q: int, base: object = _MISSING):
     """Sample an integer value log-uniformly between ``lower`` and ``upper``.
 
-    ``lower`` is inclusive, ``upper`` is also inclusive (!).
-
-    The value will be quantized, i.e. rounded to an integer increment of ``q``.
-    Quantization makes the upper bound inclusive.
+    ``lower`` is inclusive, ``upper`` is also inclusive except for q=1 where
+    its exclusive. The value will be quantized, i.e. it will be a multiple of
+    ``q``. The multiples of ``q`` between ``lower`` and ``upper`` are drawn
+    log-uniformly.
 
     .. versionchanged:: 1.5.0
         When converting Ray Tune configs to searcher-specific search spaces,

--- a/python/ray/tune/tests/test_sample.py
+++ b/python/ray/tune/tests/test_sample.py
@@ -6,7 +6,7 @@ change your pytest running directory to ray/python/ray/tune/tests/
 
 import sys
 import unittest
-from collections import defaultdict
+from collections import Counter, defaultdict
 from unittest.mock import patch
 
 import numpy as np
@@ -203,31 +203,24 @@ class SearchSpaceTest(unittest.TestCase):
             ):
                 yield generated["config"]
 
-        with patch("ray.tune.search.sample.LEGACY_RNG", True):
-            global_seed_legacy = [
-                next(config_generator(random_state=None)) for _ in range(100)
-            ]
-            seed_legacy = [
-                next(config_generator(random_state=1000)) for _ in range(100)
-            ]
-            generator_legacy = [
-                next(config_generator(random_state=np.random.RandomState(1000)))
-                for _ in range(100)
-            ]
-            for i in range(100):
-                assertDictAlmostEqual(global_seed_legacy[0], global_seed_legacy[i])
-                assertDictAlmostEqual(global_seed_legacy[0], seed_legacy[i])
-                assertDictAlmostEqual(global_seed_legacy[0], generator_legacy[i])
-
-        if not ray.tune.search.sample.LEGACY_RNG:
-            seed_new = [next(config_generator(random_state=1000)) for _ in range(100)]
-            generator_new = [
-                next(config_generator(random_state=np.random.default_rng(1000)))
-                for _ in range(100)
-            ]
-            for i in range(100):
-                assertDictAlmostEqual(seed_new[0], seed_new[i])
-                assertDictAlmostEqual(seed_new[0], generator_new[i])
+        # The global `np.random` stream and an explicit `RandomState`, both seeded
+        # with 1000, draw the same variants.
+        global_seed = [next(config_generator(random_state=None)) for _ in range(100)]
+        legacy_generator = [
+            next(config_generator(random_state=np.random.RandomState(1000)))
+            for _ in range(100)
+        ]
+        # An int seed builds a `default_rng`, which has a stream of its own.
+        seed = [next(config_generator(random_state=1000)) for _ in range(100)]
+        generator = [
+            next(config_generator(random_state=np.random.default_rng(1000)))
+            for _ in range(100)
+        ]
+        for i in range(100):
+            assertDictAlmostEqual(global_seed[0], global_seed[i])
+            assertDictAlmostEqual(global_seed[0], legacy_generator[i])
+            assertDictAlmostEqual(seed[0], seed[i])
+            assertDictAlmostEqual(seed[0], generator[i])
 
     def testReproducibilityBasicVariantGenerator(self):
         config = self.config.copy()
@@ -244,91 +237,76 @@ class SearchSpaceTest(unittest.TestCase):
             mode="max",
             num_samples=num_samples,
         )
-        with patch("ray.tune.search.sample.LEGACY_RNG", True):
-            np.random.seed(1000)
-            analysis_global_seed = tune.run(
-                search_alg=BasicVariantGenerator(max_concurrent=1),  # global seed
-                **params,
+        # The global `np.random` stream and an explicit `RandomState`, both seeded
+        # with 1000, generate the same trials.
+        np.random.seed(1000)
+        analysis_global_seed = tune.run(
+            search_alg=BasicVariantGenerator(max_concurrent=1),  # global seed
+            **params,
+        )
+        np.random.seed(1000)
+        analysis_global_seed_2 = tune.run(
+            search_alg=BasicVariantGenerator(max_concurrent=1),  # global seed
+            **params,
+        )
+        analysis_generator = tune.run(
+            search_alg=BasicVariantGenerator(
+                max_concurrent=1, random_state=np.random.RandomState(1000)
+            ),
+            **params,
+        )
+        analysis_generator_2 = tune.run(
+            search_alg=BasicVariantGenerator(
+                max_concurrent=1, random_state=np.random.RandomState(1000)
+            ),
+            **params,
+        )
+        for i in range(num_samples):
+            assertDictAlmostEqual(
+                analysis_global_seed.trials[i].config,
+                analysis_generator.trials[i].config,
             )
-            np.random.seed(1000)
-            analysis_global_seed_2 = tune.run(
-                search_alg=BasicVariantGenerator(max_concurrent=1),  # global seed
-                **params,
+            assertDictAlmostEqual(
+                analysis_global_seed.trials[i].config,
+                analysis_global_seed_2.trials[i].config,
             )
-            analysis_seed = tune.run(
-                search_alg=BasicVariantGenerator(max_concurrent=1, random_state=1000),
-                **params,
+            assertDictAlmostEqual(
+                analysis_global_seed.trials[i].config,
+                analysis_generator_2.trials[i].config,
             )
-            analysis_seed_2 = tune.run(
-                search_alg=BasicVariantGenerator(max_concurrent=1, random_state=1000),
-                **params,
-            )
-            analysis_generator = tune.run(
-                search_alg=BasicVariantGenerator(
-                    max_concurrent=1, random_state=np.random.RandomState(1000)
-                ),
-                **params,
-            )
-            analysis_generator_2 = tune.run(
-                search_alg=BasicVariantGenerator(
-                    max_concurrent=1, random_state=np.random.RandomState(1000)
-                ),
-                **params,
-            )
-            for i in range(num_samples):
-                assertDictAlmostEqual(
-                    analysis_global_seed.trials[i].config,
-                    analysis_seed.trials[i].config,
-                )
-                assertDictAlmostEqual(
-                    analysis_global_seed.trials[i].config,
-                    analysis_generator.trials[i].config,
-                )
-                assertDictAlmostEqual(
-                    analysis_global_seed.trials[i].config,
-                    analysis_global_seed_2.trials[i].config,
-                )
-                assertDictAlmostEqual(
-                    analysis_global_seed.trials[i].config,
-                    analysis_seed_2.trials[i].config,
-                )
-                assertDictAlmostEqual(
-                    analysis_global_seed.trials[i].config,
-                    analysis_generator_2.trials[i].config,
-                )
 
-        if not ray.tune.search.sample.LEGACY_RNG:
-            analysis_seed = tune.run(
-                search_alg=BasicVariantGenerator(max_concurrent=1, random_state=1000),
-                **params,
+        # An int seed builds a `default_rng`, which has a stream of its own.
+        analysis_seed = tune.run(
+            search_alg=BasicVariantGenerator(max_concurrent=1, random_state=1000),
+            **params,
+        )
+        analysis_seed_2 = tune.run(
+            search_alg=BasicVariantGenerator(max_concurrent=1, random_state=1000),
+            **params,
+        )
+        analysis_generator = tune.run(
+            search_alg=BasicVariantGenerator(
+                max_concurrent=1, random_state=np.random.default_rng(1000)
+            ),
+            **params,
+        )
+        analysis_generator_2 = tune.run(
+            search_alg=BasicVariantGenerator(
+                max_concurrent=1, random_state=np.random.default_rng(1000)
+            ),
+            **params,
+        )
+        for i in range(num_samples):
+            assertDictAlmostEqual(
+                analysis_seed.trials[i].config, analysis_generator.trials[i].config
             )
-            analysis_seed_2 = tune.run(
-                search_alg=BasicVariantGenerator(max_concurrent=1, random_state=1000),
-                **params,
+            assertDictAlmostEqual(
+                analysis_seed.trials[i].config, analysis_seed_2.trials[i].config
             )
-            analysis_generator = tune.run(
-                search_alg=BasicVariantGenerator(
-                    max_concurrent=1, random_state=np.random.default_rng(1000)
-                ),
-                **params,
+            assertDictAlmostEqual(
+                analysis_seed.trials[i].config,
+                analysis_generator_2.trials[i].config,
             )
-            analysis_generator_2 = tune.run(
-                search_alg=BasicVariantGenerator(
-                    max_concurrent=1, random_state=np.random.default_rng(1000)
-                ),
-                **params,
-            )
-            for i in range(num_samples):
-                assertDictAlmostEqual(
-                    analysis_seed.trials[i].config, analysis_generator.trials[i].config
-                )
-                assertDictAlmostEqual(
-                    analysis_seed.trials[i].config, analysis_seed_2.trials[i].config
-                )
-                assertDictAlmostEqual(
-                    analysis_seed.trials[i].config,
-                    analysis_generator_2.trials[i].config,
-                )
 
     def testBoundedFloat(self):
         bounded = ray.tune.search.sample.Float(-4.2, 8.3)
@@ -477,6 +455,129 @@ class SearchSpaceTest(unittest.TestCase):
             self.assertTrue(
                 all(isinstance(s, float) for s in array), msg=f"quniform array, q={q}"
             )
+
+    @staticmethod
+    def _quantized_integer_grid(lower, upper, q):
+        """The multiples of ``q`` in ``[lower, upper]``, which is what should be
+        sampled: the upper bound is inclusive for quantized integer domains."""
+        return [
+            k * q for k in range(int(np.ceil(lower / q)), int(np.floor(upper / q)) + 1)
+        ]
+
+    def testQuantizedIntegerGrid(self):
+        """A quantized integer domain samples the multiples of `q` in [lower, upper].
+
+        Both bounds are inclusive, so a bound that is itself a multiple of `q` is
+        drawable, and a bound that is not is rounded inwards to the nearest multiple
+        that is. `q == 1` is the documented exception: `qrandint`/`qlograndint` then
+        keep `randint`/`lograndint`'s exclusive upper bound.
+        """
+        random_state = np.random.RandomState(1000)
+
+        for lower, upper, q in [(2, 10, 2), (1, 11, 2), (1, 10, 3), (2, 20, 2)]:
+            grid = self._quantized_integer_grid(lower, upper, q)
+            for name in ("qrandint", "qlograndint"):
+                domain = getattr(tune, name)(lower, upper, q)
+                sampled = domain.sample(size=5000, random_state=random_state)
+                where = f"{name}({lower}, {upper}, {q})"
+                self.assertEqual(sorted(set(sampled)), grid, msg=where)
+
+        # Negative bounds, which `qlograndint` does not accept.
+        grid = self._quantized_integer_grid(-21, 12, 3)
+        sampled = tune.qrandint(-21, 12, 3).sample(size=5000, random_state=random_state)
+        self.assertEqual(sorted(set(sampled)), grid)
+
+        # A grid holding a single point is a valid domain of one value.
+        for name in ("qrandint", "qlograndint"):
+            domain = getattr(tune, name)(1, 9, 5)
+            sampled = domain.sample(size=100, random_state=random_state)
+            self.assertEqual(set(sampled), {5}, msg=name)
+
+        # `q == 1` keeps `randint`/`lograndint`'s exclusive upper bound.
+        for name in ("qrandint", "qlograndint"):
+            domain = getattr(tune, name)(1, 10, 1)
+            sampled = domain.sample(size=5000, random_state=random_state)
+            self.assertEqual(sorted(set(sampled)), list(range(1, 10)), msg=name)
+
+        # A range holding no multiple of `q` at all has nothing to sample.
+        with self.assertRaisesRegex(ValueError, "no multiple of the quantization"):
+            tune.qrandint(3, 4, 5).sample(random_state=random_state)
+
+    def testQuantizedFloatKeepsItsBounds(self):
+        """A quantized float domain samples the whole grid, both bounds included.
+
+        The bounds below are all divisible by `q` in exact arithmetic but not in
+        floating point - `0.6 / 0.3` is 2.0000000000000004 and `599.7 / 0.3` is
+        1998.9999999999998 which is why they are written as `k * q`. `Float.quantized`
+        accepts such bounds under `math.isclose`, so snapping them onto the grid has to
+        use the same tolerance, or a bound moves a whole step inwards and is lost.
+        """
+        random_state = np.random.RandomState(1000)
+
+        for first, last, q in [(3, 11, 0.1), (7, 13, 0.3), (3, 11, 0.05)]:
+            grid = [k * q for k in range(first, last + 1)]
+            domain = tune.quniform(first * q, last * q, q)
+            sampled = sorted(set(domain.sample(size=5000, random_state=random_state)))
+            where = f"quniform({first * q!r}, {last * q!r}, {q})"
+            self.assertEqual(len(sampled), len(grid), msg=where)
+            for got, expected in zip(sampled, grid):
+                self.assertAlmostEqual(got, expected, places=12, msg=where)
+
+    def testQuantizedIntegerUniform(self):
+        """`qrandint` draws every point of its grid with equal probability.
+
+        Each point should take 1 / len(grid) of the draws; `delta` allows for the
+        sampling error left at `size` draws from the seeded stream.
+        """
+        random_state = np.random.RandomState(1000)
+        size = 40000
+
+        for lower, upper, q in [(2, 10, 2), (-21, 12, 3), (0, 10, 5)]:
+            grid = self._quantized_integer_grid(lower, upper, q)
+            counts = Counter(
+                tune.qrandint(lower, upper, q).sample(
+                    size=size, random_state=random_state
+                )
+            )
+            expected = size / len(grid)
+            for value in grid:
+                self.assertAlmostEqual(
+                    counts[value] / expected,
+                    1.0,
+                    delta=0.05,
+                    msg=f"qrandint({lower}, {upper}, {q}) is not uniform at {value}",
+                )
+
+    def testQuantizedIntegerLogUniform(self):
+        """`qlograndint` is log-uniform over its grid, not over the raw integers.
+
+        It is `lograndint` over the grid indices, so index `k` covers [k, k + 1) in
+        log space and grid point `k * q` takes log((k + 1) / k) / log((last + 1) / first)
+        of the draws - a share that falls off as `k` grows, unlike a uniform grid.
+        """
+        random_state = np.random.RandomState(1000)
+        size = 40000
+
+        for lower, upper, q in [(1, 10, 2), (1, 128, 8), (2, 20, 2)]:
+            first = int(np.ceil(lower / q))
+            last = int(np.floor(upper / q))
+            counts = Counter(
+                tune.qlograndint(lower, upper, q).sample(
+                    size=size, random_state=random_state
+                )
+            )
+            log_range = np.log((last + 1) / first)
+            for k in range(first, last + 1):
+                expected = size * np.log((k + 1) / k) / log_range
+                self.assertAlmostEqual(
+                    counts[k * q] / expected,
+                    1.0,
+                    delta=0.15,
+                    msg=(
+                        f"qlograndint({lower}, {upper}, {q}) is not log-uniform "
+                        f"at {k * q}"
+                    ),
+                )
 
     def testCategoricalDtype(self):
         dist = tune.choice([1.0, "str"])

--- a/rllib/examples/ray_tune/appo_hyperparameter_tune.py
+++ b/rllib/examples/ray_tune/appo_hyperparameter_tune.py
@@ -131,12 +131,13 @@ config = (
         lr=tune.loguniform(0.0001, 0.005),
         vf_loss_coeff=tune.uniform(0.5, 2.0),
         entropy_coeff=tune.uniform(0.001, 0.02),
-        # Use tune.qrandint(a, b, q) for discrete params in [a, b) with step q (defaults to 1)
+        # Use tune.randint(a, b) and tune.qrandint(a, b, q) with multiples
+        # of q for discrete params
         train_batch_size_per_learner=tune.qrandint(256, 2048, 64),
-        target_network_update_freq=tune.qrandint(1, 6),
-        broadcast_interval=tune.qrandint(2, 11),
-        circular_buffer_num_batches=tune.qrandint(2, 6),
-        circular_buffer_iterations_per_batch=tune.qrandint(1, 5),
+        target_network_update_freq=tune.randint(1, 6),
+        broadcast_interval=tune.randint(2, 11),
+        circular_buffer_num_batches=tune.randint(2, 6),
+        circular_buffer_iterations_per_batch=tune.randint(1, 5),
     )
 )
 


### PR DESCRIPTION
## Description
Reviewing https://github.com/ray-project/ray/pull/65731, claude found two bugs in `ray.tune.qrandint(a, b, q)`
1. The documentation notes that for `q>=2` then `b` is inclusive (can be sampled) which testing was found to be false
2. The values weren't uniformly sampled!!!!!
3. If there is only a single value that could be sampled (e.g. `qrandint(1, 4, 3)`), this would raise an error (`ValueError: low >= high`).

This PR fixes all these issues through sampling the quantised grid to ensure that each possible value is sampled uniformly and that it will sample the upper bound when `q>=2` (inclusively) following the documentation. In short, this should be equal to

 `qrandint(lower, upper, q) == q * randint(ceil(lower / q), floor(upper / q) + 1)`
 
At the same time, I removed legacy numpy 1.17 code which we don't support anymore

## Related issues
From reviewing https://github.com/ray-project/ray/pull/65731

I got claude to confirm that none of the other sample functions have this issue