### PR TITLE
[core] Remove stale NodeManager method declarations left by old refactors

### DIFF
--- a/src/ray/raylet/node_manager.h
+++ b/src/ray/raylet/node_manager.h
@@ -420,16 +420,8 @@ class NodeManager : public rpc::NodeManagerServiceHandler,
   bool ResourceDeleted(const NodeID &node_id,
                        const std::vector<std::string> &resource_names);
 
-  /// Evaluates the local infeasible queue to check if any tasks can be scheduled.
-  /// This is called whenever there's an update to the resources on the local node.
-  void TryLocalInfeasibleTaskScheduling();
-
   /// Write out debug state to a file.
   void DumpDebugState() const;
-
-  /// Flush objects that are out of scope in the application. This will attempt
-  /// to eagerly evict all plasma copies of the object from the cluster.
-  void FlushObjectsToFree();
 
   /// Handler for a resource usage notification from the GCS.
   ///
@@ -729,26 +721,6 @@ class NodeManager : public rpc::NodeManagerServiceHandler,
   /// Warn and trigger a cluster wide GC if this node is full of actors and so we are
   /// unable to schedule new tasks or actors at all.
   void WarnAndGCStuckActors();
-
-  /// Dispatch tasks to available workers.
-  void DispatchScheduledTasksToWorkers();
-
-  /// Whether a task is an actor creation task.
-  bool IsActorCreationTask(const TaskID &task_id);
-
-  /// Return back all the bundle resource.
-  ///
-  /// \param bundle_spec: Specification of bundle whose resources will be returned.
-  /// \return Whether the resource is returned successfully.
-  bool ReturnBundleResources(const BundleSpecification &bundle_spec);
-
-  /// Populate the relevant parts of the heartbeat table. This is intended for
-  /// sending raylet <-> gcs heartbeats. In particular, this should fill in
-  /// resource_load and resource_load_by_shape.
-  ///
-  /// \param Output parameter. `resource_load` and `resource_load_by_shape` are the only
-  /// fields used.
-  void FillResourceUsage(rpc::ResourcesData &data);
 
   /// Disconnect a client.
   ///


### PR DESCRIPTION
## Description

Removes 6 method declarations from `NodeManager` that have had no implementations, purely leftover from previous refactoring

| Method | Left stale by |
| --- | --- |
| `FlushObjectsToFree()` | #11647 |
| `TryLocalInfeasibleTaskScheduling()` | #21660 |
| `DispatchScheduledTasksToWorkers()` | #55469 |
| `IsActorCreationTask(const TaskID &)` | #55469 |
| `ReturnBundleResources(const BundleSpecification &)` | #12538 |
| `FillResourceUsage(rpc::ResourcesData &)` | #14291 |