### PR TITLE
[ci][doc] Add merge-time redirect apply step (disabled pending credential)

### DIFF
--- a/.buildkite/doc.rayci.yml
+++ b/.buildkite/doc.rayci.yml
@@ -172,3 +172,67 @@ steps:
       - git fetch -q origin "$${BUILDKITE_PULL_REQUEST_BASE_BRANCH:-master}"
       - rtd-redirects validate doc/redirects/current.yaml
       - rtd-redirects diff-file --file doc/redirects/current.yaml --base FETCH_HEAD --head HEAD --repo .
+
+  # Merge-time sync: reconcile doc/redirects/current.yaml into the live
+  # anyscale-ray Read the Docs project. This is the only mutating step and the
+  # only one that holds an RtD token. It replaces the manual post-merge
+  # `rtd-redirects apply` a maintainer runs today (see doc/redirects/README.md).
+  #
+  # DISABLED until the credential lands. The `disabled` tag makes rayci skip this
+  # step in both premerge and postmerge, so it's safe to land now and turn on
+  # later, the same way doc: linkcheck landed before its Slack webhook secret.
+  # To enable, do both atomically in one PR: (1) remove the `disabled` tag below,
+  # (2) replace RTD_TOKEN_SECRET_ARN with the real Secrets Manager ARN. The bot
+  # user and token are provisioned by REEF as a dependency of this work; until
+  # that ARN exists the fetch would fail every master build, which is why the
+  # step stays disabled rather than fetch-and-skip.
+  #
+  # Postmerge-only by construction. `skip-on-premerge` removes it from every PR
+  # build (premerge skips that tag), so no PR event, fork or not, ever runs the
+  # token-bearing step. It runs only on push to master.
+  #
+  # Self-gated on the diff. rayci evaluates file-based tag rules on premerge
+  # only; master builds are run-all (see the note in .buildkite/always.rules.txt),
+  # so this step is scheduled on *every* master merge, not just redirect ones.
+  # The first command exits early when the merge didn't touch doc/redirects/, so
+  # the token and the RtD API are used only when a redirect actually changed. The
+  # gate is best-effort: if the parent commit can't be resolved (a shallow
+  # checkout), it falls through to apply rather than risk skipping a real change.
+  #
+  # Drift and deletion. `apply` converges the project to the file: a live
+  # redirect absent from current.yaml is deleted. That's the intended one-write-
+  # path behavior reinforced by the dashboard-edit freeze, but 0.2.0 has no
+  # --no-delete or --accept-drift guard, so a drifted project reconciles hard on
+  # the first automated run. The local-first manual-apply phase exists to shake
+  # that out before this turns on. On failure the step fails but master is not
+  # blocked (the docs already merged); an operator reruns after fixing the cause.
+  - label: ":book: doc: apply redirects"
+    key: doc_redirects_apply
+    depends_on: forge
+    tags:
+      - oss
+      - skip-on-premerge
+      - disabled
+    commands:
+      # Exit early unless this master commit changed doc/redirects/. Ray squash-
+      # merges, so HEAD~1..HEAD is exactly the merged change set. Fall through to
+      # apply if HEAD~1 doesn't resolve, so a shallow checkout never skips a real
+      # redirect change.
+      - >
+        if git rev-parse -q --verify HEAD~1 >/dev/null; then
+          git diff --name-only HEAD~1 HEAD -- doc/redirects/ | grep -q . ||
+          { echo "no doc/redirects/ change in this merge; nothing to apply"; exit 0; }
+        fi
+      # Same fail-closed guard as the validate step: current.yaml is the only file
+      # the compose order below names. To add another, name it here and in the
+      # apply command in compose order, then update this guard.
+      - >
+        test "$$(find doc/redirects -name '*.yaml')" = "doc/redirects/current.yaml" ||
+        { echo "doc/redirects/ holds a .yaml file this step doesn't apply; see the comment in .buildkite/doc.rayci.yml"; exit 1; }
+      - uv tool install anyscale-rtd-redirects==0.2.0
+      # Dedicated, least-privilege secret: this ARN holds only the anyscale-ray
+      # RtD bot token, is read by no other step, and grants no access beyond that
+      # one project. Do not fold the token into ci/env/setup_credentials.py's
+      # shared ray-air-test-secrets bucket, which ml/data test steps read.
+      - export RTD_API_TOKEN="$$(aws secretsmanager get-secret-value --region us-west-2 --secret-id RTD_TOKEN_SECRET_ARN --query SecretString --output text)"
+      - rtd-redirects apply --project anyscale-ray --file doc/redirects/current.yaml --yes --strict

--- a/.buildkite/doc.rayci.yml
+++ b/.buildkite/doc.rayci.yml
@@ -178,14 +178,15 @@ steps:
   # only one that holds an RtD token. It replaces the manual post-merge
   # `rtd-redirects apply` a maintainer runs today (see doc/redirects/README.md).
   #
-  # DISABLED until the credential lands. The `disabled` tag makes rayci skip this
-  # step in both premerge and postmerge, so it's safe to land now and turn on
+  # DISABLED pending the manual-apply phase. The `disabled` tag makes rayci skip
+  # this step in both premerge and postmerge, so it's safe to land now and turn on
   # later, the same way doc: linkcheck landed before its Slack webhook secret.
-  # To enable, do both atomically in one PR: (1) remove the `disabled` tag below,
-  # (2) replace RTD_TOKEN_SECRET_ARN with the real Secrets Manager ARN. The bot
-  # user and token are provisioned by REEF as a dependency of this work; until
-  # that ARN exists the fetch would fail every master build, which is why the
-  # step stays disabled rather than fetch-and-skip.
+  # The bot token is already wired: REEF provisioned it at Secrets Manager
+  # secret-id `oss-ci/rtd-api-token`, read inline below. Enabling is then a
+  # one-line flip: remove the `disabled` tag below. The step stays disabled until
+  # the local-first manual-apply phase finishes reconciling the live project, so
+  # the first automated run doesn't hard-reconcile a drifted project (see the
+  # "Drift and deletion" note below).
   #
   # Postmerge-only by construction. `skip-on-premerge` removes it from every PR
   # build (premerge skips that tag), so no PR event, fork or not, ever runs the
@@ -215,13 +216,18 @@ steps:
       - disabled
     commands:
       # Exit early unless this master commit changed doc/redirects/. Ray squash-
-      # merges, so HEAD~1..HEAD is exactly the merged change set. Fall through to
-      # apply if HEAD~1 doesn't resolve, so a shallow checkout never skips a real
-      # redirect change.
-      - >
+      # merges, so HEAD~1..HEAD is exactly the merged change set. `git diff
+      # --quiet` exits 0 for no change (skip), 1 for a change (apply), and a
+      # different non-zero on git error, so a shallow checkout or a git failure
+      # falls through to apply rather than silently skip a real redirect change.
+      # (A `git diff | grep -q .` pipe would mask the diff's exit status and skip
+      # on error, the opposite of what we want here.)
+      - |
         if git rev-parse -q --verify HEAD~1 >/dev/null; then
-          git diff --name-only HEAD~1 HEAD -- doc/redirects/ | grep -q . ||
-          { echo "no doc/redirects/ change in this merge; nothing to apply"; exit 0; }
+          if git diff --quiet HEAD~1 HEAD -- doc/redirects/; then
+            echo "no doc/redirects/ change in this merge; nothing to apply"
+            exit 0
+          fi
         fi
       # Same fail-closed guard as the validate step: current.yaml is the only file
       # the compose order below names. To add another, name it here and in the
@@ -230,9 +236,15 @@ steps:
         test "$$(find doc/redirects -name '*.yaml')" = "doc/redirects/current.yaml" ||
         { echo "doc/redirects/ holds a .yaml file this step doesn't apply; see the comment in .buildkite/doc.rayci.yml"; exit 1; }
       - uv tool install anyscale-rtd-redirects==0.2.0
-      # Dedicated, least-privilege secret: this ARN holds only the anyscale-ray
-      # RtD bot token, is read by no other step, and grants no access beyond that
-      # one project. Do not fold the token into ci/env/setup_credentials.py's
+      # Dedicated, least-privilege secret: `oss-ci/rtd-api-token` holds only the
+      # anyscale-ray RtD bot token, is read by no other step, and grants no access
+      # beyond that one project. Do not fold the token into ci/env/setup_credentials.py's
       # shared ray-air-test-secrets bucket, which ml/data test steps read.
-      - export RTD_API_TOKEN="$$(aws secretsmanager get-secret-value --region us-west-2 --secret-id RTD_TOKEN_SECRET_ARN --query SecretString --output text)"
+      #
+      # Fetch with shell tracing off so an xtrace-enabled agent can't echo the
+      # expanded token into the Buildkite log. `set +x` persists to `apply` below,
+      # which carries no secret, so leaving tracing off there is harmless.
+      - |
+        set +x
+        export RTD_API_TOKEN="$$(aws secretsmanager get-secret-value --region us-west-2 --secret-id oss-ci/rtd-api-token --query SecretString --output text)"
       - rtd-redirects apply --project anyscale-ray --file doc/redirects/current.yaml --yes --strict


### PR DESCRIPTION
## What this does

Adds the merge-time sync step that reconciles `doc/redirects/current.yaml` into
the live `anyscale-ray` Read the Docs project. This is the automation that
replaces the manual `rtd-redirects apply` a maintainer runs by hand today (see
`doc/redirects/README.md`). It completes the redirect-as-code pipeline whose
credential-free PR-time validation gate already landed in #64413.

**It lands disabled.** The dedicated bot credential it needs isn't provisioned
yet, so the step carries the `disabled` tag and rayci skips it in both premerge
and postmerge. This PR is deliberately staged, not ready to merge-and-run — it's
here so the credential wiring can be reviewed and the dependency tracked. Same
pattern the `doc: linkcheck` step used to land ahead of its Slack webhook secret.

## How it's wired

- **Postmerge-only.** The `skip-on-premerge` tag keeps it off every PR build, so
  no PR event — fork or not — ever runs the token-bearing step. It runs only on
  push to master.
- **Self-gated on the diff.** rayci evaluates file-based tag rules on premerge
  only; master builds are run-all. The step therefore exits early unless the
  merge actually touched `doc/redirects/`, so the token and the RtD API are used
  only when a redirect changed.
- **Least-privilege secret.** The token is read inline from a dedicated Secrets
  Manager ARN read by no other step — not the shared `ray-air-test-secrets`
  bucket. Blast radius stays bounded to redirects on the one RtD project.

## What I need to enable it

A dedicated bot principal with admin on the `anyscale-ray` RtD project, its API
token stored in a dedicated Secrets Manager ARN. Once that exists, enabling is a
one-PR flip: remove the `disabled` tag, replace the `RTD_TOKEN_SECRET_ARN`
placeholder with the real ARN, and update the "application is manual for now"
line in `doc/redirects/README.md`.

## One caveat for review

The pinned tool version (0.2.0) has no `--no-delete` or `--accept-drift` guard,
so the first automated `apply` reconciles hard: a live redirect absent from
`current.yaml` is deleted. That's the intended one-write-path behavior, but it's
why the manual-apply phase should finish before this is turned on.

## Test plan

- [x] YAML parses; new step present with tags `oss`, `skip-on-premerge`, `disabled`.
- [x] Tag-rules dry-run confirms the edit emits only the doc pipeline
      (`doc, doc_api, doc_redirects, lint`), no code fan-out.
- [x] `disabled` tag verified to skip in both premerge and postmerge rayci configs.
- [ ] Enablement (separate PR, after credential): real premerge/postmerge run.
