### PR TITLE
[docs] Document the :ref: label requirement and default_role in the style guide

### DIFF
--- a/doc/source/ray-contribute/writing-style.md
+++ b/doc/source/ray-contribute/writing-style.md
@@ -265,6 +265,10 @@ Don't bold ordinary prose for emphasis, and don't bold inline code. Code styling
 - Use: "supports capacity reservations, spot instances, and on-demand instances"
 - Not: "supports **capacity reservations**, **spot instances**, and **on-demand instances**"
 
+:::{note}
+To italicize a term in reStructuredText, use `*term*`. Ray sets `default_role = "code"` in `conf.py`, so a bare single-backtick `` `term` `` renders as inline code, not italics. A single backtick in an `.rst` file is intentional inline code, not a rendering bug. MyST Markdown matches this: `*term*` is italics and `` `term` `` is inline code.
+:::
+
 ### Tables
 
 Use a Markdown table for simple rows with single-line cells. Always include a header row, and introduce the table with a sentence of prose. For cells that hold code blocks, multiple lines, or other complex content, use the `list-table` directive:
@@ -293,6 +297,8 @@ Ray docs use Sphinx cross-references, which resolve at build time and survive pa
   (my-label)=
   ## The section to link
   ```
+
+  Ray docs don't enable Sphinx's `autosectionlabel` extension, so a heading's text isn't a `{ref}` target on its own. Every section you link to needs an explicit label. The tradeoff favors stability: rewording a heading can't break an existing `{ref}`, because the label is a separate line that the edit leaves untouched.
 
 - Link between `.md` pages with a standard Markdown link: `[text](other-page.md)`.
 - Link to the API reference with autodoc cross-reference roles, such as `` {py:func}`ray.init` `` or `` {py:class}`ray.data.Dataset` ``.


### PR DESCRIPTION
## Summary

Documents two facts about Ray's Sphinx configuration in the documentation style guide. Neither was written down anywhere contributors or agents would find them, and both were rediscovered from `conf.py` during recent Ray Data style passes (#65374, #65525).

- Ray doesn't enable `autosectionlabel`, so a heading's text isn't a `{ref}` target on its own and every linked section needs an explicit label. Added to the cross-references section, which already showed the `(my-label)=` pattern but never said why it's required.
- Ray sets `default_role = "code"`, so a bare single-backtick in reStructuredText renders as inline code, not italics or a broken role. Added as a note in the bold-and-italics section. This one nearly produced ~50 false "single backticks are a rendering bug" findings in a prior review pass.

## Why this isn't a duplicate

Searched open PRs with `gh pr list --search` for `writing-style`, `autosectionlabel`, `default_role`, and `anchor`. No open PR documents these.

## Test plan

Prose-only change under `doc/`. A change to only `.md` files under `doc/` runs no library test steps; the Read the Docs render gate validates the build. Both claims were verified directly against `doc/source/conf.py` (`autosectionlabel` absent from `extensions`; `default_role = "code"`).

## AI assistance

Drafted with AI assistance (Claude Code). Facts verified against `doc/source/conf.py`. The submitter reviews every changed line before requesting review.
