### PR TITLE
[Data] Track Consumer-held Object Store Memory

### DIFF
--- a/python/ray/data/_internal/batcher.py
+++ b/python/ray/data/_internal/batcher.py
@@ -45,6 +45,10 @@ class BatcherInterface:
         """Whether this Batcher has any data."""
         raise NotImplementedError()
 
+    def buffered_nbytes(self) -> int:
+        """Bytes of block data buffered here (see ``ConsumerHeldMemory``)."""
+        raise NotImplementedError()
+
     def next_batch(self) -> Block:
         """Get the next batch from the block buffer.
 
@@ -104,6 +108,10 @@ class Batcher(BatcherInterface):
     def has_any(self) -> bool:
         """Whether this Batcher has any data."""
         return self._buffer_size > 0
+
+    def buffered_nbytes(self) -> int:
+        """The number of bytes of block data buffered here (see ``ConsumerHeldMemory``)."""
+        return sum(BlockAccessor.for_block(b).size_bytes() for b in self._buffer)
 
     def next_batch(self) -> Block:
         """Get the next batch from the block buffer.
@@ -298,6 +306,11 @@ class ShufflingBatcher(BatcherInterface):
     def has_any(self) -> bool:
         """Whether this batcher has any data."""
         return self._num_rows() > 0
+
+    def buffered_nbytes(self) -> int:
+        # Only the uncompacted blocks. Compaction copies into the heap, which is
+        # a different resource and is not reported through this path.
+        return self._builder.get_estimated_memory_usage()
 
     def has_batch(self) -> bool:
         """Whether this batcher has any batches."""

--- a/python/ray/data/_internal/block_batching/interfaces.py
+++ b/python/ray/data/_internal/block_batching/interfaces.py
@@ -89,11 +89,14 @@ class BatchMetadata:
         batch_idx: The global index of this batch so that downstream operations can
             maintain ordering.
         num_rows: Number of rows in this batch (for ``iter_rows_total``).
+        nbytes: Size of the batch when it was built, used to decrement the
+            consumer's in-flight byte count once the batch is released.
         stage_timings: Per-stage timing windows.
     """
 
     batch_idx: int
     num_rows: int = 0
+    nbytes: int = 0
     stage_timings: BatchStageTimings = field(default_factory=BatchStageTimings)
 
 

--- a/python/ray/data/_internal/block_batching/iter_batches.py
+++ b/python/ray/data/_internal/block_batching/iter_batches.py
@@ -125,6 +125,8 @@ class BatchIterator:
             formatting to be overlapped with the UDF. Defaults to 1.
         prefetch_bytes_callback: A callback to report prefetched bytes to the executor's
             resource manager.
+        consumer_held_bytes_callback: A callback reporting object store memory
+            the consumer still holds after its ``ObjectRef`` was released.
         preserve_order: Whether to maintain the original order that the batches
             were formed from the blocks (e.g., the input block order).
             This only takes effect in the case that the format/collate threadpool
@@ -150,6 +152,7 @@ class BatchIterator:
         ensure_copy: bool = False,
         prefetch_batches: int = 1,
         prefetch_bytes_callback: Optional[Callable[[int], None]] = None,
+        consumer_held_bytes_callback: Optional[Callable[[int], None]] = None,
         preserve_order: bool = False,
     ):
         self._ref_bundles = ref_bundles
@@ -165,6 +168,8 @@ class BatchIterator:
         self._ensure_copy = ensure_copy
         self._prefetch_batches = prefetch_batches
         self._prefetch_bytes_callback = prefetch_bytes_callback
+        self._consumer_held_bytes_callback = consumer_held_bytes_callback
+        self._consumer_held_memory = None
         self._preserve_order = preserve_order
 
         actor_prefetcher_enabled = (
@@ -201,7 +206,7 @@ class BatchIterator:
         return resolve_block_refs(block_ref_iter=block_refs, stats=self._stats)
 
     def _blocks_to_batches(self, blocks: Iterator[Block]) -> Iterator[Batch]:
-        return blocks_to_batches(
+        batch_iter = blocks_to_batches(
             block_iter=blocks,
             stats=self._stats,
             batch_size=self._batch_size,
@@ -210,6 +215,10 @@ class BatchIterator:
             shuffle_seed=self._shuffle_seed,
             ensure_copy=self._ensure_copy,
         )
+        # Built inside the pipeline but read from the user thread on release,
+        # so publish it here rather than passing it downstream.
+        self._consumer_held_memory = batch_iter.consumer_held_memory
+        return batch_iter
 
     def _format_batches(self, batches: Iterator[Batch]) -> Iterator[Batch]:
         num_threadpool_workers = min(
@@ -375,6 +384,15 @@ class BatchIterator:
             batch.on_consume()
         with self._stats.iter_user_s.timer() if self._stats else nullcontext():
             yield
+
+        # Only now is the user done with the batch. `on_consume` above fires
+        # before the yield, so it is too early to release memory against.
+        if self._consumer_held_memory is not None:
+            self._consumer_held_memory.on_batch_released(batch.metadata.nbytes)
+            if self._consumer_held_bytes_callback is not None:
+                self._consumer_held_bytes_callback(
+                    self._consumer_held_memory.total_bytes()
+                )
 
         # Report prefetched bytes to the executor's resource manager.
         if self._prefetch_bytes_callback is not None and self._stats is not None:

--- a/python/ray/data/_internal/block_batching/util.py
+++ b/python/ray/data/_internal/block_batching/util.py
@@ -18,7 +18,7 @@ from typing import (
 
 import ray
 from ray.actor import ActorHandle
-from ray.data._internal.batcher import Batcher, ShufflingBatcher
+from ray.data._internal.batcher import Batcher, BatcherInterface, ShufflingBatcher
 from ray.data._internal.block_batching.interfaces import (
     Batch,
     BatchMetadata,
@@ -281,6 +281,35 @@ def blocks_to_batches(
     )
 
 
+class ConsumerHeldMemory:
+    """Object store memory the consumer holds after its ``ObjectRef`` is gone.
+
+    Batches are zero-copy views, so blocks stay resident once
+    ``resolve_block_refs`` drops the ref and ``BlockRefCounter`` stops counting
+    them. Locked: batches are built on the format threadpool workers and
+    released on the user thread.
+    """
+
+    def __init__(self, batcher: "BatcherInterface"):
+        self._batcher = batcher
+        self._in_flight_bytes = 0
+        self._lock = threading.Lock()
+
+    def on_batch_built(self, nbytes: int) -> None:
+        with self._lock:
+            self._in_flight_bytes += nbytes
+
+    def on_batch_released(self, nbytes: int) -> None:
+        with self._lock:
+            # Batches can be dropped without being yielded (e.g. an aborted
+            # iteration), so guard against drifting negative.
+            self._in_flight_bytes = max(self._in_flight_bytes - nbytes, 0)
+
+    def total_bytes(self) -> int:
+        with self._lock:
+            return self._batcher.buffered_nbytes() + self._in_flight_bytes
+
+
 class _BatchingIterator(Iterator[Batch]):
     """Iterator that converts blocks to batches.
 
@@ -315,6 +344,8 @@ class _BatchingIterator(Iterator[Batch]):
         else:
             self._batcher = Batcher(batch_size=batch_size, ensure_copy=ensure_copy)
 
+        self.consumer_held_memory = ConsumerHeldMemory(self._batcher)
+
     def __iter__(self) -> "_BatchingIterator":
         return self
 
@@ -332,14 +363,18 @@ class _BatchingIterator(Iterator[Batch]):
                     next_batch = self._batcher.next_batch()
                 self._pending_timings.batching = span
 
+                accessor = BlockAccessor.for_block(next_batch)
+                nbytes = accessor.size_bytes()
                 res = Batch(
                     metadata=BatchMetadata(
                         batch_idx=self._global_counter,
-                        num_rows=BlockAccessor.for_block(next_batch).num_rows(),
+                        num_rows=accessor.num_rows(),
+                        nbytes=nbytes,
                         stage_timings=self._pending_timings,
                     ),
                     data=next_batch,
                 )
+                self.consumer_held_memory.on_batch_built(nbytes)
                 self._pending_timings = BatchStageTimings()
 
                 self._global_counter += 1

--- a/python/ray/data/_internal/execution/resource_manager.py
+++ b/python/ray/data/_internal/execution/resource_manager.py
@@ -135,6 +135,7 @@ class ResourceManager:
         # - ds.iter_batches -> one iterator
         # - streaming_split -> multiple iterators
         self._external_consumer_bytes: int = 0
+        self._consumer_held_bytes: int = 0
         self._has_external_consumer: bool = False
 
         # Executor sink (DAG root: unique op with no output_dependencies).
@@ -175,6 +176,22 @@ class ResourceManager:
         """Get the bytes buffered by external consumers."""
         return self._external_consumer_bytes
 
+    def set_consumer_held_bytes(self, num_bytes: int) -> None:
+        """Set object store memory consumers hold past their ``ObjectRef``.
+
+        Zero-copy batch views keep blocks resident after the ref is released,
+        so ``BlockRefCounter`` misses them. Distinct from
+        ``external_consumer_bytes``, which measures intake capacity.
+        """
+        assert (
+            num_bytes >= 0
+        ), f"consumer held bytes must be non-negative, got {num_bytes}"
+        self._consumer_held_bytes = num_bytes
+
+    def get_consumer_held_bytes(self) -> int:
+        """Get object store memory held by consumers past their ``ObjectRef``."""
+        return self._consumer_held_bytes
+
     def _estimate_object_store_memory_usage(
         self, op: "PhysicalOperator", state: "OpState"
     ) -> int:
@@ -185,6 +202,11 @@ class ResourceManager:
 
         self._mem_op_internal[op] = op.metrics.obj_store_mem_pending_task_outputs or 0
         self._mem_op_outputs[op] = op.estimate_object_store_usage()
+        if op is self._output_operator:
+            # Blocks the consumer still reads but no longer holds a ref to.
+            # Attributed here because the consumer reports a single total and
+            # cannot say which operator produced each block.
+            self._mem_op_outputs[op] += self._consumer_held_bytes
 
         return self._mem_op_outputs[op] + self._mem_op_internal[op]
 

--- a/python/ray/data/_internal/execution/streaming_executor.py
+++ b/python/ray/data/_internal/execution/streaming_executor.py
@@ -476,6 +476,11 @@ class StreamingExecutor(Executor, threading.Thread):
         if self._resource_manager is not None:
             self._resource_manager.set_external_consumer_bytes(num_bytes)
 
+    def set_consumer_held_bytes(self, num_bytes: int) -> None:
+        """Set object store memory held by consumers past their ``ObjectRef``."""
+        if self._resource_manager is not None:
+            self._resource_manager.set_consumer_held_bytes(num_bytes)
+
     def _generate_stats(self) -> DatasetStats:
         """Create a new stats object reflecting execution status so far."""
         stats = self._initial_stats or DatasetStats(metadata={}, parent=None)

--- a/python/ray/data/_internal/iterator/stream_split_iterator.py
+++ b/python/ray/data/_internal/iterator/stream_split_iterator.py
@@ -1,7 +1,16 @@
 import logging
 import threading
 import time
-from typing import TYPE_CHECKING, Dict, Iterator, List, Optional, Set, Tuple
+from typing import (
+    TYPE_CHECKING,
+    Callable,
+    Dict,
+    Iterator,
+    List,
+    Optional,
+    Set,
+    Tuple,
+)
 
 import ray
 from ray.data._internal.execution.interfaces import (
@@ -71,9 +80,23 @@ class StreamSplitDataIterator(DataIterator):
         # picklable, since users pass split iterators to ``@ray.remote``
         # tasks.
         self._active_epoch: Optional[int] = None
+        # Object store bytes this split's batches still hold after their
+        # ObjectRef was released. Written by the consumer thread via the
+        # callback, read by ``gen_blocks`` on the prefetch worker thread.
+        self._consumer_held_bytes: int = 0
         logger.debug(
             f"StreamSplitDataIterator created: split={output_split_idx}, {world_size=}"
         )
+
+    def _make_consumer_held_bytes_callback(
+        self, executor
+    ) -> Optional[Callable[[int], None]]:
+        # ``executor`` is always None here: it lives on the SplitCoordinator
+        # actor, so the value is sent with the next get() instead.
+        def callback(num_bytes: int) -> None:
+            self._consumer_held_bytes = num_bytes
+
+        return callback
 
     def _to_ref_bundle_iterator(
         self,
@@ -89,7 +112,7 @@ class StreamSplitDataIterator(DataIterator):
 
             # Initial get with 0 prefetched bytes.
             future: ObjectRef[Optional[RefBundle]] = self._coord_actor.get.remote(
-                cur_epoch, self._output_split_idx, 0
+                cur_epoch, self._output_split_idx, 0, 0
             )
             last_log_time = 0.0
             while True:
@@ -109,6 +132,7 @@ class StreamSplitDataIterator(DataIterator):
                         cur_epoch,
                         self._output_split_idx,
                         prefetched_bytes,
+                        self._consumer_held_bytes,
                     )
                     yield RefBundle(
                         blocks=block_ref_and_md.blocks,
@@ -232,6 +256,10 @@ class SplitCoordinator:
         # Guarded by self._lock.
         self._client_prefetched_bytes: Dict[int, int] = {}
 
+        # Track object store bytes each client still holds after releasing the
+        # ObjectRef (zero-copy batch views). Guarded by self._lock.
+        self._client_held_bytes: Dict[int, int] = {}
+
         # Add a new stats field to track coordinator overhead
         self._coordinator_overhead_s = 0.0
 
@@ -320,6 +348,7 @@ class SplitCoordinator:
                     )
                     # Register the streaming split external consumers with the executor's resource manager.
                     self._current_executor.set_external_consumer_bytes(0)
+                    self._current_executor.set_consumer_held_bytes(0)
                     logger.debug(
                         f"Starting epoch {self._cur_epoch} (all {self._n} clients "
                         "synced)."
@@ -349,6 +378,7 @@ class SplitCoordinator:
         epoch_id: int,
         output_split_idx: int,
         client_prefetched_bytes: int = 0,
+        client_held_bytes: int = 0,
     ) -> Optional[RefBundle]:
         """Blocking get operation.
 
@@ -359,6 +389,8 @@ class SplitCoordinator:
             output_split_idx: The output split index for this client.
             client_prefetched_bytes: The prefetched bytes reported by the
                 client's BatchIterator, used for resource accounting.
+            client_held_bytes: Object store bytes the client still holds after
+                its ObjectRef was released, which BlockRefCounter cannot see.
 
         Returns:
             The next RefBundle for this split, or None if the epoch is done.
@@ -402,7 +434,9 @@ class SplitCoordinator:
                 self._client_prefetched_bytes[
                     output_split_idx
                 ] = client_prefetched_bytes
+                self._client_held_bytes[output_split_idx] = client_held_bytes
                 self._report_prefetched_bytes_to_executor()
+                self._report_consumer_held_bytes_to_executor()
 
                 # Track per-split row dispatch count.
                 self._num_rows_dispatched[output_split_idx] += (
@@ -445,7 +479,9 @@ class SplitCoordinator:
             if not returned_normally:
                 with self._lock:
                     self._client_prefetched_bytes[output_split_idx] = 0
+                    self._client_held_bytes[output_split_idx] = 0
                     self._report_prefetched_bytes_to_executor()
+                    self._report_consumer_held_bytes_to_executor()
             # Track overhead time in the instance variable
             self._coordinator_overhead_s += time.perf_counter() - start_time
 
@@ -468,6 +504,21 @@ class SplitCoordinator:
         if self._current_executor is not None:
             total_bytes = self._get_total_prefetched_bytes()
             self._current_executor.set_external_consumer_bytes(total_bytes)
+
+    def _report_consumer_held_bytes_to_executor(self) -> None:
+        """Report total consumer-held bytes to the executor's resource manager.
+
+        Must be called while holding self._lock.
+        """
+        if self._current_executor is not None:
+            self._current_executor.set_consumer_held_bytes(
+                sum(self._client_held_bytes.values())
+            )
+
+    def get_client_held_bytes(self) -> Dict[int, int]:
+        """Get consumer-held bytes for each client (for testing)."""
+        with self._lock:
+            return dict(self._client_held_bytes)
 
     def get_client_prefetched_bytes(self) -> Dict[int, int]:
         """Get prefetched bytes for each client (for testing)."""
@@ -538,10 +589,12 @@ class SplitCoordinator:
             self._finished_splits.add(split_idx)
 
             self._client_prefetched_bytes[split_idx] = 0
+            self._client_held_bytes[split_idx] = 0
             # Drop any blocks buffered for this split — the consumer won't
             # read them and they'd otherwise pin memory until the next epoch.
             self._next_bundle.pop(split_idx, None)
             self._report_prefetched_bytes_to_executor()
+            self._report_consumer_held_bytes_to_executor()
 
             if (
                 len(self._finished_splits) == self._n

--- a/python/ray/data/iterator.py
+++ b/python/ray/data/iterator.py
@@ -117,6 +117,22 @@ class DataIterator(abc.ABC):
         """
         ...
 
+    def _make_consumer_held_bytes_callback(
+        self, executor: Optional["StreamingExecutor"]
+    ) -> Optional[Callable[[int], None]]:
+        """Build the callback reporting object store bytes the consumer holds.
+
+        Overridden by ``StreamSplitDataIterator``, whose executor lives on a
+        remote actor and is reached over the ``SplitCoordinator`` RPC instead.
+        """
+        if executor is None:
+            return None
+
+        def callback(num_bytes: int) -> None:
+            executor.set_consumer_held_bytes(num_bytes)
+
+        return callback
+
     def _on_iteration_end(self, executor: Optional["StreamingExecutor"]) -> None:
         """Hook fired from the consumer's thread when iteration ends.
 
@@ -266,6 +282,9 @@ class DataIterator(abc.ABC):
             prefetch_bytes_callback = (
                 make_prefetch_callback(executor) if executor is not None else None
             )
+            consumer_held_bytes_callback = self._make_consumer_held_bytes_callback(
+                executor
+            )
             if prefetch_bytes_callback is not None:
                 # Register the external consumer with the executor's resource manager.
                 prefetch_bytes_callback(0)
@@ -283,6 +302,7 @@ class DataIterator(abc.ABC):
                 shuffle_seed=local_shuffle_seed,
                 prefetch_batches=prefetch_batches,
                 prefetch_bytes_callback=prefetch_bytes_callback,
+                consumer_held_bytes_callback=consumer_held_bytes_callback,
                 preserve_order=self.get_context().execution_options.preserve_order,
             )
 

--- a/python/ray/data/tests/block_batching/test_util.py
+++ b/python/ray/data/tests/block_batching/test_util.py
@@ -13,6 +13,7 @@ import pyarrow as pa
 import pytest
 
 import ray
+from ray.data._internal.batcher import Batcher
 from ray.data._internal.block_batching.interfaces import (
     Batch,
     BatchMetadata,
@@ -20,6 +21,7 @@ from ray.data._internal.block_batching.interfaces import (
     ResolvedBlock,
 )
 from ray.data._internal.block_batching.util import (
+    ConsumerHeldMemory,
     _calculate_ref_hits,
     blocks_to_batches,
     collate,
@@ -659,3 +661,20 @@ if __name__ == "__main__":
     import sys
 
     sys.exit(pytest.main(["-v", __file__]))
+
+
+def test_consumer_held_memory_tracks_in_flight_batches():
+    """Bytes stay counted from batch build until release, and never go
+    negative when a batch is dropped without being yielded."""
+    held = ConsumerHeldMemory(Batcher(batch_size=1, ensure_copy=False))
+    assert held.total_bytes() == 0
+
+    held.on_batch_built(100)
+    held.on_batch_built(50)
+    assert held.total_bytes() == 150
+
+    held.on_batch_released(100)
+    assert held.total_bytes() == 50
+
+    held.on_batch_released(999)
+    assert held.total_bytes() == 0

--- a/python/ray/data/tests/test_resource_manager.py
+++ b/python/ray/data/tests/test_resource_manager.py
@@ -368,6 +368,33 @@ class TestResourceManager:
         assert resource_manager.get_op_usage(o3).object_store_memory == 100
         assert resource_manager.get_external_consumer_bytes() == 50
 
+    def test_consumer_held_bytes_charged_to_output_op(self, restore_data_context):
+        """Zero-copy bytes the consumer still holds are invisible to
+        BlockRefCounter, so they are added to the output operator's usage and
+        thereby reach backpressure."""
+        o1 = InputDataBuffer(DataContext.get_current(), [])
+        o2 = mock_map_op(o1)
+        o3 = mock_map_op(o2)
+
+        counter = StubBlockRefCounter()
+        topo = build_streaming_topology(o3, ExecutionOptions(), counter)
+        resource_manager = ResourceManager(
+            topo,
+            ExecutionOptions(),
+            MagicMock(return_value=ExecutionResources.zero()),
+            DataContext.get_current(),
+            counter,
+        )
+
+        counter.on_block_produced(None, 100, o3.id)
+        resource_manager.set_consumer_held_bytes(50)
+        resource_manager.update_usages()
+
+        assert resource_manager.get_consumer_held_bytes() == 50
+        # Charged to the output op only; upstream ops are untouched.
+        assert resource_manager.get_op_usage(o3).object_store_memory == 150
+        assert resource_manager.get_op_usage(o2).object_store_memory == 0
+
     def test_union_no_double_counting(self, restore_data_context):
         """UnionOperator passthrough does not inflate global memory usage."""
 

--- a/python/ray/data/tests/test_split.py
+++ b/python/ray/data/tests/test_split.py
@@ -17,6 +17,9 @@ from ray.data._internal.execution.interfaces import BlockEntry, RefBundle
 from ray.data._internal.execution.interfaces.ref_bundle import (
     _ref_bundles_iterator_to_block_refs_list,
 )
+from ray.data._internal.iterator.stream_split_iterator import (
+    StreamSplitDataIterator,
+)
 from ray.data._internal.logical.interfaces import LogicalPlan
 from ray.data._internal.logical.operators import InputData
 from ray.data._internal.split import (
@@ -947,6 +950,17 @@ def test_streaming_train_test_split_wrong_params(
             hash_column=hash_column,
             seed=seed,
         )
+
+
+def test_stream_split_iterator_always_reports_consumer_held_bytes():
+    """A split consumer has no local executor, so gating the callback on one
+    silently disabled this accounting for every streaming_split job."""
+    it = StreamSplitDataIterator(coord_actor=None, output_split_idx=0, world_size=2)
+    callback = it._make_consumer_held_bytes_callback(executor=None)
+
+    assert callback is not None
+    callback(4096)
+    assert it._consumer_held_bytes == 4096
 
 
 @pytest.mark.parametrize("prefetch_batches", [0, 2])


### PR DESCRIPTION
## Description

Blocks handed to an iterator are deserialized as zero-copy views over plasma. The `ObjectRef` is dropped as soon as the view exists, so `BlockRefCounter` stops counting bytes that are still resident and the driver sees headroom that isn't there.

This PR helps track what the consumer holds (blocks in the batcher, plus batches built but not yet released) and report it to `ResourceManager`, which charges it to the output operator so it feeds backpressure.

`streaming_split` consumers have no local executor, so the value rides the `get()` RPC that already carries `prefetched_bytes`, and the coordinator sums across splits.

After this change, backpressure may get more conservative by the previously-uncounted amount.

## Additional information

Three new tests:

- `test_consumer_held_memory_tracks_in_flight_batches`: bytes stay counted from batch build to release, and never go negative when a batch is dropped without being yielded.
- `test_consumer_held_bytes_charged_to_output_op`: the reported total lands on the output operator's usage.
- `test_stream_split_iterator_always_reports_consumer_held_bytes`: a split consumer always builds a reporting callback. This is the regression test for the inert `streaming_split` path.

