### PR TITLE
[ci] soft_fail the raydepsets compile-all job during the data.pyg.org outage

### DIFF
--- a/.buildkite/dependencies.rayci.yml
+++ b/.buildkite/dependencies.rayci.yml
@@ -19,10 +19,19 @@ steps:
     job_env: oss-ci-base_test-py3.11
     depends_on: oss-ci-base_test-multipy(python=3.11)
 
+  # `soft_fail: true` is temporary. uv fails eagerly on an unreadable --find-links
+  # URL before deciding whether it needs anything from it, and data.pyg.org (the
+  # PyG wheel index every ML/data/rllib depset declares) has been a dangling CNAME
+  # since 2026-09-02 (https://github.com/pyg-team/pyg-lib/issues/719), so this job
+  # is red on every run regardless of the PR. The pip-compile step above is
+  # unaffected: pip skips an unreachable find-links and PyPI's sdist satisfies the
+  # pins. Remove soft_fail once data.pyg.org resolves and this job is green on
+  # master again.
   - label: ":tapioca: build: raydepsets: compile all dependencies"
     key: raydepsets_compile_all_dependencies
     tags: python_dependencies
     instance_type: small
+    soft_fail: true
     commands:
       - bazel run //ci/raydepsets:raydepsets -- build --all-configs --check
     job_env: manylinux-x86_64


### PR DESCRIPTION
## Why this change is needed

`data.pyg.org`, the PyG wheel index that every ML/data/rllib depset declares via `--find-links`, has been a dangling CNAME since 2026-09-02: it points at `d28mro9bmx3ky3.cloudfront.net`, and that CloudFront distribution returns `NOERROR` with zero answers from 8.8.8.8, 1.1.1.1 and 9.9.9.9. Upstream is tracking it at pyg-team/pyg-lib#719 and has said they are working on it with urgency; as of their last update there is no ETA.

uv fails eagerly on an unreadable `--find-links` URL before deciding whether it needs anything from it, so `raydepsets build --all-configs --check` is red on every run regardless of the PR's contents:

| Pipeline | Build | Time (UTC) | Result |
|---|---|---|---|
| postmerge | #19487 | Sep 2 05:05 | passed (last good) |
| postmerge | #19498 | Sep 2 15:28 | pyg DNS |
| postmerge | #19501 | Sep 2 16:09 | pyg DNS |
| postmerge | #19507 | Sep 2 20:06 | pyg DNS |
| postmerge | #19511 | Sep 3 00:05 | pyg DNS |
| premerge | #72711, #72712 | Sep 2 | pyg DNS |

Every run since ~15:30Z Sep 2 has failed. It blocks every `python_dependencies`-tagged PR and paints master red.

The `pip-compile dependencies` step is **not** affected and is left alone: pip treats an unreachable find-links as a warning, PyPI's sdist satisfies `torch-scatter==2.1.2`, and since `requirements_compiled.txt` pins without the `+pt29cpu` local version the output is byte-identical. It passed in all six of the builds above where raydepsets failed, so it keeps guarding `requirements_compiled.txt`.

## What changes

`soft_fail: true` on the `raydepsets: compile all dependencies` step, with a comment recording why and when to remove it.

`soft_fail` rather than removing the step: the job still runs and reports, so it turns green on its own when upstream restores the record, and reviewers can still see lock drift in its output in the meantime. There's precedent for this pattern in `lint.rayci.yml` (`api-param-coverage`).

## What this does not fix

- **Image builds.** 32 deplocks carry the find-links line, so any wanda image build that misses cache fails at `pip install` inside the Dockerfile (#72719 lost `docgpubuild-py3.10` and `mlgpubuild-py3.10` this way). Most PRs are unaffected because unchanged inputs reuse the cached image. Nothing CI-side fixes this without hosting the wheels somewhere else, which is a separate change.
- **Lock regeneration.** A PR that needs a new deplock still can't produce one until the index is back, since the recompile itself reads the find-links.

## Cost

While this is in, a PR that edits a requirements file without regenerating its lock can merge. The pip-compile guard still covers `requirements_compiled.txt`, and the window should be short.

## Revert when

`raydepsets: compile all dependencies` is green on a master postmerge build. Track pyg-team/pyg-lib#719.
