### PR TITLE
[core] fix typo: prom_addreses -> prom_addresses

### DIFF
--- a/python/ray/_common/test_utils.py
+++ b/python/ray/_common/test_utils.py
@@ -544,12 +544,12 @@ def fetch_prometheus(prom_addresses, timeout=None):
 
 
 def fetch_prometheus_timeseries(
-    prom_addreses: List[str],
+    prom_addresses: List[str],
     result: PrometheusTimeseries,
     timeout=None,
 ) -> PrometheusTimeseries:
     components_dict, metric_descriptors, metric_samples = fetch_prometheus(
-        prom_addreses, timeout=timeout
+        prom_addresses, timeout=timeout
     )
     for address, components in components_dict.items():
         if address not in result.components_dict:


### PR DESCRIPTION
Fixes #60874

The parameter name in `fetch_prometheus_timeseries` was misspelled as `prom_addreses` instead of `prom_addresses`. Fixed both occurrences in `python/ray/_common/test_utils.py`:
- Line 547: function parameter declaration
- Line 552: call to `fetch_prometheus()`