### PR TITLE
[llm][SGLang] Remove signal handler override from SGLang engine

### DIFF
--- a/python/ray/llm/_internal/serve/engines/sglang/sglang_engine.py
+++ b/python/ray/llm/_internal/serve/engines/sglang/sglang_engine.py
@@ -11,7 +11,6 @@ provide feedback at https://github.com/ray-project/ray/issues/61114.
 import copy
 import json
 import logging
-import signal
 import time
 import uuid
 from typing import (
@@ -133,20 +132,6 @@ class SGLangServer:
                     "deployment/replica labels."
                 )
 
-        # TODO(issue-61108): remove this once sglang#18752 is merged and included
-        # in the minimum supported SGLang version for this example.
-        original_signal_func = signal.signal
-
-        def noop_signal_handler(sig, action):
-            # Returns default handler to satisfy signal.signal() return signature
-            return signal.SIG_DFL
-
-        try:
-            # Override signal.signal with our no-op function
-            signal.signal = noop_signal_handler
-            self.engine = Engine(**self.engine_kwargs)
-        finally:
-            signal.signal = original_signal_func
 
     @staticmethod
     def _build_sampling_params(request: Any) -> dict[str, Any]:

--- a/python/ray/llm/_internal/serve/engines/sglang/sglang_engine.py
+++ b/python/ray/llm/_internal/serve/engines/sglang/sglang_engine.py
@@ -132,6 +132,7 @@ class SGLangServer:
                     "deployment/replica labels."
                 )
 
+        self.engine = Engine(**self.engine_kwargs)
 
     @staticmethod
     def _build_sampling_params(request: Any) -> dict[str, Any]:


### PR DESCRIPTION
Fixes #61894

Remove the temporary signal handler workaround now that sglang#18752 has been upstreamed.

Changes:
- Removed the `noop_signal_handler` block from `SGLangServer.__init__` (lines 136-149)
- Removed the now-unused `import signal`

This workaround was introduced to bypass SGLang's signal handler during engine initialization. With the upstream fix in sglang#18752, the workaround is no longer needed.