### PR TITLE
[Data] [1/4] Add `generated_id_column` to CheckpointConfig with V2 Parquet row-group IDs

### DIFF
--- a/python/ray/data/_internal/datasource_v2/parquet_datasource_v2.py
+++ b/python/ray/data/_internal/datasource_v2/parquet_datasource_v2.py
@@ -35,6 +35,10 @@ from ray.data._internal.datasource_v2.readers.in_memory_size_estimator import (
 )
 from ray.data._internal.datasource_v2.scanners.parquet_scanner import ParquetScanner
 from ray.data._internal.util import _is_local_scheme
+from ray.data.checkpoint.generated_id import (
+    GENERATED_ID_COLUMN_TYPE,
+    get_generated_id_column_name,
+)
 from ray.data.context import DataContext
 from ray.data.datasource.partitioning import (
     Partitioning,
@@ -334,6 +338,12 @@ class ParquetDatasourceV2(DataSourceV2[FileManifest]):
                 schema = schema.append(pa.field("row_hash", pa.uint64()))
             elif schema.field(idx).type != pa.uint64():
                 schema = schema.set(idx, pa.field("row_hash", pa.uint64()))
+
+        generated_id = get_generated_id_column_name()
+        if generated_id and schema.get_field_index(generated_id) == -1:
+            # Synthesized post-read for generated-ID checkpointing; a
+            # colliding on-disk column is rejected at read time.
+            schema = schema.append(pa.field(generated_id, GENERATED_ID_COLUMN_TYPE))
 
         check_for_legacy_tensor_type(schema)
         return schema

--- a/python/ray/data/_internal/datasource_v2/readers/file_reader.py
+++ b/python/ray/data/_internal/datasource_v2/readers/file_reader.py
@@ -12,6 +12,7 @@ from ray.data._internal.datasource.parquet_datasource import _compute_row_hashes
 from ray.data._internal.datasource_v2.listing.file_manifest import FileManifest
 from ray.data._internal.datasource_v2.readers.base_reader import Reader
 from ray.data._internal.util import iterate_with_retry, make_async_gen
+from ray.data.checkpoint.generated_id import get_generated_id_column_name
 from ray.data.context import DataContext
 from ray.data.datasource.partitioning import Partitioning, PathPartitionParser
 from ray.data.expressions import Expr
@@ -155,6 +156,11 @@ class FileReader(Reader[FileManifest]):
             # file already carries a ``row_hash`` column. Strip it from the
             # dataset schema so pyarrow doesn't try to cast.
             synthesized.add(ROW_HASH_COLUMN_NAME)
+
+        generated_id = get_generated_id_column_name()
+        if generated_id:
+            synthesized.add(generated_id)
+
         fields = [
             f
             for f in self._schema
@@ -294,6 +300,7 @@ class FileReader(Reader[FileManifest]):
                     ROW_HASH_COLUMN_NAME, pa.array(hashes, type=pa.uint64())
                 )
 
+            generated_id = get_generated_id_column_name()
             if self._columns is not None:
                 # Project/reorder to the caller's requested column order;
                 # drop any that weren't produced (matches V1's lenient
@@ -302,6 +309,12 @@ class FileReader(Reader[FileManifest]):
                 # guard below handles row preservation.
                 produced = set(table.column_names)
                 projected = [c for c in self._columns if c in produced]
+                if (
+                    generated_id
+                    and generated_id in produced
+                    and generated_id not in projected
+                ):
+                    projected.append(generated_id)
                 table = table.select(projected)
 
             if table.num_columns == 0 and table.num_rows > 0:

--- a/python/ray/data/_internal/datasource_v2/readers/parquet_file_reader.py
+++ b/python/ray/data/_internal/datasource_v2/readers/parquet_file_reader.py
@@ -1,6 +1,7 @@
 import logging
 import math
 from concurrent.futures import ThreadPoolExecutor
+from functools import partial
 from typing import TYPE_CHECKING, Any, Dict, Iterator, List, Optional, Set, Tuple
 
 import pyarrow as pa
@@ -18,6 +19,7 @@ from ray.data._internal.datasource.parquet_datasource import (
 )
 from ray.data._internal.datasource_v2.chunkers.parquet_file_chunking_utils import (
     _fragments_from_row_group_ids,
+    _with_io_retry,
 )
 from ray.data._internal.datasource_v2.listing.file_manifest import FileManifest
 from ray.data._internal.datasource_v2.listing.footer_reader import _leaf_matches
@@ -34,8 +36,13 @@ from ray.data._internal.datasource_v2.readers.supports_metadata import (
     SupportsMetadata,
 )
 from ray.data._internal.object_extensions.arrow import raise_on_pickle_object_columns
-from ray.data._internal.util import MiB
+from ray.data._internal.util import MiB, iterate_with_retry
 from ray.data.block import BlockMetadata
+from ray.data.checkpoint.generated_id import (
+    get_generated_id_column,
+    get_generated_id_column_name,
+)
+from ray.data.context import DataContext
 from ray.data.expressions import Expr
 from ray.util.annotations import DeveloperAPI
 from ray.util.debug import log_once
@@ -348,10 +355,14 @@ class ParquetFileReader(FileReader, SupportsMetadata):
           (predicate pruning + bin packing already happened in ``ListFiles``);
           we slice the fragment via
           :func:`~ray.data._internal.datasource_v2.chunkers.parquet_file_chunking_utils._fragments_from_row_group_ids`.
-          When ``include_row_hash`` is on it fans out one sub-fragment per row
-          group, each paired with its cumulative pre-filter row offset, so the
-          downstream ``_compute_row_hashes`` call keeps hashes unique across
-          sub-fragments that share ``fragment.path``.
+          When ``include_row_hash`` or a generated ID column is on it fans
+          out one sub-fragment per row group, each paired with its cumulative
+          pre-filter row offset. For row hashes this keeps
+          ``_compute_row_hashes`` keys unique across sub-fragments that share
+          ``fragment.path``; for generated IDs it establishes the
+          one-row-group-per-fragment invariant
+          :meth:`_read_fragments_sequential` relies on to derive stable
+          ``(file, row group, row)`` identifiers.
 
         Paths are deduped by :meth:`FileReader.read` before the dataset is
         built, so the dataset has exactly one fragment per file. The
@@ -362,17 +373,36 @@ class ParquetFileReader(FileReader, SupportsMetadata):
         path_to_fragment = {
             fragment.path: fragment for fragment in dataset.get_fragments()
         }
+
+        generated_id_column = self._generated_id_column
+        if generated_id_column is not None:
+            self._validate_generated_id_column(path_to_fragment)
+
+        split_per_row_group = self._include_row_hash or generated_id_column is not None
         fragments: List[Tuple[pds.Fragment, int]] = []
         for path, chunk_metadata in zip(manifest.paths, manifest.file_chunk_metadatas):
             fragment: pds.ParquetFileFragment = path_to_fragment[path]
             if chunk_metadata is None:
-                fragments.append((fragment, 0))
+                if split_per_row_group:
+                    num_row_groups = _with_io_retry(
+                        lambda: fragment.metadata.num_row_groups,
+                        f"read parquet metadata for {fragment.path}",
+                    )
+                    fragments.extend(
+                        _fragments_from_row_group_ids(
+                            fragment,
+                            range(num_row_groups),
+                            per_row_group_offsets=True,
+                        )
+                    )
+                else:
+                    fragments.append((fragment, 0))
             else:
                 fragments.extend(
                     _fragments_from_row_group_ids(
                         fragment,
                         chunk_metadata["row_group_ids"],
-                        per_row_group_offsets=self._include_row_hash,
+                        per_row_group_offsets=split_per_row_group,
                     )
                 )
         return fragments
@@ -636,3 +666,95 @@ class ParquetFileReader(FileReader, SupportsMetadata):
     @override
     def get_target_metadata_batch_size(self) -> Optional[int]:
         return self._COUNT_ROWS_BATCH_SIZE
+
+    @property
+    def _generated_id_column(self) -> Optional[str]:
+        """Name of the checkpointing-generated ID column, if configured."""
+        return get_generated_id_column_name()
+
+    def _validate_generated_id_column(
+        self, path_to_fragment: Dict[str, pds.ParquetFileFragment]
+    ) -> None:
+        """Raise if the configured generated ID column already exists on-disk.
+
+        The generated ID column is synthesized by the reader; a physical
+        column with the same name would be silently shadowed, so fail fast.
+        Checked once per read against a single fragment — ``FileReader.read``
+        builds the dataset with a unified schema, so one file is
+        representative.
+        """
+        generated_id_column = self._generated_id_column
+        if not path_to_fragment:
+            return
+        first_fragment = next(iter(path_to_fragment.values()))
+        physical_schema = _with_io_retry(
+            lambda: first_fragment.physical_schema,
+            f"read physical schema for {first_fragment.path}",
+        )
+        if physical_schema.get_field_index(generated_id_column) >= 0:
+            raise ValueError(
+                f"generated_id_column='{generated_id_column}' conflicts with an "
+                "existing column in the dataset. Choose a name that doesn't "
+                "collide with any input column."
+            )
+
+    @override
+    def _read_fragments_sequential(
+        self,
+        fragments_with_offsets: Iterator[Tuple[pds.Fragment, int]],
+        scanner_kwargs: dict,
+    ) -> Iterator[Tuple[pa.Table, str, int]]:
+        """Read fragments in order, attaching generated row IDs when configured.
+
+        Without a generated ID column this delegates to the base
+        implementation. With one, every incoming fragment must carry exactly
+        one row group (established by :meth:`_get_fragments_to_read`), and
+        each yielded batch gains a struct ID column identifying
+        ``(file, row group, row)``. ``in_group_offset`` counts rows already
+        emitted for this row group so ``row_id`` continues across batches,
+        while the yielded offset keeps the base method's file-row-offset
+        semantics for row hashing.
+        """
+        generated_id_column = self._generated_id_column
+        if generated_id_column is None:
+            yield from super()._read_fragments_sequential(
+                fragments_with_offsets, scanner_kwargs
+            )
+            return
+
+        ctx = DataContext.get_current()
+        for fragment, file_row_offset in fragments_with_offsets:
+            assert fragment.row_groups is not None and len(fragment.row_groups) == 1, (
+                "generated_id_column requires one row group per fragment, "
+                f"got {fragment.row_groups!r} for {fragment.path}"
+            )
+            row_group_idx = fragment.row_groups[0].id
+            fragment_metadata = _with_io_retry(
+                lambda: fragment.metadata,
+                f"read parquet metadata for {fragment.path}",
+            )
+            num_row_groups = fragment_metadata.num_row_groups
+            rg_num_rows = fragment_metadata.row_group(row_group_idx).num_rows
+            in_group_offset = 0
+            hash_offset = file_row_offset
+            for table in iterate_with_retry(
+                partial(self._iter_fragment_tables, fragment, scanner_kwargs),
+                f"read fragment {fragment.path}",
+                match=ctx.retried_io_errors,
+            ):
+                if table.num_rows == 0:
+                    continue
+                table = table.append_column(
+                    generated_id_column,
+                    get_generated_id_column(
+                        path=fragment.path,
+                        row_group_idx=row_group_idx,
+                        num_row_groups=num_row_groups,
+                        total_num_rows=rg_num_rows,
+                        current_row_offset=in_group_offset,
+                        current_num_rows=table.num_rows,
+                    ),
+                )
+                yield table, fragment.path, hash_offset
+                in_group_offset += table.num_rows
+                hash_offset += table.num_rows

--- a/python/ray/data/_internal/datasource_v2/scanners/parquet_scanner.py
+++ b/python/ray/data/_internal/datasource_v2/scanners/parquet_scanner.py
@@ -16,6 +16,10 @@ from ray.data._internal.datasource_v2.readers.parquet_file_reader import (
 from ray.data._internal.datasource_v2.scanners.arrow_file_scanner import (
     ArrowFileScanner,
 )
+from ray.data.checkpoint.generated_id import (
+    GENERATED_ID_COLUMN_TYPE,
+    get_generated_id_column_name,
+)
 from ray.util.annotations import DeveloperAPI
 
 
@@ -62,6 +66,10 @@ class ParquetScanner(ArrowFileScanner):
             if schema.get_field_index(name) != -1:
                 continue
             schema = schema.append(pa.field(name, dtype))
+
+        generated_id = get_generated_id_column_name()
+        if generated_id and schema.get_field_index(generated_id) == -1:
+            schema = schema.append(pa.field(generated_id, GENERATED_ID_COLUMN_TYPE))
 
         check_for_legacy_tensor_type(schema)
         return schema

--- a/python/ray/data/_internal/datasource_v2/tests/test_generated_id_reads.py
+++ b/python/ray/data/_internal/datasource_v2/tests/test_generated_id_reads.py
@@ -1,0 +1,177 @@
+"""Unit tests for generated-ID attachment in the V2 Parquet reader.
+
+Exercises :mod:`ray.data.checkpoint.generated_id` wiring through
+:class:`ParquetFileReader` directly against a local tmpdir — these tests do
+not spin up Ray. The generated ID column is configured ambiently through
+``DataContext.checkpoint_config``, mirroring how the planner-side code reads
+it.
+"""
+
+import os
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+
+from ray.data._internal.datasource_v2.listing.file_manifest import FileManifest
+from ray.data._internal.datasource_v2.parquet_datasource_v2 import ParquetDatasourceV2
+from ray.data._internal.datasource_v2.readers.parquet_file_reader import (
+    ParquetFileReader,
+)
+from ray.data.checkpoint import CheckpointConfig
+from ray.data.checkpoint.generated_id import (
+    FILE_NAME_FIELD,
+    FRAGMENT_FIELD,
+    GENERATED_ID_COLUMN_TYPE,
+    NUM_FRAGMENTS_FIELD,
+    NUM_ROWS_FIELD,
+    ROW_ID_FIELD,
+)
+from ray.data.context import DataContext
+from ray.data.expressions import col
+
+GEN_ID_COL = "__test_gen_id"
+
+
+@pytest.fixture
+def generated_id_checkpoint_config(tmp_path):
+    """Install a generated-ID ``CheckpointConfig`` on the current context."""
+    ctx = DataContext.get_current()
+    original = ctx.checkpoint_config
+    ctx.checkpoint_config = CheckpointConfig(
+        generated_id_column=GEN_ID_COL,
+        checkpoint_path=str(tmp_path / "checkpoint"),
+    )
+    yield ctx.checkpoint_config
+    ctx.checkpoint_config = original
+
+
+def _write_parquet(path: str, num_rows: int, row_group_size: int, offset: int = 0):
+    table = pa.table({"x": list(range(offset, offset + num_rows))})
+    pq.write_table(table, path, row_group_size=row_group_size)
+
+
+def _whole_file_manifest(paths):
+    return FileManifest.construct_manifest(
+        paths=paths,
+        sizes=[os.path.getsize(p) for p in paths],
+        chunk_metadatas=[None] * len(paths),
+    )
+
+
+def _id_tuples(table: pa.Table):
+    """Extract ``(file_name, fragment, row_id)`` per row from the ID column."""
+    ids = table.column(GEN_ID_COL).to_pylist()
+    return [(v[FILE_NAME_FIELD], v[FRAGMENT_FIELD], v[ROW_ID_FIELD]) for v in ids]
+
+
+def test_ids_unique_across_files_and_row_groups(
+    tmp_path, generated_id_checkpoint_config
+):
+    paths = []
+    for f in range(2):
+        path = str(tmp_path / f"f{f}.parquet")
+        # 6 rows in 2 row groups of 3.
+        _write_parquet(path, num_rows=6, row_group_size=3, offset=f * 100)
+        paths.append(path)
+
+    tables = list(ParquetFileReader().read(_whole_file_manifest(paths)))
+    combined = pa.concat_tables(tables)
+    assert combined.num_rows == 12
+
+    assert combined.schema.field(GEN_ID_COL).type == GENERATED_ID_COLUMN_TYPE
+    triples = _id_tuples(combined)
+    assert len(set(triples)) == 12
+
+    for id_value in combined.column(GEN_ID_COL).to_pylist():
+        assert id_value[NUM_FRAGMENTS_FIELD] == 2
+        assert id_value[NUM_ROWS_FIELD] == 3
+        assert id_value[FRAGMENT_FIELD] in (0, 1)
+        assert 0 <= id_value[ROW_ID_FIELD] < 3
+
+
+def test_row_id_continues_across_batches_within_row_group(
+    tmp_path, generated_id_checkpoint_config
+):
+    path = str(tmp_path / "data.parquet")
+    # One row group of 6 rows, read in batches of 2.
+    _write_parquet(path, num_rows=6, row_group_size=6)
+
+    reader = ParquetFileReader(batch_size=2)
+    tables = list(reader.read(_whole_file_manifest([path])))
+    combined = pa.concat_tables(tables)
+    row_ids = [v[ROW_ID_FIELD] for v in combined.column(GEN_ID_COL).to_pylist()]
+    assert row_ids == list(range(6))
+
+
+def test_collision_with_existing_column_raises(
+    tmp_path, generated_id_checkpoint_config
+):
+    path = str(tmp_path / "data.parquet")
+    pq.write_table(pa.table({"x": [1, 2], GEN_ID_COL: [1, 2]}), path)
+
+    with pytest.raises(ValueError, match="conflicts with an existing"):
+        list(ParquetFileReader().read(_whole_file_manifest([path])))
+
+
+def test_filter_pushdown_positions_are_deterministic(
+    tmp_path, generated_id_checkpoint_config
+):
+    """With a pushed-down predicate, ``row_id`` indexes the *filtered* stream.
+
+    IDs are attached after the pyarrow scanner applies the predicate
+    (matching RayTurbo's reader), so a resumed run with the same pipeline
+    deterministically reassigns the same IDs. ``num_rows`` still reports the
+    on-disk row-group size, so a filtered row group can never be marked
+    fully checkpointed and is re-read (then row-filtered) on resume.
+    """
+    path = str(tmp_path / "data.parquet")
+    # One row group: x = 0..5. Keep x >= 3 -> filtered-stream positions 0..2.
+    _write_parquet(path, num_rows=6, row_group_size=6)
+
+    def _read():
+        reader = ParquetFileReader(predicate=col("x") >= 3)
+        return pa.concat_tables(reader.read(_whole_file_manifest([path])))
+
+    combined = _read()
+    assert combined.column("x").to_pylist() == [3, 4, 5]
+    ids = combined.column(GEN_ID_COL).to_pylist()
+    assert [v[ROW_ID_FIELD] for v in ids] == [0, 1, 2]
+    # On-disk row-group size, not the filtered count.
+    assert all(v[NUM_ROWS_FIELD] == 6 for v in ids)
+    # Deterministic across identical runs (the resume correctness contract).
+    assert _read().column(GEN_ID_COL).to_pylist() == ids
+
+
+def test_column_projection_keeps_generated_id(tmp_path, generated_id_checkpoint_config):
+    path = str(tmp_path / "data.parquet")
+    _write_parquet(path, num_rows=4, row_group_size=4)
+
+    reader = ParquetFileReader(columns=["x"])
+    combined = pa.concat_tables(reader.read(_whole_file_manifest([path])))
+    assert set(combined.column_names) == {"x", GEN_ID_COL}
+
+
+def test_infer_schema_advertises_generated_id(tmp_path, generated_id_checkpoint_config):
+    path = str(tmp_path / "data.parquet")
+    _write_parquet(path, num_rows=4, row_group_size=4)
+
+    datasource = ParquetDatasourceV2([path])
+    schema = datasource.infer_schema(_whole_file_manifest([path]))
+    assert schema.field(GEN_ID_COL).type == GENERATED_ID_COLUMN_TYPE
+
+
+def test_reads_unaffected_without_config(tmp_path):
+    path = str(tmp_path / "data.parquet")
+    _write_parquet(path, num_rows=4, row_group_size=2)
+
+    assert DataContext.get_current().checkpoint_config is None
+    combined = pa.concat_tables(ParquetFileReader().read(_whole_file_manifest([path])))
+    assert combined.column_names == ["x"]
+    assert combined.num_rows == 4
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main(["-v", __file__]))

--- a/python/ray/data/_internal/planner/planner.py
+++ b/python/ray/data/_internal/planner/planner.py
@@ -5,6 +5,8 @@ from typing import TYPE_CHECKING, Callable, Dict, List, Optional, Tuple, Type, T
 if TYPE_CHECKING:
     import pyarrow.fs
 
+    from ray.data.checkpoint import CheckpointConfig
+
 from ray.data._internal.execution.execution_callback import ExecutionCallback
 from ray.data._internal.execution.interfaces import PhysicalOperator
 from ray.data._internal.execution.operators.aggregate_num_rows import (
@@ -286,7 +288,7 @@ class Planner:
             # Dynamically set the plan functions for checkpointing because they
             # need to a reference to the checkpoint ref.
             self._plan_fns_for_checkpointing = self._get_plan_fns_for_checkpointing(
-                data_file_dir, data_file_fs
+                checkpoint_config, data_file_dir, data_file_fs
             )
 
         elif checkpoint_config is not None:
@@ -389,9 +391,17 @@ class Planner:
 
     def _get_plan_fns_for_checkpointing(
         self,
+        checkpoint_config: "CheckpointConfig",
         data_file_dir: Optional[str] = None,
         data_file_filesystem: Optional["pyarrow.fs.FileSystem"] = None,
     ) -> Dict[Type[LogicalOperator], PlanLogicalOpFn]:
+        if getattr(checkpoint_config, "has_generated_id_column", False):
+            # Generated struct IDs can't go through the numpy-based
+            # checkpoint filter, so only the write side is planned: a rerun
+            # re-reads every row (at-least-once) instead of restoring.
+            # Restore routing for generated IDs is planned via ListFiles once
+            # the row-group skip machinery exists.
+            return {Write: plan_write_op_with_checkpoint_writer}
         plan_fns = {
             Read: partial(
                 plan_read_op_with_checkpoint_filter, data_file_dir, data_file_filesystem

--- a/python/ray/data/_internal/planner/planner.py
+++ b/python/ray/data/_internal/planner/planner.py
@@ -285,6 +285,18 @@ class Planner:
 
             callbacks.append(checkpoint_callback)
 
+            if (
+                getattr(checkpoint_config, "has_generated_id_column", False)
+                and data_file_dir is not None
+            ):
+                # The id_column path cleans up pending checkpoints (and their
+                # partially written data files) inside checkpoint load, which
+                # the generated-ID path doesn't plan. Clean here instead so a
+                # retry after a mid-write crash doesn't leave stale output.
+                self._clean_pending_checkpoints(
+                    checkpoint_config, logical_plan.context, data_file_dir, data_file_fs
+                )
+
             # Dynamically set the plan functions for checkpointing because they
             # need to a reference to the checkpoint ref.
             self._plan_fns_for_checkpointing = self._get_plan_fns_for_checkpointing(
@@ -388,6 +400,24 @@ class Planner:
             if isinstance(datasink, _FileDatasink):
                 return datasink.unresolved_path, datasink.filesystem
         return None, None
+
+    @staticmethod
+    def _clean_pending_checkpoints(
+        checkpoint_config: "CheckpointConfig",
+        data_context: DataContext,
+        data_file_dir: str,
+        data_file_filesystem: Optional["pyarrow.fs.FileSystem"],
+    ) -> None:
+        """Delete pending checkpoints and their partially written data files."""
+        # Lazy import: ``checkpoint_filter`` participates in an import cycle
+        # with ``ray.data.context``.
+        from ray.data.checkpoint.checkpoint_filter import IdColumnCheckpointManager
+
+        manager_cls = (
+            checkpoint_config.checkpoint_manager_cls or IdColumnCheckpointManager
+        )
+        manager = manager_cls(checkpoint_config, data_context)
+        manager._clean_pending_checkpoints(data_file_dir, data_file_filesystem)
 
     def _get_plan_fns_for_checkpointing(
         self,

--- a/python/ray/data/checkpoint/generated_id.py
+++ b/python/ray/data/checkpoint/generated_id.py
@@ -1,0 +1,93 @@
+"""Stable Parquet row IDs used by generated_id_column checkpointing."""
+
+import os
+from typing import Optional
+
+import numpy as np
+import pyarrow as pa
+import pyarrow.compute as pc
+
+from ray.data.context import DataContext
+
+PATH_PREFIX_FIELD = "path_prefix"
+FILE_NAME_FIELD = "file_name"
+FRAGMENT_FIELD = "fragment"
+NUM_FRAGMENTS_FIELD = "num_fragments"
+NUM_ROWS_FIELD = "num_rows"
+ROW_ID_FIELD = "row_id"
+
+GENERATED_ID_COLUMN_FIELD_NAMES = [
+    PATH_PREFIX_FIELD,
+    FILE_NAME_FIELD,
+    FRAGMENT_FIELD,
+    NUM_FRAGMENTS_FIELD,
+    NUM_ROWS_FIELD,
+    ROW_ID_FIELD,
+]
+
+GENERATED_ID_COLUMN_FIELDS = {
+    PATH_PREFIX_FIELD: pa.dictionary(pa.int32(), pa.string()),
+    FILE_NAME_FIELD: pa.dictionary(pa.int32(), pa.string()),
+    FRAGMENT_FIELD: pa.dictionary(pa.int32(), pa.int32()),
+    NUM_FRAGMENTS_FIELD: pa.dictionary(pa.int32(), pa.int32()),
+    NUM_ROWS_FIELD: pa.dictionary(pa.int32(), pa.int32()),
+    ROW_ID_FIELD: pa.int32(),
+}
+
+GENERATED_ID_COLUMN_TYPE = pa.struct(
+    [
+        pa.field(name, GENERATED_ID_COLUMN_FIELDS[name], nullable=False)
+        for name in GENERATED_ID_COLUMN_FIELD_NAMES
+    ]
+)
+
+
+def get_generated_id_column_name() -> Optional[str]:
+    ctx = DataContext.get_current()
+    config = getattr(ctx, "checkpoint_config", None)
+    return getattr(config, "generated_id_column", None)
+
+
+def get_generated_id_column(
+    path: str,
+    row_group_idx: int,
+    num_row_groups: int,
+    total_num_rows: int,
+    current_row_offset: int,
+    current_num_rows: int,
+) -> pa.Array:
+    """One struct ID per row in this batch.
+
+    ``row_id`` is the position inside this row group, starting at 0.
+    ``current_row_offset`` is how many rows of this group were already
+    emitted, so the next batch continues the count.
+    """
+    path_prefix = os.path.dirname(path)
+    file_name = os.path.basename(path)
+    row_ids = np.arange(current_row_offset, current_row_offset + current_num_rows)
+
+    def _field(name: str) -> pa.Array:
+        if name == ROW_ID_FIELD:
+            return pa.array(row_ids, type=pa.int32())
+        fill = {
+            PATH_PREFIX_FIELD: path_prefix,
+            FILE_NAME_FIELD: file_name,
+            FRAGMENT_FIELD: row_group_idx,
+            NUM_FRAGMENTS_FIELD: num_row_groups,
+            NUM_ROWS_FIELD: total_num_rows,
+        }[name]
+        base_type = (
+            pa.string() if name in (PATH_PREFIX_FIELD, FILE_NAME_FIELD) else pa.int32()
+        )
+        return pc.dictionary_encode(
+            pc.fill_null(pa.nulls(current_num_rows, type=base_type), fill)
+        )
+
+    fields = [
+        pa.field(name, dtype, nullable=False)
+        for name, dtype in GENERATED_ID_COLUMN_FIELDS.items()
+    ]
+    return pa.StructArray.from_arrays(
+        [_field(name) for name in GENERATED_ID_COLUMN_FIELD_NAMES],
+        fields=fields,
+    )

--- a/python/ray/data/checkpoint/generated_id.py
+++ b/python/ray/data/checkpoint/generated_id.py
@@ -5,7 +5,6 @@ from typing import Optional
 
 import numpy as np
 import pyarrow as pa
-import pyarrow.compute as pc
 
 from ray.data.context import DataContext
 
@@ -79,8 +78,11 @@ def get_generated_id_column(
         base_type = (
             pa.string() if name in (PATH_PREFIX_FIELD, FILE_NAME_FIELD) else pa.int32()
         )
-        return pc.dictionary_encode(
-            pc.fill_null(pa.nulls(current_num_rows, type=base_type), fill)
+        # Constant column: a one-element dictionary with repeated index 0 is
+        # cheaper than materializing and encoding N copies of the value.
+        return pa.DictionaryArray.from_arrays(
+            indices=np.zeros(current_num_rows, dtype=np.int32),
+            dictionary=pa.array([fill], type=base_type),
         )
 
     fields = [

--- a/python/ray/data/checkpoint/interfaces.py
+++ b/python/ray/data/checkpoint/interfaces.py
@@ -86,6 +86,10 @@ class CheckpointConfig:
             If the latter, the path must be a network-mounted file system (e.g.
             `/mnt/cluster_storage/`) that is accessible to the entire cluster.
             If not set, defaults to `RAY_DATA_CHECKPOINT_PATH_BUCKET/ray_data_checkpoint`.
+        generated_id_column: Name of the ID column to generate a row ID for each row.
+            Use this when you don't have an `id_column` in the input dataset.
+            Currently, only Parquet files based data sources are supported for
+            auto-generated row IDs feature.
         delete_checkpoint_on_success: If true, automatically delete checkpoint
             data when the dataset execution succeeds. Only supported for
             batch-based backend currently.
@@ -128,6 +132,7 @@ class CheckpointConfig:
         id_column: Optional[str] = None,
         checkpoint_path: Optional[str] = None,
         *,
+        generated_id_column: Optional[str] = None,
         delete_checkpoint_on_success: bool = True,
         override_filesystem: Optional["pyarrow.fs.FileSystem"] = None,
         override_backend: Optional[CheckpointBackend] = None,
@@ -136,6 +141,30 @@ class CheckpointConfig:
         checkpoint_filter_cls: Optional[Type["CheckpointFilter"]] = None,
         checkpoint_manager_cls: Optional[Type["CheckpointManager"]] = None,
     ):
+        self.generated_id_column: Optional[str] = generated_id_column
+
+        # Validate that we don't have both `id_column` and `generated_id_column`
+        # explicitly specified
+        if id_column is not None and generated_id_column is not None:
+            raise InvalidCheckpointingConfig(
+                "Cannot specify both `id_column` and `generated_id_column`. "
+                "Use `id_column` when you have an existing ID column in your dataset, "
+                "or use `generated_id_column` when you want to generate row IDs "
+                "automatically."
+            )
+
+        # If no `id_column` is provided, use the generated row ID column
+        elif id_column is None and generated_id_column is None:
+            raise InvalidCheckpointingConfig(
+                "Either `id_column` or `generated_id_column` must be provided. "
+                "Use `id_column` when you have an existing ID column in your dataset, "
+                "or use `generated_id_column` when you want to generate row IDs "
+                "automatically."
+            )
+        elif id_column is None:
+            # Use generated_id_column as the id_column
+            id_column = generated_id_column
+
         self.id_column: Optional[str] = id_column
 
         if not isinstance(self.id_column, str) or len(self.id_column) == 0:
@@ -226,6 +255,16 @@ class CheckpointConfig:
             raise InvalidCheckpointingConfig(
                 f"Invalid checkpoint path: {checkpoint_path}. "
             ) from e
+
+    @property
+    def has_generated_id_column(self) -> bool:
+        """Whether this config uses auto-generated row IDs."""
+        return self.generated_id_column is not None
+
+
+def is_generated_id_checkpoint(config: Optional["CheckpointConfig"]) -> bool:
+    """Whether ``config`` uses auto-generated row IDs (None-safe)."""
+    return getattr(config, "has_generated_id_column", False)
 
 
 @DeveloperAPI

--- a/python/ray/data/checkpoint/interfaces.py
+++ b/python/ray/data/checkpoint/interfaces.py
@@ -262,11 +262,6 @@ class CheckpointConfig:
         return self.generated_id_column is not None
 
 
-def is_generated_id_checkpoint(config: Optional["CheckpointConfig"]) -> bool:
-    """Whether ``config`` uses auto-generated row IDs (None-safe)."""
-    return getattr(config, "has_generated_id_column", False)
-
-
 @DeveloperAPI
 class InvalidCheckpointingConfig(Exception):
     """Exception which indicates that the checkpointing

--- a/python/ray/data/tests/test_checkpoint.py
+++ b/python/ray/data/tests/test_checkpoint.py
@@ -416,6 +416,48 @@ def test_generated_id_rerun_rereads_all_rows(
     assert sorted(result[ID_COL].to_pylist()) == list(range(SAMPLE_DATA_NUM_ROWS))
 
 
+def test_generated_id_pending_cleanup_before_rerun(
+    ray_start_10_cpus_shared, generate_sample_data_parquet, tmp_path
+):
+    """Pending-checkpoint cleanup doesn't depend on the ID type: a generated-ID
+    rerun after a mid-write crash must delete leftover pending checkpoints and
+    their partially written data files before writing again."""
+    ctx = ray.data.DataContext.get_current()
+    ckpt_path = os.path.join(tmp_path, "generated_id_ckpt")
+    out = os.path.join(tmp_path, "out")
+    ctx.checkpoint_config = CheckpointConfig(
+        checkpoint_path=ckpt_path,
+        generated_id_column="generated_id_col",
+        delete_checkpoint_on_success=False,
+    )
+    f_dir = generate_sample_data_parquet()
+
+    ray.data.read_parquet(f_dir).write_parquet(out)
+    committed_before = {
+        f
+        for f in os.listdir(ckpt_path)
+        if f.endswith(".parquet") and ".pending" not in f
+    }
+    assert committed_before
+
+    # Simulate a crashed run: a pending checkpoint whose 2PC never committed,
+    # plus the matching partially written data file.
+    stale_base = "crashed_write_0000"
+    pq.write_table(
+        pa.table({"generated_id_col": ["fake"]}),
+        os.path.join(ckpt_path, f"{stale_base}{PENDING_CHECKPOINT_SUFFIX}.parquet"),
+    )
+    stale_data_file = os.path.join(out, f"{stale_base}.parquet")
+    pq.write_table(pa.table({ID_COL: [-1]}), stale_data_file)
+
+    ray.data.read_parquet(f_dir).write_parquet(out)
+
+    remaining = os.listdir(ckpt_path)
+    assert not any(PENDING_CHECKPOINT_SUFFIX in f for f in remaining)
+    assert committed_before <= set(remaining)
+    assert not os.path.exists(stale_data_file)
+
+
 @pytest.mark.parametrize(
     "backend,fs,data_path",
     [

--- a/python/ray/data/tests/test_checkpoint.py
+++ b/python/ray/data/tests/test_checkpoint.py
@@ -362,6 +362,60 @@ class TestCheckpointConfig:
                 CheckpointConfig(ID_COL, local_path, checkpoint_filter_cls=cls)
 
 
+def _collect_physical_op_names(physical_plan) -> List[str]:
+    names = []
+    to_visit = [physical_plan.dag]
+    while to_visit:
+        op = to_visit.pop()
+        names.append(op.name)
+        to_visit.extend(op.input_dependencies)
+    return names
+
+
+def test_generated_id_rerun_rereads_all_rows(
+    ray_start_10_cpus_shared, generate_sample_data_parquet, tmp_path
+):
+    """Generated struct IDs can't go through the numpy-based restore path, so
+    only the write side is planned: a rerun that finds committed checkpoint
+    files must re-read every row (at-least-once) instead of crashing during
+    checkpoint load."""
+    ctx = ray.data.DataContext.get_current()
+    ckpt_path = os.path.join(tmp_path, "generated_id_ckpt")
+    ctx.checkpoint_config = CheckpointConfig(
+        checkpoint_path=ckpt_path,
+        generated_id_column="generated_id_col",
+        # Keep the committed checkpoint so the second run sees it.
+        delete_checkpoint_on_success=False,
+    )
+    f_dir = generate_sample_data_parquet()
+
+    ray.data.read_parquet(f_dir).write_parquet(os.path.join(tmp_path, "out1"))
+
+    committed = [
+        f
+        for f in os.listdir(ckpt_path)
+        if f.endswith(".parquet") and ".pending" not in f
+    ]
+    assert committed, "first run should have committed checkpoint files"
+
+    # No filter op is planned for generated IDs; the checkpoint is only written.
+    ds = ray.data.read_parquet(f_dir)
+    write_op = Write(
+        ParquetDatasink(os.path.join(tmp_path, "unused")),
+        input_dependencies=[ds._logical_plan.dag],
+    )
+    physical_plan, _ = get_execution_plan(LogicalPlan(write_op, ctx))
+    assert not any(
+        "CheckpointFilter" in name for name in _collect_physical_op_names(physical_plan)
+    )
+
+    # The rerun must complete and rewrite every input row.
+    out2 = os.path.join(tmp_path, "out2")
+    ray.data.read_parquet(f_dir).write_parquet(out2)
+    result = pq.read_table(out2)
+    assert sorted(result[ID_COL].to_pylist()) == list(range(SAMPLE_DATA_NUM_ROWS))
+
+
 @pytest.mark.parametrize(
     "backend,fs,data_path",
     [

--- a/python/ray/data/tests/test_checkpoint.py
+++ b/python/ray/data/tests/test_checkpoint.py
@@ -46,6 +46,7 @@ from ray.data.checkpoint.checkpoint_writer import (
 from ray.data.checkpoint.interfaces import (
     CheckpointBackend,
     InvalidCheckpointingConfig,
+    is_generated_id_checkpoint,
 )
 from ray.data.checkpoint.util import PrefixTrie
 from ray.data.context import DataContext
@@ -185,6 +186,38 @@ class TestCheckpointConfig:
             match="Checkpoint ID column",
         ):
             CheckpointConfig(id_column, local_path)
+
+    def test_id_column_and_generated_id_column_mutually_exclusive(self, local_path):
+        with pytest.raises(
+            InvalidCheckpointingConfig,
+            match="Cannot specify both",
+        ):
+            CheckpointConfig(ID_COL, local_path, generated_id_column="generated_id_col")
+
+    def test_id_column_or_generated_id_column_required(self, local_path):
+        with pytest.raises(
+            InvalidCheckpointingConfig,
+            match="Either `id_column` or `generated_id_column`",
+        ):
+            CheckpointConfig(checkpoint_path=local_path)
+
+    def test_generated_id_column_aliases_id_column(self, local_path):
+        """Downstream code (write 2PC, filters) keys off ``id_column``, so a
+        generated-ID config must expose the generated name there too."""
+        config = CheckpointConfig(
+            checkpoint_path=local_path, generated_id_column="generated_id_col"
+        )
+        assert config.id_column == "generated_id_col"
+        assert config.generated_id_column == "generated_id_col"
+        assert config.has_generated_id_column
+        assert is_generated_id_checkpoint(config)
+
+    def test_id_column_config_is_not_generated_id(self, local_path):
+        config = CheckpointConfig(ID_COL, local_path)
+        assert config.generated_id_column is None
+        assert not config.has_generated_id_column
+        assert not is_generated_id_checkpoint(config)
+        assert not is_generated_id_checkpoint(None)
 
     def test_override_backend_emits_deprecation_warning(self):
         with pytest.warns(FutureWarning, match="deprecated"):

--- a/python/ray/data/tests/test_checkpoint.py
+++ b/python/ray/data/tests/test_checkpoint.py
@@ -46,7 +46,6 @@ from ray.data.checkpoint.checkpoint_writer import (
 from ray.data.checkpoint.interfaces import (
     CheckpointBackend,
     InvalidCheckpointingConfig,
-    is_generated_id_checkpoint,
 )
 from ray.data.checkpoint.util import PrefixTrie
 from ray.data.context import DataContext
@@ -210,14 +209,11 @@ class TestCheckpointConfig:
         assert config.id_column == "generated_id_col"
         assert config.generated_id_column == "generated_id_col"
         assert config.has_generated_id_column
-        assert is_generated_id_checkpoint(config)
 
     def test_id_column_config_is_not_generated_id(self, local_path):
         config = CheckpointConfig(ID_COL, local_path)
         assert config.generated_id_column is None
         assert not config.has_generated_id_column
-        assert not is_generated_id_checkpoint(config)
-        assert not is_generated_id_checkpoint(None)
 
     def test_override_backend_emits_deprecation_warning(self):
         with pytest.warns(FutureWarning, match="deprecated"):


### PR DESCRIPTION

**Stack:** PR 1 of 4 porting row-group–based job-level checkpointing to the V2 datasource path. This PR is standalone; follow-ups: [2/4] compact checkpoint load, [3/4] list/read-time skipping, [4/4] planner routing + docs.

## Why are these changes needed?

Job-level checkpointing (`CheckpointConfig`) currently requires the dataset to carry a unique `id_column`. Many batch-inference datasets have no natural ID. This PR adds `CheckpointConfig(generated_id_column=...)`: for Parquet sources on the V2 datasource path, the reader synthesizes a stable struct ID per row derived from the physical file layout — `{path_prefix, file_name, fragment (= row group index), num_fragments, num_rows, row_id}` (dictionary-encoded; `row_id` is the position within the row group).

In this PR the column only gets generated and written through the existing checkpoint 2PC (the generated name is aliased onto `CheckpointConfig.id_column`, so the write path is untouched). Skipping committed work on resume lands in the follow-up PRs; until then, enabling `generated_id_column` produces IDs but a rerun re-reads everything.

Key pieces:
- `python/ray/data/checkpoint/generated_id.py` (new): ID struct type and construction.
- `CheckpointConfig`: `generated_id_column` XOR `id_column` validation; aliasing so downstream code keys off `id_column` unchanged.
- `ParquetFileReader`: fans out one sub-fragment per row group when the feature is on (the invariant the ID derivation relies on) and attaches the ID per batch; `row_id` continues across batches within a row group; raises on collision with an existing on-disk column.
- Schema consistency: the ID column is advertised on both `ParquetScanner.read_schema()` (what `ds.schema()` shows) and `ParquetDatasourceV2.infer_schema()` (what plan construction uses), survives column projection, and is stripped from the pyarrow dataset schema (it's synthesized, not on disk).

Design note (deliberate, matches the reference implementation): under a pushed-down predicate, `row_id` indexes the *filtered* stream, not on-disk positions. ID assignment is deterministic for an unchanged pipeline, which is the standing correctness assumption for checkpoint resume; the ID's `num_rows` field still reports the on-disk row-group size, so a predicate-filtered row group can never be considered fully checkpointed. Pinned by `test_filter_pushdown_positions_are_deterministic`.

## Related issue number

N/A. Not a duplicate: searched open PRs/issues in ray-project/ray for `generated_id_column`, "row group checkpoint", "checkpoint generated id" — no overlapping work.

## Checks

- [x] I've signed off every commit (DCO).
- [x] I've run pre-commit hooks (`pre-commit run` on all touched files — clean).
- [x] AI assistance (Claude Code) was used for the development of this PR. I, Abhishek Verma, am the human submitter signing off on it: I have reviewed every changed line, run the tests below locally, and can defend the change end-to-end.
- Testing:
  - New unit tests: `python/ray/data/_internal/datasource_v2/tests/test_generated_id_reads.py` (ID uniqueness across files/row groups, `row_id` continuation across batches, collision rejection, projection survival, `infer_schema` advertisement, filter-pushdown determinism, no-op without config) — `pytest ... -q` → 7 passed.
  - Config tests in `python/ray/data/tests/test_checkpoint.py::TestCheckpointConfig` (XOR/neither-set errors, aliasing) — 27 passed.
  - Regression: full `test_checkpoint.py` (97/98 locally; the one failure is `test_skip_checkpoint_flag[s3]`, a pre-existing local moto-server slowness that also fails on clean master), `_internal/datasource_v2/tests/` (99 passed), `tests/test_parquet.py` (passed).