### PR TITLE
[Data] [2/4] Add GeneratedIdColumnCheckpointManager with compact per-file checkpoint load

### DIFF
--- a/python/ray/data/_internal/planner/planner.py
+++ b/python/ray/data/_internal/planner/planner.py
@@ -295,6 +295,8 @@ class Planner:
 
             checkpoint_callback = self._create_checkpoint_callback(
                 checkpoint_config,
+                data_file_dir,
+                data_file_fs,
             )
 
             callbacks.append(checkpoint_callback)
@@ -392,13 +394,19 @@ class Planner:
     def _create_checkpoint_callback(
         self,
         checkpoint_config,
+        data_file_dir=None,
+        data_file_filesystem=None,
     ) -> LoadCheckpointCallback:
         """Factory method to create the LoadCheckpointCallback.
 
         Subclasses can override this to use a different callback implementation.
+        The data-file location lets the generated-ID path clean up pending
+        checkpoints before loading.
         """
         return LoadCheckpointCallback(
             checkpoint_config,
+            data_file_dir=data_file_dir,
+            data_file_filesystem=data_file_filesystem,
         )
 
     @staticmethod

--- a/python/ray/data/checkpoint/__init__.py
+++ b/python/ray/data/checkpoint/__init__.py
@@ -10,6 +10,7 @@ if TYPE_CHECKING:
     from .checkpoint_filter import (  # noqa: F401
         CheckpointFilter,
         CheckpointManager,
+        GeneratedIdColumnCheckpointManager,
         IdColumnCheckpointManager,
         NumpyArrayBasedCheckpointFilter,
     )
@@ -19,6 +20,7 @@ __all__ = [
     "CheckpointBackend",
     "CheckpointFilter",
     "CheckpointManager",
+    "GeneratedIdColumnCheckpointManager",
     "IdColumnCheckpointManager",
     "NumpyArrayBasedCheckpointFilter",
 ]
@@ -26,6 +28,7 @@ __all__ = [
 _LAZY_EXPORTS = (
     "CheckpointFilter",
     "CheckpointManager",
+    "GeneratedIdColumnCheckpointManager",
     "IdColumnCheckpointManager",
     "NumpyArrayBasedCheckpointFilter",
 )

--- a/python/ray/data/checkpoint/checkpoint_filter.py
+++ b/python/ray/data/checkpoint/checkpoint_filter.py
@@ -9,6 +9,7 @@ from typing import List, Optional, Tuple
 
 import numpy as np
 import pyarrow
+import pyarrow.compute as pc
 from pyarrow.fs import FileSelector, FileType
 
 import ray
@@ -18,8 +19,21 @@ from ray.data._internal.execution.interfaces.ref_bundle import RefBundle
 from ray.data.block import Block, BlockMetadata, Schema
 from ray.data.checkpoint import CheckpointConfig
 from ray.data.checkpoint.checkpoint_writer import PENDING_CHECKPOINT_SUFFIX
+from ray.data.checkpoint.generated_id import (
+    CHECKPOINTED_FILE_COLUMN_NAME,
+    CHECKPOINTED_FILE_FRAGMENTS_TYPE,
+    CHECKPOINTED_FRAGMENT_TYPE,
+    CHECKPOINTED_GENERATED_ID_COLUMN_TABLE_SCHEMA,
+    FILE_NAME_FIELD,
+    FRAGMENT_FIELD,
+    NUM_FRAGMENTS_FIELD,
+    NUM_ROWS_FIELD,
+    PATH_PREFIX_FIELD,
+    ROW_ID_FIELD,
+    get_struct_field_index,
+)
 from ray.data.checkpoint.util import build_pending_checkpoint_trie
-from ray.data.context import DataContext
+from ray.data.context import DataContext, ShuffleStrategy
 from ray.data.datasource.path_util import _unwrap_protocol
 from ray.types import ObjectRef
 from ray.util.annotations import DeveloperAPI
@@ -231,11 +245,55 @@ class CheckpointManager(abc.ABC):
             ObjectRef: The ref of checkpointed IDs array. None if no checkpoint was loaded.
             int: the size of the checkpointed IDs array.
         """
+        start_t = time.time()
+
+        loaded = self._load_checkpoint_block(data_file_dir, data_file_filesystem)
+        if loaded is None:
+            return None, 0
+        block_ref, schema, _ = loaded
+
+        # Convert arrow-typed ids to sorted numpy-typed ids.
+        # Note: the convert is very time-consuming.
+        # Get the object ref the checkpointed IDs, because we do not want the IDs
+        # to occupy the memory of the head node.
+        ctx_label_selector = self._data_context.execution_options.label_selector
+        task = convert_and_sort_checkpointed_ids
+        if ctx_label_selector:
+            task = task.options(label_selector=ctx_label_selector)
+        (
+            checkpointed_ids_ref,
+            checkpoint_size_ref,
+        ) = task.remote(block_ref, self.id_column)
+
+        checkpoint_size = ray.get(checkpoint_size_ref)
+
+        logger.info(
+            "Checkpoint loaded for %s in %.2f seconds. SizeBytes = %d, Schema = %s",
+            type(self).__name__,
+            time.time() - start_t,
+            checkpoint_size,
+            schema.to_string(),
+        )
+        return checkpointed_ids_ref, checkpoint_size
+
+    def _load_checkpoint_block(
+        self,
+        data_file_dir: Optional[str] = None,
+        data_file_filesystem: Optional["pyarrow.fs.FileSystem"] = None,
+    ) -> Optional[Tuple[ObjectRef[Block], Schema, BlockMetadata]]:
+        """Clean pending checkpoints, then load committed IDs as one block.
+
+        Shared by :meth:`load_checkpoint` (which converts the block to a
+        sorted numpy array for the actor-pool filter) and
+        ``GeneratedIdColumnCheckpointManager.load_checkpoint_as_block``
+        (which hands the compact block to ``ListFiles`` / the Parquet
+        reader directly).
+
+        Returns None when there is no committed checkpoint data.
+        """
         logger.info(
             "Loading checkpoint from %s, this could take a while.", self.checkpoint_path
         )
-
-        start_t = time.time()
 
         # Clean up pending checkpoints before loading (runs as a Ray task)
         if data_file_dir is not None:
@@ -257,7 +315,7 @@ class CheckpointManager(abc.ABC):
             )
         )
         if not any(f.type == FileType.File for f in entries):
-            return None, 0
+            return None
 
         # Load the checkpoint data
         checkpoint_ds: ray.data.Dataset = ray.data.read_parquet(
@@ -284,9 +342,9 @@ class CheckpointManager(abc.ABC):
 
         assert len(ref_bundles) == 1
 
-        # If there are no valid files under the checkpoint_path, return None, 0.
+        # If there are no valid files under the checkpoint_path, return None.
         if ref_bundles[0].num_rows() == 0:
-            return None, 0
+            return None
 
         ref_bundle: RefBundle = ref_bundles[0]
         schema: Schema = ref_bundle.schema
@@ -295,30 +353,7 @@ class CheckpointManager(abc.ABC):
         metadata: BlockMetadata = ref_bundle.blocks[0].metadata
         # Validate the loaded checkpoint
         self._validate_loaded_checkpoint(schema, metadata)
-
-        # Convert arrow-typed ids to sorted numpy-typed ids.
-        # Note: the convert is very time-consuming.
-        # Get the object ref the checkpointed IDs, because we do not want the IDs
-        # to occupy the memory of the head node.
-        ctx_label_selector = self._data_context.execution_options.label_selector
-        task = convert_and_sort_checkpointed_ids
-        if ctx_label_selector:
-            task = task.options(label_selector=ctx_label_selector)
-        (
-            checkpointed_ids_ref,
-            checkpoint_size_ref,
-        ) = task.remote(block_ref, self.id_column)
-
-        checkpoint_size = ray.get(checkpoint_size_ref)
-
-        logger.info(
-            "Checkpoint loaded for %s in %.2f seconds. SizeBytes = %d, Schema = %s",
-            type(self).__name__,
-            time.time() - start_t,
-            checkpoint_size,
-            schema.to_string(),
-        )
-        return checkpointed_ids_ref, checkpoint_size
+        return block_ref, schema, metadata
 
     def _clean_pending_checkpoints(
         self,
@@ -380,6 +415,261 @@ class CheckpointManager(abc.ABC):
 @DeveloperAPI
 class IdColumnCheckpointManager(CheckpointManager):
     """Manager for regular ID columns."""
+
+
+@DeveloperAPI
+class GeneratedIdColumnCheckpointManager(CheckpointManager):
+    """Manager for auto-generated row-ID columns.
+
+    Committed checkpoint files store one struct ID per output row. At load
+    time this manager compacts them into one row per input file
+    (``CHECKPOINTED_GENERATED_ID_COLUMN_TABLE_SCHEMA``): the raw IDs are
+    grouped by file, then per row group either marked fully checkpointed
+    (empty ``checkpointed_row_ids`` list) or given a dense boolean mask of
+    committed positions. ``ListFiles`` uses the compact block to drop
+    fully-done files, and the Parquet reader uses it to skip fully-done row
+    groups and filter partially-done ones — the actor-pool
+    ``CheckpointFilter`` path is not used for generated IDs.
+    """
+
+    def _extract_grouping_fields(self, batch: pyarrow.Table) -> pyarrow.Table:
+        """Project the struct ID column into groupable path columns."""
+        id_col: pyarrow.ChunkedArray = batch[self.id_column]
+
+        path_prefix_idx = get_struct_field_index(id_col, PATH_PREFIX_FIELD)
+        path_prefix = pc.struct_field(id_col, [path_prefix_idx])
+
+        file_name_idx = get_struct_field_index(id_col, FILE_NAME_FIELD)
+        file_name = pc.struct_field(id_col, [file_name_idx])
+
+        return pyarrow.Table.from_arrays(
+            [
+                path_prefix.cast(pyarrow.large_string()),
+                file_name.cast(pyarrow.large_string()),
+                batch[self.id_column],
+            ],
+            names=[PATH_PREFIX_FIELD, FILE_NAME_FIELD, self.id_column],
+        )
+
+    def _process_file_group(self, file_group_batch: pyarrow.Table) -> pyarrow.Table:
+        """Compact one file's committed IDs into a single checkpoint row.
+
+        Args:
+            file_group_batch: Rows of a single ``(path_prefix, file_name)``
+                group.
+
+        Returns:
+            One-row table with ``CHECKPOINTED_GENERATED_ID_COLUMN_TABLE_SCHEMA``.
+        """
+        path_prefix = file_group_batch[PATH_PREFIX_FIELD][0].as_py()
+        file_name = file_group_batch[FILE_NAME_FIELD][0].as_py()
+        file_path = f"{path_prefix}/{file_name}"
+
+        id_columns = file_group_batch[self.id_column]
+
+        # NUM_FRAGMENTS is the file's total row-group count — identical for
+        # every row of the file.
+        num_fragments_field_idx = get_struct_field_index(
+            id_columns[0], NUM_FRAGMENTS_FIELD
+        )
+        num_fragments = pc.struct_field(id_columns, [num_fragments_field_idx])[
+            0
+        ].as_py()
+
+        fragment_field_idx = get_struct_field_index(id_columns[0], FRAGMENT_FIELD)
+        fragments_array = pc.struct_field(id_columns, [fragment_field_idx])
+
+        num_rows_field_idx = get_struct_field_index(id_columns[0], NUM_ROWS_FIELD)
+        num_rows_array = pc.struct_field(id_columns, [num_rows_field_idx])
+
+        row_id_field_idx = get_struct_field_index(id_columns[0], ROW_ID_FIELD)
+        row_ids_array = pc.struct_field(id_columns, [row_id_field_idx])
+
+        # Group committed row IDs by row group.
+        fragment_table = pyarrow.table(
+            {
+                "fragment": fragments_array,
+                "row_id": row_ids_array,
+                "num_rows": num_rows_array,
+            }
+        )
+        grouped = fragment_table.group_by("fragment").aggregate(
+            [
+                ("row_id", "list"),
+                # num_rows is the same for all rows in a row group; min is
+                # just a way to pick it.
+                ("num_rows", "min"),
+            ]
+        )
+
+        fragments_array = grouped["fragment"]
+        row_ids_lists = grouped["row_id_list"]
+        num_rows_array = grouped["num_rows_min"]
+
+        checkpointed_row_counts = pc.cast(
+            pc.list_value_length(row_ids_lists), pyarrow.int32()
+        )
+        fully_checkpointed_mask = pc.equal(checkpointed_row_counts, num_rows_array)
+        num_fragments_fully_checkpointed = pc.sum(fully_checkpointed_mask).as_py() or 0
+
+        # Per row group: empty list when fully committed, else a dense
+        # boolean mask over the row group.
+        checkpointed_row_ids_arrays = []
+        for i in range(len(grouped)):
+            num_rows = num_rows_array[i].as_py()
+            checkpointed_row_count = checkpointed_row_counts[i].as_py()
+            row_ids_list = row_ids_lists[i]
+
+            if checkpointed_row_count == num_rows:
+                checkpointed_row_ids_col = pyarrow.array(
+                    [[]], type=pyarrow.large_list(pyarrow.bool_())
+                )
+            else:
+                row_indices = pyarrow.array(np.arange(num_rows), type=pyarrow.int32())
+                # ``pc.is_in`` requires a sorted value set.
+                row_ids_values = row_ids_list.values
+                sorted_row_ids = row_ids_values.take(pc.sort_indices(row_ids_values))
+                boolean_array = pc.is_in(row_indices, sorted_row_ids)
+                offsets = pyarrow.array([0, len(boolean_array)], type=pyarrow.int64())
+                checkpointed_row_ids_col = pyarrow.LargeListArray.from_arrays(
+                    offsets, boolean_array
+                )
+
+            checkpointed_row_ids_arrays.append(checkpointed_row_ids_col)
+
+        if checkpointed_row_ids_arrays:
+            checkpointed_row_ids_array = pyarrow.concat_arrays(
+                checkpointed_row_ids_arrays
+            )
+        else:
+            checkpointed_row_ids_array = pyarrow.array(
+                [[]], type=pyarrow.large_list(pyarrow.bool_())
+            )
+
+        fragment_structs = pyarrow.StructArray.from_arrays(
+            [
+                pc.cast(fragments_array.combine_chunks(), pyarrow.int32()),
+                pc.cast(num_rows_array.combine_chunks(), pyarrow.int32()),
+                checkpointed_row_counts.combine_chunks(),
+                checkpointed_row_ids_array,
+            ],
+            fields=list(CHECKPOINTED_FRAGMENT_TYPE),
+        )
+
+        if len(fragment_structs) > 0:
+            offsets = pyarrow.array([0, len(fragment_structs)], type=pyarrow.int64())
+            fragments_list = pyarrow.LargeListArray.from_arrays(
+                offsets, fragment_structs
+            )
+        else:
+            fragments_list = pyarrow.array(
+                [[]], type=pyarrow.large_list(CHECKPOINTED_FRAGMENT_TYPE)
+            )
+
+        # The file is fully checkpointed only when every one of its row
+        # groups was seen and fully committed.
+        fully_checkpointed = num_fragments_fully_checkpointed == num_fragments
+        checkpointed_fragment_col = pyarrow.StructArray.from_arrays(
+            [
+                pyarrow.array([len(fragment_structs)], type=pyarrow.int32()),
+                pyarrow.array([fully_checkpointed], type=pyarrow.bool_()),
+                fragments_list,
+            ],
+            fields=list(CHECKPOINTED_FILE_FRAGMENTS_TYPE),
+        )
+
+        logger.debug(
+            "Compacted checkpoint for file %s: %d/%d row groups fully "
+            "checkpointed, fully_checkpointed=%s",
+            file_path,
+            num_fragments_fully_checkpointed,
+            num_fragments,
+            fully_checkpointed,
+        )
+
+        return pyarrow.Table.from_arrays(
+            [pyarrow.array([file_path]), checkpointed_fragment_col],
+            schema=CHECKPOINTED_GENERATED_ID_COLUMN_TABLE_SCHEMA,
+        )
+
+    def _preprocess_data_pipeline(
+        self, checkpoint_ds: "ray.data.Dataset"
+    ) -> "ray.data.Dataset":
+        """Compact raw committed IDs into one row per file, sorted by path."""
+        checkpoint_ds = checkpoint_ds.map_batches(
+            self._extract_grouping_fields,
+            batch_format="pyarrow",
+            batch_size=None,
+        )
+        # The sort-based shuffle materializes every group on one node;
+        # hash shuffle keeps the groupby streaming.
+        checkpoint_ds.context._shuffle_strategy = ShuffleStrategy.HASH_SHUFFLE
+
+        checkpoint_ds = checkpoint_ds.groupby([PATH_PREFIX_FIELD, FILE_NAME_FIELD])
+        checkpoint_ds = checkpoint_ds.map_groups(
+            self._process_file_group, batch_format="pyarrow"
+        )
+        return checkpoint_ds.sort(CHECKPOINTED_FILE_COLUMN_NAME)
+
+    def _validate_loaded_checkpoint(
+        self, schema: Schema, metadata: BlockMetadata
+    ) -> None:
+        if metadata.num_rows > 0:
+            assert schema == CHECKPOINTED_GENERATED_ID_COLUMN_TABLE_SCHEMA, (
+                f"Schema mismatch: {schema} != "
+                f"{CHECKPOINTED_GENERATED_ID_COLUMN_TABLE_SCHEMA}"
+            )
+
+    def load_checkpoint_as_block(
+        self,
+        data_file_dir: Optional[str] = None,
+        data_file_filesystem: Optional["pyarrow.fs.FileSystem"] = None,
+    ) -> ObjectRef[Block]:
+        """Load the compact checkpoint as an ``ObjectRef[Block]``.
+
+        Unlike :meth:`load_checkpoint`, the block is not converted to a
+        numpy array — the struct-typed compact table is passed as a task
+        kwarg to ``ListFiles`` and consumed as a pyarrow table. An empty
+        (schema-less) table means there is no checkpoint data.
+        """
+        start_t = time.time()
+        loaded = self._load_checkpoint_block(data_file_dir, data_file_filesystem)
+        if loaded is None:
+            return ray.put(pyarrow.table({}))
+        block_ref, schema, _ = loaded
+        logger.info(
+            "Checkpoint loaded for %s in %.2f seconds. Schema = %s",
+            type(self).__name__,
+            time.time() - start_t,
+            schema.to_string(),
+        )
+        return block_ref
+
+
+def load_generated_id_checkpoint_as_block(
+    config: CheckpointConfig,
+    data_file_dir: Optional[str] = None,
+    data_file_filesystem: Optional["pyarrow.fs.FileSystem"] = None,
+    data_context: Optional[DataContext] = None,
+) -> ObjectRef[Block]:
+    """Load the generated-ID checkpoint as a compact per-file Block.
+
+    The returned block has ``CHECKPOINTED_GENERATED_ID_COLUMN_TABLE_SCHEMA``
+    and is consumed by ``ListFiles`` (file-level skipping) and the V2
+    Parquet reader (row-group and row-level skipping). Regular ``id_column``
+    checkpointing does not go through this path — it uses the actor-pool
+    ``CheckpointFilter`` wired up by
+    ``ray.data._internal.planner.checkpoint.create_checkpoint_filter_op``.
+    """
+    assert getattr(config, "generated_id_column", None), (
+        "load_generated_id_checkpoint_as_block() is only for "
+        "generated_id_column configs; id_column uses the actor-pool pattern."
+    )
+    manager = GeneratedIdColumnCheckpointManager(
+        checkpoint_config=config,
+        data_context=data_context or DataContext.get_current(),
+    )
+    return manager.load_checkpoint_as_block(data_file_dir, data_file_filesystem)
 
 
 @DeveloperAPI

--- a/python/ray/data/checkpoint/generated_id.py
+++ b/python/ray/data/checkpoint/generated_id.py
@@ -1,12 +1,41 @@
-"""Stable Parquet row IDs used by generated_id_column checkpointing."""
+"""Stable Parquet row IDs used by generated_id_column checkpointing.
+
+This module holds everything specific to the generated-ID checkpoint format:
+
+- The per-row struct ID type (``GENERATED_ID_COLUMN_TYPE``) and its
+  construction (:func:`get_generated_id_column`).
+- The compact per-file checkpoint representation
+  (``CHECKPOINTED_GENERATED_ID_COLUMN_TABLE_SCHEMA``) that
+  ``GeneratedIdColumnCheckpointManager`` builds from committed row IDs at
+  load time, plus the helpers that consume it at list time
+  (:func:`index_checkpointed_fragments`,
+  :func:`get_checkpoint_fragments_info_for_file`,
+  :func:`is_file_fragments_fully_checkpointed`) and at read time
+  (:func:`parse_checkpointed_fragment_info`,
+  :func:`exclude_checkpointed_rows`).
+
+Compact-representation semantics: a file that was never read has no row in
+the checkpoint table (a null struct downstream); a fully-committed row group
+stores an empty ``checkpointed_row_ids`` list; a partially-committed row
+group stores a dense boolean mask of length ``num_rows`` (True =
+checkpointed). Unfinished work is encoded as absence — uncommitted rows are
+never stored.
+"""
 
 import os
-from typing import Optional
+from dataclasses import dataclass
+from typing import Dict, Optional, Union
 
 import numpy as np
 import pyarrow as pa
+import pyarrow.compute as pc
+import pyarrow.dataset
 
+from ray.data.block import Block, BlockAccessor
 from ray.data.context import DataContext
+
+# Name of the kwarg carrying the loaded checkpoint block into ListFiles tasks.
+CHECKPOINTED_IDS_KWARG_NAME = "checkpointed_ids"
 
 PATH_PREFIX_FIELD = "path_prefix"
 FILE_NAME_FIELD = "file_name"
@@ -39,6 +68,343 @@ GENERATED_ID_COLUMN_TYPE = pa.struct(
         for name in GENERATED_ID_COLUMN_FIELD_NAMES
     ]
 )
+
+#
+# Compact checkpoint table schema (built at load time from committed IDs).
+#
+
+CHECKPOINTED_FILE_COLUMN_NAME = "checkpointed_file"
+CHECKPOINTED_FILE_FRAGMENTS_COLUMN_NAME = "checkpointed_file_fragments"
+
+# Per-row-group struct fields.
+CHECKPOINTED_FILE_FRAGMENT_ID_FIELD = "fragment_id"
+CHECKPOINTED_FILE_FRAGMENT_NUM_ROWS_FIELD = "num_rows"
+CHECKPOINTED_FILE_FRAGMENT_NUM_CHECKPOINTED_ROWS_FIELD = "num_checkpointed_rows"
+CHECKPOINTED_FILE_FRAGMENT_CHECKPOINTED_ROW_IDS_FIELD = "checkpointed_row_ids"
+
+CHECKPOINTED_FRAGMENT_TYPE = pa.struct(
+    [
+        # Row group index within the file.
+        pa.field(CHECKPOINTED_FILE_FRAGMENT_ID_FIELD, pa.int32(), nullable=False),
+        # Total number of rows in this row group (on-disk).
+        pa.field(CHECKPOINTED_FILE_FRAGMENT_NUM_ROWS_FIELD, pa.int32(), nullable=False),
+        # Number of already-checkpointed rows in this row group.
+        pa.field(
+            CHECKPOINTED_FILE_FRAGMENT_NUM_CHECKPOINTED_ROWS_FIELD,
+            pa.int32(),
+            nullable=False,
+        ),
+        # Dense boolean mask of length ``num_rows`` (True = checkpointed).
+        # An empty list means every row is checkpointed.
+        pa.field(
+            CHECKPOINTED_FILE_FRAGMENT_CHECKPOINTED_ROW_IDS_FIELD,
+            pa.large_list(pa.bool_()),
+            nullable=True,
+        ),
+    ]
+)
+
+# Per-file struct fields. This struct rides on the file manifest into readers.
+CHECKPOINTED_FILE_FRAGMENTS_NUM_FRAGMENTS_FIELD = "num_fragments"
+CHECKPOINTED_FILE_FULLY_CHECKPOINTED_FIELD = "fully_checkpointed"
+CHECKPOINTED_FILE_FRAGMENTS_INFO_FIELD = "fragments"
+
+CHECKPOINTED_FILE_FRAGMENTS_TYPE = pa.struct(
+    [
+        # Number of row groups with checkpoint entries for this file.
+        pa.field(
+            CHECKPOINTED_FILE_FRAGMENTS_NUM_FRAGMENTS_FIELD, pa.int32(), nullable=False
+        ),
+        # Whether every row group of the file is fully checkpointed.
+        pa.field(
+            CHECKPOINTED_FILE_FULLY_CHECKPOINTED_FIELD, pa.bool_(), nullable=False
+        ),
+        # One CHECKPOINTED_FRAGMENT_TYPE entry per touched row group.
+        pa.field(
+            CHECKPOINTED_FILE_FRAGMENTS_INFO_FIELD,
+            pa.large_list(CHECKPOINTED_FRAGMENT_TYPE),
+            nullable=True,
+        ),
+    ]
+)
+
+CHECKPOINTED_GENERATED_ID_COLUMN_TABLE_SCHEMA = pa.schema(
+    [
+        pa.field(CHECKPOINTED_FILE_COLUMN_NAME, pa.string()),
+        pa.field(
+            CHECKPOINTED_FILE_FRAGMENTS_COLUMN_NAME, CHECKPOINTED_FILE_FRAGMENTS_TYPE
+        ),
+    ]
+)
+
+
+@dataclass
+class CheckpointedFragmentInfo:
+    """Checkpoint state of one row group, resolved for a read."""
+
+    # The Parquet fragment (one row group).
+    fragment: pa.dataset.ParquetFileFragment
+    # The row group index within the file.
+    row_group_idx: int
+    # Total number of rows in the row group (on-disk).
+    num_rows: int
+    # Whether every row of the row group is checkpointed.
+    fully_checkpointed: bool
+    # Boolean mask over the row group (True = checkpointed), or None when
+    # nothing is checkpointed. Empty array means fully checkpointed.
+    checkpointed_row_ids: Optional[pa.Array]
+    # Number of checkpointed rows in the row group.
+    checkpointed_row_count: int
+
+
+@dataclass
+class CheckpointFragmentsInfo:
+    """Checkpoint state of one file, as looked up from the compact table."""
+
+    # The file path.
+    path: str
+    # The file's CHECKPOINTED_FILE_FRAGMENTS_TYPE struct scalar, or None when
+    # the file has no checkpoint entry (never seen).
+    checkpointed_file_fragments: Optional[pa.StructScalar]
+
+
+def get_struct_field_index(
+    struct_value: Union[pa.Array, pa.ChunkedArray, pa.Scalar], field_name: str
+) -> int:
+    """Return the index of ``field_name`` in a struct array/scalar's type.
+
+    Struct field order is not preserved through an Arrow -> Parquet -> Arrow
+    round-trip, so struct fields must always be resolved by name, never
+    positionally.
+    """
+    if isinstance(struct_value, pa.ChunkedArray):
+        struct_type = struct_value.chunks[0].type
+    else:
+        struct_type = struct_value.type
+
+    field_index = struct_type.get_field_index(field_name)
+    if field_index == -1:
+        raise ValueError(f"Field '{field_name}' not found in struct type {struct_type}")
+    return field_index
+
+
+def _create_empty_checkpointed_fragment_info(
+    fragment: pa.dataset.ParquetFileFragment,
+    row_group_idx: int,
+) -> CheckpointedFragmentInfo:
+    """Info for a row group with no checkpointed rows."""
+    return CheckpointedFragmentInfo(
+        fragment=fragment,
+        row_group_idx=row_group_idx,
+        num_rows=fragment.metadata.row_group(row_group_idx).num_rows,
+        fully_checkpointed=False,
+        checkpointed_row_ids=None,
+        checkpointed_row_count=0,
+    )
+
+
+def parse_checkpointed_fragment_info(
+    fragment: pa.dataset.ParquetFileFragment,
+    row_group_idx: int,
+    checkpointed_file_fragments: Optional[pa.StructScalar],
+) -> CheckpointedFragmentInfo:
+    """Resolve one row group's checkpoint state from its file's struct scalar.
+
+    Args:
+        fragment: Parquet fragment carrying exactly this row group.
+        row_group_idx: Row group index within the file.
+        checkpointed_file_fragments: The file's
+            ``CHECKPOINTED_FILE_FRAGMENTS_TYPE`` struct scalar from the
+            manifest, or None / a null scalar when the file was never seen.
+
+    Returns:
+        The row group's :class:`CheckpointedFragmentInfo`. When the file or
+        row group has no checkpoint entry, an empty info (nothing
+        checkpointed) is returned.
+    """
+    if (
+        checkpointed_file_fragments is None
+        or checkpointed_file_fragments.is_valid is False
+    ):
+        return _create_empty_checkpointed_fragment_info(fragment, row_group_idx)
+
+    fragments_field_idx = get_struct_field_index(
+        checkpointed_file_fragments, CHECKPOINTED_FILE_FRAGMENTS_INFO_FIELD
+    )
+    fragments = pc.struct_field(checkpointed_file_fragments, [fragments_field_idx])
+    if fragments.is_valid is False or len(fragments) == 0:
+        return _create_empty_checkpointed_fragment_info(fragment, row_group_idx)
+    fragments_values = fragments.values  # StructArray
+
+    fragment_id_field_idx = get_struct_field_index(
+        fragments_values, CHECKPOINTED_FILE_FRAGMENT_ID_FIELD
+    )
+    fragment_ids = pc.struct_field(fragments_values, [fragment_id_field_idx])
+
+    wanted_mask = pc.equal(fragment_ids, pa.scalar(row_group_idx, fragment_ids.type))
+    indices = pc.indices_nonzero(wanted_mask)
+    if len(indices) == 0:
+        return _create_empty_checkpointed_fragment_info(fragment, row_group_idx)
+
+    checkpointed_fragment = fragments_values[indices[0].as_py()]
+    checkpointed_row_ids = pc.struct_field(
+        checkpointed_fragment,
+        [
+            get_struct_field_index(
+                checkpointed_fragment,
+                CHECKPOINTED_FILE_FRAGMENT_CHECKPOINTED_ROW_IDS_FIELD,
+            )
+        ],
+    )
+    num_rows = pc.struct_field(
+        checkpointed_fragment,
+        [
+            get_struct_field_index(
+                checkpointed_fragment, CHECKPOINTED_FILE_FRAGMENT_NUM_ROWS_FIELD
+            )
+        ],
+    ).as_py()
+    num_checkpointed_rows = pc.struct_field(
+        checkpointed_fragment,
+        [
+            get_struct_field_index(
+                checkpointed_fragment,
+                CHECKPOINTED_FILE_FRAGMENT_NUM_CHECKPOINTED_ROWS_FIELD,
+            )
+        ],
+    ).as_py()
+
+    actual_num_rows = fragment.metadata.row_group(row_group_idx).num_rows
+    assert num_rows == actual_num_rows, (
+        f"Number of rows in the row group {actual_num_rows} does not match "
+        f"the number of rows in the checkpointed fragment {num_rows}"
+    )
+
+    if len(checkpointed_row_ids) == 0:
+        # Empty list encodes "every row checkpointed".
+        assert num_checkpointed_rows == num_rows, (
+            f"Number of checkpointed rows {num_checkpointed_rows} does not match "
+            f"the number of rows in the checkpointed fragment {num_rows}"
+        )
+        fully_checkpointed = True
+        final_checkpointed_row_ids = pa.array([], type=pa.bool_())
+    else:
+        fully_checkpointed = False
+        final_checkpointed_row_ids = checkpointed_row_ids.values
+
+    return CheckpointedFragmentInfo(
+        fragment=fragment,
+        row_group_idx=row_group_idx,
+        num_rows=num_rows,
+        fully_checkpointed=fully_checkpointed,
+        checkpointed_row_ids=final_checkpointed_row_ids,
+        checkpointed_row_count=num_checkpointed_rows,
+    )
+
+
+def exclude_checkpointed_rows(
+    table: pa.Table,
+    checkpointed_fragment_info: CheckpointedFragmentInfo,
+    current_row_offset: int,
+    current_num_rows: int,
+) -> pa.Table:
+    """Drop already-checkpointed rows from a batch of one row group.
+
+    Args:
+        table: The batch to filter (rows of a single row group).
+        checkpointed_fragment_info: The row group's checkpoint state.
+        current_row_offset: Position of the batch's first row within the row
+            group's read stream (pre-filter).
+        current_num_rows: Number of rows the batch had before filtering.
+
+    Returns:
+        The batch with already-checkpointed rows removed.
+    """
+    checkpointed_row_ids = checkpointed_fragment_info.checkpointed_row_ids
+
+    if checkpointed_row_ids is None:
+        assert (
+            not checkpointed_fragment_info.fully_checkpointed
+        ), "Checkpointed row ids is None, intended to be empty checkpointed fragment"
+        return table
+
+    if len(checkpointed_row_ids) == 0:
+        assert checkpointed_fragment_info.fully_checkpointed, (
+            "Checkpointed row ids is empty array, intended to be fully "
+            "checkpointed fragment"
+        )
+        return table.slice(0, 0)
+
+    assert current_row_offset + current_num_rows <= len(checkpointed_row_ids), (
+        f"Current row offset {current_row_offset} + current num rows "
+        f"{current_num_rows} is greater than the length of the boolean mask "
+        f"{len(checkpointed_row_ids)}"
+    )
+
+    relevant_bools = checkpointed_row_ids.slice(current_row_offset, current_num_rows)
+    # True (checkpointed) rows are excluded; False (pending) rows are kept.
+    return table.filter(pc.invert(relevant_bools))
+
+
+def index_checkpointed_fragments(checkpointed_ids: Optional[Block]) -> Dict[str, int]:
+    """Map file path -> row index in the compact checkpoint block."""
+    if checkpointed_ids is None:
+        return {}
+
+    checkpointed_ids_table = BlockAccessor.for_block(checkpointed_ids).to_arrow()
+    if checkpointed_ids_table.num_rows == 0:
+        return {}
+
+    file_paths = checkpointed_ids_table[CHECKPOINTED_FILE_COLUMN_NAME].to_pylist()
+    return {file_path: i for i, file_path in enumerate(file_paths)}
+
+
+def get_checkpoint_fragments_info_for_file(
+    checkpointed_ids: Optional[Block],
+    path: str,
+    checkpointed_fragments_by_path: Dict[str, int],
+) -> CheckpointFragmentsInfo:
+    """Look up one file's checkpoint struct from the compact checkpoint block.
+
+    Args:
+        checkpointed_ids: Block with
+            ``CHECKPOINTED_GENERATED_ID_COLUMN_TABLE_SCHEMA``, or None.
+        path: The file path to look up.
+        checkpointed_fragments_by_path: Index built by
+            :func:`index_checkpointed_fragments` over the same block.
+
+    Returns:
+        The file's :class:`CheckpointFragmentsInfo`; its struct scalar is
+        None when the file has no checkpoint entry.
+    """
+    if checkpointed_ids is None or path not in checkpointed_fragments_by_path:
+        return CheckpointFragmentsInfo(path=path, checkpointed_file_fragments=None)
+
+    checkpointed_ids_table = BlockAccessor.for_block(checkpointed_ids).to_arrow()
+    if checkpointed_ids_table.num_rows == 0:
+        return CheckpointFragmentsInfo(path=path, checkpointed_file_fragments=None)
+
+    file_index = checkpointed_fragments_by_path[path]
+    checkpointed_file_fragments = checkpointed_ids_table[
+        CHECKPOINTED_FILE_FRAGMENTS_COLUMN_NAME
+    ][file_index]
+    return CheckpointFragmentsInfo(
+        path=path, checkpointed_file_fragments=checkpointed_file_fragments
+    )
+
+
+def is_file_fragments_fully_checkpointed(
+    checkpointed_fragments_info: CheckpointFragmentsInfo,
+) -> bool:
+    """Whether every row group of the file is fully checkpointed."""
+    fully_checkpointed_field_idx = get_struct_field_index(
+        checkpointed_fragments_info.checkpointed_file_fragments,
+        CHECKPOINTED_FILE_FULLY_CHECKPOINTED_FIELD,
+    )
+    return pc.struct_field(
+        checkpointed_fragments_info.checkpointed_file_fragments,
+        [fully_checkpointed_field_idx],
+    ).as_py()
 
 
 def get_generated_id_column_name() -> Optional[str]:

--- a/python/ray/data/checkpoint/load_checkpoint_callback.py
+++ b/python/ray/data/checkpoint/load_checkpoint_callback.py
@@ -1,32 +1,75 @@
 import logging
+from typing import Optional
+
+import pyarrow.fs
 
 from ray.data._internal.execution.execution_callback import (
     ExecutionCallback,
 )
 from ray.data._internal.execution.streaming_executor import StreamingExecutor
+from ray.data.block import Block
 from ray.data.checkpoint import CheckpointConfig
 from ray.data.datasource.path_util import _unwrap_protocol
+from ray.types import ObjectRef
 
 logger = logging.getLogger(__name__)
 
 
 class LoadCheckpointCallback(ExecutionCallback):
     """
-    ExecutionCallback that handles checkpoints. This Callback is responsible for
-    deleting the checkpoint directory when these conditions are met:
-    1. `delete_checkpoint_on_success` is True.
-    2. The job finishes successfully.
+    ExecutionCallback that handles checkpoints.
+
+    1. For ``generated_id_column``: loads the compact checkpoint block before
+       execution starts and exposes it via :meth:`load_checkpoint` so the
+       ``ListFiles`` plan function can inject it into listing tasks.
+    2. For regular ``id_column``: no loading here — the actor-pool filter
+       loads inside its plan function.
+    3. For both: deletes the checkpoint directory when
+       `delete_checkpoint_on_success` is True and the job finishes
+       successfully. On failure, nothing is deleted: pending checkpoint files
+       are the recovery record consumed on the next run.
     """
 
     def __init__(
         self,
         config: CheckpointConfig,
+        data_file_dir: Optional[str] = None,
+        data_file_filesystem: Optional["pyarrow.fs.FileSystem"] = None,
     ):
         assert config is not None
         self._config = config
+        self._data_file_dir = data_file_dir
+        self._data_file_filesystem = data_file_filesystem
+        self._checkpoint_ref: Optional[ObjectRef[Block]] = None
 
     def before_execution_starts(self, executor: StreamingExecutor):
         assert self._config is executor._data_context.checkpoint_config
+
+        if self._config.has_generated_id_column:
+            # Import here to avoid a checkpoint_filter <-> callback cycle.
+            from ray.data.checkpoint.checkpoint_filter import (
+                load_generated_id_checkpoint_as_block,
+            )
+
+            self._checkpoint_ref = load_generated_id_checkpoint_as_block(
+                self._config,
+                data_file_dir=self._data_file_dir,
+                data_file_filesystem=self._data_file_filesystem,
+                data_context=executor._data_context,
+            )
+
+    def load_checkpoint(self) -> ObjectRef[Block]:
+        """Return the cached compact checkpoint block ref.
+
+        Only valid for the ``generated_id_column`` path, after
+        ``before_execution_starts`` has run.
+        """
+        assert self._config.has_generated_id_column, (
+            "load_checkpoint() is only valid for generated_id_column. "
+            "Regular id_column uses the actor-pool pattern."
+        )
+        assert self._checkpoint_ref is not None
+        return self._checkpoint_ref
 
     def _delete_checkpoint(self):
         checkpoint_path_unwrapped = _unwrap_protocol(self._config.checkpoint_path)

--- a/python/ray/data/tests/test_checkpoint.py
+++ b/python/ray/data/tests/test_checkpoint.py
@@ -2,6 +2,7 @@ import csv
 import os
 import random
 from typing import List, Literal, Union
+from unittest.mock import MagicMock
 
 import numpy as np
 import pandas as pd
@@ -36,12 +37,25 @@ from ray.data._internal.planner.checkpoint.plan_write_op import (
 from ray.data.block import BlockAccessor
 from ray.data.checkpoint import CheckpointConfig
 from ray.data.checkpoint.checkpoint_filter import (
+    GeneratedIdColumnCheckpointManager,
     IdColumnCheckpointManager,
     NumpyArrayBasedCheckpointFilter,
 )
 from ray.data.checkpoint.checkpoint_writer import (
     PENDING_CHECKPOINT_SUFFIX,
     BatchBasedCheckpointWriter,
+)
+from ray.data.checkpoint.generated_id import (
+    CHECKPOINTED_FILE_COLUMN_NAME,
+    CHECKPOINTED_FILE_FRAGMENTS_COLUMN_NAME,
+    CHECKPOINTED_FILE_FRAGMENTS_TYPE,
+    CHECKPOINTED_GENERATED_ID_COLUMN_TABLE_SCHEMA,
+    exclude_checkpointed_rows,
+    get_checkpoint_fragments_info_for_file,
+    get_generated_id_column,
+    index_checkpointed_fragments,
+    is_file_fragments_fully_checkpointed,
+    parse_checkpointed_fragment_info,
 )
 from ray.data.checkpoint.interfaces import (
     CheckpointBackend,
@@ -2289,6 +2303,257 @@ def test_clean_pending_checkpoints_no_pending(ray_start_10_cpus_shared, fs, base
 
     # Data file should still exist (no pending checkpoints means nothing to clean)
     assert fs.get_file_info(data_file).type != FileType.NotFound
+
+
+def _make_file_fragments_scalar(fragments: list) -> pa.StructScalar:
+    """Build one file's CHECKPOINTED_FILE_FRAGMENTS_TYPE struct scalar.
+
+    Args:
+        fragments: List of ``(fragment_id, num_rows, committed_row_ids)``.
+            A fragment whose committed rows cover ``num_rows`` is stored the
+            compact way (empty mask list).
+
+    Returns:
+        The file's struct scalar.
+    """
+    fragment_entries = []
+    num_fully = 0
+    for fragment_id, num_rows, committed_row_ids in fragments:
+        fully = len(committed_row_ids) == num_rows
+        num_fully += fully
+        fragment_entries.append(
+            {
+                "fragment_id": fragment_id,
+                "num_rows": num_rows,
+                "num_checkpointed_rows": len(committed_row_ids),
+                "checkpointed_row_ids": (
+                    []
+                    if fully
+                    else [i in set(committed_row_ids) for i in range(num_rows)]
+                ),
+            }
+        )
+    value = {
+        "num_fragments": len(fragments),
+        "fully_checkpointed": num_fully == len(fragments),
+        "fragments": fragment_entries,
+    }
+    return pa.array([value], type=CHECKPOINTED_FILE_FRAGMENTS_TYPE)[0]
+
+
+def _mock_fragment(path: str, row_group_num_rows: int) -> MagicMock:
+    fragment = MagicMock()
+    fragment.path = path
+    row_group = MagicMock()
+    row_group.num_rows = row_group_num_rows
+    fragment.metadata.row_group.return_value = row_group
+    return fragment
+
+
+class TestGeneratedIdFragmentParsing:
+    """Unit tests for the compact-representation parse/exclude helpers."""
+
+    def test_parse_fully_checkpointed_row_group(self):
+        scalar = _make_file_fragments_scalar([(0, 3, [0, 1, 2])])
+        info = parse_checkpointed_fragment_info(_mock_fragment("f", 3), 0, scalar)
+        assert info.fully_checkpointed
+        assert info.checkpointed_row_count == 3
+        assert len(info.checkpointed_row_ids) == 0
+
+    def test_parse_partially_checkpointed_row_group(self):
+        scalar = _make_file_fragments_scalar([(1, 4, [0, 2])])
+        info = parse_checkpointed_fragment_info(_mock_fragment("f", 4), 1, scalar)
+        assert not info.fully_checkpointed
+        assert info.checkpointed_row_count == 2
+        assert info.checkpointed_row_ids.to_pylist() == [True, False, True, False]
+
+    def test_parse_row_group_without_checkpoint_entry(self):
+        # Row group 1 has an entry; row group 0 doesn't.
+        scalar = _make_file_fragments_scalar([(1, 4, [0])])
+        info = parse_checkpointed_fragment_info(_mock_fragment("f", 3), 0, scalar)
+        assert not info.fully_checkpointed
+        assert info.checkpointed_row_count == 0
+        assert info.checkpointed_row_ids is None
+
+    def test_parse_never_seen_file(self):
+        null_scalar = pa.array([None], type=CHECKPOINTED_FILE_FRAGMENTS_TYPE)[0]
+        for scalar in (None, null_scalar):
+            info = parse_checkpointed_fragment_info(_mock_fragment("f", 5), 0, scalar)
+            assert not info.fully_checkpointed
+            assert info.checkpointed_row_ids is None
+            assert info.num_rows == 5
+
+    def test_parse_num_rows_mismatch_raises(self):
+        scalar = _make_file_fragments_scalar([(0, 4, [0])])
+        # On-disk row group has 3 rows but the checkpoint recorded 4.
+        with pytest.raises(AssertionError, match="does not match"):
+            parse_checkpointed_fragment_info(_mock_fragment("f", 3), 0, scalar)
+
+    def test_exclude_nothing_checkpointed(self):
+        table = pa.table({"x": [1, 2, 3]})
+        info = parse_checkpointed_fragment_info(_mock_fragment("f", 3), 0, None)
+        assert exclude_checkpointed_rows(table, info, 0, 3) is table
+
+    def test_exclude_fully_checkpointed(self):
+        table = pa.table({"x": [1, 2, 3]})
+        scalar = _make_file_fragments_scalar([(0, 3, [0, 1, 2])])
+        info = parse_checkpointed_fragment_info(_mock_fragment("f", 3), 0, scalar)
+        assert exclude_checkpointed_rows(table, info, 0, 3).num_rows == 0
+
+    def test_exclude_partial_with_batch_offsets(self):
+        # Row group of 6 rows, rows 1 and 4 committed, read in two batches.
+        scalar = _make_file_fragments_scalar([(0, 6, [1, 4])])
+        info = parse_checkpointed_fragment_info(_mock_fragment("f", 6), 0, scalar)
+
+        batch1 = pa.table({"x": [0, 1, 2]})
+        assert exclude_checkpointed_rows(batch1, info, 0, 3)["x"].to_pylist() == [0, 2]
+        batch2 = pa.table({"x": [3, 4, 5]})
+        assert exclude_checkpointed_rows(batch2, info, 3, 3)["x"].to_pylist() == [3, 5]
+
+    def test_exclude_out_of_bounds_batch_raises(self):
+        scalar = _make_file_fragments_scalar([(0, 3, [0])])
+        info = parse_checkpointed_fragment_info(_mock_fragment("f", 3), 0, scalar)
+        with pytest.raises(AssertionError, match="greater than the length"):
+            exclude_checkpointed_rows(pa.table({"x": [1, 2]}), info, 2, 2)
+
+    def test_index_and_lookup_by_file(self):
+        table = pa.table(
+            {
+                CHECKPOINTED_FILE_COLUMN_NAME: ["/data/a.parquet", "/data/b.parquet"],
+                CHECKPOINTED_FILE_FRAGMENTS_COLUMN_NAME: pa.array(
+                    [
+                        _make_file_fragments_scalar([(0, 2, [0, 1])]).as_py(),
+                        _make_file_fragments_scalar([(0, 2, [0])]).as_py(),
+                    ],
+                    type=CHECKPOINTED_FILE_FRAGMENTS_TYPE,
+                ),
+            },
+            schema=CHECKPOINTED_GENERATED_ID_COLUMN_TABLE_SCHEMA,
+        )
+        by_path = index_checkpointed_fragments(table)
+        assert by_path == {"/data/a.parquet": 0, "/data/b.parquet": 1}
+
+        info_a = get_checkpoint_fragments_info_for_file(
+            table, "/data/a.parquet", by_path
+        )
+        assert is_file_fragments_fully_checkpointed(info_a)
+        info_b = get_checkpoint_fragments_info_for_file(
+            table, "/data/b.parquet", by_path
+        )
+        assert not is_file_fragments_fully_checkpointed(info_b)
+
+        info_missing = get_checkpoint_fragments_info_for_file(
+            table, "/data/missing.parquet", by_path
+        )
+        assert info_missing.checkpointed_file_fragments is None
+
+        assert index_checkpointed_fragments(None) == {}
+        assert index_checkpointed_fragments(pa.table({})) == {}
+
+
+def _write_generated_id_checkpoint_file(
+    checkpoint_dir: str,
+    file_name: str,
+    committed: list,
+):
+    """Write one committed checkpoint parquet holding raw struct IDs.
+
+    Args:
+        checkpoint_dir: Directory to write the checkpoint file into.
+        file_name: Name of the checkpoint parquet file.
+        committed: List of ``(path, row_group_idx, num_row_groups,
+            rg_num_rows, row_ids)`` entries.
+    """
+    id_arrays = []
+    for path, row_group_idx, num_row_groups, rg_num_rows, row_ids in committed:
+        full = get_generated_id_column(
+            path=path,
+            row_group_idx=row_group_idx,
+            num_row_groups=num_row_groups,
+            total_num_rows=rg_num_rows,
+            current_row_offset=0,
+            current_num_rows=rg_num_rows,
+        )
+        id_arrays.append(full.take(pa.array(row_ids, type=pa.int32())))
+    ids = pa.concat_arrays(id_arrays)
+    os.makedirs(checkpoint_dir, exist_ok=True)
+    pq.write_table(
+        pa.table({GENERATED_ID_TEST_COL: ids}),
+        os.path.join(checkpoint_dir, file_name),
+    )
+
+
+GENERATED_ID_TEST_COL = "__gen_id"
+
+
+def test_generated_id_checkpoint_compaction(tmp_path):
+    """End-to-end: raw committed struct IDs compact into one row per file."""
+    checkpoint_dir = str(tmp_path / "ckpt")
+    config = CheckpointConfig(
+        generated_id_column=GENERATED_ID_TEST_COL, checkpoint_path=checkpoint_dir
+    )
+
+    # File a: 2 row groups (3 rows each), both fully committed.
+    # File b: 2 row groups, group 0 partial (row 1 of 3), group 1 untouched.
+    # File c: never committed (absent).
+    _write_generated_id_checkpoint_file(
+        checkpoint_dir,
+        "task1.parquet",
+        [
+            ("/data/a.parquet", 0, 2, 3, [0, 1, 2]),
+            ("/data/b.parquet", 0, 2, 3, [1]),
+        ],
+    )
+    _write_generated_id_checkpoint_file(
+        checkpoint_dir,
+        "task2.parquet",
+        [("/data/a.parquet", 1, 2, 3, [0, 1, 2])],
+    )
+
+    manager = GeneratedIdColumnCheckpointManager(
+        checkpoint_config=config, data_context=DataContext.get_current()
+    )
+    block = ray.get(manager.load_checkpoint_as_block())
+    table = pa.table(block)
+
+    assert table.schema == CHECKPOINTED_GENERATED_ID_COLUMN_TABLE_SCHEMA
+    # One row per file, sorted by path; never-seen file c is absent.
+    assert table[CHECKPOINTED_FILE_COLUMN_NAME].to_pylist() == [
+        "/data/a.parquet",
+        "/data/b.parquet",
+    ]
+
+    by_path = index_checkpointed_fragments(table)
+    info_a = get_checkpoint_fragments_info_for_file(table, "/data/a.parquet", by_path)
+    assert is_file_fragments_fully_checkpointed(info_a)
+
+    info_b = get_checkpoint_fragments_info_for_file(table, "/data/b.parquet", by_path)
+    assert not is_file_fragments_fully_checkpointed(info_b)
+    parsed = parse_checkpointed_fragment_info(
+        _mock_fragment("/data/b.parquet", 3), 0, info_b.checkpointed_file_fragments
+    )
+    assert not parsed.fully_checkpointed
+    assert parsed.checkpointed_row_ids.to_pylist() == [False, True, False]
+    # Row group 1 of file b was never committed.
+    parsed_untouched = parse_checkpointed_fragment_info(
+        _mock_fragment("/data/b.parquet", 3), 1, info_b.checkpointed_file_fragments
+    )
+    assert parsed_untouched.checkpointed_row_ids is None
+
+
+def test_generated_id_checkpoint_load_empty(tmp_path):
+    """An empty or missing checkpoint dir loads as an empty sentinel block."""
+    checkpoint_dir = str(tmp_path / "ckpt")
+    os.makedirs(checkpoint_dir)
+    config = CheckpointConfig(
+        generated_id_column=GENERATED_ID_TEST_COL, checkpoint_path=checkpoint_dir
+    )
+    manager = GeneratedIdColumnCheckpointManager(
+        checkpoint_config=config, data_context=DataContext.get_current()
+    )
+    block = ray.get(manager.load_checkpoint_as_block())
+    assert pa.table(block).num_rows == 0
+    assert index_checkpointed_fragments(block) == {}
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
**Stack:** PR 2 of 4 — stacked on https://github.com/ray-project/ray/pull/65885 (`generated_id_column` config + ID generation). Review scope: the last commit only ("Add GeneratedIdColumnCheckpointManager with compact per-file checkpoint load"). Follow-ups: [3/4] list/read-time skipping, [4/4] planner routing + docs.

## Why are these changes needed?

Committed checkpoint files store one generated struct ID per output row. The existing restore path (`CheckpointManager.load_checkpoint` → `convert_and_sort_checkpointed_ids` → sorted numpy array → actor-pool `NumpyArrayBasedCheckpointFilter`) cannot consume a struct-typed ID column, and a per-row anti-join would defeat the point of row-group-addressed IDs.

This PR adds the load side of the generated-ID design: at restore time, raw committed IDs are compacted into **one row per input file** with schema
`(checkpointed_file: string, checkpointed_file_fragments: struct{num_fragments, fully_checkpointed, fragments: list<struct{fragment_id, num_rows, num_checkpointed_rows, checkpointed_row_ids: list<bool>}>})`.

Compact-representation semantics (consumed by PR 3/4): a never-seen file has no row; a fully committed row group stores an empty mask list; a partially committed row group stores a dense boolean mask. Unfinished work is encoded as absence — uncommitted rows are never stored.

Key pieces:
- `GeneratedIdColumnCheckpointManager` (in `checkpoint_filter.py`): overrides the existing `_preprocess_data_pipeline` hook — `map_batches` extracts `(path_prefix, file_name)` from the struct → hash-shuffle `groupby` → `map_groups` compacts each file → `sort(checkpointed_file)` — and `_validate_loaded_checkpoint` (schema check). New `load_checkpoint_as_block()` returns the compact block ref (empty sentinel `pa.table({})` when there's no checkpoint data).
- Refactor: `CheckpointManager.load_checkpoint` now shares `_load_checkpoint_block` (pending-2PC cleanup **first**, then read committed IDs, preprocess, repartition to one block) with the new block-returning path. The numpy tail of the id_column path is unchanged.
- `generated_id.py` gains the compact schema constants plus its consumers: `parse_checkpointed_fragment_info` / `exclude_checkpointed_rows` (read-time row filtering, used in PR 3) and `index_checkpointed_fragments` / `get_checkpoint_fragments_info_for_file` / `is_file_fragments_fully_checkpointed` (list-time lookup, used in PR 3). Struct fields are always resolved by name (`get_struct_field_index`) because Parquet round-trips don't preserve struct field order.
- `LoadCheckpointCallback` loads the compact block in `before_execution_starts` for generated-ID configs and exposes `load_checkpoint()` (consumed by the ListFiles plan function in PR 4). Delete-on-success is unchanged for both paths; failures still leave pending files as the recovery record.

Nothing routes to this code yet — the planner switch-on is PR 4.

## Related issue number

N/A. Not a duplicate: searched open PRs/issues in ray-project/ray for `generated_id_column`, "row group checkpoint" — no overlapping work.

## Checks

- [x] I've signed off every commit (DCO).
- [x] I've run pre-commit hooks on all touched files — clean.
- [x] AI assistance (Claude Code) was used for the development of this PR. I, Abhishek Verma, am the human submitter signing off on it: I have reviewed every changed line, run the tests below locally, and can defend the change end-to-end.
- Testing:
  - New tests in `python/ray/data/tests/test_checkpoint.py`: `TestGeneratedIdFragmentParsing` (parse full/partial/no-entry/never-seen, num_rows-mismatch assertion, exclude with batch offsets and bounds, index/lookup) and `test_generated_id_checkpoint_compaction` / `test_generated_id_checkpoint_load_empty` (end-to-end compaction through real Ray groupby/map_groups; mixed full/partial/never-seen files; empty sentinel) — 12 passed.
  - Regression: full `test_checkpoint.py` — 97/98 locally (the one failure is the pre-existing `test_skip_checkpoint_flag[s3]` local moto-server slowness, also failing on clean master).