### PR TITLE
[Data] [3/4] Skip checkpointed files, row groups and rows on the V2 read path

### DIFF
--- a/python/ray/data/_internal/datasource_v2/listing/file_indexer.py
+++ b/python/ray/data/_internal/datasource_v2/listing/file_indexer.py
@@ -20,7 +20,13 @@ from ray.data._internal.datasource_v2.listing.indexing_utils import (
     _get_path_contents,
 )
 from ray.data._internal.dynamic_work_queue import parallel_process_work_stealing
-from ray.data.block import BlockColumn
+from ray.data.block import Block, BlockColumn
+from ray.data.checkpoint.generated_id import (
+    CheckpointFragmentsInfo,
+    get_checkpoint_fragments_info_for_file,
+    index_checkpointed_fragments,
+    is_file_fragments_fully_checkpointed,
+)
 from ray.data.datasource.path_util import _resolve_paths_and_filesystem
 
 if TYPE_CHECKING:
@@ -64,6 +70,7 @@ class FileIndexer(ABC):
         projected_columns: Optional[List[str]] = None,
         shuffle_config: Optional["FileShuffleConfig"] = None,
         execution_idx: int = 0,
+        checkpoint_ids: Optional[Block] = None,
     ) -> Iterable[FileManifest]:
         """List files and their on-disk sizes for the given path.
 
@@ -84,6 +91,11 @@ class FileIndexer(ABC):
                 :meth:`list_file_infos` is never shuffled.
             execution_idx: Execution index used with ``shuffle_config`` to
                 derive a per-execution seed.
+            checkpoint_ids: Compact generated-ID checkpoint block
+                (``CHECKPOINTED_GENERATED_ID_COLUMN_TABLE_SCHEMA``). When
+                set, fully-checkpointed files are dropped before chunking
+                and every emitted manifest carries the per-file checkpoint
+                struct column.
 
         Returns:
             An iterator of `FileManifest` objects, each of which contains a file path
@@ -255,6 +267,7 @@ class NonSamplingFileIndexer(FileIndexer):
         projected_columns: Optional[List[str]] = None,
         shuffle_config: Optional["FileShuffleConfig"] = None,
         execution_idx: int = 0,
+        checkpoint_ids: Optional[Block] = None,
     ) -> Iterable[FileManifest]:
         # This per-file listing path ignores predicate/limit/projected_columns;
         # they're consumed by metadata-aware indexers (e.g. the footer indexer).
@@ -269,7 +282,9 @@ class NonSamplingFileIndexer(FileIndexer):
             shuffle_config=shuffle_config,
             execution_idx=execution_idx,
         )
-        yield from self._process_file_infos_to_manifests(file_infos)
+        yield from self._process_file_infos_to_manifests(
+            file_infos, checkpoint_ids=checkpoint_ids
+        )
 
     def _iter_file_infos_for_list(
         self,
@@ -461,12 +476,17 @@ class NonSamplingFileIndexer(FileIndexer):
     def _process_file_infos_to_manifests(
         self,
         file_infos: Iterable[FileInfo],
+        checkpoint_ids: Optional[Block] = None,
     ) -> Iterable[FileManifest]:
         # ``file_infos`` are already filtered (zero-size skipped, pruners applied)
-        # by ``list_file_infos``; this method only chunks them into manifests.
+        # by ``list_file_infos``; this method only chunks them into manifests —
+        # and, when a checkpoint block is given, drops fully-checkpointed files
+        # before chunking and stamps the per-file checkpoint struct on every row.
+        checkpointed_fragments_by_path = index_checkpointed_fragments(checkpoint_ids)
         running_paths: List[str] = []
         running_file_sizes: List[int] = []
         running_chunk_metadatas: List[Optional[ChunkMetadata]] = []
+        running_checkpoint_infos: List[Optional[CheckpointFragmentsInfo]] = []
         manifests_count = 0
         chunks_count = 0
 
@@ -474,6 +494,18 @@ class NonSamplingFileIndexer(FileIndexer):
             # ``list_file_infos`` already dropped zero/None-size files.
             assert file_info.size is not None
             path, file_size = file_info.path, file_info.size
+
+            checkpoint_info: Optional[CheckpointFragmentsInfo] = None
+            if checkpoint_ids is not None:
+                checkpoint_info = get_checkpoint_fragments_info_for_file(
+                    checkpoint_ids, path, checkpointed_fragments_by_path
+                )
+                if (
+                    checkpoint_info.checkpointed_file_fragments is not None
+                    and is_file_fragments_fully_checkpointed(checkpoint_info)
+                ):
+                    logger.debug("Skipping fully checkpointed file: %r", path)
+                    continue
 
             # Drive the chunker once per file; emit one manifest row per chunk.
             # ``chunk_metadata`` is ``None`` for whole-file chunks (the default
@@ -485,6 +517,7 @@ class NonSamplingFileIndexer(FileIndexer):
                 running_paths.append(path)
                 running_file_sizes.append(chunk_size)
                 running_chunk_metadatas.append(chunk_metadata)
+                running_checkpoint_infos.append(checkpoint_info)
                 chunks_count += 1
 
                 if len(running_paths) >= self._max_paths_per_output:
@@ -493,10 +526,16 @@ class NonSamplingFileIndexer(FileIndexer):
                         paths=running_paths,
                         sizes=running_file_sizes,
                         chunk_metadatas=running_chunk_metadatas,
+                        checkpoint_file_fragments=(
+                            running_checkpoint_infos
+                            if checkpoint_ids is not None
+                            else None
+                        ),
                     )
                     running_paths = []
                     running_file_sizes = []
                     running_chunk_metadatas = []
+                    running_checkpoint_infos = []
 
         if running_paths:
             manifests_count += 1
@@ -504,6 +543,9 @@ class NonSamplingFileIndexer(FileIndexer):
                 paths=running_paths,
                 sizes=running_file_sizes,
                 chunk_metadatas=running_chunk_metadatas,
+                checkpoint_file_fragments=(
+                    running_checkpoint_infos if checkpoint_ids is not None else None
+                ),
             )
 
         logger.debug(

--- a/python/ray/data/_internal/datasource_v2/listing/file_manifest.py
+++ b/python/ray/data/_internal/datasource_v2/listing/file_manifest.py
@@ -6,11 +6,32 @@ import pyarrow as pa
 
 from ray.data._internal.datasource_v2.chunkers.file_chunker import ChunkMetadata
 from ray.data.block import Block, BlockAccessor, BlockColumnAccessor
+from ray.data.checkpoint.generated_id import (
+    CHECKPOINTED_FILE_FRAGMENTS_TYPE,
+    CheckpointFragmentsInfo,
+)
 
 # File manifest column names
 PATH_COLUMN_NAME = "__path"
 FILE_SIZE_COLUMN_NAME = "__file_size"
 FILE_CHUNK_METADATA_COLUMN_NAME = "__file_chunk_metadata"
+# Optional column, present only when generated-ID checkpointing is active:
+# the file's compact checkpoint struct (null = file never checkpointed).
+FILE_FRAGMENTS_CHECKPOINT_COLUMN_NAME = "__file_fragments_checkpoint"
+
+
+def _to_checkpoint_scalar_value(value):
+    """Normalize one checkpoint entry for ``pa.array``.
+
+    Accepts ``None``, a ``CheckpointFragmentsInfo``, or a raw
+    ``pa.StructScalar`` (as carried through partitioners). A null struct
+    scalar normalizes to ``None``.
+    """
+    if isinstance(value, CheckpointFragmentsInfo):
+        value = value.checkpointed_file_fragments
+    if isinstance(value, pa.Scalar) and not value.is_valid:
+        return None
+    return value
 
 
 class FileManifest:
@@ -66,6 +87,15 @@ class FileManifest:
     @cached_property
     def file_chunk_metadatas(self) -> np.ndarray:
         return BlockColumnAccessor.for_column(self._file_chunk_metadatas).to_numpy()
+
+    @property
+    def file_fragments_checkpoint(self) -> Optional[pa.ChunkedArray]:
+        """Per-row compact checkpoint structs, or None when checkpointing is
+        off. Kept as an Arrow column (not numpy) so struct scalars survive."""
+        column_names = BlockAccessor.for_block(self._block).column_names()
+        if FILE_FRAGMENTS_CHECKPOINT_COLUMN_NAME not in column_names:
+            return None
+        return self._block[FILE_FRAGMENTS_CHECKPOINT_COLUMN_NAME]
 
     def as_block(self) -> Block:
         """Return the underlying block for the `FileManifest`.
@@ -129,14 +159,35 @@ class FileManifest:
         paths: List[str],
         sizes: List[int],
         chunk_metadatas: List[Optional[ChunkMetadata]],
+        checkpoint_file_fragments: Optional[List] = None,
     ) -> "FileManifest":
+        """Build a manifest block from parallel per-row lists.
+
+        Args:
+            paths: One file path per row.
+            sizes: On-disk size (or chunk size) per row.
+            chunk_metadatas: Chunk metadata per row; None for whole-file rows.
+            checkpoint_file_fragments: When generated-ID checkpointing is
+                active, one entry per row: a ``CheckpointFragmentsInfo``, a
+                raw ``CHECKPOINTED_FILE_FRAGMENTS_TYPE`` struct scalar, or
+                None for a file with no checkpoint entry. Omit (None) to
+                leave the column out entirely.
+
+        Returns:
+            The constructed ``FileManifest``.
+        """
         assert len(paths) == len(sizes) == len(chunk_metadatas)
 
-        block = pa.table(
-            {
-                PATH_COLUMN_NAME: paths,
-                FILE_SIZE_COLUMN_NAME: sizes,
-                FILE_CHUNK_METADATA_COLUMN_NAME: chunk_metadatas,
-            }
-        )
+        columns = {
+            PATH_COLUMN_NAME: paths,
+            FILE_SIZE_COLUMN_NAME: sizes,
+            FILE_CHUNK_METADATA_COLUMN_NAME: chunk_metadatas,
+        }
+        if checkpoint_file_fragments is not None:
+            assert len(checkpoint_file_fragments) == len(paths)
+            columns[FILE_FRAGMENTS_CHECKPOINT_COLUMN_NAME] = pa.array(
+                [_to_checkpoint_scalar_value(v) for v in checkpoint_file_fragments],
+                type=CHECKPOINTED_FILE_FRAGMENTS_TYPE,
+            )
+        block = pa.table(columns)
         return cls(block)

--- a/python/ray/data/_internal/datasource_v2/listing/footer_file_indexer.py
+++ b/python/ray/data/_internal/datasource_v2/listing/footer_file_indexer.py
@@ -18,6 +18,12 @@ from ray.data._internal.datasource_v2.listing.file_manifest import (
     FileManifest,
 )
 from ray.data._internal.datasource_v2.listing.footer_reader import FooterReaderActor
+from ray.data.block import Block
+from ray.data.checkpoint.generated_id import (
+    get_checkpoint_fragments_info_for_file,
+    index_checkpointed_fragments,
+    is_file_fragments_fully_checkpointed,
+)
 
 if TYPE_CHECKING:
     from pyarrow.fs import FileSystem
@@ -27,6 +33,7 @@ if TYPE_CHECKING:
     from ray.data._internal.datasource_v2.listing.file_pruners import FilePruner
     from ray.data._internal.datasource_v2.listing.footer_reader import FooterReader
     from ray.data.block import BlockColumn
+    from ray.data.checkpoint.generated_id import CheckpointFragmentsInfo
     from ray.data.datasource.file_based_datasource import FileShuffleConfig
     from ray.data.expressions import Expr
 
@@ -54,13 +61,20 @@ _DEFAULT_MAX_INFLIGHT_BATCHES: Optional[int] = env_integer(
 # as a ``FilePartitioner``; see ``ParquetDatasourceV2.get_file_partitioner``.
 
 
-def _file_chunks_to_manifest(file_chunks: FileChunks) -> FileManifest:
+def _file_chunks_to_manifest(
+    file_chunks: FileChunks,
+    checkpoint_info: Optional["CheckpointFragmentsInfo"] = None,
+    include_checkpoint_column: bool = False,
+) -> FileManifest:
     """One listing row per row-group run of a file.
 
     The row carries the run's exact footer stats, so a downstream partitioner
     can group runs into read units -- and split them at row-group boundaries --
     without re-reading the footer. Grouping is deliberately *not* done here:
-    listing discovers, the partitioner groups.
+    listing discovers, the partitioner groups. With
+    ``include_checkpoint_column``, every row is also stamped with the file's
+    compact checkpoint struct (``checkpoint_info``; None for a never-seen
+    file).
     """
     n = len(file_chunks.row_groups)
     return FileManifest.construct_manifest(
@@ -78,6 +92,9 @@ def _file_chunks_to_manifest(file_chunks: FileChunks) -> FileManifest:
             )
             for rg in file_chunks.row_groups
         ],
+        checkpoint_file_fragments=(
+            [checkpoint_info] * n if include_checkpoint_column else None
+        ),
     )
 
 
@@ -164,6 +181,7 @@ class FooterFileIndexer(NonSamplingFileIndexer):
         projected_columns: Optional[List[str]] = None,
         shuffle_config: Optional["FileShuffleConfig"] = None,
         execution_idx: int = 0,
+        checkpoint_ids: Optional[Block] = None,
     ) -> Iterable[FileManifest]:
         file_infos = self._iter_file_infos_for_list(
             paths,
@@ -173,6 +191,13 @@ class FooterFileIndexer(NonSamplingFileIndexer):
             shuffle_config=shuffle_config,
             execution_idx=execution_idx,
         )
+        checkpointed_fragments_by_path = index_checkpointed_fragments(checkpoint_ids)
+        if checkpoint_ids is not None:
+            # Drop fully-checkpointed files before footer reads — their
+            # footers never need to be fetched on resume.
+            file_infos = self._drop_fully_checkpointed_files(
+                file_infos, checkpoint_ids, checkpointed_fragments_by_path
+            )
         actors: List[ActorProxy[FooterReader]] = [
             FooterReaderActor.options(scheduling_strategy="SPREAD").remote(
                 filesystem,
@@ -190,13 +215,36 @@ class FooterFileIndexer(NonSamplingFileIndexer):
         )
         try:
             yield from self._read_footers(
-                actors, file_infos, limit, preserve_order=preserve_order
+                actors,
+                file_infos,
+                limit,
+                preserve_order=preserve_order,
+                checkpoint_ids=checkpoint_ids,
+                checkpointed_fragments_by_path=checkpointed_fragments_by_path,
             )
         finally:
             for actor in actors:
                 # ``ActorProxy`` is ``ActorHandle | type[T]``; kill wants a handle.
                 # pyrefly: ignore[bad-argument-type]
                 ray.kill(actor)
+
+    @staticmethod
+    def _drop_fully_checkpointed_files(
+        file_infos: "Iterable[FileInfo]",
+        checkpoint_ids: Block,
+        checkpointed_fragments_by_path: dict,
+    ) -> "Iterator[FileInfo]":
+        for file_info in file_infos:
+            checkpoint_info = get_checkpoint_fragments_info_for_file(
+                checkpoint_ids, file_info.path, checkpointed_fragments_by_path
+            )
+            if (
+                checkpoint_info.checkpointed_file_fragments is not None
+                and is_file_fragments_fully_checkpointed(checkpoint_info)
+            ):
+                logger.debug("Skipping fully checkpointed file: %r", file_info.path)
+                continue
+            yield file_info
 
     def _read_footers(
         self,
@@ -205,6 +253,8 @@ class FooterFileIndexer(NonSamplingFileIndexer):
         limit: Optional[int],
         *,
         preserve_order: bool = False,
+        checkpoint_ids: Optional[Block] = None,
+        checkpointed_fragments_by_path: Optional[dict] = None,
     ) -> Iterator[FileManifest]:
         # Bound the number of in-flight footer batches so listing stays roughly
         # demand-driven (matters under a limit) and memory stays flat.
@@ -242,7 +292,20 @@ class FooterFileIndexer(NonSamplingFileIndexer):
             gen = pending.popleft()
             for ref in gen:  # blocks until this generator's next result lands
                 for file_chunks in ray.get(ref):
-                    yield _file_chunks_to_manifest(file_chunks)
+                    checkpoint_info = None
+                    if checkpoint_ids is not None:
+                        # Fully-checkpointed files were dropped pre-footer;
+                        # what's left is stamped for reader-side skipping.
+                        checkpoint_info = get_checkpoint_fragments_info_for_file(
+                            checkpoint_ids,
+                            file_chunks.path,
+                            checkpointed_fragments_by_path,
+                        )
+                    yield _file_chunks_to_manifest(
+                        file_chunks,
+                        checkpoint_info=checkpoint_info,
+                        include_checkpoint_column=checkpoint_ids is not None,
+                    )
                     if limit is not None:
                         # Count only fully-matched (exact-survivor) rows so
                         # stopping can never under-deliver under a filter.

--- a/python/ray/data/_internal/datasource_v2/listing/listing_utils.py
+++ b/python/ray/data/_internal/datasource_v2/listing/listing_utils.py
@@ -16,6 +16,7 @@ from ray.data._internal.datasource_v2.partitioners.file_partitioner import (
 )
 from ray.data._internal.execution.interfaces.task_context import TaskContext
 from ray.data.block import Block
+from ray.data.checkpoint.generated_id import CHECKPOINTED_IDS_KWARG_NAME
 
 if TYPE_CHECKING:
     from pyarrow.fs import FileSystem
@@ -59,7 +60,7 @@ def _build_pruners(
 
 def list_files_for_each_block(
     blocks: Iterable[Block],
-    _: TaskContext,
+    ctx: TaskContext,
     *,
     indexer: "FileIndexer",
     filesystem: "FileSystem",
@@ -91,8 +92,14 @@ def list_files_for_each_block(
     after path discovery and before metadata fetch. Listing still runs as a
     single task when shuffle is requested so the indexer sees the full file
     set.
+
+    Generated-ID checkpointing injects the compact checkpoint block lazily
+    via ``ctx.kwargs`` (see ``plan_list_files_op_with_checkpoint_filter``);
+    the indexer uses it to drop fully-checkpointed files and stamp the
+    per-file checkpoint struct onto manifest rows.
     """
     pruners = _build_pruners(file_extensions, partition_filter, partition_pruner)
+    checkpoint_ids = ctx.kwargs.get(CHECKPOINTED_IDS_KWARG_NAME)
     for block in blocks:
         for manifest in indexer.list_files(
             block[PATH_COLUMN_NAME],
@@ -104,6 +111,7 @@ def list_files_for_each_block(
             projected_columns=projected_columns,
             shuffle_config=shuffle_config,
             execution_idx=execution_idx,
+            checkpoint_ids=checkpoint_ids,
         ):
             if len(manifest) > 0:
                 yield manifest.as_block()

--- a/python/ray/data/_internal/datasource_v2/partitioners/online_bin_packer.py
+++ b/python/ray/data/_internal/datasource_v2/partitioners/online_bin_packer.py
@@ -311,6 +311,10 @@ class OnlineBinPacker(FilePartitioner):
             self._cap, self._output, max_shared_open_bins
         )  # non-isolated bins (mixed files)
         self._heavy = _SingleFileBinPool(self._cap, self._output)
+        # Per-file compact checkpoint structs (generated-ID checkpointing),
+        # carried from input manifests to rebuilt bin manifests.
+        self._has_checkpoint_column = False
+        self._checkpoint_by_path: dict = {}
 
     @property
     def requires_global_input(self) -> bool:
@@ -319,6 +323,13 @@ class OnlineBinPacker(FilePartitioner):
     # === Feeding ===
 
     def add_input(self, input_manifest: FileManifest) -> None:
+        checkpoint_column = input_manifest.file_fragments_checkpoint
+        if checkpoint_column is not None:
+            self._has_checkpoint_column = True
+            # The struct is per file (all of a file's rows carry the same
+            # value), so a path-keyed map survives bin splits and re-unions.
+            for path, checkpoint_value in zip(input_manifest.paths, checkpoint_column):
+                self._checkpoint_by_path[str(path)] = checkpoint_value
         for item in _bin_items(input_manifest):
             self._place(item)
 
@@ -393,8 +404,7 @@ class OnlineBinPacker(FilePartitioner):
         self._heavy.flush()
         self._shared.flush()
 
-    @staticmethod
-    def _bin_to_manifest(bin_: Bin) -> FileManifest:
+    def _bin_to_manifest(self, bin_: Bin) -> FileManifest:
         # One manifest row per distinct file in the bin. A file's (possibly-split)
         # items cover disjoint contiguous runs, so union their physical row-group
         # ids into the read unit for that file.
@@ -436,4 +446,9 @@ class OnlineBinPacker(FilePartitioner):
             paths=paths,
             sizes=sizes,
             chunk_metadatas=cast(List[Optional[ChunkMetadata]], chunk_metadatas),
+            checkpoint_file_fragments=(
+                [self._checkpoint_by_path.get(path) for path in paths]
+                if self._has_checkpoint_column
+                else None
+            ),
         )

--- a/python/ray/data/_internal/datasource_v2/partitioners/round_robin_partitioner.py
+++ b/python/ray/data/_internal/datasource_v2/partitioners/round_robin_partitioner.py
@@ -48,24 +48,35 @@ class RoundRobinPartitioner(FilePartitioner):
             max_bucket_size=max_bucket_size,
             num_buckets=num_buckets,
         )
+        self._has_checkpoint_column = False
 
     def add_input(self, input_manifest: FileManifest):
         in_memory_size_estimates = (
             self._in_memory_size_estimator.estimate_in_memory_sizes(input_manifest)
         )
+        # Carry the per-row checkpoint struct (generated-ID checkpointing)
+        # through bucketing; a rebuilt manifest must not drop the column.
+        checkpoint_column = input_manifest.file_fragments_checkpoint
+        if checkpoint_column is not None:
+            self._has_checkpoint_column = True
+            checkpoint_values = list(checkpoint_column)
+        else:
+            checkpoint_values = [None] * len(input_manifest)
         for (
             file_path,
             file_size,
             file_chunk_metadata,
+            checkpoint_value,
             in_memory_size_estimate,
         ) in zip(
             input_manifest.paths,
             input_manifest.file_sizes,
             input_manifest.file_chunk_metadatas,
+            checkpoint_values,
             in_memory_size_estimates,
         ):
             self._partitioner.add_item(
-                (file_path, file_size, file_chunk_metadata),
+                (file_path, file_size, file_chunk_metadata, checkpoint_value),
                 in_memory_size_estimate,
             )
 
@@ -78,11 +89,14 @@ class RoundRobinPartitioner(FilePartitioner):
 
     def next_partition(self) -> FileManifest:
         partition = self._partitioner.next_partition()
-        paths, file_sizes, file_chunk_metadatas = zip(*partition)
+        paths, file_sizes, file_chunk_metadatas, checkpoint_values = zip(*partition)
         return FileManifest.construct_manifest(
             paths=list(paths),
             sizes=list(file_sizes),
             chunk_metadatas=list(file_chunk_metadatas),
+            checkpoint_file_fragments=(
+                list(checkpoint_values) if self._has_checkpoint_column else None
+            ),
         )
 
     def finalize(self):

--- a/python/ray/data/_internal/datasource_v2/readers/parquet_file_reader.py
+++ b/python/ray/data/_internal/datasource_v2/readers/parquet_file_reader.py
@@ -39,8 +39,11 @@ from ray.data._internal.object_extensions.arrow import raise_on_pickle_object_co
 from ray.data._internal.util import MiB, iterate_with_retry
 from ray.data.block import BlockMetadata
 from ray.data.checkpoint.generated_id import (
+    CheckpointedFragmentInfo,
+    exclude_checkpointed_rows,
     get_generated_id_column,
     get_generated_id_column_name,
+    parse_checkpointed_fragment_info,
 )
 from ray.data.context import DataContext
 from ray.data.expressions import Expr
@@ -342,7 +345,7 @@ class ParquetFileReader(FileReader, SupportsMetadata):
         self,
         dataset: pds.Dataset,
         manifest: FileManifest,
-    ) -> List[Tuple[pds.Fragment, int]]:
+    ) -> List[Tuple]:
         """Fan file fragments into read-level sub-fragments per manifest row.
 
         For each manifest row, looks up the file's fragment by path and:
@@ -369,6 +372,14 @@ class ParquetFileReader(FileReader, SupportsMetadata):
         per-row chunk metadata drives the fan-out here, not the dataset
         itself — multiple manifest rows can share a single path with
         different row-group sets.
+
+        With a generated ID column, elements are widened to
+        ``(fragment, file_row_offset, Optional[CheckpointedFragmentInfo])``:
+        each row-group sub-fragment is resolved against the manifest's
+        compact checkpoint struct, fully-checkpointed row groups are dropped
+        here (never scanned), and partially-checkpointed ones carry their
+        info for row filtering in :meth:`_read_fragments_sequential`. The
+        base class never sees the 3-tuples — the override consumes them.
         """
         path_to_fragment = {
             fragment.path: fragment for fragment in dataset.get_fragments()
@@ -378,9 +389,17 @@ class ParquetFileReader(FileReader, SupportsMetadata):
         if generated_id_column is not None:
             self._validate_generated_id_column(path_to_fragment)
 
+        checkpoint_column = (
+            manifest.file_fragments_checkpoint
+            if generated_id_column is not None
+            else None
+        )
+
         split_per_row_group = self._include_row_hash or generated_id_column is not None
         fragments: List[Tuple[pds.Fragment, int]] = []
-        for path, chunk_metadata in zip(manifest.paths, manifest.file_chunk_metadatas):
+        for row_idx, (path, chunk_metadata) in enumerate(
+            zip(manifest.paths, manifest.file_chunk_metadatas)
+        ):
             fragment: pds.ParquetFileFragment = path_to_fragment[path]
             if chunk_metadata is None:
                 if split_per_row_group:
@@ -388,24 +407,65 @@ class ParquetFileReader(FileReader, SupportsMetadata):
                         lambda: fragment.metadata.num_row_groups,
                         f"read parquet metadata for {fragment.path}",
                     )
-                    fragments.extend(
-                        _fragments_from_row_group_ids(
-                            fragment,
-                            range(num_row_groups),
-                            per_row_group_offsets=True,
-                        )
+                    sub_fragments = _fragments_from_row_group_ids(
+                        fragment,
+                        range(num_row_groups),
+                        per_row_group_offsets=True,
                     )
                 else:
-                    fragments.append((fragment, 0))
+                    sub_fragments = [(fragment, 0)]
             else:
-                fragments.extend(
-                    _fragments_from_row_group_ids(
-                        fragment,
-                        chunk_metadata["row_group_ids"],
-                        per_row_group_offsets=split_per_row_group,
-                    )
+                sub_fragments = _fragments_from_row_group_ids(
+                    fragment,
+                    chunk_metadata["row_group_ids"],
+                    per_row_group_offsets=split_per_row_group,
                 )
+
+            if generated_id_column is None:
+                fragments.extend(sub_fragments)
+                continue
+
+            checkpoint_scalar = (
+                checkpoint_column[row_idx] if checkpoint_column is not None else None
+            )
+            fragments.extend(
+                self._attach_checkpoint_infos(sub_fragments, checkpoint_scalar)
+            )
         return fragments
+
+    def _attach_checkpoint_infos(
+        self,
+        sub_fragments: List[Tuple[pds.ParquetFileFragment, int]],
+        checkpoint_scalar: Optional[pa.StructScalar],
+    ) -> List[Tuple[pds.ParquetFileFragment, int, Optional[CheckpointedFragmentInfo]]]:
+        """Widen row-group sub-fragments with their checkpoint state.
+
+        Fully-checkpointed row groups are dropped (never scanned). Row groups
+        with no checkpointed rows carry ``None`` so the read path skips the
+        filtering work entirely.
+        """
+        result = []
+        for sub_fragment, offset in sub_fragments:
+            info: Optional[CheckpointedFragmentInfo] = None
+            if checkpoint_scalar is not None and checkpoint_scalar.is_valid:
+                assert (
+                    sub_fragment.row_groups is not None
+                    and len(sub_fragment.row_groups) == 1
+                )
+                info = parse_checkpointed_fragment_info(
+                    sub_fragment, sub_fragment.row_groups[0].id, checkpoint_scalar
+                )
+                if info.fully_checkpointed:
+                    logger.debug(
+                        "Skipping fully checkpointed row group %d of %r",
+                        info.row_group_idx,
+                        sub_fragment.path,
+                    )
+                    continue
+                if info.checkpointed_row_count == 0:
+                    info = None
+            result.append((sub_fragment, offset, info))
+        return result
 
     @override
     def _iter_fragment_tables(
@@ -701,19 +761,22 @@ class ParquetFileReader(FileReader, SupportsMetadata):
     @override
     def _read_fragments_sequential(
         self,
-        fragments_with_offsets: Iterator[Tuple[pds.Fragment, int]],
+        fragments_with_offsets: Iterator[Tuple],
         scanner_kwargs: dict,
     ) -> Iterator[Tuple[pa.Table, str, int]]:
         """Read fragments in order, attaching generated row IDs when configured.
 
         Without a generated ID column this delegates to the base
-        implementation. With one, every incoming fragment must carry exactly
-        one row group (established by :meth:`_get_fragments_to_read`), and
-        each yielded batch gains a struct ID column identifying
-        ``(file, row group, row)``. ``in_group_offset`` counts rows already
-        emitted for this row group so ``row_id`` continues across batches,
-        while the yielded offset keeps the base method's file-row-offset
-        semantics for row hashing.
+        implementation. With one, elements are the widened
+        ``(fragment, file_row_offset, checkpoint_info)`` tuples from
+        :meth:`_get_fragments_to_read`: every fragment carries exactly one
+        row group, each batch gains a struct ID column identifying
+        ``(file, row group, row)``, and — when the row group is partially
+        checkpointed — already-committed rows are dropped *after* the IDs
+        are attached, so ``row_id`` assignment is independent of resume
+        state. ``in_group_offset`` counts pre-filter rows so ``row_id``
+        continues across batches; the yielded offset keeps the base
+        method's post-filter file-row-offset semantics for row hashing.
         """
         generated_id_column = self._generated_id_column
         if generated_id_column is None:
@@ -723,7 +786,7 @@ class ParquetFileReader(FileReader, SupportsMetadata):
             return
 
         ctx = DataContext.get_current()
-        for fragment, file_row_offset in fragments_with_offsets:
+        for fragment, file_row_offset, checkpoint_info in fragments_with_offsets:
             assert fragment.row_groups is not None and len(fragment.row_groups) == 1, (
                 "generated_id_column requires one row group per fragment, "
                 f"got {fragment.row_groups!r} for {fragment.path}"
@@ -744,6 +807,7 @@ class ParquetFileReader(FileReader, SupportsMetadata):
             ):
                 if table.num_rows == 0:
                     continue
+                batch_num_rows_pre_filtering = table.num_rows
                 table = table.append_column(
                     generated_id_column,
                     get_generated_id_column(
@@ -752,9 +816,32 @@ class ParquetFileReader(FileReader, SupportsMetadata):
                         num_row_groups=num_row_groups,
                         total_num_rows=rg_num_rows,
                         current_row_offset=in_group_offset,
-                        current_num_rows=table.num_rows,
+                        current_num_rows=batch_num_rows_pre_filtering,
                     ),
                 )
+                prev_in_group_offset = in_group_offset
+                in_group_offset += batch_num_rows_pre_filtering
+
+                if checkpoint_info is not None:
+                    assert not checkpoint_info.fully_checkpointed, (
+                        "Fully-checkpointed row groups should have been "
+                        "dropped in _get_fragments_to_read"
+                    )
+                    table = exclude_checkpointed_rows(
+                        table=table,
+                        checkpointed_fragment_info=checkpoint_info,
+                        current_row_offset=prev_in_group_offset,
+                        current_num_rows=batch_num_rows_pre_filtering,
+                    )
+                    if table.num_rows < batch_num_rows_pre_filtering:
+                        logger.debug(
+                            "Excluded %d checkpointed rows from %r row group %d",
+                            batch_num_rows_pre_filtering - table.num_rows,
+                            fragment.path,
+                            row_group_idx,
+                        )
+                    if table.num_rows == 0:
+                        continue
+
                 yield table, fragment.path, hash_offset
-                in_group_offset += table.num_rows
                 hash_offset += table.num_rows

--- a/python/ray/data/_internal/datasource_v2/tests/test_generated_id_listing.py
+++ b/python/ray/data/_internal/datasource_v2/tests/test_generated_id_listing.py
@@ -1,0 +1,293 @@
+"""List-time skip tests for generated-ID checkpointing.
+
+Covers the compact checkpoint block flowing through listing: both indexers
+drop fully-checkpointed files and stamp the per-file checkpoint struct onto
+manifest rows, and the struct column survives manifest reconstruction in the
+partitioners.
+"""
+
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+
+from ray.data._internal.datasource_v2.listing.file_indexer import (
+    NonSamplingFileIndexer,
+)
+from ray.data._internal.datasource_v2.listing.file_manifest import (
+    FILE_FRAGMENTS_CHECKPOINT_COLUMN_NAME,
+    FileManifest,
+)
+from ray.data._internal.datasource_v2.listing.footer_file_indexer import (
+    FooterFileIndexer,
+)
+from ray.data._internal.datasource_v2.partitioners.online_bin_packer import (
+    OnlineBinPacker,
+)
+from ray.data._internal.datasource_v2.partitioners.round_robin_partitioner import (
+    RoundRobinPartitioner,
+)
+from ray.data.checkpoint.generated_id import (
+    CHECKPOINTED_FILE_COLUMN_NAME,
+    CHECKPOINTED_FILE_FRAGMENTS_COLUMN_NAME,
+    CHECKPOINTED_FILE_FRAGMENTS_TYPE,
+    CHECKPOINTED_GENERATED_ID_COLUMN_TABLE_SCHEMA,
+    CheckpointFragmentsInfo,
+)
+
+
+def _file_fragments_value(fragments):
+    """One file's struct value from (fragment_id, num_rows, committed) tuples."""
+    entries = []
+    num_fully = 0
+    for fragment_id, num_rows, committed in fragments:
+        fully = len(committed) == num_rows
+        num_fully += fully
+        entries.append(
+            {
+                "fragment_id": fragment_id,
+                "num_rows": num_rows,
+                "num_checkpointed_rows": len(committed),
+                "checkpointed_row_ids": (
+                    [] if fully else [i in set(committed) for i in range(num_rows)]
+                ),
+            }
+        )
+    return {
+        "num_fragments": len(fragments),
+        "fully_checkpointed": num_fully == len(fragments),
+        "fragments": entries,
+    }
+
+
+def _checkpoint_block(files):
+    """Compact checkpoint table from {path: [(fragment_id, num_rows, committed)]}."""
+    return pa.table(
+        {
+            CHECKPOINTED_FILE_COLUMN_NAME: list(files.keys()),
+            CHECKPOINTED_FILE_FRAGMENTS_COLUMN_NAME: pa.array(
+                [_file_fragments_value(f) for f in files.values()],
+                type=CHECKPOINTED_FILE_FRAGMENTS_TYPE,
+            ),
+        },
+        schema=CHECKPOINTED_GENERATED_ID_COLUMN_TABLE_SCHEMA,
+    )
+
+
+def _write_parquet(path: str, num_rows: int, row_group_size: int):
+    pq.write_table(
+        pa.table({"x": list(range(num_rows))}), path, row_group_size=row_group_size
+    )
+
+
+def _fully_checkpointed_flags(manifest: FileManifest):
+    column = manifest.file_fragments_checkpoint
+    assert column is not None
+    return [
+        None if scalar.as_py() is None else scalar["fully_checkpointed"].as_py()
+        for scalar in column
+    ]
+
+
+# --- FileManifest column behavior ---
+
+
+def test_manifest_checkpoint_column_optional():
+    manifest = FileManifest.construct_manifest(
+        paths=["a"], sizes=[1], chunk_metadatas=[None]
+    )
+    assert manifest.file_fragments_checkpoint is None
+    assert FILE_FRAGMENTS_CHECKPOINT_COLUMN_NAME not in manifest.as_block().column_names
+
+
+def test_manifest_checkpoint_column_from_mixed_values():
+    """construct_manifest accepts infos, raw scalars, and None per row."""
+    scalar = pa.array(
+        [_file_fragments_value([(0, 2, [0])])], type=CHECKPOINTED_FILE_FRAGMENTS_TYPE
+    )[0]
+    null_scalar = pa.array([None], type=CHECKPOINTED_FILE_FRAGMENTS_TYPE)[0]
+    info = CheckpointFragmentsInfo(path="b", checkpointed_file_fragments=scalar)
+    never_seen = CheckpointFragmentsInfo(path="c", checkpointed_file_fragments=None)
+
+    manifest = FileManifest.construct_manifest(
+        paths=["a", "b", "c", "d"],
+        sizes=[1, 1, 1, 1],
+        chunk_metadatas=[None] * 4,
+        checkpoint_file_fragments=[scalar, info, never_seen, null_scalar],
+    )
+    column = manifest.file_fragments_checkpoint
+    assert column is not None
+    assert column.type == CHECKPOINTED_FILE_FRAGMENTS_TYPE
+    assert [s.is_valid for s in column] == [True, True, False, False]
+
+
+def test_manifest_checkpoint_column_survives_concat_and_shuffle():
+    scalar = pa.array(
+        [_file_fragments_value([(0, 2, [0])])], type=CHECKPOINTED_FILE_FRAGMENTS_TYPE
+    )[0]
+    m1 = FileManifest.construct_manifest(
+        paths=["a"],
+        sizes=[1],
+        chunk_metadatas=[None],
+        checkpoint_file_fragments=[scalar],
+    )
+    m2 = FileManifest.construct_manifest(
+        paths=["b"],
+        sizes=[2],
+        chunk_metadatas=[None],
+        checkpoint_file_fragments=[None],
+    )
+    merged = FileManifest.concat([m1, m2])
+    assert [s.is_valid for s in merged.file_fragments_checkpoint] == [True, False]
+
+    shuffled = merged.shuffle(seed=42)
+    by_path = dict(zip(shuffled.paths, shuffled.file_fragments_checkpoint))
+    assert by_path["a"].is_valid and not by_path["b"].is_valid
+
+
+# --- Indexer skip + stamp ---
+
+
+@pytest.fixture
+def three_file_dataset(tmp_path):
+    """Files a (2 row groups, fully done), b (partial), c (never seen)."""
+    paths = {}
+    for name in ("a", "b", "c"):
+        path = str(tmp_path / f"{name}.parquet")
+        _write_parquet(path, num_rows=6, row_group_size=3)
+        paths[name] = path
+    checkpoint_block = _checkpoint_block(
+        {
+            paths["a"]: [(0, 3, [0, 1, 2]), (1, 3, [0, 1, 2])],
+            paths["b"]: [(0, 3, [1])],
+        }
+    )
+    return tmp_path, paths, checkpoint_block
+
+
+@pytest.mark.parametrize("indexer_cls", [NonSamplingFileIndexer, FooterFileIndexer])
+def test_indexer_drops_fully_checkpointed_and_stamps(indexer_cls, three_file_dataset):
+    tmp_path, paths, checkpoint_block = three_file_dataset
+    from pyarrow.fs import LocalFileSystem
+
+    indexer = indexer_cls(ignore_missing_paths=False)
+    manifests = list(
+        indexer.list_files(
+            pa.array([str(tmp_path)]),
+            filesystem=LocalFileSystem(),
+            checkpoint_ids=checkpoint_block,
+        )
+    )
+    merged = FileManifest.concat(manifests)
+
+    listed_paths = set(merged.paths)
+    assert paths["a"] not in listed_paths
+    assert {paths["b"], paths["c"]} == listed_paths
+
+    flags = dict(zip(merged.paths, _fully_checkpointed_flags(merged)))
+    assert flags[paths["b"]] is False  # partial file, stamped struct
+    assert flags[paths["c"]] is None  # never seen -> null struct
+
+
+@pytest.mark.parametrize("indexer_cls", [NonSamplingFileIndexer, FooterFileIndexer])
+def test_indexer_without_checkpoint_block_unchanged(indexer_cls, three_file_dataset):
+    tmp_path, paths, _ = three_file_dataset
+    from pyarrow.fs import LocalFileSystem
+
+    indexer = indexer_cls(ignore_missing_paths=False)
+    manifests = list(
+        indexer.list_files(pa.array([str(tmp_path)]), filesystem=LocalFileSystem())
+    )
+    merged = FileManifest.concat(manifests)
+    assert set(merged.paths) == set(paths.values())
+    assert merged.file_fragments_checkpoint is None
+
+
+# --- Partitioners preserve the column ---
+
+
+class _FixedSizeEstimator:
+    def estimate_in_memory_sizes(self, manifest):
+        return [100] * len(manifest)
+
+
+def _stamped_manifest(paths):
+    """Manifest whose even-indexed rows carry a checkpoint struct."""
+    scalar_values = [
+        _file_fragments_value([(0, 2, [0])]) if i % 2 == 0 else None
+        for i in range(len(paths))
+    ]
+    return FileManifest.construct_manifest(
+        paths=paths,
+        sizes=[10] * len(paths),
+        chunk_metadatas=[None] * len(paths),
+        checkpoint_file_fragments=[
+            pa.array([v], type=CHECKPOINTED_FILE_FRAGMENTS_TYPE)[0]
+            for v in scalar_values
+        ],
+    )
+
+
+def test_round_robin_partitioner_preserves_checkpoint_column():
+    partitioner = RoundRobinPartitioner(
+        _FixedSizeEstimator(), min_bucket_size=1, max_bucket_size=200, num_buckets=2
+    )
+    paths = [f"f{i}.parquet" for i in range(4)]
+    partitioner.add_input(_stamped_manifest(paths))
+    partitioner.finalize()
+
+    out_flags = {}
+    while partitioner.has_partition():
+        manifest = partitioner.next_partition()
+        out_flags.update(zip(manifest.paths, _fully_checkpointed_flags(manifest)))
+    assert set(out_flags) == set(paths)
+    # Even-indexed files carried a struct; odd ones were null.
+    for i, path in enumerate(paths):
+        assert (out_flags[path] is not None) == (i % 2 == 0)
+
+
+def test_round_robin_partitioner_without_column():
+    partitioner = RoundRobinPartitioner(
+        _FixedSizeEstimator(), min_bucket_size=1, max_bucket_size=200, num_buckets=2
+    )
+    partitioner.add_input(
+        FileManifest.construct_manifest(
+            paths=["a", "b"], sizes=[1, 1], chunk_metadatas=[None, None]
+        )
+    )
+    partitioner.finalize()
+    while partitioner.has_partition():
+        assert partitioner.next_partition().file_fragments_checkpoint is None
+
+
+def test_online_bin_packer_preserves_checkpoint_column():
+    packer = OnlineBinPacker(max_bin_bytes=15)
+    paths = [f"f{i}.parquet" for i in range(4)]
+    packer.add_input(_stamped_manifest(paths))
+    packer.finalize()
+
+    out_flags = {}
+    while packer.has_partition():
+        manifest = packer.next_partition()
+        out_flags.update(zip(manifest.paths, _fully_checkpointed_flags(manifest)))
+    assert set(out_flags) == set(paths)
+    for i, path in enumerate(paths):
+        assert (out_flags[path] is not None) == (i % 2 == 0)
+
+
+def test_online_bin_packer_without_column():
+    packer = OnlineBinPacker(max_bin_bytes=15)
+    packer.add_input(
+        FileManifest.construct_manifest(
+            paths=["a", "b"], sizes=[1, 1], chunk_metadatas=[None, None]
+        )
+    )
+    packer.finalize()
+    while packer.has_partition():
+        assert packer.next_partition().file_fragments_checkpoint is None
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main(["-v", __file__]))

--- a/python/ray/data/_internal/datasource_v2/tests/test_generated_id_reads.py
+++ b/python/ray/data/_internal/datasource_v2/tests/test_generated_id_reads.py
@@ -161,6 +161,116 @@ def test_infer_schema_advertises_generated_id(tmp_path, generated_id_checkpoint_
     assert schema.field(GEN_ID_COL).type == GENERATED_ID_COLUMN_TYPE
 
 
+def _file_fragments_value(fragments):
+    """One file's struct value from (fragment_id, num_rows, committed) tuples."""
+    entries = []
+    num_fully = 0
+    for fragment_id, num_rows, committed in fragments:
+        fully = len(committed) == num_rows
+        num_fully += fully
+        entries.append(
+            {
+                "fragment_id": fragment_id,
+                "num_rows": num_rows,
+                "num_checkpointed_rows": len(committed),
+                "checkpointed_row_ids": (
+                    [] if fully else [i in set(committed) for i in range(num_rows)]
+                ),
+            }
+        )
+    return {
+        "num_fragments": len(fragments),
+        "fully_checkpointed": num_fully == len(fragments),
+        "fragments": entries,
+    }
+
+
+def _checkpointed_manifest(paths, fragments_by_path):
+    """Whole-file manifest whose rows carry compact checkpoint structs."""
+    from ray.data.checkpoint.generated_id import CHECKPOINTED_FILE_FRAGMENTS_TYPE
+
+    values = [
+        (
+            _file_fragments_value(fragments_by_path[p])
+            if p in fragments_by_path
+            else None
+        )
+        for p in paths
+    ]
+    return FileManifest.construct_manifest(
+        paths=paths,
+        sizes=[os.path.getsize(p) for p in paths],
+        chunk_metadatas=[None] * len(paths),
+        checkpoint_file_fragments=[
+            pa.array([v], type=CHECKPOINTED_FILE_FRAGMENTS_TYPE)[0] for v in values
+        ],
+    )
+
+
+def test_reader_skips_fully_checkpointed_row_groups(
+    tmp_path, generated_id_checkpoint_config
+):
+    path = str(tmp_path / "data.parquet")
+    # 2 row groups of 3 rows; both fully committed -> nothing to read.
+    _write_parquet(path, num_rows=6, row_group_size=3)
+    manifest = _checkpointed_manifest(
+        [path], {path: [(0, 3, [0, 1, 2]), (1, 3, [0, 1, 2])]}
+    )
+    tables = list(ParquetFileReader().read(manifest))
+    assert tables == []
+
+
+def test_reader_filters_partially_checkpointed_row_group(
+    tmp_path, generated_id_checkpoint_config
+):
+    path = str(tmp_path / "data.parquet")
+    # Row group 0 (x=0..2): row 1 committed. Row group 1 (x=3..5): fully
+    # committed. x equals the file row position.
+    _write_parquet(path, num_rows=6, row_group_size=3)
+    manifest = _checkpointed_manifest([path], {path: [(0, 3, [1]), (1, 3, [0, 1, 2])]})
+    combined = pa.concat_tables(ParquetFileReader().read(manifest))
+    assert combined.column("x").to_pylist() == [0, 2]
+    # Surviving rows keep their original in-group positions.
+    ids = combined.column(GEN_ID_COL).to_pylist()
+    assert [(v[FRAGMENT_FIELD], v[ROW_ID_FIELD]) for v in ids] == [(0, 0), (0, 2)]
+
+
+def test_reader_partial_filter_across_batches(tmp_path, generated_id_checkpoint_config):
+    path = str(tmp_path / "data.parquet")
+    # One row group of 6 rows, rows 1 and 4 committed, read in batches of 2.
+    _write_parquet(path, num_rows=6, row_group_size=6)
+    manifest = _checkpointed_manifest([path], {path: [(0, 6, [1, 4])]})
+    reader = ParquetFileReader(batch_size=2)
+    combined = pa.concat_tables(reader.read(manifest))
+    assert combined.column("x").to_pylist() == [0, 2, 3, 5]
+    row_ids = [v[ROW_ID_FIELD] for v in combined.column(GEN_ID_COL).to_pylist()]
+    assert row_ids == [0, 2, 3, 5]
+
+
+def test_reader_no_skip_for_unmatched_checkpoint(
+    tmp_path, generated_id_checkpoint_config
+):
+    path = str(tmp_path / "data.parquet")
+    other = str(tmp_path / "other.parquet")
+    _write_parquet(path, num_rows=4, row_group_size=2)
+    _write_parquet(other, num_rows=4, row_group_size=2)
+    # The checkpoint only covers a different file; this one reads in full.
+    manifest = _checkpointed_manifest([path], {other: [(0, 2, [0, 1])]})
+    combined = pa.concat_tables(ParquetFileReader().read(manifest))
+    assert combined.num_rows == 4
+
+
+def test_reader_ignores_manifest_without_checkpoint_column(
+    tmp_path, generated_id_checkpoint_config
+):
+    """First run: generated-ID on, but no checkpoint column on the manifest."""
+    path = str(tmp_path / "data.parquet")
+    _write_parquet(path, num_rows=4, row_group_size=2)
+    combined = pa.concat_tables(ParquetFileReader().read(_whole_file_manifest([path])))
+    assert combined.num_rows == 4
+    assert GEN_ID_COL in combined.column_names
+
+
 def test_reads_unaffected_without_config(tmp_path):
     path = str(tmp_path / "data.parquet")
     _write_parquet(path, num_rows=4, row_group_size=2)

--- a/python/ray/data/_internal/planner/checkpoint/__init__.py
+++ b/python/ray/data/_internal/planner/checkpoint/__init__.py
@@ -1,3 +1,4 @@
+from .plan_list_files_op import plan_list_files_op_with_checkpoint_filter
 from .plan_read_files_op import plan_read_files_op_with_checkpoint_filter
 from .plan_read_op import (
     create_checkpoint_filter_op,
@@ -6,6 +7,7 @@ from .plan_read_op import (
 from .plan_write_op import plan_write_op_with_checkpoint_writer
 
 __all__ = [
+    "plan_list_files_op_with_checkpoint_filter",
     "plan_read_files_op_with_checkpoint_filter",
     "create_checkpoint_filter_op",
     "plan_read_op_with_checkpoint_filter",

--- a/python/ray/data/_internal/planner/checkpoint/plan_list_files_op.py
+++ b/python/ray/data/_internal/planner/checkpoint/plan_list_files_op.py
@@ -1,0 +1,50 @@
+"""ListFiles planning for generated-ID checkpointing.
+
+The id_column path filters rows downstream (an actor-pool wrap around
+``Read`` / ``ReadFiles``); the generated-ID path instead skips work at the
+source: listing tasks receive the compact checkpoint block and drop
+fully-checkpointed files before chunking, and the manifest rows they emit
+carry the per-file checkpoint struct for reader-side row-group and row
+skipping.
+
+The checkpoint block does not exist at planning time — it is loaded by
+``LoadCheckpointCallback.before_execution_starts`` — so it is attached as a
+lazy map-task kwarg resolved when listing tasks launch.
+"""
+
+from typing import Callable, List
+
+from ray.data._internal.execution.interfaces import PhysicalOperator
+from ray.data._internal.execution.operators.map_operator import MapOperator
+from ray.data._internal.logical.operators import ListFiles
+from ray.data._internal.planner.plan_list_files_op import plan_list_files_op
+from ray.data.block import Block
+from ray.data.checkpoint.generated_id import CHECKPOINTED_IDS_KWARG_NAME
+from ray.data.context import DataContext
+from ray.types import ObjectRef
+
+
+def plan_list_files_op_with_checkpoint_filter(
+    op: ListFiles,
+    physical_children: List[PhysicalOperator],
+    data_context: DataContext,
+    *,
+    load_checkpoint: Callable[[], ObjectRef[Block]],
+) -> MapOperator:
+    """Plan ``ListFiles`` with the compact checkpoint block injected.
+
+    Args:
+        op: The ``ListFiles`` logical operator.
+        physical_children: Planned physical children (always empty).
+        data_context: The data context.
+        load_checkpoint: Zero-arg callable returning the compact checkpoint
+            block ref; typically ``LoadCheckpointCallback.load_checkpoint``.
+
+    Returns:
+        The planned ``ListFiles`` map operator.
+    """
+    map_op = plan_list_files_op(op, physical_children, data_context)
+    map_op.add_map_task_kwargs_fn(
+        lambda: {CHECKPOINTED_IDS_KWARG_NAME: load_checkpoint()}
+    )
+    return map_op

--- a/python/ray/data/_internal/planner/plan_list_files_op.py
+++ b/python/ray/data/_internal/planner/plan_list_files_op.py
@@ -9,10 +9,13 @@ the downstream ``ReadFiles`` physical op consumes them.
 A later FileDiscovery physical step will split path listing from metadata
 fetch; this planner only relocates shuffle into the indexer.
 
-Checkpoint filtering is not attached here — it's wrapped around the
-downstream ``ReadFiles`` physical op by
+id_column checkpoint filtering is not attached here — it's wrapped around
+the downstream ``ReadFiles`` physical op by
 :func:`plan_read_files_op_with_checkpoint_filter`, matching V1's
-dispatch pattern.
+dispatch pattern. Generated-ID checkpointing, by contrast, does hook in at
+listing time: :func:`plan_list_files_op_with_checkpoint_filter` wraps this
+planner to inject the compact checkpoint block into listing tasks so
+fully-checkpointed files are dropped at the source.
 """
 from __future__ import annotations
 

--- a/python/ray/data/_internal/planner/planner.py
+++ b/python/ray/data/_internal/planner/planner.py
@@ -295,6 +295,8 @@ class Planner:
 
             checkpoint_callback = self._create_checkpoint_callback(
                 checkpoint_config,
+                data_file_dir,
+                data_file_fs,
             )
 
             callbacks.append(checkpoint_callback)
@@ -392,13 +394,19 @@ class Planner:
     def _create_checkpoint_callback(
         self,
         checkpoint_config,
+        data_file_dir=None,
+        data_file_filesystem=None,
     ) -> LoadCheckpointCallback:
         """Factory method to create the LoadCheckpointCallback.
 
         Subclasses can override this to use a different callback implementation.
+        The data-file location lets the generated-ID path clean up pending
+        checkpoints before loading.
         """
         return LoadCheckpointCallback(
             checkpoint_config,
+            data_file_dir=data_file_dir,
+            data_file_filesystem=data_file_filesystem,
         )
 
     @staticmethod

--- a/python/ray/data/checkpoint/__init__.py
+++ b/python/ray/data/checkpoint/__init__.py
@@ -10,6 +10,7 @@ if TYPE_CHECKING:
     from .checkpoint_filter import (  # noqa: F401
         CheckpointFilter,
         CheckpointManager,
+        GeneratedIdColumnCheckpointManager,
         IdColumnCheckpointManager,
         NumpyArrayBasedCheckpointFilter,
     )
@@ -19,6 +20,7 @@ __all__ = [
     "CheckpointBackend",
     "CheckpointFilter",
     "CheckpointManager",
+    "GeneratedIdColumnCheckpointManager",
     "IdColumnCheckpointManager",
     "NumpyArrayBasedCheckpointFilter",
 ]
@@ -26,6 +28,7 @@ __all__ = [
 _LAZY_EXPORTS = (
     "CheckpointFilter",
     "CheckpointManager",
+    "GeneratedIdColumnCheckpointManager",
     "IdColumnCheckpointManager",
     "NumpyArrayBasedCheckpointFilter",
 )

--- a/python/ray/data/checkpoint/checkpoint_filter.py
+++ b/python/ray/data/checkpoint/checkpoint_filter.py
@@ -9,6 +9,7 @@ from typing import List, Optional, Tuple
 
 import numpy as np
 import pyarrow
+import pyarrow.compute as pc
 from pyarrow.fs import FileSelector, FileType
 
 import ray
@@ -18,8 +19,21 @@ from ray.data._internal.execution.interfaces.ref_bundle import RefBundle
 from ray.data.block import Block, BlockMetadata, Schema
 from ray.data.checkpoint import CheckpointConfig
 from ray.data.checkpoint.checkpoint_writer import PENDING_CHECKPOINT_SUFFIX
+from ray.data.checkpoint.generated_id import (
+    CHECKPOINTED_FILE_COLUMN_NAME,
+    CHECKPOINTED_FILE_FRAGMENTS_TYPE,
+    CHECKPOINTED_FRAGMENT_TYPE,
+    CHECKPOINTED_GENERATED_ID_COLUMN_TABLE_SCHEMA,
+    FILE_NAME_FIELD,
+    FRAGMENT_FIELD,
+    NUM_FRAGMENTS_FIELD,
+    NUM_ROWS_FIELD,
+    PATH_PREFIX_FIELD,
+    ROW_ID_FIELD,
+    get_struct_field_index,
+)
 from ray.data.checkpoint.util import build_pending_checkpoint_trie
-from ray.data.context import DataContext
+from ray.data.context import DataContext, ShuffleStrategy
 from ray.data.datasource.path_util import _unwrap_protocol
 from ray.types import ObjectRef
 from ray.util.annotations import DeveloperAPI
@@ -231,11 +245,55 @@ class CheckpointManager(abc.ABC):
             ObjectRef: The ref of checkpointed IDs array. None if no checkpoint was loaded.
             int: the size of the checkpointed IDs array.
         """
+        start_t = time.time()
+
+        loaded = self._load_checkpoint_block(data_file_dir, data_file_filesystem)
+        if loaded is None:
+            return None, 0
+        block_ref, schema, _ = loaded
+
+        # Convert arrow-typed ids to sorted numpy-typed ids.
+        # Note: the convert is very time-consuming.
+        # Get the object ref the checkpointed IDs, because we do not want the IDs
+        # to occupy the memory of the head node.
+        ctx_label_selector = self._data_context.execution_options.label_selector
+        task = convert_and_sort_checkpointed_ids
+        if ctx_label_selector:
+            task = task.options(label_selector=ctx_label_selector)
+        (
+            checkpointed_ids_ref,
+            checkpoint_size_ref,
+        ) = task.remote(block_ref, self.id_column)
+
+        checkpoint_size = ray.get(checkpoint_size_ref)
+
+        logger.info(
+            "Checkpoint loaded for %s in %.2f seconds. SizeBytes = %d, Schema = %s",
+            type(self).__name__,
+            time.time() - start_t,
+            checkpoint_size,
+            schema.to_string(),
+        )
+        return checkpointed_ids_ref, checkpoint_size
+
+    def _load_checkpoint_block(
+        self,
+        data_file_dir: Optional[str] = None,
+        data_file_filesystem: Optional["pyarrow.fs.FileSystem"] = None,
+    ) -> Optional[Tuple[ObjectRef[Block], Schema, BlockMetadata]]:
+        """Clean pending checkpoints, then load committed IDs as one block.
+
+        Shared by :meth:`load_checkpoint` (which converts the block to a
+        sorted numpy array for the actor-pool filter) and
+        ``GeneratedIdColumnCheckpointManager.load_checkpoint_as_block``
+        (which hands the compact block to ``ListFiles`` / the Parquet
+        reader directly).
+
+        Returns None when there is no committed checkpoint data.
+        """
         logger.info(
             "Loading checkpoint from %s, this could take a while.", self.checkpoint_path
         )
-
-        start_t = time.time()
 
         # Clean up pending checkpoints before loading (runs as a Ray task)
         if data_file_dir is not None:
@@ -257,7 +315,7 @@ class CheckpointManager(abc.ABC):
             )
         )
         if not any(f.type == FileType.File for f in entries):
-            return None, 0
+            return None
 
         # Load the checkpoint data
         checkpoint_ds: ray.data.Dataset = ray.data.read_parquet(
@@ -284,9 +342,9 @@ class CheckpointManager(abc.ABC):
 
         assert len(ref_bundles) == 1
 
-        # If there are no valid files under the checkpoint_path, return None, 0.
+        # If there are no valid files under the checkpoint_path, return None.
         if ref_bundles[0].num_rows() == 0:
-            return None, 0
+            return None
 
         ref_bundle: RefBundle = ref_bundles[0]
         schema: Schema = ref_bundle.schema
@@ -295,30 +353,7 @@ class CheckpointManager(abc.ABC):
         metadata: BlockMetadata = ref_bundle.blocks[0].metadata
         # Validate the loaded checkpoint
         self._validate_loaded_checkpoint(schema, metadata)
-
-        # Convert arrow-typed ids to sorted numpy-typed ids.
-        # Note: the convert is very time-consuming.
-        # Get the object ref the checkpointed IDs, because we do not want the IDs
-        # to occupy the memory of the head node.
-        ctx_label_selector = self._data_context.execution_options.label_selector
-        task = convert_and_sort_checkpointed_ids
-        if ctx_label_selector:
-            task = task.options(label_selector=ctx_label_selector)
-        (
-            checkpointed_ids_ref,
-            checkpoint_size_ref,
-        ) = task.remote(block_ref, self.id_column)
-
-        checkpoint_size = ray.get(checkpoint_size_ref)
-
-        logger.info(
-            "Checkpoint loaded for %s in %.2f seconds. SizeBytes = %d, Schema = %s",
-            type(self).__name__,
-            time.time() - start_t,
-            checkpoint_size,
-            schema.to_string(),
-        )
-        return checkpointed_ids_ref, checkpoint_size
+        return block_ref, schema, metadata
 
     def _clean_pending_checkpoints(
         self,
@@ -380,6 +415,261 @@ class CheckpointManager(abc.ABC):
 @DeveloperAPI
 class IdColumnCheckpointManager(CheckpointManager):
     """Manager for regular ID columns."""
+
+
+@DeveloperAPI
+class GeneratedIdColumnCheckpointManager(CheckpointManager):
+    """Manager for auto-generated row-ID columns.
+
+    Committed checkpoint files store one struct ID per output row. At load
+    time this manager compacts them into one row per input file
+    (``CHECKPOINTED_GENERATED_ID_COLUMN_TABLE_SCHEMA``): the raw IDs are
+    grouped by file, then per row group either marked fully checkpointed
+    (empty ``checkpointed_row_ids`` list) or given a dense boolean mask of
+    committed positions. ``ListFiles`` uses the compact block to drop
+    fully-done files, and the Parquet reader uses it to skip fully-done row
+    groups and filter partially-done ones — the actor-pool
+    ``CheckpointFilter`` path is not used for generated IDs.
+    """
+
+    def _extract_grouping_fields(self, batch: pyarrow.Table) -> pyarrow.Table:
+        """Project the struct ID column into groupable path columns."""
+        id_col: pyarrow.ChunkedArray = batch[self.id_column]
+
+        path_prefix_idx = get_struct_field_index(id_col, PATH_PREFIX_FIELD)
+        path_prefix = pc.struct_field(id_col, [path_prefix_idx])
+
+        file_name_idx = get_struct_field_index(id_col, FILE_NAME_FIELD)
+        file_name = pc.struct_field(id_col, [file_name_idx])
+
+        return pyarrow.Table.from_arrays(
+            [
+                path_prefix.cast(pyarrow.large_string()),
+                file_name.cast(pyarrow.large_string()),
+                batch[self.id_column],
+            ],
+            names=[PATH_PREFIX_FIELD, FILE_NAME_FIELD, self.id_column],
+        )
+
+    def _process_file_group(self, file_group_batch: pyarrow.Table) -> pyarrow.Table:
+        """Compact one file's committed IDs into a single checkpoint row.
+
+        Args:
+            file_group_batch: Rows of a single ``(path_prefix, file_name)``
+                group.
+
+        Returns:
+            One-row table with ``CHECKPOINTED_GENERATED_ID_COLUMN_TABLE_SCHEMA``.
+        """
+        path_prefix = file_group_batch[PATH_PREFIX_FIELD][0].as_py()
+        file_name = file_group_batch[FILE_NAME_FIELD][0].as_py()
+        file_path = f"{path_prefix}/{file_name}"
+
+        id_columns = file_group_batch[self.id_column]
+
+        # NUM_FRAGMENTS is the file's total row-group count — identical for
+        # every row of the file.
+        num_fragments_field_idx = get_struct_field_index(
+            id_columns[0], NUM_FRAGMENTS_FIELD
+        )
+        num_fragments = pc.struct_field(id_columns, [num_fragments_field_idx])[
+            0
+        ].as_py()
+
+        fragment_field_idx = get_struct_field_index(id_columns[0], FRAGMENT_FIELD)
+        fragments_array = pc.struct_field(id_columns, [fragment_field_idx])
+
+        num_rows_field_idx = get_struct_field_index(id_columns[0], NUM_ROWS_FIELD)
+        num_rows_array = pc.struct_field(id_columns, [num_rows_field_idx])
+
+        row_id_field_idx = get_struct_field_index(id_columns[0], ROW_ID_FIELD)
+        row_ids_array = pc.struct_field(id_columns, [row_id_field_idx])
+
+        # Group committed row IDs by row group.
+        fragment_table = pyarrow.table(
+            {
+                "fragment": fragments_array,
+                "row_id": row_ids_array,
+                "num_rows": num_rows_array,
+            }
+        )
+        grouped = fragment_table.group_by("fragment").aggregate(
+            [
+                ("row_id", "list"),
+                # num_rows is the same for all rows in a row group; min is
+                # just a way to pick it.
+                ("num_rows", "min"),
+            ]
+        )
+
+        fragments_array = grouped["fragment"]
+        row_ids_lists = grouped["row_id_list"]
+        num_rows_array = grouped["num_rows_min"]
+
+        checkpointed_row_counts = pc.cast(
+            pc.list_value_length(row_ids_lists), pyarrow.int32()
+        )
+        fully_checkpointed_mask = pc.equal(checkpointed_row_counts, num_rows_array)
+        num_fragments_fully_checkpointed = pc.sum(fully_checkpointed_mask).as_py() or 0
+
+        # Per row group: empty list when fully committed, else a dense
+        # boolean mask over the row group.
+        checkpointed_row_ids_arrays = []
+        for i in range(len(grouped)):
+            num_rows = num_rows_array[i].as_py()
+            checkpointed_row_count = checkpointed_row_counts[i].as_py()
+            row_ids_list = row_ids_lists[i]
+
+            if checkpointed_row_count == num_rows:
+                checkpointed_row_ids_col = pyarrow.array(
+                    [[]], type=pyarrow.large_list(pyarrow.bool_())
+                )
+            else:
+                row_indices = pyarrow.array(np.arange(num_rows), type=pyarrow.int32())
+                # ``pc.is_in`` requires a sorted value set.
+                row_ids_values = row_ids_list.values
+                sorted_row_ids = row_ids_values.take(pc.sort_indices(row_ids_values))
+                boolean_array = pc.is_in(row_indices, sorted_row_ids)
+                offsets = pyarrow.array([0, len(boolean_array)], type=pyarrow.int64())
+                checkpointed_row_ids_col = pyarrow.LargeListArray.from_arrays(
+                    offsets, boolean_array
+                )
+
+            checkpointed_row_ids_arrays.append(checkpointed_row_ids_col)
+
+        if checkpointed_row_ids_arrays:
+            checkpointed_row_ids_array = pyarrow.concat_arrays(
+                checkpointed_row_ids_arrays
+            )
+        else:
+            checkpointed_row_ids_array = pyarrow.array(
+                [[]], type=pyarrow.large_list(pyarrow.bool_())
+            )
+
+        fragment_structs = pyarrow.StructArray.from_arrays(
+            [
+                pc.cast(fragments_array.combine_chunks(), pyarrow.int32()),
+                pc.cast(num_rows_array.combine_chunks(), pyarrow.int32()),
+                checkpointed_row_counts.combine_chunks(),
+                checkpointed_row_ids_array,
+            ],
+            fields=list(CHECKPOINTED_FRAGMENT_TYPE),
+        )
+
+        if len(fragment_structs) > 0:
+            offsets = pyarrow.array([0, len(fragment_structs)], type=pyarrow.int64())
+            fragments_list = pyarrow.LargeListArray.from_arrays(
+                offsets, fragment_structs
+            )
+        else:
+            fragments_list = pyarrow.array(
+                [[]], type=pyarrow.large_list(CHECKPOINTED_FRAGMENT_TYPE)
+            )
+
+        # The file is fully checkpointed only when every one of its row
+        # groups was seen and fully committed.
+        fully_checkpointed = num_fragments_fully_checkpointed == num_fragments
+        checkpointed_fragment_col = pyarrow.StructArray.from_arrays(
+            [
+                pyarrow.array([len(fragment_structs)], type=pyarrow.int32()),
+                pyarrow.array([fully_checkpointed], type=pyarrow.bool_()),
+                fragments_list,
+            ],
+            fields=list(CHECKPOINTED_FILE_FRAGMENTS_TYPE),
+        )
+
+        logger.debug(
+            "Compacted checkpoint for file %s: %d/%d row groups fully "
+            "checkpointed, fully_checkpointed=%s",
+            file_path,
+            num_fragments_fully_checkpointed,
+            num_fragments,
+            fully_checkpointed,
+        )
+
+        return pyarrow.Table.from_arrays(
+            [pyarrow.array([file_path]), checkpointed_fragment_col],
+            schema=CHECKPOINTED_GENERATED_ID_COLUMN_TABLE_SCHEMA,
+        )
+
+    def _preprocess_data_pipeline(
+        self, checkpoint_ds: "ray.data.Dataset"
+    ) -> "ray.data.Dataset":
+        """Compact raw committed IDs into one row per file, sorted by path."""
+        checkpoint_ds = checkpoint_ds.map_batches(
+            self._extract_grouping_fields,
+            batch_format="pyarrow",
+            batch_size=None,
+        )
+        # The sort-based shuffle materializes every group on one node;
+        # hash shuffle keeps the groupby streaming.
+        checkpoint_ds.context._shuffle_strategy = ShuffleStrategy.HASH_SHUFFLE
+
+        checkpoint_ds = checkpoint_ds.groupby([PATH_PREFIX_FIELD, FILE_NAME_FIELD])
+        checkpoint_ds = checkpoint_ds.map_groups(
+            self._process_file_group, batch_format="pyarrow"
+        )
+        return checkpoint_ds.sort(CHECKPOINTED_FILE_COLUMN_NAME)
+
+    def _validate_loaded_checkpoint(
+        self, schema: Schema, metadata: BlockMetadata
+    ) -> None:
+        if metadata.num_rows > 0:
+            assert schema == CHECKPOINTED_GENERATED_ID_COLUMN_TABLE_SCHEMA, (
+                f"Schema mismatch: {schema} != "
+                f"{CHECKPOINTED_GENERATED_ID_COLUMN_TABLE_SCHEMA}"
+            )
+
+    def load_checkpoint_as_block(
+        self,
+        data_file_dir: Optional[str] = None,
+        data_file_filesystem: Optional["pyarrow.fs.FileSystem"] = None,
+    ) -> ObjectRef[Block]:
+        """Load the compact checkpoint as an ``ObjectRef[Block]``.
+
+        Unlike :meth:`load_checkpoint`, the block is not converted to a
+        numpy array — the struct-typed compact table is passed as a task
+        kwarg to ``ListFiles`` and consumed as a pyarrow table. An empty
+        (schema-less) table means there is no checkpoint data.
+        """
+        start_t = time.time()
+        loaded = self._load_checkpoint_block(data_file_dir, data_file_filesystem)
+        if loaded is None:
+            return ray.put(pyarrow.table({}))
+        block_ref, schema, _ = loaded
+        logger.info(
+            "Checkpoint loaded for %s in %.2f seconds. Schema = %s",
+            type(self).__name__,
+            time.time() - start_t,
+            schema.to_string(),
+        )
+        return block_ref
+
+
+def load_generated_id_checkpoint_as_block(
+    config: CheckpointConfig,
+    data_file_dir: Optional[str] = None,
+    data_file_filesystem: Optional["pyarrow.fs.FileSystem"] = None,
+    data_context: Optional[DataContext] = None,
+) -> ObjectRef[Block]:
+    """Load the generated-ID checkpoint as a compact per-file Block.
+
+    The returned block has ``CHECKPOINTED_GENERATED_ID_COLUMN_TABLE_SCHEMA``
+    and is consumed by ``ListFiles`` (file-level skipping) and the V2
+    Parquet reader (row-group and row-level skipping). Regular ``id_column``
+    checkpointing does not go through this path — it uses the actor-pool
+    ``CheckpointFilter`` wired up by
+    ``ray.data._internal.planner.checkpoint.create_checkpoint_filter_op``.
+    """
+    assert getattr(config, "generated_id_column", None), (
+        "load_generated_id_checkpoint_as_block() is only for "
+        "generated_id_column configs; id_column uses the actor-pool pattern."
+    )
+    manager = GeneratedIdColumnCheckpointManager(
+        checkpoint_config=config,
+        data_context=data_context or DataContext.get_current(),
+    )
+    return manager.load_checkpoint_as_block(data_file_dir, data_file_filesystem)
 
 
 @DeveloperAPI

--- a/python/ray/data/checkpoint/generated_id.py
+++ b/python/ray/data/checkpoint/generated_id.py
@@ -1,12 +1,41 @@
-"""Stable Parquet row IDs used by generated_id_column checkpointing."""
+"""Stable Parquet row IDs used by generated_id_column checkpointing.
+
+This module holds everything specific to the generated-ID checkpoint format:
+
+- The per-row struct ID type (``GENERATED_ID_COLUMN_TYPE``) and its
+  construction (:func:`get_generated_id_column`).
+- The compact per-file checkpoint representation
+  (``CHECKPOINTED_GENERATED_ID_COLUMN_TABLE_SCHEMA``) that
+  ``GeneratedIdColumnCheckpointManager`` builds from committed row IDs at
+  load time, plus the helpers that consume it at list time
+  (:func:`index_checkpointed_fragments`,
+  :func:`get_checkpoint_fragments_info_for_file`,
+  :func:`is_file_fragments_fully_checkpointed`) and at read time
+  (:func:`parse_checkpointed_fragment_info`,
+  :func:`exclude_checkpointed_rows`).
+
+Compact-representation semantics: a file that was never read has no row in
+the checkpoint table (a null struct downstream); a fully-committed row group
+stores an empty ``checkpointed_row_ids`` list; a partially-committed row
+group stores a dense boolean mask of length ``num_rows`` (True =
+checkpointed). Unfinished work is encoded as absence — uncommitted rows are
+never stored.
+"""
 
 import os
-from typing import Optional
+from dataclasses import dataclass
+from typing import Dict, Optional, Union
 
 import numpy as np
 import pyarrow as pa
+import pyarrow.compute as pc
+import pyarrow.dataset
 
+from ray.data.block import Block, BlockAccessor
 from ray.data.context import DataContext
+
+# Name of the kwarg carrying the loaded checkpoint block into ListFiles tasks.
+CHECKPOINTED_IDS_KWARG_NAME = "checkpointed_ids"
 
 PATH_PREFIX_FIELD = "path_prefix"
 FILE_NAME_FIELD = "file_name"
@@ -39,6 +68,343 @@ GENERATED_ID_COLUMN_TYPE = pa.struct(
         for name in GENERATED_ID_COLUMN_FIELD_NAMES
     ]
 )
+
+#
+# Compact checkpoint table schema (built at load time from committed IDs).
+#
+
+CHECKPOINTED_FILE_COLUMN_NAME = "checkpointed_file"
+CHECKPOINTED_FILE_FRAGMENTS_COLUMN_NAME = "checkpointed_file_fragments"
+
+# Per-row-group struct fields.
+CHECKPOINTED_FILE_FRAGMENT_ID_FIELD = "fragment_id"
+CHECKPOINTED_FILE_FRAGMENT_NUM_ROWS_FIELD = "num_rows"
+CHECKPOINTED_FILE_FRAGMENT_NUM_CHECKPOINTED_ROWS_FIELD = "num_checkpointed_rows"
+CHECKPOINTED_FILE_FRAGMENT_CHECKPOINTED_ROW_IDS_FIELD = "checkpointed_row_ids"
+
+CHECKPOINTED_FRAGMENT_TYPE = pa.struct(
+    [
+        # Row group index within the file.
+        pa.field(CHECKPOINTED_FILE_FRAGMENT_ID_FIELD, pa.int32(), nullable=False),
+        # Total number of rows in this row group (on-disk).
+        pa.field(CHECKPOINTED_FILE_FRAGMENT_NUM_ROWS_FIELD, pa.int32(), nullable=False),
+        # Number of already-checkpointed rows in this row group.
+        pa.field(
+            CHECKPOINTED_FILE_FRAGMENT_NUM_CHECKPOINTED_ROWS_FIELD,
+            pa.int32(),
+            nullable=False,
+        ),
+        # Dense boolean mask of length ``num_rows`` (True = checkpointed).
+        # An empty list means every row is checkpointed.
+        pa.field(
+            CHECKPOINTED_FILE_FRAGMENT_CHECKPOINTED_ROW_IDS_FIELD,
+            pa.large_list(pa.bool_()),
+            nullable=True,
+        ),
+    ]
+)
+
+# Per-file struct fields. This struct rides on the file manifest into readers.
+CHECKPOINTED_FILE_FRAGMENTS_NUM_FRAGMENTS_FIELD = "num_fragments"
+CHECKPOINTED_FILE_FULLY_CHECKPOINTED_FIELD = "fully_checkpointed"
+CHECKPOINTED_FILE_FRAGMENTS_INFO_FIELD = "fragments"
+
+CHECKPOINTED_FILE_FRAGMENTS_TYPE = pa.struct(
+    [
+        # Number of row groups with checkpoint entries for this file.
+        pa.field(
+            CHECKPOINTED_FILE_FRAGMENTS_NUM_FRAGMENTS_FIELD, pa.int32(), nullable=False
+        ),
+        # Whether every row group of the file is fully checkpointed.
+        pa.field(
+            CHECKPOINTED_FILE_FULLY_CHECKPOINTED_FIELD, pa.bool_(), nullable=False
+        ),
+        # One CHECKPOINTED_FRAGMENT_TYPE entry per touched row group.
+        pa.field(
+            CHECKPOINTED_FILE_FRAGMENTS_INFO_FIELD,
+            pa.large_list(CHECKPOINTED_FRAGMENT_TYPE),
+            nullable=True,
+        ),
+    ]
+)
+
+CHECKPOINTED_GENERATED_ID_COLUMN_TABLE_SCHEMA = pa.schema(
+    [
+        pa.field(CHECKPOINTED_FILE_COLUMN_NAME, pa.string()),
+        pa.field(
+            CHECKPOINTED_FILE_FRAGMENTS_COLUMN_NAME, CHECKPOINTED_FILE_FRAGMENTS_TYPE
+        ),
+    ]
+)
+
+
+@dataclass
+class CheckpointedFragmentInfo:
+    """Checkpoint state of one row group, resolved for a read."""
+
+    # The Parquet fragment (one row group).
+    fragment: pa.dataset.ParquetFileFragment
+    # The row group index within the file.
+    row_group_idx: int
+    # Total number of rows in the row group (on-disk).
+    num_rows: int
+    # Whether every row of the row group is checkpointed.
+    fully_checkpointed: bool
+    # Boolean mask over the row group (True = checkpointed), or None when
+    # nothing is checkpointed. Empty array means fully checkpointed.
+    checkpointed_row_ids: Optional[pa.Array]
+    # Number of checkpointed rows in the row group.
+    checkpointed_row_count: int
+
+
+@dataclass
+class CheckpointFragmentsInfo:
+    """Checkpoint state of one file, as looked up from the compact table."""
+
+    # The file path.
+    path: str
+    # The file's CHECKPOINTED_FILE_FRAGMENTS_TYPE struct scalar, or None when
+    # the file has no checkpoint entry (never seen).
+    checkpointed_file_fragments: Optional[pa.StructScalar]
+
+
+def get_struct_field_index(
+    struct_value: Union[pa.Array, pa.ChunkedArray, pa.Scalar], field_name: str
+) -> int:
+    """Return the index of ``field_name`` in a struct array/scalar's type.
+
+    Struct field order is not preserved through an Arrow -> Parquet -> Arrow
+    round-trip, so struct fields must always be resolved by name, never
+    positionally.
+    """
+    if isinstance(struct_value, pa.ChunkedArray):
+        struct_type = struct_value.chunks[0].type
+    else:
+        struct_type = struct_value.type
+
+    field_index = struct_type.get_field_index(field_name)
+    if field_index == -1:
+        raise ValueError(f"Field '{field_name}' not found in struct type {struct_type}")
+    return field_index
+
+
+def _create_empty_checkpointed_fragment_info(
+    fragment: pa.dataset.ParquetFileFragment,
+    row_group_idx: int,
+) -> CheckpointedFragmentInfo:
+    """Info for a row group with no checkpointed rows."""
+    return CheckpointedFragmentInfo(
+        fragment=fragment,
+        row_group_idx=row_group_idx,
+        num_rows=fragment.metadata.row_group(row_group_idx).num_rows,
+        fully_checkpointed=False,
+        checkpointed_row_ids=None,
+        checkpointed_row_count=0,
+    )
+
+
+def parse_checkpointed_fragment_info(
+    fragment: pa.dataset.ParquetFileFragment,
+    row_group_idx: int,
+    checkpointed_file_fragments: Optional[pa.StructScalar],
+) -> CheckpointedFragmentInfo:
+    """Resolve one row group's checkpoint state from its file's struct scalar.
+
+    Args:
+        fragment: Parquet fragment carrying exactly this row group.
+        row_group_idx: Row group index within the file.
+        checkpointed_file_fragments: The file's
+            ``CHECKPOINTED_FILE_FRAGMENTS_TYPE`` struct scalar from the
+            manifest, or None / a null scalar when the file was never seen.
+
+    Returns:
+        The row group's :class:`CheckpointedFragmentInfo`. When the file or
+        row group has no checkpoint entry, an empty info (nothing
+        checkpointed) is returned.
+    """
+    if (
+        checkpointed_file_fragments is None
+        or checkpointed_file_fragments.is_valid is False
+    ):
+        return _create_empty_checkpointed_fragment_info(fragment, row_group_idx)
+
+    fragments_field_idx = get_struct_field_index(
+        checkpointed_file_fragments, CHECKPOINTED_FILE_FRAGMENTS_INFO_FIELD
+    )
+    fragments = pc.struct_field(checkpointed_file_fragments, [fragments_field_idx])
+    if fragments.is_valid is False or len(fragments) == 0:
+        return _create_empty_checkpointed_fragment_info(fragment, row_group_idx)
+    fragments_values = fragments.values  # StructArray
+
+    fragment_id_field_idx = get_struct_field_index(
+        fragments_values, CHECKPOINTED_FILE_FRAGMENT_ID_FIELD
+    )
+    fragment_ids = pc.struct_field(fragments_values, [fragment_id_field_idx])
+
+    wanted_mask = pc.equal(fragment_ids, pa.scalar(row_group_idx, fragment_ids.type))
+    indices = pc.indices_nonzero(wanted_mask)
+    if len(indices) == 0:
+        return _create_empty_checkpointed_fragment_info(fragment, row_group_idx)
+
+    checkpointed_fragment = fragments_values[indices[0].as_py()]
+    checkpointed_row_ids = pc.struct_field(
+        checkpointed_fragment,
+        [
+            get_struct_field_index(
+                checkpointed_fragment,
+                CHECKPOINTED_FILE_FRAGMENT_CHECKPOINTED_ROW_IDS_FIELD,
+            )
+        ],
+    )
+    num_rows = pc.struct_field(
+        checkpointed_fragment,
+        [
+            get_struct_field_index(
+                checkpointed_fragment, CHECKPOINTED_FILE_FRAGMENT_NUM_ROWS_FIELD
+            )
+        ],
+    ).as_py()
+    num_checkpointed_rows = pc.struct_field(
+        checkpointed_fragment,
+        [
+            get_struct_field_index(
+                checkpointed_fragment,
+                CHECKPOINTED_FILE_FRAGMENT_NUM_CHECKPOINTED_ROWS_FIELD,
+            )
+        ],
+    ).as_py()
+
+    actual_num_rows = fragment.metadata.row_group(row_group_idx).num_rows
+    assert num_rows == actual_num_rows, (
+        f"Number of rows in the row group {actual_num_rows} does not match "
+        f"the number of rows in the checkpointed fragment {num_rows}"
+    )
+
+    if len(checkpointed_row_ids) == 0:
+        # Empty list encodes "every row checkpointed".
+        assert num_checkpointed_rows == num_rows, (
+            f"Number of checkpointed rows {num_checkpointed_rows} does not match "
+            f"the number of rows in the checkpointed fragment {num_rows}"
+        )
+        fully_checkpointed = True
+        final_checkpointed_row_ids = pa.array([], type=pa.bool_())
+    else:
+        fully_checkpointed = False
+        final_checkpointed_row_ids = checkpointed_row_ids.values
+
+    return CheckpointedFragmentInfo(
+        fragment=fragment,
+        row_group_idx=row_group_idx,
+        num_rows=num_rows,
+        fully_checkpointed=fully_checkpointed,
+        checkpointed_row_ids=final_checkpointed_row_ids,
+        checkpointed_row_count=num_checkpointed_rows,
+    )
+
+
+def exclude_checkpointed_rows(
+    table: pa.Table,
+    checkpointed_fragment_info: CheckpointedFragmentInfo,
+    current_row_offset: int,
+    current_num_rows: int,
+) -> pa.Table:
+    """Drop already-checkpointed rows from a batch of one row group.
+
+    Args:
+        table: The batch to filter (rows of a single row group).
+        checkpointed_fragment_info: The row group's checkpoint state.
+        current_row_offset: Position of the batch's first row within the row
+            group's read stream (pre-filter).
+        current_num_rows: Number of rows the batch had before filtering.
+
+    Returns:
+        The batch with already-checkpointed rows removed.
+    """
+    checkpointed_row_ids = checkpointed_fragment_info.checkpointed_row_ids
+
+    if checkpointed_row_ids is None:
+        assert (
+            not checkpointed_fragment_info.fully_checkpointed
+        ), "Checkpointed row ids is None, intended to be empty checkpointed fragment"
+        return table
+
+    if len(checkpointed_row_ids) == 0:
+        assert checkpointed_fragment_info.fully_checkpointed, (
+            "Checkpointed row ids is empty array, intended to be fully "
+            "checkpointed fragment"
+        )
+        return table.slice(0, 0)
+
+    assert current_row_offset + current_num_rows <= len(checkpointed_row_ids), (
+        f"Current row offset {current_row_offset} + current num rows "
+        f"{current_num_rows} is greater than the length of the boolean mask "
+        f"{len(checkpointed_row_ids)}"
+    )
+
+    relevant_bools = checkpointed_row_ids.slice(current_row_offset, current_num_rows)
+    # True (checkpointed) rows are excluded; False (pending) rows are kept.
+    return table.filter(pc.invert(relevant_bools))
+
+
+def index_checkpointed_fragments(checkpointed_ids: Optional[Block]) -> Dict[str, int]:
+    """Map file path -> row index in the compact checkpoint block."""
+    if checkpointed_ids is None:
+        return {}
+
+    checkpointed_ids_table = BlockAccessor.for_block(checkpointed_ids).to_arrow()
+    if checkpointed_ids_table.num_rows == 0:
+        return {}
+
+    file_paths = checkpointed_ids_table[CHECKPOINTED_FILE_COLUMN_NAME].to_pylist()
+    return {file_path: i for i, file_path in enumerate(file_paths)}
+
+
+def get_checkpoint_fragments_info_for_file(
+    checkpointed_ids: Optional[Block],
+    path: str,
+    checkpointed_fragments_by_path: Dict[str, int],
+) -> CheckpointFragmentsInfo:
+    """Look up one file's checkpoint struct from the compact checkpoint block.
+
+    Args:
+        checkpointed_ids: Block with
+            ``CHECKPOINTED_GENERATED_ID_COLUMN_TABLE_SCHEMA``, or None.
+        path: The file path to look up.
+        checkpointed_fragments_by_path: Index built by
+            :func:`index_checkpointed_fragments` over the same block.
+
+    Returns:
+        The file's :class:`CheckpointFragmentsInfo`; its struct scalar is
+        None when the file has no checkpoint entry.
+    """
+    if checkpointed_ids is None or path not in checkpointed_fragments_by_path:
+        return CheckpointFragmentsInfo(path=path, checkpointed_file_fragments=None)
+
+    checkpointed_ids_table = BlockAccessor.for_block(checkpointed_ids).to_arrow()
+    if checkpointed_ids_table.num_rows == 0:
+        return CheckpointFragmentsInfo(path=path, checkpointed_file_fragments=None)
+
+    file_index = checkpointed_fragments_by_path[path]
+    checkpointed_file_fragments = checkpointed_ids_table[
+        CHECKPOINTED_FILE_FRAGMENTS_COLUMN_NAME
+    ][file_index]
+    return CheckpointFragmentsInfo(
+        path=path, checkpointed_file_fragments=checkpointed_file_fragments
+    )
+
+
+def is_file_fragments_fully_checkpointed(
+    checkpointed_fragments_info: CheckpointFragmentsInfo,
+) -> bool:
+    """Whether every row group of the file is fully checkpointed."""
+    fully_checkpointed_field_idx = get_struct_field_index(
+        checkpointed_fragments_info.checkpointed_file_fragments,
+        CHECKPOINTED_FILE_FULLY_CHECKPOINTED_FIELD,
+    )
+    return pc.struct_field(
+        checkpointed_fragments_info.checkpointed_file_fragments,
+        [fully_checkpointed_field_idx],
+    ).as_py()
 
 
 def get_generated_id_column_name() -> Optional[str]:

--- a/python/ray/data/checkpoint/load_checkpoint_callback.py
+++ b/python/ray/data/checkpoint/load_checkpoint_callback.py
@@ -1,32 +1,75 @@
 import logging
+from typing import Optional
+
+import pyarrow.fs
 
 from ray.data._internal.execution.execution_callback import (
     ExecutionCallback,
 )
 from ray.data._internal.execution.streaming_executor import StreamingExecutor
+from ray.data.block import Block
 from ray.data.checkpoint import CheckpointConfig
 from ray.data.datasource.path_util import _unwrap_protocol
+from ray.types import ObjectRef
 
 logger = logging.getLogger(__name__)
 
 
 class LoadCheckpointCallback(ExecutionCallback):
     """
-    ExecutionCallback that handles checkpoints. This Callback is responsible for
-    deleting the checkpoint directory when these conditions are met:
-    1. `delete_checkpoint_on_success` is True.
-    2. The job finishes successfully.
+    ExecutionCallback that handles checkpoints.
+
+    1. For ``generated_id_column``: loads the compact checkpoint block before
+       execution starts and exposes it via :meth:`load_checkpoint` so the
+       ``ListFiles`` plan function can inject it into listing tasks.
+    2. For regular ``id_column``: no loading here — the actor-pool filter
+       loads inside its plan function.
+    3. For both: deletes the checkpoint directory when
+       `delete_checkpoint_on_success` is True and the job finishes
+       successfully. On failure, nothing is deleted: pending checkpoint files
+       are the recovery record consumed on the next run.
     """
 
     def __init__(
         self,
         config: CheckpointConfig,
+        data_file_dir: Optional[str] = None,
+        data_file_filesystem: Optional["pyarrow.fs.FileSystem"] = None,
     ):
         assert config is not None
         self._config = config
+        self._data_file_dir = data_file_dir
+        self._data_file_filesystem = data_file_filesystem
+        self._checkpoint_ref: Optional[ObjectRef[Block]] = None
 
     def before_execution_starts(self, executor: StreamingExecutor):
         assert self._config is executor._data_context.checkpoint_config
+
+        if self._config.has_generated_id_column:
+            # Import here to avoid a checkpoint_filter <-> callback cycle.
+            from ray.data.checkpoint.checkpoint_filter import (
+                load_generated_id_checkpoint_as_block,
+            )
+
+            self._checkpoint_ref = load_generated_id_checkpoint_as_block(
+                self._config,
+                data_file_dir=self._data_file_dir,
+                data_file_filesystem=self._data_file_filesystem,
+                data_context=executor._data_context,
+            )
+
+    def load_checkpoint(self) -> ObjectRef[Block]:
+        """Return the cached compact checkpoint block ref.
+
+        Only valid for the ``generated_id_column`` path, after
+        ``before_execution_starts`` has run.
+        """
+        assert self._config.has_generated_id_column, (
+            "load_checkpoint() is only valid for generated_id_column. "
+            "Regular id_column uses the actor-pool pattern."
+        )
+        assert self._checkpoint_ref is not None
+        return self._checkpoint_ref
 
     def _delete_checkpoint(self):
         checkpoint_path_unwrapped = _unwrap_protocol(self._config.checkpoint_path)

--- a/python/ray/data/tests/test_checkpoint.py
+++ b/python/ray/data/tests/test_checkpoint.py
@@ -2,6 +2,7 @@ import csv
 import os
 import random
 from typing import List, Literal, Union
+from unittest.mock import MagicMock
 
 import numpy as np
 import pandas as pd
@@ -36,12 +37,25 @@ from ray.data._internal.planner.checkpoint.plan_write_op import (
 from ray.data.block import BlockAccessor
 from ray.data.checkpoint import CheckpointConfig
 from ray.data.checkpoint.checkpoint_filter import (
+    GeneratedIdColumnCheckpointManager,
     IdColumnCheckpointManager,
     NumpyArrayBasedCheckpointFilter,
 )
 from ray.data.checkpoint.checkpoint_writer import (
     PENDING_CHECKPOINT_SUFFIX,
     BatchBasedCheckpointWriter,
+)
+from ray.data.checkpoint.generated_id import (
+    CHECKPOINTED_FILE_COLUMN_NAME,
+    CHECKPOINTED_FILE_FRAGMENTS_COLUMN_NAME,
+    CHECKPOINTED_FILE_FRAGMENTS_TYPE,
+    CHECKPOINTED_GENERATED_ID_COLUMN_TABLE_SCHEMA,
+    exclude_checkpointed_rows,
+    get_checkpoint_fragments_info_for_file,
+    get_generated_id_column,
+    index_checkpointed_fragments,
+    is_file_fragments_fully_checkpointed,
+    parse_checkpointed_fragment_info,
 )
 from ray.data.checkpoint.interfaces import (
     CheckpointBackend,
@@ -2289,6 +2303,257 @@ def test_clean_pending_checkpoints_no_pending(ray_start_10_cpus_shared, fs, base
 
     # Data file should still exist (no pending checkpoints means nothing to clean)
     assert fs.get_file_info(data_file).type != FileType.NotFound
+
+
+def _make_file_fragments_scalar(fragments: list) -> pa.StructScalar:
+    """Build one file's CHECKPOINTED_FILE_FRAGMENTS_TYPE struct scalar.
+
+    Args:
+        fragments: List of ``(fragment_id, num_rows, committed_row_ids)``.
+            A fragment whose committed rows cover ``num_rows`` is stored the
+            compact way (empty mask list).
+
+    Returns:
+        The file's struct scalar.
+    """
+    fragment_entries = []
+    num_fully = 0
+    for fragment_id, num_rows, committed_row_ids in fragments:
+        fully = len(committed_row_ids) == num_rows
+        num_fully += fully
+        fragment_entries.append(
+            {
+                "fragment_id": fragment_id,
+                "num_rows": num_rows,
+                "num_checkpointed_rows": len(committed_row_ids),
+                "checkpointed_row_ids": (
+                    []
+                    if fully
+                    else [i in set(committed_row_ids) for i in range(num_rows)]
+                ),
+            }
+        )
+    value = {
+        "num_fragments": len(fragments),
+        "fully_checkpointed": num_fully == len(fragments),
+        "fragments": fragment_entries,
+    }
+    return pa.array([value], type=CHECKPOINTED_FILE_FRAGMENTS_TYPE)[0]
+
+
+def _mock_fragment(path: str, row_group_num_rows: int) -> MagicMock:
+    fragment = MagicMock()
+    fragment.path = path
+    row_group = MagicMock()
+    row_group.num_rows = row_group_num_rows
+    fragment.metadata.row_group.return_value = row_group
+    return fragment
+
+
+class TestGeneratedIdFragmentParsing:
+    """Unit tests for the compact-representation parse/exclude helpers."""
+
+    def test_parse_fully_checkpointed_row_group(self):
+        scalar = _make_file_fragments_scalar([(0, 3, [0, 1, 2])])
+        info = parse_checkpointed_fragment_info(_mock_fragment("f", 3), 0, scalar)
+        assert info.fully_checkpointed
+        assert info.checkpointed_row_count == 3
+        assert len(info.checkpointed_row_ids) == 0
+
+    def test_parse_partially_checkpointed_row_group(self):
+        scalar = _make_file_fragments_scalar([(1, 4, [0, 2])])
+        info = parse_checkpointed_fragment_info(_mock_fragment("f", 4), 1, scalar)
+        assert not info.fully_checkpointed
+        assert info.checkpointed_row_count == 2
+        assert info.checkpointed_row_ids.to_pylist() == [True, False, True, False]
+
+    def test_parse_row_group_without_checkpoint_entry(self):
+        # Row group 1 has an entry; row group 0 doesn't.
+        scalar = _make_file_fragments_scalar([(1, 4, [0])])
+        info = parse_checkpointed_fragment_info(_mock_fragment("f", 3), 0, scalar)
+        assert not info.fully_checkpointed
+        assert info.checkpointed_row_count == 0
+        assert info.checkpointed_row_ids is None
+
+    def test_parse_never_seen_file(self):
+        null_scalar = pa.array([None], type=CHECKPOINTED_FILE_FRAGMENTS_TYPE)[0]
+        for scalar in (None, null_scalar):
+            info = parse_checkpointed_fragment_info(_mock_fragment("f", 5), 0, scalar)
+            assert not info.fully_checkpointed
+            assert info.checkpointed_row_ids is None
+            assert info.num_rows == 5
+
+    def test_parse_num_rows_mismatch_raises(self):
+        scalar = _make_file_fragments_scalar([(0, 4, [0])])
+        # On-disk row group has 3 rows but the checkpoint recorded 4.
+        with pytest.raises(AssertionError, match="does not match"):
+            parse_checkpointed_fragment_info(_mock_fragment("f", 3), 0, scalar)
+
+    def test_exclude_nothing_checkpointed(self):
+        table = pa.table({"x": [1, 2, 3]})
+        info = parse_checkpointed_fragment_info(_mock_fragment("f", 3), 0, None)
+        assert exclude_checkpointed_rows(table, info, 0, 3) is table
+
+    def test_exclude_fully_checkpointed(self):
+        table = pa.table({"x": [1, 2, 3]})
+        scalar = _make_file_fragments_scalar([(0, 3, [0, 1, 2])])
+        info = parse_checkpointed_fragment_info(_mock_fragment("f", 3), 0, scalar)
+        assert exclude_checkpointed_rows(table, info, 0, 3).num_rows == 0
+
+    def test_exclude_partial_with_batch_offsets(self):
+        # Row group of 6 rows, rows 1 and 4 committed, read in two batches.
+        scalar = _make_file_fragments_scalar([(0, 6, [1, 4])])
+        info = parse_checkpointed_fragment_info(_mock_fragment("f", 6), 0, scalar)
+
+        batch1 = pa.table({"x": [0, 1, 2]})
+        assert exclude_checkpointed_rows(batch1, info, 0, 3)["x"].to_pylist() == [0, 2]
+        batch2 = pa.table({"x": [3, 4, 5]})
+        assert exclude_checkpointed_rows(batch2, info, 3, 3)["x"].to_pylist() == [3, 5]
+
+    def test_exclude_out_of_bounds_batch_raises(self):
+        scalar = _make_file_fragments_scalar([(0, 3, [0])])
+        info = parse_checkpointed_fragment_info(_mock_fragment("f", 3), 0, scalar)
+        with pytest.raises(AssertionError, match="greater than the length"):
+            exclude_checkpointed_rows(pa.table({"x": [1, 2]}), info, 2, 2)
+
+    def test_index_and_lookup_by_file(self):
+        table = pa.table(
+            {
+                CHECKPOINTED_FILE_COLUMN_NAME: ["/data/a.parquet", "/data/b.parquet"],
+                CHECKPOINTED_FILE_FRAGMENTS_COLUMN_NAME: pa.array(
+                    [
+                        _make_file_fragments_scalar([(0, 2, [0, 1])]).as_py(),
+                        _make_file_fragments_scalar([(0, 2, [0])]).as_py(),
+                    ],
+                    type=CHECKPOINTED_FILE_FRAGMENTS_TYPE,
+                ),
+            },
+            schema=CHECKPOINTED_GENERATED_ID_COLUMN_TABLE_SCHEMA,
+        )
+        by_path = index_checkpointed_fragments(table)
+        assert by_path == {"/data/a.parquet": 0, "/data/b.parquet": 1}
+
+        info_a = get_checkpoint_fragments_info_for_file(
+            table, "/data/a.parquet", by_path
+        )
+        assert is_file_fragments_fully_checkpointed(info_a)
+        info_b = get_checkpoint_fragments_info_for_file(
+            table, "/data/b.parquet", by_path
+        )
+        assert not is_file_fragments_fully_checkpointed(info_b)
+
+        info_missing = get_checkpoint_fragments_info_for_file(
+            table, "/data/missing.parquet", by_path
+        )
+        assert info_missing.checkpointed_file_fragments is None
+
+        assert index_checkpointed_fragments(None) == {}
+        assert index_checkpointed_fragments(pa.table({})) == {}
+
+
+def _write_generated_id_checkpoint_file(
+    checkpoint_dir: str,
+    file_name: str,
+    committed: list,
+):
+    """Write one committed checkpoint parquet holding raw struct IDs.
+
+    Args:
+        checkpoint_dir: Directory to write the checkpoint file into.
+        file_name: Name of the checkpoint parquet file.
+        committed: List of ``(path, row_group_idx, num_row_groups,
+            rg_num_rows, row_ids)`` entries.
+    """
+    id_arrays = []
+    for path, row_group_idx, num_row_groups, rg_num_rows, row_ids in committed:
+        full = get_generated_id_column(
+            path=path,
+            row_group_idx=row_group_idx,
+            num_row_groups=num_row_groups,
+            total_num_rows=rg_num_rows,
+            current_row_offset=0,
+            current_num_rows=rg_num_rows,
+        )
+        id_arrays.append(full.take(pa.array(row_ids, type=pa.int32())))
+    ids = pa.concat_arrays(id_arrays)
+    os.makedirs(checkpoint_dir, exist_ok=True)
+    pq.write_table(
+        pa.table({GENERATED_ID_TEST_COL: ids}),
+        os.path.join(checkpoint_dir, file_name),
+    )
+
+
+GENERATED_ID_TEST_COL = "__gen_id"
+
+
+def test_generated_id_checkpoint_compaction(tmp_path):
+    """End-to-end: raw committed struct IDs compact into one row per file."""
+    checkpoint_dir = str(tmp_path / "ckpt")
+    config = CheckpointConfig(
+        generated_id_column=GENERATED_ID_TEST_COL, checkpoint_path=checkpoint_dir
+    )
+
+    # File a: 2 row groups (3 rows each), both fully committed.
+    # File b: 2 row groups, group 0 partial (row 1 of 3), group 1 untouched.
+    # File c: never committed (absent).
+    _write_generated_id_checkpoint_file(
+        checkpoint_dir,
+        "task1.parquet",
+        [
+            ("/data/a.parquet", 0, 2, 3, [0, 1, 2]),
+            ("/data/b.parquet", 0, 2, 3, [1]),
+        ],
+    )
+    _write_generated_id_checkpoint_file(
+        checkpoint_dir,
+        "task2.parquet",
+        [("/data/a.parquet", 1, 2, 3, [0, 1, 2])],
+    )
+
+    manager = GeneratedIdColumnCheckpointManager(
+        checkpoint_config=config, data_context=DataContext.get_current()
+    )
+    block = ray.get(manager.load_checkpoint_as_block())
+    table = pa.table(block)
+
+    assert table.schema == CHECKPOINTED_GENERATED_ID_COLUMN_TABLE_SCHEMA
+    # One row per file, sorted by path; never-seen file c is absent.
+    assert table[CHECKPOINTED_FILE_COLUMN_NAME].to_pylist() == [
+        "/data/a.parquet",
+        "/data/b.parquet",
+    ]
+
+    by_path = index_checkpointed_fragments(table)
+    info_a = get_checkpoint_fragments_info_for_file(table, "/data/a.parquet", by_path)
+    assert is_file_fragments_fully_checkpointed(info_a)
+
+    info_b = get_checkpoint_fragments_info_for_file(table, "/data/b.parquet", by_path)
+    assert not is_file_fragments_fully_checkpointed(info_b)
+    parsed = parse_checkpointed_fragment_info(
+        _mock_fragment("/data/b.parquet", 3), 0, info_b.checkpointed_file_fragments
+    )
+    assert not parsed.fully_checkpointed
+    assert parsed.checkpointed_row_ids.to_pylist() == [False, True, False]
+    # Row group 1 of file b was never committed.
+    parsed_untouched = parse_checkpointed_fragment_info(
+        _mock_fragment("/data/b.parquet", 3), 1, info_b.checkpointed_file_fragments
+    )
+    assert parsed_untouched.checkpointed_row_ids is None
+
+
+def test_generated_id_checkpoint_load_empty(tmp_path):
+    """An empty or missing checkpoint dir loads as an empty sentinel block."""
+    checkpoint_dir = str(tmp_path / "ckpt")
+    os.makedirs(checkpoint_dir)
+    config = CheckpointConfig(
+        generated_id_column=GENERATED_ID_TEST_COL, checkpoint_path=checkpoint_dir
+    )
+    manager = GeneratedIdColumnCheckpointManager(
+        checkpoint_config=config, data_context=DataContext.get_current()
+    )
+    block = ray.get(manager.load_checkpoint_as_block())
+    assert pa.table(block).num_rows == 0
+    assert index_checkpointed_fragments(block) == {}
 
 
 if __name__ == "__main__":


### PR DESCRIPTION

**Stack:** PR 3 of 4 — stacked on https://github.com/ray-project/ray/pull/65886 (compact checkpoint load). Review scope: the last two commits ("Skip fully checkpointed files at list time..." and "Skip checkpointed row groups and rows in the V2 Parquet reader"). Follow-up: [4/4] planner routing + docs.

## Why are these changes needed?

This PR adds the skip mechanics that make generated-ID resume cheap, at every level of granularity. All of it is **inert until the planner routes to it in PR 4** — no behavior change for existing workloads (verified by the without-checkpoint tests and regression suites).

**List-time (file granularity):**
- `FileManifest` gains an optional `__file_fragments_checkpoint` column: the file's compact checkpoint struct (null = never seen), present only when generated-ID checkpointing is active. Kept as an Arrow column so struct scalars survive; `concat`/`shuffle` are whole-block operations and preserve it for free.
- Both indexers (`NonSamplingFileIndexer`, `FooterFileIndexer`) accept a `checkpoint_ids` block: fully-checkpointed files are dropped before chunking — on the footer path **before footer reads**, so resumed jobs don't even fetch footers of finished files — and surviving rows are stamped with their file's struct.
- Both partitioners (`RoundRobinPartitioner`, `OnlineBinPacker`) carry the column through manifest reconstruction — they rebuild manifests via `construct_manifest`, which would otherwise silently drop it (the bin packer keys a per-path map, since a file's rows all share one struct and bins may split/re-union runs).
- `list_files_for_each_block` reads the block from `TaskContext.kwargs`; `plan_list_files_op_with_checkpoint_filter` attaches it lazily via `MapOperator.add_map_task_kwargs_fn` because the block is only loaded at execution start (registered with the planner in PR 4).

**Read-time (row-group and row granularity):**
- `ParquetFileReader._get_fragments_to_read` resolves each row-group sub-fragment against the manifest's struct: fully-checkpointed row groups are dropped before any scan; partially checkpointed ones carry their `CheckpointedFragmentInfo` in a widened `(fragment, offset, info)` tuple consumed only by this class's own `_read_fragments_sequential` override.
- Committed rows are excluded **after** the ID column is attached (offsets counted on pre-filter batch sizes), so `row_id` assignment is identical whether or not a resume is filtering — the invariant that makes checkpoints written by one run addressable by the next.

## Related issue number

N/A. Not a duplicate: searched open PRs/issues in ray-project/ray for `generated_id_column`, "row group checkpoint" — no overlapping work.

## Checks

- [x] I've signed off every commit (DCO).
- [x] I've run pre-commit hooks on all touched files — clean.
- [x] AI assistance (Claude Code) was used for the development of this PR. I, Abhishek Verma, am the human submitter signing off on it: I have reviewed every changed line, run the tests below locally, and can defend the change end-to-end.
- Testing:
  - New: `_internal/datasource_v2/tests/test_generated_id_listing.py` (manifest column optional/mixed-values/concat/shuffle; both indexers drop fully-done files and stamp partial/null structs; both indexers unchanged without a checkpoint block; both partitioners preserve the column and stay unchanged without it) — 11 passed; reader-skip additions in `test_generated_id_reads.py` (fully-skip → zero tables, partial masks across batches keep original in-group positions, unmatched checkpoint reads in full, manifest without the column unaffected) — 12 passed.
  - Regression: `_internal/datasource_v2/tests/` (99 passed), `tests/unit/datasource_v2/` (100 passed), `tests/test_parquet.py` (passed), full `test_checkpoint.py` (97/98; known pre-existing local moto-S3 flake).