### PR TITLE
[Core] Warn on invalid numeric environment variables

### DIFF
--- a/python/ray/_common/utils.py
+++ b/python/ray/_common/utils.py
@@ -31,7 +31,7 @@ def env_integer(key, default):
         try:
             return int(value)
         except ValueError:
-            logger.debug(
+            logger.warning(
                 f"Found {key} in environment, but value must "
                 f"be an integer. Got: {value}. Returning "
                 f"provided default {default}."
@@ -46,7 +46,7 @@ def env_float(key, default):
         try:
             return float(value)
         except ValueError:
-            logger.debug(
+            logger.warning(
                 f"Found {key} in environment, but value must "
                 f"be a float. Got: {value}. Returning "
                 f"provided default {default}."


### PR DESCRIPTION
## Description

Invalid integer and float environment variables currently fall back silently because their messages are logged at DEBUG level. Promote these messages to WARNING so production misconfigurations are visible.

The helpers were moved from ray._private.ray_constants to ray._common.utils in #60642 without changing the existing log level.

## Related issues

This PR is simple enough not to create a issue.
