### PR TITLE
[ci][deps] Source torch-scatter from Astral's GPU index and drop the dead data.pyg.org find-links

### DIFF
--- a/.buildkite/dependencies.rayci.yml
+++ b/.buildkite/dependencies.rayci.yml
@@ -19,19 +19,10 @@ steps:
     job_env: oss-ci-base_test-py3.11
     depends_on: oss-ci-base_test-multipy(python=3.11)
 
-  # `soft_fail: true` is temporary. uv fails eagerly on an unreadable --find-links
-  # URL before deciding whether it needs anything from it, and data.pyg.org (the
-  # PyG wheel index every ML/data/rllib depset declares) has been a dangling CNAME
-  # since 2026-09-02 (https://github.com/pyg-team/pyg-lib/issues/719), so this job
-  # is red on every run regardless of the PR. The pip-compile step above is
-  # unaffected: pip skips an unreachable find-links and PyPI's sdist satisfies the
-  # pins. Remove soft_fail once data.pyg.org resolves and this job is green on
-  # master again.
   - label: ":tapioca: build: raydepsets: compile all dependencies"
     key: raydepsets_compile_all_dependencies
     tags: python_dependencies
     instance_type: small
-    soft_fail: true
     commands:
       - bazel run //ci/raydepsets:raydepsets -- build --all-configs --check
     job_env: manylinux-x86_64

--- a/ci/ci.sh
+++ b/ci/ci.sh
@@ -80,8 +80,10 @@ compile_pip_dependencies() {
     # Astral's +cpu.torch.2.9. The result has to be the bare public version --
     # this file is also the constraint for the GPU depsets, and only a bare
     # torch-scatter==2.1.2 lets their +cu.12.8.torch.2.9 pin satisfy it. The old
-    # pattern stopped at the first "cpu" and left 2.1.2.torch.2.9 behind.
-    sed -i -E 's/==([.0-9]+)\+[A-Za-z0-9.]*cpu[A-Za-z0-9.]*/==\1/g' "python/$TARGET"
+    # pattern stopped at the first "cpu" and left 2.1.2.torch.2.9 behind. The
+    # public version may carry a pre/post/dev suffix (2.10.0rc1, 2.10.0.post0),
+    # hence letters in the first class.
+    sed -i -E 's/==([A-Za-z0-9.]+)[+][A-Za-z0-9.]*cpu[A-Za-z0-9.]*/==\1/g' "python/$TARGET"
 
     cat "python/$TARGET"
 

--- a/ci/ci.sh
+++ b/ci/ci.sh
@@ -83,7 +83,7 @@ compile_pip_dependencies() {
     # pattern stopped at the first "cpu" and left 2.1.2.torch.2.9 behind. The
     # public version may carry a pre/post/dev suffix (2.10.0rc1, 2.10.0.post0),
     # hence letters in the first class.
-    sed -i -E 's/==([A-Za-z0-9.]+)[+][A-Za-z0-9.]*cpu[A-Za-z0-9.]*/==\1/g' "python/$TARGET"
+    sed -i -E 's/==([A-Za-z0-9.]+)[+][A-Za-z0-9._-]*cpu[A-Za-z0-9._-]*/==\1/g' "python/$TARGET"
 
     cat "python/$TARGET"
 

--- a/ci/ci.sh
+++ b/ci/ci.sh
@@ -76,7 +76,12 @@ compile_pip_dependencies() {
     # This is needed because we specify the requirements as torch==version, but
     # the resolver adds the device-specific version tag. If this is not removed,
     # pip install will complain about irresolvable constraints.
-    sed -i -E 's/==([\.0-9]+)\+[^\b]*cpu/==\1/g' "python/$TARGET"
+    # Strip the whole local segment whenever it names cpu: +cpu, +pt29cpu, and
+    # Astral's +cpu.torch.2.9. The result has to be the bare public version --
+    # this file is also the constraint for the GPU depsets, and only a bare
+    # torch-scatter==2.1.2 lets their +cu.12.8.torch.2.9 pin satisfy it. The old
+    # pattern stopped at the first "cpu" and left 2.1.2.torch.2.9 behind.
+    sed -i -E 's/==([.0-9]+)\+[A-Za-z0-9.]*cpu[A-Za-z0-9.]*/==\1/g' "python/$TARGET"
 
     cat "python/$TARGET"
 

--- a/ci/env/install-dependencies.sh
+++ b/ci/env/install-dependencies.sh
@@ -324,7 +324,7 @@ install_pip_packages() {
   if [[ -n "${TORCH_VERSION-}" || "${DL-}" == "1" || "${RLLIB_TESTING-}" == 1 || "${TRAIN_TESTING-}" == 1 || "${TUNE_TESTING-}" == 1 || "${DOC_TESTING-}" == 1 ]]; then
       # If we require a custom torch version, use that
       if [[ -n "${TORCH_VERSION-}" ]]; then
-        # Install right away, as some dependencies (e.g. torch-spline-conv) need
+        # Install right away, as some dependencies (e.g. torch-scatter) need
         # torch to be installed for their own install.
         pip install -U "torch==${TORCH_VERSION-1.9.0}" "torchvision==${TORCHVISION_VERSION-0.10.0}"
         # We won't add dl-cpu-requirements.txt as it would otherwise overwrite our custom
@@ -336,7 +336,7 @@ install_pip_packages() {
         pip install -U "${TF_PACKAGE%%;*}" "${TFPROB_PACKAGE%%;*}"
       else
         # Otherwise, use pinned default torch version.
-        # Again, install right away, as some dependencies (e.g. torch-spline-conv) need
+        # Again, install right away, as some dependencies (e.g. torch-scatter) need
         # torch to be installed for their own install.
         TORCH_PACKAGE=$(grep -ohE "torch==[^ ;]+" "${WORKSPACE_DIR}/python/requirements/ml/dl-cpu-requirements.txt" | head -n 1)
         TORCHVISION_PACKAGE=$(grep -ohE "torchvision==[^ ;]+" "${WORKSPACE_DIR}/python/requirements/ml/dl-cpu-requirements.txt" | head -n 1)

--- a/ci/raydepsets/configs/ci_windows.depsets.yaml
+++ b/ci/raydepsets/configs/ci_windows.depsets.yaml
@@ -48,12 +48,6 @@ depsets:
     packages:
       - torch
       - torchvision
-      # ABI-coupled PyG binaries; re-pinned as +pt27cpu builds in
-      # windows-requirements.txt.
-      - torch-scatter
-      - torch-sparse
-      - torch-cluster
-      - torch-spline-conv
     output: python/deplocks/ci/relaxed_windows-tests-ci_depset_py${PYTHON_VERSION}.lock
     build_arg_sets:
       - py310

--- a/doc/source/ray-contribute/dependency-management.md
+++ b/doc/source/ray-contribute/dependency-management.md
@@ -195,7 +195,7 @@ pip show ax-platform botorch gpytorch jaxtyping   # who pulls what, what's insta
 
 ### Platform-specific GPU dependencies
 
-`torch` and the PyTorch Geometric packages (`torch-scatter`, `torch-sparse`, `torch-cluster`, `torch-spline-conv`) ship CPU and GPU builds as distinct PEP 440 versions (`1.2.2`, `1.2.2+pt27cpu`, `1.2.2+pt27cu128`) on separate indexes. A single compile pass resolves against one index, so you can't put both the CPU and GPU requirement files in one dependency set — the resolver is asked to satisfy `+cpu` and `+cu128` of the same package at once and declares the requirements unsatisfiable.
+`torch` and `torch-scatter` ship CPU and GPU builds as distinct PEP 440 versions (`2.9.0`, `2.9.0+cpu`, `2.9.0+cu128`; `2.1.2+cpu.torch.2.9`, `2.1.2+cu.12.8.torch.2.9`) on separate indexes (`download.pytorch.org/whl/<backend>`, `wheels.astral.sh/simple/<backend>/`). A single compile pass resolves against one index, so you can't put both the CPU and GPU requirement files in one dependency set — the resolver is asked to satisfy `+cpu` and `+cu128` of the same package at once and declares the requirements unsatisfiable.
 
 The fix is to keep CPU and GPU as separate dependency sets, each with its own `--index`. Environment markers don't work here: a CPU-only and a GPU x86_64 Linux host match the same markers, so a marker-based split installs CUDA wheels on CPU-only machines. This mirrors the existing `ci_ml_build_depset` (CPU) and `ci_ml_gpubuild_depset` (GPU) split.
 

--- a/python/deplocks/ci/core-build-ci_depset_py3.10.lock
+++ b/python/deplocks/ci/core-build-ci_depset_py3.10.lock
@@ -1,5 +1,6 @@
 --extra-index-url https://download.pytorch.org/whl/cpu
 --extra-index-url https://wheels.astral.sh/simple/cpu/
+--find-links https://data.pyg.org/whl/torch-2.9.0+cpu.html
 
 absl-py==2.4.0 \
     --hash=sha256:88476fd881ca8aab94ffa78b7b6c632a782ab3ba1cd19c9bd423abc4fb4cd28d \
@@ -5680,6 +5681,7 @@ scipy==1.15.3 \
     #   scikit-learn
     #   skops
     #   torch-geometric
+    #   torch-sparse
     #   xgboost
 segment-analytics-python==2.2.0 \
     --hash=sha256:b511dce9d22fa31c8a3f1b0e69d15af9705aeeed066fb317bd64bec8b786b0b2 \
@@ -6209,6 +6211,11 @@ torch-scatter==2.1.2+cpu.torch.2.9 ; sys_platform == 'linux' \
     --hash=sha256:db5a7d61692c7827de77dfa79a4b18bf158c296e5d1a822bcd4c8ef90f204243 \
     --hash=sha256:e176fba25b4658fa13ae8e54bcfbc2758b1d45cea78a308ea5562bc42a62f04e \
     --hash=sha256:ff2a52e3bfd25fc06b8454ade9759506ddb053ea614a36c8b09cb75163075e6f
+    # via
+    #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
+    #   -r python/requirements/ml/dl-cpu-requirements.txt
+torch-sparse==0.6.18+pt29cpu ; sys_platform == 'linux' \
+    --hash=sha256:e4b76895717d17a635dbda6880ae46d7e5ef4438d66ffa6c45f85c74f50ea9e3
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
     #   -r python/requirements/ml/dl-cpu-requirements.txt

--- a/python/deplocks/ci/core-build-ci_depset_py3.10.lock
+++ b/python/deplocks/ci/core-build-ci_depset_py3.10.lock
@@ -1,5 +1,5 @@
 --extra-index-url https://download.pytorch.org/whl/cpu
---find-links https://data.pyg.org/whl/torch-2.9.0+cpu.html
+--extra-index-url https://wheels.astral.sh/simple/cpu/
 
 absl-py==2.4.0 \
     --hash=sha256:88476fd881ca8aab94ffa78b7b6c632a782ab3ba1cd19c9bd423abc4fb4cd28d \
@@ -5679,9 +5679,7 @@ scipy==1.15.3 \
     #   ray
     #   scikit-learn
     #   skops
-    #   torch-cluster
     #   torch-geometric
-    #   torch-sparse
     #   xgboost
 segment-analytics-python==2.2.0 \
     --hash=sha256:b511dce9d22fa31c8a3f1b0e69d15af9705aeeed066fb317bd64bec8b786b0b2 \
@@ -6190,32 +6188,27 @@ torch==2.9.0+cpu \
     #   -r python/requirements/ml/dl-cpu-requirements.txt
     #   accelerate
     #   tensordict
+    #   torch-scatter
     #   torchmetrics
     #   torchtext
     #   torchvision
-torch-cluster==1.6.3+pt29cpu \
-    --hash=sha256:250b7d207623831c03bf162bc45381c57dc19884be9b1b6f2fcaf00749202a42
-    # via
-    #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
-    #   -r python/requirements/ml/dl-cpu-requirements.txt
 torch-geometric==2.5.3 \
     --hash=sha256:8277abfc12600b0e8047e0c3ea2d55cc43f08c1448e73e924de827c15d0b5f85 \
     --hash=sha256:ad0761650c8fa56cdc46ee61c564fd4995f07f079965fe732b3a76d109fd3edc
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
     #   -r python/requirements/ml/dl-cpu-requirements.txt
-torch-scatter==2.1.2+pt29cpu \
-    --hash=sha256:62a0ad1d9e51da83d3c775b24cb498dc5b94075d18644653a3b24c158f288db6
-    # via
-    #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
-    #   -r python/requirements/ml/dl-cpu-requirements.txt
-torch-sparse==0.6.18+pt29cpu \
-    --hash=sha256:e4b76895717d17a635dbda6880ae46d7e5ef4438d66ffa6c45f85c74f50ea9e3
-    # via
-    #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
-    #   -r python/requirements/ml/dl-cpu-requirements.txt
-torch-spline-conv==1.2.2+pt29cpu \
-    --hash=sha256:d450dae7a383a08fa6ba57a800589becaa79a330fd81700f3255c13d29708283
+torch-scatter==2.1.2+cpu.torch.2.9 ; sys_platform == 'linux' \
+    --hash=sha256:2e34f7d83b32512b349e93355b18b1db48e317f30828d7ab717df6628825e000 \
+    --hash=sha256:34a11594df5338600a3fd55986fed088e4186ba56f2524a0a962cc3e40f75a4d \
+    --hash=sha256:51bcef861b61095f1b00f8451fe179fbfa48dc7f03af80dd01f29635090d66eb \
+    --hash=sha256:53ea146be456e3defaec4e70ad482a7c257db9eb8499865dc76ffe8310212cb1 \
+    --hash=sha256:6f9c0cce6e58e94aa9d0db24f9c579c1189973e03e9e1aa57f1e6492694af48d \
+    --hash=sha256:a2ef52eb9376db18986499b226ee54b94e8c1c39bfdf7f0d0a093a95dd3d3f4a \
+    --hash=sha256:b158c84bbff4554fc244f89e920ccfb2a437e13eb905d16d8b53c911dab467ad \
+    --hash=sha256:db5a7d61692c7827de77dfa79a4b18bf158c296e5d1a822bcd4c8ef90f204243 \
+    --hash=sha256:e176fba25b4658fa13ae8e54bcfbc2758b1d45cea78a308ea5562bc42a62f04e \
+    --hash=sha256:ff2a52e3bfd25fc06b8454ade9759506ddb053ea614a36c8b09cb75163075e6f
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
     #   -r python/requirements/ml/dl-cpu-requirements.txt

--- a/python/deplocks/ci/core-build-ci_depset_py3.12.lock
+++ b/python/deplocks/ci/core-build-ci_depset_py3.12.lock
@@ -1,5 +1,6 @@
 --extra-index-url https://download.pytorch.org/whl/cpu
 --extra-index-url https://wheels.astral.sh/simple/cpu/
+--find-links https://data.pyg.org/whl/torch-2.9.0+cpu.html
 
 absl-py==2.4.0 \
     --hash=sha256:88476fd881ca8aab94ffa78b7b6c632a782ab3ba1cd19c9bd423abc4fb4cd28d \
@@ -5620,6 +5621,7 @@ scipy==1.17.1 \
     #   scikit-learn
     #   skops
     #   torch-geometric
+    #   torch-sparse
     #   xgboost
 segment-analytics-python==2.2.0 \
     --hash=sha256:b511dce9d22fa31c8a3f1b0e69d15af9705aeeed066fb317bd64bec8b786b0b2 \
@@ -6096,6 +6098,11 @@ torch-scatter==2.1.2+cpu.torch.2.9 ; sys_platform == 'linux' \
     --hash=sha256:db5a7d61692c7827de77dfa79a4b18bf158c296e5d1a822bcd4c8ef90f204243 \
     --hash=sha256:e176fba25b4658fa13ae8e54bcfbc2758b1d45cea78a308ea5562bc42a62f04e \
     --hash=sha256:ff2a52e3bfd25fc06b8454ade9759506ddb053ea614a36c8b09cb75163075e6f
+    # via
+    #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
+    #   -r python/requirements/ml/dl-cpu-requirements.txt
+torch-sparse==0.6.18+pt29cpu ; sys_platform == 'linux' \
+    --hash=sha256:e1434c9ebe78727576ddbd279b2322a81e97060c31ef97145f47db173d81ef93
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
     #   -r python/requirements/ml/dl-cpu-requirements.txt

--- a/python/deplocks/ci/core-build-ci_depset_py3.12.lock
+++ b/python/deplocks/ci/core-build-ci_depset_py3.12.lock
@@ -1,5 +1,5 @@
 --extra-index-url https://download.pytorch.org/whl/cpu
---find-links https://data.pyg.org/whl/torch-2.9.0+cpu.html
+--extra-index-url https://wheels.astral.sh/simple/cpu/
 
 absl-py==2.4.0 \
     --hash=sha256:88476fd881ca8aab94ffa78b7b6c632a782ab3ba1cd19c9bd423abc4fb4cd28d \
@@ -5619,9 +5619,7 @@ scipy==1.17.1 \
     #   ray
     #   scikit-learn
     #   skops
-    #   torch-cluster
     #   torch-geometric
-    #   torch-sparse
     #   xgboost
 segment-analytics-python==2.2.0 \
     --hash=sha256:b511dce9d22fa31c8a3f1b0e69d15af9705aeeed066fb317bd64bec8b786b0b2 \
@@ -6077,32 +6075,27 @@ torch==2.9.0+cpu \
     #   -r python/requirements/ml/dl-cpu-requirements.txt
     #   accelerate
     #   tensordict
+    #   torch-scatter
     #   torchmetrics
     #   torchtext
     #   torchvision
-torch-cluster==1.6.3+pt29cpu \
-    --hash=sha256:562d2ea316ba0e9173915ae9bc9906eb35455969e6414fa0fe63d08023222a12
-    # via
-    #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
-    #   -r python/requirements/ml/dl-cpu-requirements.txt
 torch-geometric==2.5.3 \
     --hash=sha256:8277abfc12600b0e8047e0c3ea2d55cc43f08c1448e73e924de827c15d0b5f85 \
     --hash=sha256:ad0761650c8fa56cdc46ee61c564fd4995f07f079965fe732b3a76d109fd3edc
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
     #   -r python/requirements/ml/dl-cpu-requirements.txt
-torch-scatter==2.1.2+pt29cpu \
-    --hash=sha256:ff4aa866c5fde07fa153622df4f833af19ec2335736c1072e8c2c1f48f7d5745
-    # via
-    #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
-    #   -r python/requirements/ml/dl-cpu-requirements.txt
-torch-sparse==0.6.18+pt29cpu \
-    --hash=sha256:e1434c9ebe78727576ddbd279b2322a81e97060c31ef97145f47db173d81ef93
-    # via
-    #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
-    #   -r python/requirements/ml/dl-cpu-requirements.txt
-torch-spline-conv==1.2.2+pt29cpu \
-    --hash=sha256:2155b53ae8bf02d40522a4567eb8a7ba8e1c26d605323b3774fd7b0055ec3400
+torch-scatter==2.1.2+cpu.torch.2.9 ; sys_platform == 'linux' \
+    --hash=sha256:2e34f7d83b32512b349e93355b18b1db48e317f30828d7ab717df6628825e000 \
+    --hash=sha256:34a11594df5338600a3fd55986fed088e4186ba56f2524a0a962cc3e40f75a4d \
+    --hash=sha256:51bcef861b61095f1b00f8451fe179fbfa48dc7f03af80dd01f29635090d66eb \
+    --hash=sha256:53ea146be456e3defaec4e70ad482a7c257db9eb8499865dc76ffe8310212cb1 \
+    --hash=sha256:6f9c0cce6e58e94aa9d0db24f9c579c1189973e03e9e1aa57f1e6492694af48d \
+    --hash=sha256:a2ef52eb9376db18986499b226ee54b94e8c1c39bfdf7f0d0a093a95dd3d3f4a \
+    --hash=sha256:b158c84bbff4554fc244f89e920ccfb2a437e13eb905d16d8b53c911dab467ad \
+    --hash=sha256:db5a7d61692c7827de77dfa79a4b18bf158c296e5d1a822bcd4c8ef90f204243 \
+    --hash=sha256:e176fba25b4658fa13ae8e54bcfbc2758b1d45cea78a308ea5562bc42a62f04e \
+    --hash=sha256:ff2a52e3bfd25fc06b8454ade9759506ddb053ea614a36c8b09cb75163075e6f
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
     #   -r python/requirements/ml/dl-cpu-requirements.txt

--- a/python/deplocks/ci/core-gpu-cu130-build-ci_depset_py3.10.lock
+++ b/python/deplocks/ci/core-gpu-cu130-build-ci_depset_py3.10.lock
@@ -1,5 +1,6 @@
 --extra-index-url https://download.pytorch.org/whl/cu128
 --extra-index-url https://wheels.astral.sh/simple/cu128/
+--find-links https://data.pyg.org/whl/torch-2.9.0+cu128.html
 
 absl-py==2.4.0 \
     --hash=sha256:88476fd881ca8aab94ffa78b7b6c632a782ab3ba1cd19c9bd423abc4fb4cd28d \
@@ -5719,6 +5720,7 @@ scipy==1.15.3 \
     #   scikit-learn
     #   skops
     #   torch-geometric
+    #   torch-sparse
     #   xgboost
 segment-analytics-python==2.2.0 \
     --hash=sha256:b511dce9d22fa31c8a3f1b0e69d15af9705aeeed066fb317bd64bec8b786b0b2 \
@@ -6202,6 +6204,11 @@ torch-scatter==2.1.2+cu.12.8.torch.2.9 \
     --hash=sha256:c835645d889838a09ca4db931783c9260fb5773c3aa569760aae5b887789ddea \
     --hash=sha256:d60df986a621bd3691e885e814391f38f771de72188a28d930955ff59a78ce83 \
     --hash=sha256:e6388f4e267cea521d04d10040fdb91fc49e47b0e1489f76764e26aecbcf7c48
+    # via
+    #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
+    #   -r python/requirements/ml/dl-gpu-requirements.txt
+torch-sparse==0.6.18+pt29cu128 \
+    --hash=sha256:af0a0ea9a902f868e0d40165e331291063f1ead5a0e07565b9d8f3ebe19f3f9b
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
     #   -r python/requirements/ml/dl-gpu-requirements.txt

--- a/python/deplocks/ci/core-gpu-cu130-build-ci_depset_py3.10.lock
+++ b/python/deplocks/ci/core-gpu-cu130-build-ci_depset_py3.10.lock
@@ -1,5 +1,5 @@
 --extra-index-url https://download.pytorch.org/whl/cu128
---find-links https://data.pyg.org/whl/torch-2.9.0+cu128.html
+--extra-index-url https://wheels.astral.sh/simple/cu128/
 
 absl-py==2.4.0 \
     --hash=sha256:88476fd881ca8aab94ffa78b7b6c632a782ab3ba1cd19c9bd423abc4fb4cd28d \
@@ -5718,9 +5718,7 @@ scipy==1.15.3 \
     #   ray
     #   scikit-learn
     #   skops
-    #   torch-cluster
     #   torch-geometric
-    #   torch-sparse
     #   xgboost
 segment-analytics-python==2.2.0 \
     --hash=sha256:b511dce9d22fa31c8a3f1b0e69d15af9705aeeed066fb317bd64bec8b786b0b2 \
@@ -6185,30 +6183,25 @@ torch==2.9.0+cu128 \
     #   accelerate
     #   nixl
     #   tensordict
+    #   torch-scatter
     #   torchvision
-torch-cluster==1.6.3+pt29cu128 \
-    --hash=sha256:53d269f1fd489709ad047b6fe253fefe3299616c61888047c7365baab83cf620
-    # via
-    #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
-    #   -r python/requirements/ml/dl-gpu-requirements.txt
 torch-geometric==2.5.3 \
     --hash=sha256:8277abfc12600b0e8047e0c3ea2d55cc43f08c1448e73e924de827c15d0b5f85 \
     --hash=sha256:ad0761650c8fa56cdc46ee61c564fd4995f07f079965fe732b3a76d109fd3edc
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
     #   -r python/requirements/ml/dl-gpu-requirements.txt
-torch-scatter==2.1.2+pt29cu128 \
-    --hash=sha256:7c6d1c2fa5c950593f83f38a6f880a0de70329af39c4d7aa8e51ed80b35f744f
-    # via
-    #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
-    #   -r python/requirements/ml/dl-gpu-requirements.txt
-torch-sparse==0.6.18+pt29cu128 \
-    --hash=sha256:af0a0ea9a902f868e0d40165e331291063f1ead5a0e07565b9d8f3ebe19f3f9b
-    # via
-    #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
-    #   -r python/requirements/ml/dl-gpu-requirements.txt
-torch-spline-conv==1.2.2+pt29cu128 \
-    --hash=sha256:3cd22a139a7f35c57d7297f19a47ca233caf2e86d22d92d2d1a2ee2dd0ccb6b6
+torch-scatter==2.1.2+cu.12.8.torch.2.9 \
+    --hash=sha256:35385c774a1792d719608f132c3d50e941aaa3a697dcec72fe54a715d6f6023c \
+    --hash=sha256:57bc485d4d911ad1c88606cf3e6b246ef8d49a448dfc6f03d8e2d19e9be82242 \
+    --hash=sha256:6893a3b00bd6b13e154edb251edd647f00846ca177c53fcc73e3d49c50e76994 \
+    --hash=sha256:97c513c5fb211ff784e7628666c8da648e0605389f4a8c5c8fac84cf06ea9ca2 \
+    --hash=sha256:97cad80ca9d2639988c57003425f92e01d4f9bda522809d0fd38629a1ce3e7fc \
+    --hash=sha256:a3887cef3f3012dc6e3da88116af3bcabbcaaf70c807085659dd3a8bd74ed503 \
+    --hash=sha256:bbc9402c01238cc5671a0b3ff9f055e983e6d2390ff3b56130a715daf5719f55 \
+    --hash=sha256:c835645d889838a09ca4db931783c9260fb5773c3aa569760aae5b887789ddea \
+    --hash=sha256:d60df986a621bd3691e885e814391f38f771de72188a28d930955ff59a78ce83 \
+    --hash=sha256:e6388f4e267cea521d04d10040fdb91fc49e47b0e1489f76764e26aecbcf7c48
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
     #   -r python/requirements/ml/dl-gpu-requirements.txt

--- a/python/deplocks/ci/core-gpu-cu130-build-ci_depset_py3.12.lock
+++ b/python/deplocks/ci/core-gpu-cu130-build-ci_depset_py3.12.lock
@@ -1,5 +1,5 @@
 --extra-index-url https://download.pytorch.org/whl/cu128
---find-links https://data.pyg.org/whl/torch-2.9.0+cu128.html
+--extra-index-url https://wheels.astral.sh/simple/cu128/
 
 absl-py==2.4.0 \
     --hash=sha256:88476fd881ca8aab94ffa78b7b6c632a782ab3ba1cd19c9bd423abc4fb4cd28d \
@@ -5887,9 +5887,7 @@ scipy==1.17.1 \
     #   ray
     #   scikit-learn
     #   skops
-    #   torch-cluster
     #   torch-geometric
-    #   torch-sparse
     #   xgboost
 segment-analytics-python==2.2.0 \
     --hash=sha256:b511dce9d22fa31c8a3f1b0e69d15af9705aeeed066fb317bd64bec8b786b0b2 \
@@ -6343,30 +6341,25 @@ torch==2.9.0+cu128 \
     #   accelerate
     #   nixl
     #   tensordict
+    #   torch-scatter
     #   torchvision
-torch-cluster==1.6.3+pt29cu128 \
-    --hash=sha256:0a6fe034d4cd1fddfa930624c4c9a0e10e7eec1c9477af0cf51fa1f2b845111b
-    # via
-    #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
-    #   -r python/requirements/ml/dl-gpu-requirements.txt
 torch-geometric==2.5.3 \
     --hash=sha256:8277abfc12600b0e8047e0c3ea2d55cc43f08c1448e73e924de827c15d0b5f85 \
     --hash=sha256:ad0761650c8fa56cdc46ee61c564fd4995f07f079965fe732b3a76d109fd3edc
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
     #   -r python/requirements/ml/dl-gpu-requirements.txt
-torch-scatter==2.1.2+pt29cu128 \
-    --hash=sha256:06b3c6b95a8fdeef8ffc274919d4b1f68cad14035e667b9eeb4d2934011064b6
-    # via
-    #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
-    #   -r python/requirements/ml/dl-gpu-requirements.txt
-torch-sparse==0.6.18+pt29cu128 \
-    --hash=sha256:93d7f07210e1316736c09d14c019793bb7627f4b39a4df67ab93166444d25db0
-    # via
-    #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
-    #   -r python/requirements/ml/dl-gpu-requirements.txt
-torch-spline-conv==1.2.2+pt29cu128 \
-    --hash=sha256:f648e9bf06bfdcfd3b2ba4927c786be0378ebc2a70e05d47d4c1949af04c3988
+torch-scatter==2.1.2+cu.12.8.torch.2.9 \
+    --hash=sha256:35385c774a1792d719608f132c3d50e941aaa3a697dcec72fe54a715d6f6023c \
+    --hash=sha256:57bc485d4d911ad1c88606cf3e6b246ef8d49a448dfc6f03d8e2d19e9be82242 \
+    --hash=sha256:6893a3b00bd6b13e154edb251edd647f00846ca177c53fcc73e3d49c50e76994 \
+    --hash=sha256:97c513c5fb211ff784e7628666c8da648e0605389f4a8c5c8fac84cf06ea9ca2 \
+    --hash=sha256:97cad80ca9d2639988c57003425f92e01d4f9bda522809d0fd38629a1ce3e7fc \
+    --hash=sha256:a3887cef3f3012dc6e3da88116af3bcabbcaaf70c807085659dd3a8bd74ed503 \
+    --hash=sha256:bbc9402c01238cc5671a0b3ff9f055e983e6d2390ff3b56130a715daf5719f55 \
+    --hash=sha256:c835645d889838a09ca4db931783c9260fb5773c3aa569760aae5b887789ddea \
+    --hash=sha256:d60df986a621bd3691e885e814391f38f771de72188a28d930955ff59a78ce83 \
+    --hash=sha256:e6388f4e267cea521d04d10040fdb91fc49e47b0e1489f76764e26aecbcf7c48
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
     #   -r python/requirements/ml/dl-gpu-requirements.txt

--- a/python/deplocks/ci/core-gpu-cu130-build-ci_depset_py3.12.lock
+++ b/python/deplocks/ci/core-gpu-cu130-build-ci_depset_py3.12.lock
@@ -1,5 +1,6 @@
 --extra-index-url https://download.pytorch.org/whl/cu128
 --extra-index-url https://wheels.astral.sh/simple/cu128/
+--find-links https://data.pyg.org/whl/torch-2.9.0+cu128.html
 
 absl-py==2.4.0 \
     --hash=sha256:88476fd881ca8aab94ffa78b7b6c632a782ab3ba1cd19c9bd423abc4fb4cd28d \
@@ -5888,6 +5889,7 @@ scipy==1.17.1 \
     #   scikit-learn
     #   skops
     #   torch-geometric
+    #   torch-sparse
     #   xgboost
 segment-analytics-python==2.2.0 \
     --hash=sha256:b511dce9d22fa31c8a3f1b0e69d15af9705aeeed066fb317bd64bec8b786b0b2 \
@@ -6360,6 +6362,11 @@ torch-scatter==2.1.2+cu.12.8.torch.2.9 \
     --hash=sha256:c835645d889838a09ca4db931783c9260fb5773c3aa569760aae5b887789ddea \
     --hash=sha256:d60df986a621bd3691e885e814391f38f771de72188a28d930955ff59a78ce83 \
     --hash=sha256:e6388f4e267cea521d04d10040fdb91fc49e47b0e1489f76764e26aecbcf7c48
+    # via
+    #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
+    #   -r python/requirements/ml/dl-gpu-requirements.txt
+torch-sparse==0.6.18+pt29cu128 \
+    --hash=sha256:93d7f07210e1316736c09d14c019793bb7627f4b39a4df67ab93166444d25db0
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
     #   -r python/requirements/ml/dl-gpu-requirements.txt

--- a/python/deplocks/ci/core-gpubuild-ci_depset_py3.10.lock
+++ b/python/deplocks/ci/core-gpubuild-ci_depset_py3.10.lock
@@ -1,5 +1,6 @@
 --extra-index-url https://download.pytorch.org/whl/cu128
 --extra-index-url https://wheels.astral.sh/simple/cu128/
+--find-links https://data.pyg.org/whl/torch-2.9.0+cu128.html
 
 absl-py==2.4.0 \
     --hash=sha256:88476fd881ca8aab94ffa78b7b6c632a782ab3ba1cd19c9bd423abc4fb4cd28d \
@@ -5721,6 +5722,7 @@ scipy==1.15.3 \
     #   scikit-learn
     #   skops
     #   torch-geometric
+    #   torch-sparse
     #   xgboost
 segment-analytics-python==2.2.0 \
     --hash=sha256:b511dce9d22fa31c8a3f1b0e69d15af9705aeeed066fb317bd64bec8b786b0b2 \
@@ -6204,6 +6206,11 @@ torch-scatter==2.1.2+cu.12.8.torch.2.9 \
     --hash=sha256:c835645d889838a09ca4db931783c9260fb5773c3aa569760aae5b887789ddea \
     --hash=sha256:d60df986a621bd3691e885e814391f38f771de72188a28d930955ff59a78ce83 \
     --hash=sha256:e6388f4e267cea521d04d10040fdb91fc49e47b0e1489f76764e26aecbcf7c48
+    # via
+    #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
+    #   -r python/requirements/ml/dl-gpu-requirements.txt
+torch-sparse==0.6.18+pt29cu128 \
+    --hash=sha256:af0a0ea9a902f868e0d40165e331291063f1ead5a0e07565b9d8f3ebe19f3f9b
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
     #   -r python/requirements/ml/dl-gpu-requirements.txt

--- a/python/deplocks/ci/core-gpubuild-ci_depset_py3.10.lock
+++ b/python/deplocks/ci/core-gpubuild-ci_depset_py3.10.lock
@@ -1,5 +1,5 @@
 --extra-index-url https://download.pytorch.org/whl/cu128
---find-links https://data.pyg.org/whl/torch-2.9.0+cu128.html
+--extra-index-url https://wheels.astral.sh/simple/cu128/
 
 absl-py==2.4.0 \
     --hash=sha256:88476fd881ca8aab94ffa78b7b6c632a782ab3ba1cd19c9bd423abc4fb4cd28d \
@@ -5720,9 +5720,7 @@ scipy==1.15.3 \
     #   ray
     #   scikit-learn
     #   skops
-    #   torch-cluster
     #   torch-geometric
-    #   torch-sparse
     #   xgboost
 segment-analytics-python==2.2.0 \
     --hash=sha256:b511dce9d22fa31c8a3f1b0e69d15af9705aeeed066fb317bd64bec8b786b0b2 \
@@ -6187,30 +6185,25 @@ torch==2.9.0+cu128 \
     #   accelerate
     #   nixl
     #   tensordict
+    #   torch-scatter
     #   torchvision
-torch-cluster==1.6.3+pt29cu128 \
-    --hash=sha256:53d269f1fd489709ad047b6fe253fefe3299616c61888047c7365baab83cf620
-    # via
-    #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
-    #   -r python/requirements/ml/dl-gpu-requirements.txt
 torch-geometric==2.5.3 \
     --hash=sha256:8277abfc12600b0e8047e0c3ea2d55cc43f08c1448e73e924de827c15d0b5f85 \
     --hash=sha256:ad0761650c8fa56cdc46ee61c564fd4995f07f079965fe732b3a76d109fd3edc
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
     #   -r python/requirements/ml/dl-gpu-requirements.txt
-torch-scatter==2.1.2+pt29cu128 \
-    --hash=sha256:7c6d1c2fa5c950593f83f38a6f880a0de70329af39c4d7aa8e51ed80b35f744f
-    # via
-    #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
-    #   -r python/requirements/ml/dl-gpu-requirements.txt
-torch-sparse==0.6.18+pt29cu128 \
-    --hash=sha256:af0a0ea9a902f868e0d40165e331291063f1ead5a0e07565b9d8f3ebe19f3f9b
-    # via
-    #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
-    #   -r python/requirements/ml/dl-gpu-requirements.txt
-torch-spline-conv==1.2.2+pt29cu128 \
-    --hash=sha256:3cd22a139a7f35c57d7297f19a47ca233caf2e86d22d92d2d1a2ee2dd0ccb6b6
+torch-scatter==2.1.2+cu.12.8.torch.2.9 \
+    --hash=sha256:35385c774a1792d719608f132c3d50e941aaa3a697dcec72fe54a715d6f6023c \
+    --hash=sha256:57bc485d4d911ad1c88606cf3e6b246ef8d49a448dfc6f03d8e2d19e9be82242 \
+    --hash=sha256:6893a3b00bd6b13e154edb251edd647f00846ca177c53fcc73e3d49c50e76994 \
+    --hash=sha256:97c513c5fb211ff784e7628666c8da648e0605389f4a8c5c8fac84cf06ea9ca2 \
+    --hash=sha256:97cad80ca9d2639988c57003425f92e01d4f9bda522809d0fd38629a1ce3e7fc \
+    --hash=sha256:a3887cef3f3012dc6e3da88116af3bcabbcaaf70c807085659dd3a8bd74ed503 \
+    --hash=sha256:bbc9402c01238cc5671a0b3ff9f055e983e6d2390ff3b56130a715daf5719f55 \
+    --hash=sha256:c835645d889838a09ca4db931783c9260fb5773c3aa569760aae5b887789ddea \
+    --hash=sha256:d60df986a621bd3691e885e814391f38f771de72188a28d930955ff59a78ce83 \
+    --hash=sha256:e6388f4e267cea521d04d10040fdb91fc49e47b0e1489f76764e26aecbcf7c48
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
     #   -r python/requirements/ml/dl-gpu-requirements.txt

--- a/python/deplocks/ci/core-gpubuild-ci_depset_py3.12.lock
+++ b/python/deplocks/ci/core-gpubuild-ci_depset_py3.12.lock
@@ -1,5 +1,6 @@
 --extra-index-url https://download.pytorch.org/whl/cu128
 --extra-index-url https://wheels.astral.sh/simple/cu128/
+--find-links https://data.pyg.org/whl/torch-2.9.0+cu128.html
 
 absl-py==2.4.0 \
     --hash=sha256:88476fd881ca8aab94ffa78b7b6c632a782ab3ba1cd19c9bd423abc4fb4cd28d \
@@ -5890,6 +5891,7 @@ scipy==1.17.1 \
     #   scikit-learn
     #   skops
     #   torch-geometric
+    #   torch-sparse
     #   xgboost
 segment-analytics-python==2.2.0 \
     --hash=sha256:b511dce9d22fa31c8a3f1b0e69d15af9705aeeed066fb317bd64bec8b786b0b2 \
@@ -6362,6 +6364,11 @@ torch-scatter==2.1.2+cu.12.8.torch.2.9 \
     --hash=sha256:c835645d889838a09ca4db931783c9260fb5773c3aa569760aae5b887789ddea \
     --hash=sha256:d60df986a621bd3691e885e814391f38f771de72188a28d930955ff59a78ce83 \
     --hash=sha256:e6388f4e267cea521d04d10040fdb91fc49e47b0e1489f76764e26aecbcf7c48
+    # via
+    #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
+    #   -r python/requirements/ml/dl-gpu-requirements.txt
+torch-sparse==0.6.18+pt29cu128 \
+    --hash=sha256:93d7f07210e1316736c09d14c019793bb7627f4b39a4df67ab93166444d25db0
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
     #   -r python/requirements/ml/dl-gpu-requirements.txt

--- a/python/deplocks/ci/core-gpubuild-ci_depset_py3.12.lock
+++ b/python/deplocks/ci/core-gpubuild-ci_depset_py3.12.lock
@@ -1,5 +1,5 @@
 --extra-index-url https://download.pytorch.org/whl/cu128
---find-links https://data.pyg.org/whl/torch-2.9.0+cu128.html
+--extra-index-url https://wheels.astral.sh/simple/cu128/
 
 absl-py==2.4.0 \
     --hash=sha256:88476fd881ca8aab94ffa78b7b6c632a782ab3ba1cd19c9bd423abc4fb4cd28d \
@@ -5889,9 +5889,7 @@ scipy==1.17.1 \
     #   ray
     #   scikit-learn
     #   skops
-    #   torch-cluster
     #   torch-geometric
-    #   torch-sparse
     #   xgboost
 segment-analytics-python==2.2.0 \
     --hash=sha256:b511dce9d22fa31c8a3f1b0e69d15af9705aeeed066fb317bd64bec8b786b0b2 \
@@ -6345,30 +6343,25 @@ torch==2.9.0+cu128 \
     #   accelerate
     #   nixl
     #   tensordict
+    #   torch-scatter
     #   torchvision
-torch-cluster==1.6.3+pt29cu128 \
-    --hash=sha256:0a6fe034d4cd1fddfa930624c4c9a0e10e7eec1c9477af0cf51fa1f2b845111b
-    # via
-    #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
-    #   -r python/requirements/ml/dl-gpu-requirements.txt
 torch-geometric==2.5.3 \
     --hash=sha256:8277abfc12600b0e8047e0c3ea2d55cc43f08c1448e73e924de827c15d0b5f85 \
     --hash=sha256:ad0761650c8fa56cdc46ee61c564fd4995f07f079965fe732b3a76d109fd3edc
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
     #   -r python/requirements/ml/dl-gpu-requirements.txt
-torch-scatter==2.1.2+pt29cu128 \
-    --hash=sha256:06b3c6b95a8fdeef8ffc274919d4b1f68cad14035e667b9eeb4d2934011064b6
-    # via
-    #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
-    #   -r python/requirements/ml/dl-gpu-requirements.txt
-torch-sparse==0.6.18+pt29cu128 \
-    --hash=sha256:93d7f07210e1316736c09d14c019793bb7627f4b39a4df67ab93166444d25db0
-    # via
-    #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
-    #   -r python/requirements/ml/dl-gpu-requirements.txt
-torch-spline-conv==1.2.2+pt29cu128 \
-    --hash=sha256:f648e9bf06bfdcfd3b2ba4927c786be0378ebc2a70e05d47d4c1949af04c3988
+torch-scatter==2.1.2+cu.12.8.torch.2.9 \
+    --hash=sha256:35385c774a1792d719608f132c3d50e941aaa3a697dcec72fe54a715d6f6023c \
+    --hash=sha256:57bc485d4d911ad1c88606cf3e6b246ef8d49a448dfc6f03d8e2d19e9be82242 \
+    --hash=sha256:6893a3b00bd6b13e154edb251edd647f00846ca177c53fcc73e3d49c50e76994 \
+    --hash=sha256:97c513c5fb211ff784e7628666c8da648e0605389f4a8c5c8fac84cf06ea9ca2 \
+    --hash=sha256:97cad80ca9d2639988c57003425f92e01d4f9bda522809d0fd38629a1ce3e7fc \
+    --hash=sha256:a3887cef3f3012dc6e3da88116af3bcabbcaaf70c807085659dd3a8bd74ed503 \
+    --hash=sha256:bbc9402c01238cc5671a0b3ff9f055e983e6d2390ff3b56130a715daf5719f55 \
+    --hash=sha256:c835645d889838a09ca4db931783c9260fb5773c3aa569760aae5b887789ddea \
+    --hash=sha256:d60df986a621bd3691e885e814391f38f771de72188a28d930955ff59a78ce83 \
+    --hash=sha256:e6388f4e267cea521d04d10040fdb91fc49e47b0e1489f76764e26aecbcf7c48
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
     #   -r python/requirements/ml/dl-gpu-requirements.txt

--- a/python/deplocks/ci/data-base-ci_depset_py3.10.lock
+++ b/python/deplocks/ci/data-base-ci_depset_py3.10.lock
@@ -1,5 +1,5 @@
 --extra-index-url https://download.pytorch.org/whl/cpu
---find-links https://data.pyg.org/whl/torch-2.9.0+cpu.html
+--extra-index-url https://wheels.astral.sh/simple/cpu/
 
 absl-py==2.4.0 \
     --hash=sha256:88476fd881ca8aab94ffa78b7b6c632a782ab3ba1cd19c9bd423abc4fb4cd28d \
@@ -4684,9 +4684,7 @@ scipy==1.14.1 \
     #   pymars
     #   ray
     #   scikit-learn
-    #   torch-cluster
     #   torch-geometric
-    #   torch-sparse
 shellingham==1.5.4 \
     --hash=sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686 \
     --hash=sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de
@@ -5043,32 +5041,27 @@ torch==2.9.0+cpu \
     #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
     #   -r python/requirements/ml/data-test-requirements.txt
     #   -r python/requirements/ml/dl-cpu-requirements.txt
+    #   torch-scatter
     #   torchmetrics
     #   torchtext
     #   torchvision
-torch-cluster==1.6.3+pt29cpu \
-    --hash=sha256:250b7d207623831c03bf162bc45381c57dc19884be9b1b6f2fcaf00749202a42
-    # via
-    #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
-    #   -r python/requirements/ml/dl-cpu-requirements.txt
 torch-geometric==2.5.3 \
     --hash=sha256:8277abfc12600b0e8047e0c3ea2d55cc43f08c1448e73e924de827c15d0b5f85 \
     --hash=sha256:ad0761650c8fa56cdc46ee61c564fd4995f07f079965fe732b3a76d109fd3edc
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
     #   -r python/requirements/ml/dl-cpu-requirements.txt
-torch-scatter==2.1.2+pt29cpu \
-    --hash=sha256:62a0ad1d9e51da83d3c775b24cb498dc5b94075d18644653a3b24c158f288db6
-    # via
-    #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
-    #   -r python/requirements/ml/dl-cpu-requirements.txt
-torch-sparse==0.6.18+pt29cpu \
-    --hash=sha256:e4b76895717d17a635dbda6880ae46d7e5ef4438d66ffa6c45f85c74f50ea9e3
-    # via
-    #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
-    #   -r python/requirements/ml/dl-cpu-requirements.txt
-torch-spline-conv==1.2.2+pt29cpu \
-    --hash=sha256:d450dae7a383a08fa6ba57a800589becaa79a330fd81700f3255c13d29708283
+torch-scatter==2.1.2+cpu.torch.2.9 ; sys_platform == 'linux' \
+    --hash=sha256:2e34f7d83b32512b349e93355b18b1db48e317f30828d7ab717df6628825e000 \
+    --hash=sha256:34a11594df5338600a3fd55986fed088e4186ba56f2524a0a962cc3e40f75a4d \
+    --hash=sha256:51bcef861b61095f1b00f8451fe179fbfa48dc7f03af80dd01f29635090d66eb \
+    --hash=sha256:53ea146be456e3defaec4e70ad482a7c257db9eb8499865dc76ffe8310212cb1 \
+    --hash=sha256:6f9c0cce6e58e94aa9d0db24f9c579c1189973e03e9e1aa57f1e6492694af48d \
+    --hash=sha256:a2ef52eb9376db18986499b226ee54b94e8c1c39bfdf7f0d0a093a95dd3d3f4a \
+    --hash=sha256:b158c84bbff4554fc244f89e920ccfb2a437e13eb905d16d8b53c911dab467ad \
+    --hash=sha256:db5a7d61692c7827de77dfa79a4b18bf158c296e5d1a822bcd4c8ef90f204243 \
+    --hash=sha256:e176fba25b4658fa13ae8e54bcfbc2758b1d45cea78a308ea5562bc42a62f04e \
+    --hash=sha256:ff2a52e3bfd25fc06b8454ade9759506ddb053ea614a36c8b09cb75163075e6f
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
     #   -r python/requirements/ml/dl-cpu-requirements.txt

--- a/python/deplocks/ci/data-base-ci_depset_py3.10.lock
+++ b/python/deplocks/ci/data-base-ci_depset_py3.10.lock
@@ -1,5 +1,6 @@
 --extra-index-url https://download.pytorch.org/whl/cpu
 --extra-index-url https://wheels.astral.sh/simple/cpu/
+--find-links https://data.pyg.org/whl/torch-2.9.0+cpu.html
 
 absl-py==2.4.0 \
     --hash=sha256:88476fd881ca8aab94ffa78b7b6c632a782ab3ba1cd19c9bd423abc4fb4cd28d \
@@ -4685,6 +4686,7 @@ scipy==1.14.1 \
     #   ray
     #   scikit-learn
     #   torch-geometric
+    #   torch-sparse
 shellingham==1.5.4 \
     --hash=sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686 \
     --hash=sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de
@@ -5062,6 +5064,11 @@ torch-scatter==2.1.2+cpu.torch.2.9 ; sys_platform == 'linux' \
     --hash=sha256:db5a7d61692c7827de77dfa79a4b18bf158c296e5d1a822bcd4c8ef90f204243 \
     --hash=sha256:e176fba25b4658fa13ae8e54bcfbc2758b1d45cea78a308ea5562bc42a62f04e \
     --hash=sha256:ff2a52e3bfd25fc06b8454ade9759506ddb053ea614a36c8b09cb75163075e6f
+    # via
+    #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
+    #   -r python/requirements/ml/dl-cpu-requirements.txt
+torch-sparse==0.6.18+pt29cpu ; sys_platform == 'linux' \
+    --hash=sha256:e4b76895717d17a635dbda6880ae46d7e5ef4438d66ffa6c45f85c74f50ea9e3
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
     #   -r python/requirements/ml/dl-cpu-requirements.txt

--- a/python/deplocks/ci/data-base-ci_depset_py3.11.lock
+++ b/python/deplocks/ci/data-base-ci_depset_py3.11.lock
@@ -1,5 +1,5 @@
 --extra-index-url https://download.pytorch.org/whl/cpu
---find-links https://data.pyg.org/whl/torch-2.9.0+cpu.html
+--extra-index-url https://wheels.astral.sh/simple/cpu/
 
 absl-py==2.4.0 \
     --hash=sha256:88476fd881ca8aab94ffa78b7b6c632a782ab3ba1cd19c9bd423abc4fb4cd28d \
@@ -4722,9 +4722,7 @@ scipy==1.17.1 \
     #   pymars
     #   ray
     #   scikit-learn
-    #   torch-cluster
     #   torch-geometric
-    #   torch-sparse
 shellingham==1.5.4 \
     --hash=sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686 \
     --hash=sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de
@@ -5075,32 +5073,27 @@ torch==2.9.0+cpu \
     #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
     #   -r python/requirements/ml/data-test-requirements.txt
     #   -r python/requirements/ml/dl-cpu-requirements.txt
+    #   torch-scatter
     #   torchmetrics
     #   torchtext
     #   torchvision
-torch-cluster==1.6.3+pt29cpu \
-    --hash=sha256:53e31c99156e4f540a4de03d8c0a512c1d71a833c44e75037c880b3aecfad910
-    # via
-    #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
-    #   -r python/requirements/ml/dl-cpu-requirements.txt
 torch-geometric==2.5.3 \
     --hash=sha256:8277abfc12600b0e8047e0c3ea2d55cc43f08c1448e73e924de827c15d0b5f85 \
     --hash=sha256:ad0761650c8fa56cdc46ee61c564fd4995f07f079965fe732b3a76d109fd3edc
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
     #   -r python/requirements/ml/dl-cpu-requirements.txt
-torch-scatter==2.1.2+pt29cpu \
-    --hash=sha256:aa98fc4a64b962ae2a9290cfcc53a750c9a7d6907820a98026da278a13b203e8
-    # via
-    #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
-    #   -r python/requirements/ml/dl-cpu-requirements.txt
-torch-sparse==0.6.18+pt29cpu \
-    --hash=sha256:48b1bc1c2cf6122f8c2d7cd6a96ab2b28a19e7d1d943d40a9026f2a4239c26d4
-    # via
-    #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
-    #   -r python/requirements/ml/dl-cpu-requirements.txt
-torch-spline-conv==1.2.2+pt29cpu \
-    --hash=sha256:95c083dba9e5297b0244808fe5f9b8225a457314b1af5c4d5ea93eb0a97c6621
+torch-scatter==2.1.2+cpu.torch.2.9 ; sys_platform == 'linux' \
+    --hash=sha256:2e34f7d83b32512b349e93355b18b1db48e317f30828d7ab717df6628825e000 \
+    --hash=sha256:34a11594df5338600a3fd55986fed088e4186ba56f2524a0a962cc3e40f75a4d \
+    --hash=sha256:51bcef861b61095f1b00f8451fe179fbfa48dc7f03af80dd01f29635090d66eb \
+    --hash=sha256:53ea146be456e3defaec4e70ad482a7c257db9eb8499865dc76ffe8310212cb1 \
+    --hash=sha256:6f9c0cce6e58e94aa9d0db24f9c579c1189973e03e9e1aa57f1e6492694af48d \
+    --hash=sha256:a2ef52eb9376db18986499b226ee54b94e8c1c39bfdf7f0d0a093a95dd3d3f4a \
+    --hash=sha256:b158c84bbff4554fc244f89e920ccfb2a437e13eb905d16d8b53c911dab467ad \
+    --hash=sha256:db5a7d61692c7827de77dfa79a4b18bf158c296e5d1a822bcd4c8ef90f204243 \
+    --hash=sha256:e176fba25b4658fa13ae8e54bcfbc2758b1d45cea78a308ea5562bc42a62f04e \
+    --hash=sha256:ff2a52e3bfd25fc06b8454ade9759506ddb053ea614a36c8b09cb75163075e6f
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
     #   -r python/requirements/ml/dl-cpu-requirements.txt

--- a/python/deplocks/ci/data-base-ci_depset_py3.11.lock
+++ b/python/deplocks/ci/data-base-ci_depset_py3.11.lock
@@ -1,5 +1,6 @@
 --extra-index-url https://download.pytorch.org/whl/cpu
 --extra-index-url https://wheels.astral.sh/simple/cpu/
+--find-links https://data.pyg.org/whl/torch-2.9.0+cpu.html
 
 absl-py==2.4.0 \
     --hash=sha256:88476fd881ca8aab94ffa78b7b6c632a782ab3ba1cd19c9bd423abc4fb4cd28d \
@@ -4723,6 +4724,7 @@ scipy==1.17.1 \
     #   ray
     #   scikit-learn
     #   torch-geometric
+    #   torch-sparse
 shellingham==1.5.4 \
     --hash=sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686 \
     --hash=sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de
@@ -5094,6 +5096,11 @@ torch-scatter==2.1.2+cpu.torch.2.9 ; sys_platform == 'linux' \
     --hash=sha256:db5a7d61692c7827de77dfa79a4b18bf158c296e5d1a822bcd4c8ef90f204243 \
     --hash=sha256:e176fba25b4658fa13ae8e54bcfbc2758b1d45cea78a308ea5562bc42a62f04e \
     --hash=sha256:ff2a52e3bfd25fc06b8454ade9759506ddb053ea614a36c8b09cb75163075e6f
+    # via
+    #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
+    #   -r python/requirements/ml/dl-cpu-requirements.txt
+torch-sparse==0.6.18+pt29cpu ; sys_platform == 'linux' \
+    --hash=sha256:48b1bc1c2cf6122f8c2d7cd6a96ab2b28a19e7d1d943d40a9026f2a4239c26d4
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
     #   -r python/requirements/ml/dl-cpu-requirements.txt

--- a/python/deplocks/ci/data-base-ci_depset_py3.12.lock
+++ b/python/deplocks/ci/data-base-ci_depset_py3.12.lock
@@ -1,5 +1,6 @@
 --extra-index-url https://download.pytorch.org/whl/cpu
 --extra-index-url https://wheels.astral.sh/simple/cpu/
+--find-links https://data.pyg.org/whl/torch-2.9.0+cpu.html
 
 absl-py==2.4.0 \
     --hash=sha256:88476fd881ca8aab94ffa78b7b6c632a782ab3ba1cd19c9bd423abc4fb4cd28d \
@@ -4970,6 +4971,7 @@ scipy==1.17.1 \
     #   ray
     #   scikit-learn
     #   torch-geometric
+    #   torch-sparse
 sentry-sdk==2.58.0 \
     --hash=sha256:688d1c704ddecf382ea3326f21a67453d4caa95592d722b7c780a36a9d23109e \
     --hash=sha256:c1144d947352d54e5b7daa63596d9f848adf684989c06c4f5a659f0c85a18f6f
@@ -5332,6 +5334,11 @@ torch-scatter==2.1.2+cpu.torch.2.9 ; sys_platform == 'linux' \
     --hash=sha256:db5a7d61692c7827de77dfa79a4b18bf158c296e5d1a822bcd4c8ef90f204243 \
     --hash=sha256:e176fba25b4658fa13ae8e54bcfbc2758b1d45cea78a308ea5562bc42a62f04e \
     --hash=sha256:ff2a52e3bfd25fc06b8454ade9759506ddb053ea614a36c8b09cb75163075e6f
+    # via
+    #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
+    #   -r python/requirements/ml/dl-cpu-requirements.txt
+torch-sparse==0.6.18+pt29cpu ; sys_platform == 'linux' \
+    --hash=sha256:e1434c9ebe78727576ddbd279b2322a81e97060c31ef97145f47db173d81ef93
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
     #   -r python/requirements/ml/dl-cpu-requirements.txt

--- a/python/deplocks/ci/data-base-ci_depset_py3.12.lock
+++ b/python/deplocks/ci/data-base-ci_depset_py3.12.lock
@@ -1,5 +1,5 @@
 --extra-index-url https://download.pytorch.org/whl/cpu
---find-links https://data.pyg.org/whl/torch-2.9.0+cpu.html
+--extra-index-url https://wheels.astral.sh/simple/cpu/
 
 absl-py==2.4.0 \
     --hash=sha256:88476fd881ca8aab94ffa78b7b6c632a782ab3ba1cd19c9bd423abc4fb4cd28d \
@@ -4969,9 +4969,7 @@ scipy==1.17.1 \
     #   jaxlib
     #   ray
     #   scikit-learn
-    #   torch-cluster
     #   torch-geometric
-    #   torch-sparse
 sentry-sdk==2.58.0 \
     --hash=sha256:688d1c704ddecf382ea3326f21a67453d4caa95592d722b7c780a36a9d23109e \
     --hash=sha256:c1144d947352d54e5b7daa63596d9f848adf684989c06c4f5a659f0c85a18f6f
@@ -5313,32 +5311,27 @@ torch==2.9.0+cpu \
     #   -r python/requirements/ml/dl-cpu-requirements.txt
     #   accelerate
     #   lerobot
+    #   torch-scatter
     #   torchmetrics
     #   torchtext
     #   torchvision
-torch-cluster==1.6.3+pt29cpu \
-    --hash=sha256:562d2ea316ba0e9173915ae9bc9906eb35455969e6414fa0fe63d08023222a12
-    # via
-    #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
-    #   -r python/requirements/ml/dl-cpu-requirements.txt
 torch-geometric==2.5.3 \
     --hash=sha256:8277abfc12600b0e8047e0c3ea2d55cc43f08c1448e73e924de827c15d0b5f85 \
     --hash=sha256:ad0761650c8fa56cdc46ee61c564fd4995f07f079965fe732b3a76d109fd3edc
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
     #   -r python/requirements/ml/dl-cpu-requirements.txt
-torch-scatter==2.1.2+pt29cpu \
-    --hash=sha256:ff4aa866c5fde07fa153622df4f833af19ec2335736c1072e8c2c1f48f7d5745
-    # via
-    #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
-    #   -r python/requirements/ml/dl-cpu-requirements.txt
-torch-sparse==0.6.18+pt29cpu \
-    --hash=sha256:e1434c9ebe78727576ddbd279b2322a81e97060c31ef97145f47db173d81ef93
-    # via
-    #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
-    #   -r python/requirements/ml/dl-cpu-requirements.txt
-torch-spline-conv==1.2.2+pt29cpu \
-    --hash=sha256:2155b53ae8bf02d40522a4567eb8a7ba8e1c26d605323b3774fd7b0055ec3400
+torch-scatter==2.1.2+cpu.torch.2.9 ; sys_platform == 'linux' \
+    --hash=sha256:2e34f7d83b32512b349e93355b18b1db48e317f30828d7ab717df6628825e000 \
+    --hash=sha256:34a11594df5338600a3fd55986fed088e4186ba56f2524a0a962cc3e40f75a4d \
+    --hash=sha256:51bcef861b61095f1b00f8451fe179fbfa48dc7f03af80dd01f29635090d66eb \
+    --hash=sha256:53ea146be456e3defaec4e70ad482a7c257db9eb8499865dc76ffe8310212cb1 \
+    --hash=sha256:6f9c0cce6e58e94aa9d0db24f9c579c1189973e03e9e1aa57f1e6492694af48d \
+    --hash=sha256:a2ef52eb9376db18986499b226ee54b94e8c1c39bfdf7f0d0a093a95dd3d3f4a \
+    --hash=sha256:b158c84bbff4554fc244f89e920ccfb2a437e13eb905d16d8b53c911dab467ad \
+    --hash=sha256:db5a7d61692c7827de77dfa79a4b18bf158c296e5d1a822bcd4c8ef90f204243 \
+    --hash=sha256:e176fba25b4658fa13ae8e54bcfbc2758b1d45cea78a308ea5562bc42a62f04e \
+    --hash=sha256:ff2a52e3bfd25fc06b8454ade9759506ddb053ea614a36c8b09cb75163075e6f
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
     #   -r python/requirements/ml/dl-cpu-requirements.txt

--- a/python/deplocks/ci/data-mongo-ci_depset_py3.10.lock
+++ b/python/deplocks/ci/data-mongo-ci_depset_py3.10.lock
@@ -1,5 +1,6 @@
 --extra-index-url https://download.pytorch.org/whl/cpu
 --extra-index-url https://wheels.astral.sh/simple/cpu/
+--find-links https://data.pyg.org/whl/torch-2.9.0+cpu.html
 
 absl-py==2.4.0 \
     --hash=sha256:88476fd881ca8aab94ffa78b7b6c632a782ab3ba1cd19c9bd423abc4fb4cd28d \
@@ -4581,6 +4582,7 @@ scipy==1.14.1 \
     #   pymars
     #   scikit-learn
     #   torch-geometric
+    #   torch-sparse
 shellingham==1.5.4 \
     --hash=sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686 \
     --hash=sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de
@@ -4927,6 +4929,9 @@ torch-scatter==2.1.2+cpu.torch.2.9 ; sys_platform == 'linux' \
     --hash=sha256:db5a7d61692c7827de77dfa79a4b18bf158c296e5d1a822bcd4c8ef90f204243 \
     --hash=sha256:e176fba25b4658fa13ae8e54bcfbc2758b1d45cea78a308ea5562bc42a62f04e \
     --hash=sha256:ff2a52e3bfd25fc06b8454ade9759506ddb053ea614a36c8b09cb75163075e6f
+    # via -r python/deplocks/ci/relaxed_data-ci_depset_py3.10.lock
+torch-sparse==0.6.18+pt29cpu ; sys_platform == 'linux' \
+    --hash=sha256:e4b76895717d17a635dbda6880ae46d7e5ef4438d66ffa6c45f85c74f50ea9e3
     # via -r python/deplocks/ci/relaxed_data-ci_depset_py3.10.lock
 torchmetrics==0.10.3 \
     --hash=sha256:9e6ab66175f2dc13e246c37485b2c27c77931dfe47fc2b81c76217b8efdc1e57 \

--- a/python/deplocks/ci/data-mongo-ci_depset_py3.10.lock
+++ b/python/deplocks/ci/data-mongo-ci_depset_py3.10.lock
@@ -1,5 +1,5 @@
 --extra-index-url https://download.pytorch.org/whl/cpu
---find-links https://data.pyg.org/whl/torch-2.9.0+cpu.html
+--extra-index-url https://wheels.astral.sh/simple/cpu/
 
 absl-py==2.4.0 \
     --hash=sha256:88476fd881ca8aab94ffa78b7b6c632a782ab3ba1cd19c9bd423abc4fb4cd28d \
@@ -4580,9 +4580,7 @@ scipy==1.14.1 \
     #   jaxlib
     #   pymars
     #   scikit-learn
-    #   torch-cluster
     #   torch-geometric
-    #   torch-sparse
 shellingham==1.5.4 \
     --hash=sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686 \
     --hash=sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de
@@ -4910,24 +4908,25 @@ torch==2.9.0+cpu \
     --hash=sha256:fa0d1373d04b30ff8f12d542135d292f1a1ddb7c0d852a3d487a320360e5dab9
     # via
     #   -r python/deplocks/ci/relaxed_data-ci_depset_py3.10.lock
+    #   torch-scatter
     #   torchmetrics
     #   torchtext
     #   torchvision
-torch-cluster==1.6.3+pt29cpu \
-    --hash=sha256:250b7d207623831c03bf162bc45381c57dc19884be9b1b6f2fcaf00749202a42
-    # via -r python/deplocks/ci/relaxed_data-ci_depset_py3.10.lock
 torch-geometric==2.5.3 \
     --hash=sha256:8277abfc12600b0e8047e0c3ea2d55cc43f08c1448e73e924de827c15d0b5f85 \
     --hash=sha256:ad0761650c8fa56cdc46ee61c564fd4995f07f079965fe732b3a76d109fd3edc
     # via -r python/deplocks/ci/relaxed_data-ci_depset_py3.10.lock
-torch-scatter==2.1.2+pt29cpu \
-    --hash=sha256:62a0ad1d9e51da83d3c775b24cb498dc5b94075d18644653a3b24c158f288db6
-    # via -r python/deplocks/ci/relaxed_data-ci_depset_py3.10.lock
-torch-sparse==0.6.18+pt29cpu \
-    --hash=sha256:e4b76895717d17a635dbda6880ae46d7e5ef4438d66ffa6c45f85c74f50ea9e3
-    # via -r python/deplocks/ci/relaxed_data-ci_depset_py3.10.lock
-torch-spline-conv==1.2.2+pt29cpu \
-    --hash=sha256:d450dae7a383a08fa6ba57a800589becaa79a330fd81700f3255c13d29708283
+torch-scatter==2.1.2+cpu.torch.2.9 ; sys_platform == 'linux' \
+    --hash=sha256:2e34f7d83b32512b349e93355b18b1db48e317f30828d7ab717df6628825e000 \
+    --hash=sha256:34a11594df5338600a3fd55986fed088e4186ba56f2524a0a962cc3e40f75a4d \
+    --hash=sha256:51bcef861b61095f1b00f8451fe179fbfa48dc7f03af80dd01f29635090d66eb \
+    --hash=sha256:53ea146be456e3defaec4e70ad482a7c257db9eb8499865dc76ffe8310212cb1 \
+    --hash=sha256:6f9c0cce6e58e94aa9d0db24f9c579c1189973e03e9e1aa57f1e6492694af48d \
+    --hash=sha256:a2ef52eb9376db18986499b226ee54b94e8c1c39bfdf7f0d0a093a95dd3d3f4a \
+    --hash=sha256:b158c84bbff4554fc244f89e920ccfb2a437e13eb905d16d8b53c911dab467ad \
+    --hash=sha256:db5a7d61692c7827de77dfa79a4b18bf158c296e5d1a822bcd4c8ef90f204243 \
+    --hash=sha256:e176fba25b4658fa13ae8e54bcfbc2758b1d45cea78a308ea5562bc42a62f04e \
+    --hash=sha256:ff2a52e3bfd25fc06b8454ade9759506ddb053ea614a36c8b09cb75163075e6f
     # via -r python/deplocks/ci/relaxed_data-ci_depset_py3.10.lock
 torchmetrics==0.10.3 \
     --hash=sha256:9e6ab66175f2dc13e246c37485b2c27c77931dfe47fc2b81c76217b8efdc1e57 \

--- a/python/deplocks/ci/data-pyarrow-latest-ci_depset_py3.10.lock
+++ b/python/deplocks/ci/data-pyarrow-latest-ci_depset_py3.10.lock
@@ -1,5 +1,5 @@
 --extra-index-url https://download.pytorch.org/whl/cpu
---find-links https://data.pyg.org/whl/torch-2.9.0+cpu.html
+--extra-index-url https://wheels.astral.sh/simple/cpu/
 
 absl-py==2.4.0 \
     --hash=sha256:88476fd881ca8aab94ffa78b7b6c632a782ab3ba1cd19c9bd423abc4fb4cd28d \
@@ -4526,9 +4526,7 @@ scipy==1.14.1 \
     #   jaxlib
     #   pymars
     #   scikit-learn
-    #   torch-cluster
     #   torch-geometric
-    #   torch-sparse
 shellingham==1.5.4 \
     --hash=sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686 \
     --hash=sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de
@@ -4856,24 +4854,25 @@ torch==2.9.0+cpu \
     --hash=sha256:fa0d1373d04b30ff8f12d542135d292f1a1ddb7c0d852a3d487a320360e5dab9
     # via
     #   -r python/deplocks/ci/relaxed_data-ci_depset_py3.10.lock
+    #   torch-scatter
     #   torchmetrics
     #   torchtext
     #   torchvision
-torch-cluster==1.6.3+pt29cpu \
-    --hash=sha256:250b7d207623831c03bf162bc45381c57dc19884be9b1b6f2fcaf00749202a42
-    # via -r python/deplocks/ci/relaxed_data-ci_depset_py3.10.lock
 torch-geometric==2.5.3 \
     --hash=sha256:8277abfc12600b0e8047e0c3ea2d55cc43f08c1448e73e924de827c15d0b5f85 \
     --hash=sha256:ad0761650c8fa56cdc46ee61c564fd4995f07f079965fe732b3a76d109fd3edc
     # via -r python/deplocks/ci/relaxed_data-ci_depset_py3.10.lock
-torch-scatter==2.1.2+pt29cpu \
-    --hash=sha256:62a0ad1d9e51da83d3c775b24cb498dc5b94075d18644653a3b24c158f288db6
-    # via -r python/deplocks/ci/relaxed_data-ci_depset_py3.10.lock
-torch-sparse==0.6.18+pt29cpu \
-    --hash=sha256:e4b76895717d17a635dbda6880ae46d7e5ef4438d66ffa6c45f85c74f50ea9e3
-    # via -r python/deplocks/ci/relaxed_data-ci_depset_py3.10.lock
-torch-spline-conv==1.2.2+pt29cpu \
-    --hash=sha256:d450dae7a383a08fa6ba57a800589becaa79a330fd81700f3255c13d29708283
+torch-scatter==2.1.2+cpu.torch.2.9 ; sys_platform == 'linux' \
+    --hash=sha256:2e34f7d83b32512b349e93355b18b1db48e317f30828d7ab717df6628825e000 \
+    --hash=sha256:34a11594df5338600a3fd55986fed088e4186ba56f2524a0a962cc3e40f75a4d \
+    --hash=sha256:51bcef861b61095f1b00f8451fe179fbfa48dc7f03af80dd01f29635090d66eb \
+    --hash=sha256:53ea146be456e3defaec4e70ad482a7c257db9eb8499865dc76ffe8310212cb1 \
+    --hash=sha256:6f9c0cce6e58e94aa9d0db24f9c579c1189973e03e9e1aa57f1e6492694af48d \
+    --hash=sha256:a2ef52eb9376db18986499b226ee54b94e8c1c39bfdf7f0d0a093a95dd3d3f4a \
+    --hash=sha256:b158c84bbff4554fc244f89e920ccfb2a437e13eb905d16d8b53c911dab467ad \
+    --hash=sha256:db5a7d61692c7827de77dfa79a4b18bf158c296e5d1a822bcd4c8ef90f204243 \
+    --hash=sha256:e176fba25b4658fa13ae8e54bcfbc2758b1d45cea78a308ea5562bc42a62f04e \
+    --hash=sha256:ff2a52e3bfd25fc06b8454ade9759506ddb053ea614a36c8b09cb75163075e6f
     # via -r python/deplocks/ci/relaxed_data-ci_depset_py3.10.lock
 torchmetrics==0.10.3 \
     --hash=sha256:9e6ab66175f2dc13e246c37485b2c27c77931dfe47fc2b81c76217b8efdc1e57 \

--- a/python/deplocks/ci/data-pyarrow-latest-ci_depset_py3.10.lock
+++ b/python/deplocks/ci/data-pyarrow-latest-ci_depset_py3.10.lock
@@ -1,5 +1,6 @@
 --extra-index-url https://download.pytorch.org/whl/cpu
 --extra-index-url https://wheels.astral.sh/simple/cpu/
+--find-links https://data.pyg.org/whl/torch-2.9.0+cpu.html
 
 absl-py==2.4.0 \
     --hash=sha256:88476fd881ca8aab94ffa78b7b6c632a782ab3ba1cd19c9bd423abc4fb4cd28d \
@@ -4527,6 +4528,7 @@ scipy==1.14.1 \
     #   pymars
     #   scikit-learn
     #   torch-geometric
+    #   torch-sparse
 shellingham==1.5.4 \
     --hash=sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686 \
     --hash=sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de
@@ -4873,6 +4875,9 @@ torch-scatter==2.1.2+cpu.torch.2.9 ; sys_platform == 'linux' \
     --hash=sha256:db5a7d61692c7827de77dfa79a4b18bf158c296e5d1a822bcd4c8ef90f204243 \
     --hash=sha256:e176fba25b4658fa13ae8e54bcfbc2758b1d45cea78a308ea5562bc42a62f04e \
     --hash=sha256:ff2a52e3bfd25fc06b8454ade9759506ddb053ea614a36c8b09cb75163075e6f
+    # via -r python/deplocks/ci/relaxed_data-ci_depset_py3.10.lock
+torch-sparse==0.6.18+pt29cpu ; sys_platform == 'linux' \
+    --hash=sha256:e4b76895717d17a635dbda6880ae46d7e5ef4438d66ffa6c45f85c74f50ea9e3
     # via -r python/deplocks/ci/relaxed_data-ci_depset_py3.10.lock
 torchmetrics==0.10.3 \
     --hash=sha256:9e6ab66175f2dc13e246c37485b2c27c77931dfe47fc2b81c76217b8efdc1e57 \

--- a/python/deplocks/ci/data-pyarrow-latest-ci_depset_py3.12.lock
+++ b/python/deplocks/ci/data-pyarrow-latest-ci_depset_py3.12.lock
@@ -1,5 +1,6 @@
 --extra-index-url https://download.pytorch.org/whl/cpu
 --extra-index-url https://wheels.astral.sh/simple/cpu/
+--find-links https://data.pyg.org/whl/torch-2.9.0+cpu.html
 
 absl-py==2.4.0 \
     --hash=sha256:88476fd881ca8aab94ffa78b7b6c632a782ab3ba1cd19c9bd423abc4fb4cd28d \
@@ -4878,6 +4879,7 @@ scipy==1.17.1 \
     #   jaxlib
     #   scikit-learn
     #   torch-geometric
+    #   torch-sparse
 sentry-sdk==2.58.0 \
     --hash=sha256:688d1c704ddecf382ea3326f21a67453d4caa95592d722b7c780a36a9d23109e \
     --hash=sha256:c1144d947352d54e5b7daa63596d9f848adf684989c06c4f5a659f0c85a18f6f
@@ -5213,6 +5215,9 @@ torch-scatter==2.1.2+cpu.torch.2.9 ; sys_platform == 'linux' \
     --hash=sha256:db5a7d61692c7827de77dfa79a4b18bf158c296e5d1a822bcd4c8ef90f204243 \
     --hash=sha256:e176fba25b4658fa13ae8e54bcfbc2758b1d45cea78a308ea5562bc42a62f04e \
     --hash=sha256:ff2a52e3bfd25fc06b8454ade9759506ddb053ea614a36c8b09cb75163075e6f
+    # via -r python/deplocks/ci/relaxed_data-ci_depset_py3.12.lock
+torch-sparse==0.6.18+pt29cpu ; sys_platform == 'linux' \
+    --hash=sha256:e1434c9ebe78727576ddbd279b2322a81e97060c31ef97145f47db173d81ef93
     # via -r python/deplocks/ci/relaxed_data-ci_depset_py3.12.lock
 torchcodec==0.9.1 \
     --hash=sha256:0643c5e9c3a51fdafdea87935d5b0a38e99626c664f47a150482d77ab370a877 \

--- a/python/deplocks/ci/data-pyarrow-latest-ci_depset_py3.12.lock
+++ b/python/deplocks/ci/data-pyarrow-latest-ci_depset_py3.12.lock
@@ -1,5 +1,5 @@
 --extra-index-url https://download.pytorch.org/whl/cpu
---find-links https://data.pyg.org/whl/torch-2.9.0+cpu.html
+--extra-index-url https://wheels.astral.sh/simple/cpu/
 
 absl-py==2.4.0 \
     --hash=sha256:88476fd881ca8aab94ffa78b7b6c632a782ab3ba1cd19c9bd423abc4fb4cd28d \
@@ -4877,9 +4877,7 @@ scipy==1.17.1 \
     #   jax
     #   jaxlib
     #   scikit-learn
-    #   torch-cluster
     #   torch-geometric
-    #   torch-sparse
 sentry-sdk==2.58.0 \
     --hash=sha256:688d1c704ddecf382ea3326f21a67453d4caa95592d722b7c780a36a9d23109e \
     --hash=sha256:c1144d947352d54e5b7daa63596d9f848adf684989c06c4f5a659f0c85a18f6f
@@ -5196,24 +5194,25 @@ torch==2.9.0+cpu \
     #   -r python/deplocks/ci/relaxed_data-ci_depset_py3.12.lock
     #   accelerate
     #   lerobot
+    #   torch-scatter
     #   torchmetrics
     #   torchtext
     #   torchvision
-torch-cluster==1.6.3+pt29cpu \
-    --hash=sha256:562d2ea316ba0e9173915ae9bc9906eb35455969e6414fa0fe63d08023222a12
-    # via -r python/deplocks/ci/relaxed_data-ci_depset_py3.12.lock
 torch-geometric==2.5.3 \
     --hash=sha256:8277abfc12600b0e8047e0c3ea2d55cc43f08c1448e73e924de827c15d0b5f85 \
     --hash=sha256:ad0761650c8fa56cdc46ee61c564fd4995f07f079965fe732b3a76d109fd3edc
     # via -r python/deplocks/ci/relaxed_data-ci_depset_py3.12.lock
-torch-scatter==2.1.2+pt29cpu \
-    --hash=sha256:ff4aa866c5fde07fa153622df4f833af19ec2335736c1072e8c2c1f48f7d5745
-    # via -r python/deplocks/ci/relaxed_data-ci_depset_py3.12.lock
-torch-sparse==0.6.18+pt29cpu \
-    --hash=sha256:e1434c9ebe78727576ddbd279b2322a81e97060c31ef97145f47db173d81ef93
-    # via -r python/deplocks/ci/relaxed_data-ci_depset_py3.12.lock
-torch-spline-conv==1.2.2+pt29cpu \
-    --hash=sha256:2155b53ae8bf02d40522a4567eb8a7ba8e1c26d605323b3774fd7b0055ec3400
+torch-scatter==2.1.2+cpu.torch.2.9 ; sys_platform == 'linux' \
+    --hash=sha256:2e34f7d83b32512b349e93355b18b1db48e317f30828d7ab717df6628825e000 \
+    --hash=sha256:34a11594df5338600a3fd55986fed088e4186ba56f2524a0a962cc3e40f75a4d \
+    --hash=sha256:51bcef861b61095f1b00f8451fe179fbfa48dc7f03af80dd01f29635090d66eb \
+    --hash=sha256:53ea146be456e3defaec4e70ad482a7c257db9eb8499865dc76ffe8310212cb1 \
+    --hash=sha256:6f9c0cce6e58e94aa9d0db24f9c579c1189973e03e9e1aa57f1e6492694af48d \
+    --hash=sha256:a2ef52eb9376db18986499b226ee54b94e8c1c39bfdf7f0d0a093a95dd3d3f4a \
+    --hash=sha256:b158c84bbff4554fc244f89e920ccfb2a437e13eb905d16d8b53c911dab467ad \
+    --hash=sha256:db5a7d61692c7827de77dfa79a4b18bf158c296e5d1a822bcd4c8ef90f204243 \
+    --hash=sha256:e176fba25b4658fa13ae8e54bcfbc2758b1d45cea78a308ea5562bc42a62f04e \
+    --hash=sha256:ff2a52e3bfd25fc06b8454ade9759506ddb053ea614a36c8b09cb75163075e6f
     # via -r python/deplocks/ci/relaxed_data-ci_depset_py3.12.lock
 torchcodec==0.9.1 \
     --hash=sha256:0643c5e9c3a51fdafdea87935d5b0a38e99626c664f47a150482d77ab370a877 \

--- a/python/deplocks/ci/data-pyarrow-nightly-ci_depset_py3.10.lock
+++ b/python/deplocks/ci/data-pyarrow-nightly-ci_depset_py3.10.lock
@@ -1,5 +1,6 @@
 --extra-index-url https://download.pytorch.org/whl/cpu
 --extra-index-url https://wheels.astral.sh/simple/cpu/
+--find-links https://data.pyg.org/whl/torch-2.9.0+cpu.html
 
 absl-py==2.4.0 \
     --hash=sha256:88476fd881ca8aab94ffa78b7b6c632a782ab3ba1cd19c9bd423abc4fb4cd28d \
@@ -4512,6 +4513,7 @@ scipy==1.14.1 \
     #   pymars
     #   scikit-learn
     #   torch-geometric
+    #   torch-sparse
 shellingham==1.5.4 \
     --hash=sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686 \
     --hash=sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de
@@ -4858,6 +4860,9 @@ torch-scatter==2.1.2+cpu.torch.2.9 ; sys_platform == 'linux' \
     --hash=sha256:db5a7d61692c7827de77dfa79a4b18bf158c296e5d1a822bcd4c8ef90f204243 \
     --hash=sha256:e176fba25b4658fa13ae8e54bcfbc2758b1d45cea78a308ea5562bc42a62f04e \
     --hash=sha256:ff2a52e3bfd25fc06b8454ade9759506ddb053ea614a36c8b09cb75163075e6f
+    # via -r python/deplocks/ci/relaxed_data-ci_depset_py3.10.lock
+torch-sparse==0.6.18+pt29cpu ; sys_platform == 'linux' \
+    --hash=sha256:e4b76895717d17a635dbda6880ae46d7e5ef4438d66ffa6c45f85c74f50ea9e3
     # via -r python/deplocks/ci/relaxed_data-ci_depset_py3.10.lock
 torchmetrics==0.10.3 \
     --hash=sha256:9e6ab66175f2dc13e246c37485b2c27c77931dfe47fc2b81c76217b8efdc1e57 \

--- a/python/deplocks/ci/data-pyarrow-nightly-ci_depset_py3.10.lock
+++ b/python/deplocks/ci/data-pyarrow-nightly-ci_depset_py3.10.lock
@@ -1,5 +1,5 @@
 --extra-index-url https://download.pytorch.org/whl/cpu
---find-links https://data.pyg.org/whl/torch-2.9.0+cpu.html
+--extra-index-url https://wheels.astral.sh/simple/cpu/
 
 absl-py==2.4.0 \
     --hash=sha256:88476fd881ca8aab94ffa78b7b6c632a782ab3ba1cd19c9bd423abc4fb4cd28d \
@@ -4511,9 +4511,7 @@ scipy==1.14.1 \
     #   jaxlib
     #   pymars
     #   scikit-learn
-    #   torch-cluster
     #   torch-geometric
-    #   torch-sparse
 shellingham==1.5.4 \
     --hash=sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686 \
     --hash=sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de
@@ -4841,24 +4839,25 @@ torch==2.9.0+cpu \
     --hash=sha256:fa0d1373d04b30ff8f12d542135d292f1a1ddb7c0d852a3d487a320360e5dab9
     # via
     #   -r python/deplocks/ci/relaxed_data-ci_depset_py3.10.lock
+    #   torch-scatter
     #   torchmetrics
     #   torchtext
     #   torchvision
-torch-cluster==1.6.3+pt29cpu \
-    --hash=sha256:250b7d207623831c03bf162bc45381c57dc19884be9b1b6f2fcaf00749202a42
-    # via -r python/deplocks/ci/relaxed_data-ci_depset_py3.10.lock
 torch-geometric==2.5.3 \
     --hash=sha256:8277abfc12600b0e8047e0c3ea2d55cc43f08c1448e73e924de827c15d0b5f85 \
     --hash=sha256:ad0761650c8fa56cdc46ee61c564fd4995f07f079965fe732b3a76d109fd3edc
     # via -r python/deplocks/ci/relaxed_data-ci_depset_py3.10.lock
-torch-scatter==2.1.2+pt29cpu \
-    --hash=sha256:62a0ad1d9e51da83d3c775b24cb498dc5b94075d18644653a3b24c158f288db6
-    # via -r python/deplocks/ci/relaxed_data-ci_depset_py3.10.lock
-torch-sparse==0.6.18+pt29cpu \
-    --hash=sha256:e4b76895717d17a635dbda6880ae46d7e5ef4438d66ffa6c45f85c74f50ea9e3
-    # via -r python/deplocks/ci/relaxed_data-ci_depset_py3.10.lock
-torch-spline-conv==1.2.2+pt29cpu \
-    --hash=sha256:d450dae7a383a08fa6ba57a800589becaa79a330fd81700f3255c13d29708283
+torch-scatter==2.1.2+cpu.torch.2.9 ; sys_platform == 'linux' \
+    --hash=sha256:2e34f7d83b32512b349e93355b18b1db48e317f30828d7ab717df6628825e000 \
+    --hash=sha256:34a11594df5338600a3fd55986fed088e4186ba56f2524a0a962cc3e40f75a4d \
+    --hash=sha256:51bcef861b61095f1b00f8451fe179fbfa48dc7f03af80dd01f29635090d66eb \
+    --hash=sha256:53ea146be456e3defaec4e70ad482a7c257db9eb8499865dc76ffe8310212cb1 \
+    --hash=sha256:6f9c0cce6e58e94aa9d0db24f9c579c1189973e03e9e1aa57f1e6492694af48d \
+    --hash=sha256:a2ef52eb9376db18986499b226ee54b94e8c1c39bfdf7f0d0a093a95dd3d3f4a \
+    --hash=sha256:b158c84bbff4554fc244f89e920ccfb2a437e13eb905d16d8b53c911dab467ad \
+    --hash=sha256:db5a7d61692c7827de77dfa79a4b18bf158c296e5d1a822bcd4c8ef90f204243 \
+    --hash=sha256:e176fba25b4658fa13ae8e54bcfbc2758b1d45cea78a308ea5562bc42a62f04e \
+    --hash=sha256:ff2a52e3bfd25fc06b8454ade9759506ddb053ea614a36c8b09cb75163075e6f
     # via -r python/deplocks/ci/relaxed_data-ci_depset_py3.10.lock
 torchmetrics==0.10.3 \
     --hash=sha256:9e6ab66175f2dc13e246c37485b2c27c77931dfe47fc2b81c76217b8efdc1e57 \

--- a/python/deplocks/ci/data-pyarrow-v17-ci_depset_py3.10.lock
+++ b/python/deplocks/ci/data-pyarrow-v17-ci_depset_py3.10.lock
@@ -1,5 +1,5 @@
 --extra-index-url https://download.pytorch.org/whl/cpu
---find-links https://data.pyg.org/whl/torch-2.9.0+cpu.html
+--extra-index-url https://wheels.astral.sh/simple/cpu/
 
 absl-py==2.4.0 \
     --hash=sha256:88476fd881ca8aab94ffa78b7b6c632a782ab3ba1cd19c9bd423abc4fb4cd28d \
@@ -4540,9 +4540,7 @@ scipy==1.14.1 \
     #   jaxlib
     #   pymars
     #   scikit-learn
-    #   torch-cluster
     #   torch-geometric
-    #   torch-sparse
 shellingham==1.5.4 \
     --hash=sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686 \
     --hash=sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de
@@ -4870,24 +4868,25 @@ torch==2.9.0+cpu \
     --hash=sha256:fa0d1373d04b30ff8f12d542135d292f1a1ddb7c0d852a3d487a320360e5dab9
     # via
     #   -r python/deplocks/ci/relaxed_data-ci_depset_py3.10.lock
+    #   torch-scatter
     #   torchmetrics
     #   torchtext
     #   torchvision
-torch-cluster==1.6.3+pt29cpu \
-    --hash=sha256:250b7d207623831c03bf162bc45381c57dc19884be9b1b6f2fcaf00749202a42
-    # via -r python/deplocks/ci/relaxed_data-ci_depset_py3.10.lock
 torch-geometric==2.5.3 \
     --hash=sha256:8277abfc12600b0e8047e0c3ea2d55cc43f08c1448e73e924de827c15d0b5f85 \
     --hash=sha256:ad0761650c8fa56cdc46ee61c564fd4995f07f079965fe732b3a76d109fd3edc
     # via -r python/deplocks/ci/relaxed_data-ci_depset_py3.10.lock
-torch-scatter==2.1.2+pt29cpu \
-    --hash=sha256:62a0ad1d9e51da83d3c775b24cb498dc5b94075d18644653a3b24c158f288db6
-    # via -r python/deplocks/ci/relaxed_data-ci_depset_py3.10.lock
-torch-sparse==0.6.18+pt29cpu \
-    --hash=sha256:e4b76895717d17a635dbda6880ae46d7e5ef4438d66ffa6c45f85c74f50ea9e3
-    # via -r python/deplocks/ci/relaxed_data-ci_depset_py3.10.lock
-torch-spline-conv==1.2.2+pt29cpu \
-    --hash=sha256:d450dae7a383a08fa6ba57a800589becaa79a330fd81700f3255c13d29708283
+torch-scatter==2.1.2+cpu.torch.2.9 ; sys_platform == 'linux' \
+    --hash=sha256:2e34f7d83b32512b349e93355b18b1db48e317f30828d7ab717df6628825e000 \
+    --hash=sha256:34a11594df5338600a3fd55986fed088e4186ba56f2524a0a962cc3e40f75a4d \
+    --hash=sha256:51bcef861b61095f1b00f8451fe179fbfa48dc7f03af80dd01f29635090d66eb \
+    --hash=sha256:53ea146be456e3defaec4e70ad482a7c257db9eb8499865dc76ffe8310212cb1 \
+    --hash=sha256:6f9c0cce6e58e94aa9d0db24f9c579c1189973e03e9e1aa57f1e6492694af48d \
+    --hash=sha256:a2ef52eb9376db18986499b226ee54b94e8c1c39bfdf7f0d0a093a95dd3d3f4a \
+    --hash=sha256:b158c84bbff4554fc244f89e920ccfb2a437e13eb905d16d8b53c911dab467ad \
+    --hash=sha256:db5a7d61692c7827de77dfa79a4b18bf158c296e5d1a822bcd4c8ef90f204243 \
+    --hash=sha256:e176fba25b4658fa13ae8e54bcfbc2758b1d45cea78a308ea5562bc42a62f04e \
+    --hash=sha256:ff2a52e3bfd25fc06b8454ade9759506ddb053ea614a36c8b09cb75163075e6f
     # via -r python/deplocks/ci/relaxed_data-ci_depset_py3.10.lock
 torchmetrics==0.10.3 \
     --hash=sha256:9e6ab66175f2dc13e246c37485b2c27c77931dfe47fc2b81c76217b8efdc1e57 \

--- a/python/deplocks/ci/data-pyarrow-v17-ci_depset_py3.10.lock
+++ b/python/deplocks/ci/data-pyarrow-v17-ci_depset_py3.10.lock
@@ -1,5 +1,6 @@
 --extra-index-url https://download.pytorch.org/whl/cpu
 --extra-index-url https://wheels.astral.sh/simple/cpu/
+--find-links https://data.pyg.org/whl/torch-2.9.0+cpu.html
 
 absl-py==2.4.0 \
     --hash=sha256:88476fd881ca8aab94ffa78b7b6c632a782ab3ba1cd19c9bd423abc4fb4cd28d \
@@ -4541,6 +4542,7 @@ scipy==1.14.1 \
     #   pymars
     #   scikit-learn
     #   torch-geometric
+    #   torch-sparse
 shellingham==1.5.4 \
     --hash=sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686 \
     --hash=sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de
@@ -4887,6 +4889,9 @@ torch-scatter==2.1.2+cpu.torch.2.9 ; sys_platform == 'linux' \
     --hash=sha256:db5a7d61692c7827de77dfa79a4b18bf158c296e5d1a822bcd4c8ef90f204243 \
     --hash=sha256:e176fba25b4658fa13ae8e54bcfbc2758b1d45cea78a308ea5562bc42a62f04e \
     --hash=sha256:ff2a52e3bfd25fc06b8454ade9759506ddb053ea614a36c8b09cb75163075e6f
+    # via -r python/deplocks/ci/relaxed_data-ci_depset_py3.10.lock
+torch-sparse==0.6.18+pt29cpu ; sys_platform == 'linux' \
+    --hash=sha256:e4b76895717d17a635dbda6880ae46d7e5ef4438d66ffa6c45f85c74f50ea9e3
     # via -r python/deplocks/ci/relaxed_data-ci_depset_py3.10.lock
 torchmetrics==0.10.3 \
     --hash=sha256:9e6ab66175f2dc13e246c37485b2c27c77931dfe47fc2b81c76217b8efdc1e57 \

--- a/python/deplocks/ci/docgpu_depset_py3.10.lock
+++ b/python/deplocks/ci/docgpu_depset_py3.10.lock
@@ -1,5 +1,6 @@
 --extra-index-url https://download.pytorch.org/whl/cu128
 --extra-index-url https://wheels.astral.sh/simple/cu128/
+--find-links https://data.pyg.org/whl/torch-2.9.0+cu128.html
 
 about-time==4.2.1 \
     --hash=sha256:6a538862d33ce67d997429d14998310e1dbfda6cb7d9bbfbf799c4709847fece \
@@ -7419,6 +7420,7 @@ scipy==1.15.3 \
     #   statsforecast
     #   statsmodels
     #   torch-geometric
+    #   torch-sparse
     #   xgboost
 segment-analytics-python==2.2.0 \
     --hash=sha256:b511dce9d22fa31c8a3f1b0e69d15af9705aeeed066fb317bd64bec8b786b0b2 \
@@ -8151,6 +8153,11 @@ torch-scatter==2.1.2+cu.12.8.torch.2.9 \
     --hash=sha256:c835645d889838a09ca4db931783c9260fb5773c3aa569760aae5b887789ddea \
     --hash=sha256:d60df986a621bd3691e885e814391f38f771de72188a28d930955ff59a78ce83 \
     --hash=sha256:e6388f4e267cea521d04d10040fdb91fc49e47b0e1489f76764e26aecbcf7c48
+    # via
+    #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
+    #   -r python/requirements/ml/dl-gpu-requirements.txt
+torch-sparse==0.6.18+pt29cu128 \
+    --hash=sha256:af0a0ea9a902f868e0d40165e331291063f1ead5a0e07565b9d8f3ebe19f3f9b
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
     #   -r python/requirements/ml/dl-gpu-requirements.txt

--- a/python/deplocks/ci/docgpu_depset_py3.10.lock
+++ b/python/deplocks/ci/docgpu_depset_py3.10.lock
@@ -1,5 +1,5 @@
 --extra-index-url https://download.pytorch.org/whl/cu128
---find-links https://data.pyg.org/whl/torch-2.9.0+cu128.html
+--extra-index-url https://wheels.astral.sh/simple/cu128/
 
 about-time==4.2.1 \
     --hash=sha256:6a538862d33ce67d997429d14998310e1dbfda6cb7d9bbfbf799c4709847fece \
@@ -7418,9 +7418,7 @@ scipy==1.15.3 \
     #   skops
     #   statsforecast
     #   statsmodels
-    #   torch-cluster
     #   torch-geometric
-    #   torch-sparse
     #   xgboost
 segment-analytics-python==2.2.0 \
     --hash=sha256:b511dce9d22fa31c8a3f1b0e69d15af9705aeeed066fb317bd64bec8b786b0b2 \
@@ -8127,13 +8125,9 @@ torch==2.9.0+cu128 \
     #   tensordict
     #   timm
     #   torch-optimizer
+    #   torch-scatter
     #   torchmetrics
     #   torchvision
-torch-cluster==1.6.3+pt29cu128 \
-    --hash=sha256:53d269f1fd489709ad047b6fe253fefe3299616c61888047c7365baab83cf620
-    # via
-    #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
-    #   -r python/requirements/ml/dl-gpu-requirements.txt
 torch-geometric==2.5.3 \
     --hash=sha256:8277abfc12600b0e8047e0c3ea2d55cc43f08c1448e73e924de827c15d0b5f85 \
     --hash=sha256:ad0761650c8fa56cdc46ee61c564fd4995f07f079965fe732b3a76d109fd3edc
@@ -8146,18 +8140,17 @@ torch-optimizer==0.1.0 ; python_full_version < '3.12' \
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
     #   mosaicml
-torch-scatter==2.1.2+pt29cu128 \
-    --hash=sha256:7c6d1c2fa5c950593f83f38a6f880a0de70329af39c4d7aa8e51ed80b35f744f
-    # via
-    #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
-    #   -r python/requirements/ml/dl-gpu-requirements.txt
-torch-sparse==0.6.18+pt29cu128 \
-    --hash=sha256:af0a0ea9a902f868e0d40165e331291063f1ead5a0e07565b9d8f3ebe19f3f9b
-    # via
-    #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
-    #   -r python/requirements/ml/dl-gpu-requirements.txt
-torch-spline-conv==1.2.2+pt29cu128 \
-    --hash=sha256:3cd22a139a7f35c57d7297f19a47ca233caf2e86d22d92d2d1a2ee2dd0ccb6b6
+torch-scatter==2.1.2+cu.12.8.torch.2.9 \
+    --hash=sha256:35385c774a1792d719608f132c3d50e941aaa3a697dcec72fe54a715d6f6023c \
+    --hash=sha256:57bc485d4d911ad1c88606cf3e6b246ef8d49a448dfc6f03d8e2d19e9be82242 \
+    --hash=sha256:6893a3b00bd6b13e154edb251edd647f00846ca177c53fcc73e3d49c50e76994 \
+    --hash=sha256:97c513c5fb211ff784e7628666c8da648e0605389f4a8c5c8fac84cf06ea9ca2 \
+    --hash=sha256:97cad80ca9d2639988c57003425f92e01d4f9bda522809d0fd38629a1ce3e7fc \
+    --hash=sha256:a3887cef3f3012dc6e3da88116af3bcabbcaaf70c807085659dd3a8bd74ed503 \
+    --hash=sha256:bbc9402c01238cc5671a0b3ff9f055e983e6d2390ff3b56130a715daf5719f55 \
+    --hash=sha256:c835645d889838a09ca4db931783c9260fb5773c3aa569760aae5b887789ddea \
+    --hash=sha256:d60df986a621bd3691e885e814391f38f771de72188a28d930955ff59a78ce83 \
+    --hash=sha256:e6388f4e267cea521d04d10040fdb91fc49e47b0e1489f76764e26aecbcf7c48
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
     #   -r python/requirements/ml/dl-gpu-requirements.txt

--- a/python/deplocks/ci/docgpu_depset_py3.12.lock
+++ b/python/deplocks/ci/docgpu_depset_py3.12.lock
@@ -1,5 +1,5 @@
 --extra-index-url https://download.pytorch.org/whl/cu128
---find-links https://data.pyg.org/whl/torch-2.9.0+cu128.html
+--extra-index-url https://wheels.astral.sh/simple/cu128/
 
 about-time==4.2.1 \
     --hash=sha256:6a538862d33ce67d997429d14998310e1dbfda6cb7d9bbfbf799c4709847fece \
@@ -7185,9 +7185,7 @@ scipy==1.17.1 \
     #   skops
     #   statsforecast
     #   statsmodels
-    #   torch-cluster
     #   torch-geometric
-    #   torch-sparse
     #   xgboost
 segment-analytics-python==2.2.0 \
     --hash=sha256:b511dce9d22fa31c8a3f1b0e69d15af9705aeeed066fb317bd64bec8b786b0b2 \
@@ -7869,31 +7867,26 @@ torch==2.9.0+cu128 \
     #   s3torchconnector
     #   tensordict
     #   timm
+    #   torch-scatter
     #   torchmetrics
     #   torchvision
-torch-cluster==1.6.3+pt29cu128 \
-    --hash=sha256:0a6fe034d4cd1fddfa930624c4c9a0e10e7eec1c9477af0cf51fa1f2b845111b
-    # via
-    #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
-    #   -r python/requirements/ml/dl-gpu-requirements.txt
 torch-geometric==2.5.3 \
     --hash=sha256:8277abfc12600b0e8047e0c3ea2d55cc43f08c1448e73e924de827c15d0b5f85 \
     --hash=sha256:ad0761650c8fa56cdc46ee61c564fd4995f07f079965fe732b3a76d109fd3edc
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
     #   -r python/requirements/ml/dl-gpu-requirements.txt
-torch-scatter==2.1.2+pt29cu128 \
-    --hash=sha256:06b3c6b95a8fdeef8ffc274919d4b1f68cad14035e667b9eeb4d2934011064b6
-    # via
-    #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
-    #   -r python/requirements/ml/dl-gpu-requirements.txt
-torch-sparse==0.6.18+pt29cu128 \
-    --hash=sha256:93d7f07210e1316736c09d14c019793bb7627f4b39a4df67ab93166444d25db0
-    # via
-    #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
-    #   -r python/requirements/ml/dl-gpu-requirements.txt
-torch-spline-conv==1.2.2+pt29cu128 \
-    --hash=sha256:f648e9bf06bfdcfd3b2ba4927c786be0378ebc2a70e05d47d4c1949af04c3988
+torch-scatter==2.1.2+cu.12.8.torch.2.9 \
+    --hash=sha256:35385c774a1792d719608f132c3d50e941aaa3a697dcec72fe54a715d6f6023c \
+    --hash=sha256:57bc485d4d911ad1c88606cf3e6b246ef8d49a448dfc6f03d8e2d19e9be82242 \
+    --hash=sha256:6893a3b00bd6b13e154edb251edd647f00846ca177c53fcc73e3d49c50e76994 \
+    --hash=sha256:97c513c5fb211ff784e7628666c8da648e0605389f4a8c5c8fac84cf06ea9ca2 \
+    --hash=sha256:97cad80ca9d2639988c57003425f92e01d4f9bda522809d0fd38629a1ce3e7fc \
+    --hash=sha256:a3887cef3f3012dc6e3da88116af3bcabbcaaf70c807085659dd3a8bd74ed503 \
+    --hash=sha256:bbc9402c01238cc5671a0b3ff9f055e983e6d2390ff3b56130a715daf5719f55 \
+    --hash=sha256:c835645d889838a09ca4db931783c9260fb5773c3aa569760aae5b887789ddea \
+    --hash=sha256:d60df986a621bd3691e885e814391f38f771de72188a28d930955ff59a78ce83 \
+    --hash=sha256:e6388f4e267cea521d04d10040fdb91fc49e47b0e1489f76764e26aecbcf7c48
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
     #   -r python/requirements/ml/dl-gpu-requirements.txt

--- a/python/deplocks/ci/docgpu_depset_py3.12.lock
+++ b/python/deplocks/ci/docgpu_depset_py3.12.lock
@@ -1,5 +1,6 @@
 --extra-index-url https://download.pytorch.org/whl/cu128
 --extra-index-url https://wheels.astral.sh/simple/cu128/
+--find-links https://data.pyg.org/whl/torch-2.9.0+cu128.html
 
 about-time==4.2.1 \
     --hash=sha256:6a538862d33ce67d997429d14998310e1dbfda6cb7d9bbfbf799c4709847fece \
@@ -7186,6 +7187,7 @@ scipy==1.17.1 \
     #   statsforecast
     #   statsmodels
     #   torch-geometric
+    #   torch-sparse
     #   xgboost
 segment-analytics-python==2.2.0 \
     --hash=sha256:b511dce9d22fa31c8a3f1b0e69d15af9705aeeed066fb317bd64bec8b786b0b2 \
@@ -7887,6 +7889,11 @@ torch-scatter==2.1.2+cu.12.8.torch.2.9 \
     --hash=sha256:c835645d889838a09ca4db931783c9260fb5773c3aa569760aae5b887789ddea \
     --hash=sha256:d60df986a621bd3691e885e814391f38f771de72188a28d930955ff59a78ce83 \
     --hash=sha256:e6388f4e267cea521d04d10040fdb91fc49e47b0e1489f76764e26aecbcf7c48
+    # via
+    #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
+    #   -r python/requirements/ml/dl-gpu-requirements.txt
+torch-sparse==0.6.18+pt29cu128 \
+    --hash=sha256:93d7f07210e1316736c09d14c019793bb7627f4b39a4df67ab93166444d25db0
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
     #   -r python/requirements/ml/dl-gpu-requirements.txt

--- a/python/deplocks/ci/ml-build-ci_depset_py3.10.lock
+++ b/python/deplocks/ci/ml-build-ci_depset_py3.10.lock
@@ -1,5 +1,5 @@
 --extra-index-url https://download.pytorch.org/whl/cpu
---find-links https://data.pyg.org/whl/torch-2.9.0+cpu.html
+--extra-index-url https://wheels.astral.sh/simple/cpu/
 
 about-time==4.2.1 \
     --hash=sha256:6a538862d33ce67d997429d14998310e1dbfda6cb7d9bbfbf799c4709847fece \
@@ -5591,9 +5591,7 @@ scipy==1.14.1 \
     #   scikit-learn
     #   statsforecast
     #   statsmodels
-    #   torch-cluster
     #   torch-geometric
-    #   torch-sparse
 send2trash==2.1.0 \
     --hash=sha256:0da2f112e6d6bb22de6aa6daa7e144831a4febf2a87261451c4ad849fe9a873c \
     --hash=sha256:1c72b39f09457db3c05ce1d19158c2cbef4c32b8bedd02c155e49282b7ea7459
@@ -6128,14 +6126,10 @@ torch==2.9.0+cpu \
     #   s3torchconnector
     #   timm
     #   torch-optimizer
+    #   torch-scatter
     #   torchmetrics
     #   torchtext
     #   torchvision
-torch-cluster==1.6.3+pt29cpu \
-    --hash=sha256:250b7d207623831c03bf162bc45381c57dc19884be9b1b6f2fcaf00749202a42
-    # via
-    #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
-    #   -r python/requirements/ml/dl-cpu-requirements.txt
 torch-geometric==2.5.3 \
     --hash=sha256:8277abfc12600b0e8047e0c3ea2d55cc43f08c1448e73e924de827c15d0b5f85 \
     --hash=sha256:ad0761650c8fa56cdc46ee61c564fd4995f07f079965fe732b3a76d109fd3edc
@@ -6148,18 +6142,17 @@ torch-optimizer==0.1.0 ; python_full_version < '3.12' \
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
     #   mosaicml
-torch-scatter==2.1.2+pt29cpu \
-    --hash=sha256:62a0ad1d9e51da83d3c775b24cb498dc5b94075d18644653a3b24c158f288db6
-    # via
-    #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
-    #   -r python/requirements/ml/dl-cpu-requirements.txt
-torch-sparse==0.6.18+pt29cpu \
-    --hash=sha256:e4b76895717d17a635dbda6880ae46d7e5ef4438d66ffa6c45f85c74f50ea9e3
-    # via
-    #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
-    #   -r python/requirements/ml/dl-cpu-requirements.txt
-torch-spline-conv==1.2.2+pt29cpu \
-    --hash=sha256:d450dae7a383a08fa6ba57a800589becaa79a330fd81700f3255c13d29708283
+torch-scatter==2.1.2+cpu.torch.2.9 ; sys_platform == 'linux' \
+    --hash=sha256:2e34f7d83b32512b349e93355b18b1db48e317f30828d7ab717df6628825e000 \
+    --hash=sha256:34a11594df5338600a3fd55986fed088e4186ba56f2524a0a962cc3e40f75a4d \
+    --hash=sha256:51bcef861b61095f1b00f8451fe179fbfa48dc7f03af80dd01f29635090d66eb \
+    --hash=sha256:53ea146be456e3defaec4e70ad482a7c257db9eb8499865dc76ffe8310212cb1 \
+    --hash=sha256:6f9c0cce6e58e94aa9d0db24f9c579c1189973e03e9e1aa57f1e6492694af48d \
+    --hash=sha256:a2ef52eb9376db18986499b226ee54b94e8c1c39bfdf7f0d0a093a95dd3d3f4a \
+    --hash=sha256:b158c84bbff4554fc244f89e920ccfb2a437e13eb905d16d8b53c911dab467ad \
+    --hash=sha256:db5a7d61692c7827de77dfa79a4b18bf158c296e5d1a822bcd4c8ef90f204243 \
+    --hash=sha256:e176fba25b4658fa13ae8e54bcfbc2758b1d45cea78a308ea5562bc42a62f04e \
+    --hash=sha256:ff2a52e3bfd25fc06b8454ade9759506ddb053ea614a36c8b09cb75163075e6f
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
     #   -r python/requirements/ml/dl-cpu-requirements.txt

--- a/python/deplocks/ci/ml-build-ci_depset_py3.10.lock
+++ b/python/deplocks/ci/ml-build-ci_depset_py3.10.lock
@@ -1,5 +1,6 @@
 --extra-index-url https://download.pytorch.org/whl/cpu
 --extra-index-url https://wheels.astral.sh/simple/cpu/
+--find-links https://data.pyg.org/whl/torch-2.9.0+cpu.html
 
 about-time==4.2.1 \
     --hash=sha256:6a538862d33ce67d997429d14998310e1dbfda6cb7d9bbfbf799c4709847fece \
@@ -5592,6 +5593,7 @@ scipy==1.14.1 \
     #   statsforecast
     #   statsmodels
     #   torch-geometric
+    #   torch-sparse
 send2trash==2.1.0 \
     --hash=sha256:0da2f112e6d6bb22de6aa6daa7e144831a4febf2a87261451c4ad849fe9a873c \
     --hash=sha256:1c72b39f09457db3c05ce1d19158c2cbef4c32b8bedd02c155e49282b7ea7459
@@ -6153,6 +6155,11 @@ torch-scatter==2.1.2+cpu.torch.2.9 ; sys_platform == 'linux' \
     --hash=sha256:db5a7d61692c7827de77dfa79a4b18bf158c296e5d1a822bcd4c8ef90f204243 \
     --hash=sha256:e176fba25b4658fa13ae8e54bcfbc2758b1d45cea78a308ea5562bc42a62f04e \
     --hash=sha256:ff2a52e3bfd25fc06b8454ade9759506ddb053ea614a36c8b09cb75163075e6f
+    # via
+    #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
+    #   -r python/requirements/ml/dl-cpu-requirements.txt
+torch-sparse==0.6.18+pt29cpu ; sys_platform == 'linux' \
+    --hash=sha256:e4b76895717d17a635dbda6880ae46d7e5ef4438d66ffa6c45f85c74f50ea9e3
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
     #   -r python/requirements/ml/dl-cpu-requirements.txt

--- a/python/deplocks/ci/ml-build-ci_depset_py3.12.lock
+++ b/python/deplocks/ci/ml-build-ci_depset_py3.12.lock
@@ -1,5 +1,6 @@
 --extra-index-url https://download.pytorch.org/whl/cpu
 --extra-index-url https://wheels.astral.sh/simple/cpu/
+--find-links https://data.pyg.org/whl/torch-2.9.0+cpu.html
 
 about-time==4.2.1 \
     --hash=sha256:6a538862d33ce67d997429d14998310e1dbfda6cb7d9bbfbf799c4709847fece \
@@ -5078,6 +5079,7 @@ scipy==1.17.1 \
     #   statsforecast
     #   statsmodels
     #   torch-geometric
+    #   torch-sparse
 send2trash==2.1.0 \
     --hash=sha256:0da2f112e6d6bb22de6aa6daa7e144831a4febf2a87261451c4ad849fe9a873c \
     --hash=sha256:1c72b39f09457db3c05ce1d19158c2cbef4c32b8bedd02c155e49282b7ea7459
@@ -5570,6 +5572,11 @@ torch-scatter==2.1.2+cpu.torch.2.9 ; sys_platform == 'linux' \
     --hash=sha256:db5a7d61692c7827de77dfa79a4b18bf158c296e5d1a822bcd4c8ef90f204243 \
     --hash=sha256:e176fba25b4658fa13ae8e54bcfbc2758b1d45cea78a308ea5562bc42a62f04e \
     --hash=sha256:ff2a52e3bfd25fc06b8454ade9759506ddb053ea614a36c8b09cb75163075e6f
+    # via
+    #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
+    #   -r python/requirements/ml/dl-cpu-requirements.txt
+torch-sparse==0.6.18+pt29cpu ; sys_platform == 'linux' \
+    --hash=sha256:e1434c9ebe78727576ddbd279b2322a81e97060c31ef97145f47db173d81ef93
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
     #   -r python/requirements/ml/dl-cpu-requirements.txt

--- a/python/deplocks/ci/ml-build-ci_depset_py3.12.lock
+++ b/python/deplocks/ci/ml-build-ci_depset_py3.12.lock
@@ -1,5 +1,5 @@
 --extra-index-url https://download.pytorch.org/whl/cpu
---find-links https://data.pyg.org/whl/torch-2.9.0+cpu.html
+--extra-index-url https://wheels.astral.sh/simple/cpu/
 
 about-time==4.2.1 \
     --hash=sha256:6a538862d33ce67d997429d14998310e1dbfda6cb7d9bbfbf799c4709847fece \
@@ -5077,9 +5077,7 @@ scipy==1.17.1 \
     #   scikit-learn
     #   statsforecast
     #   statsmodels
-    #   torch-cluster
     #   torch-geometric
-    #   torch-sparse
 send2trash==2.1.0 \
     --hash=sha256:0da2f112e6d6bb22de6aa6daa7e144831a4febf2a87261451c4ad849fe9a873c \
     --hash=sha256:1c72b39f09457db3c05ce1d19158c2cbef4c32b8bedd02c155e49282b7ea7459
@@ -5551,32 +5549,27 @@ torch==2.9.0+cpu \
     #   pytorch-lightning
     #   s3torchconnector
     #   timm
+    #   torch-scatter
     #   torchmetrics
     #   torchtext
     #   torchvision
-torch-cluster==1.6.3+pt29cpu \
-    --hash=sha256:562d2ea316ba0e9173915ae9bc9906eb35455969e6414fa0fe63d08023222a12
-    # via
-    #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
-    #   -r python/requirements/ml/dl-cpu-requirements.txt
 torch-geometric==2.5.3 \
     --hash=sha256:8277abfc12600b0e8047e0c3ea2d55cc43f08c1448e73e924de827c15d0b5f85 \
     --hash=sha256:ad0761650c8fa56cdc46ee61c564fd4995f07f079965fe732b3a76d109fd3edc
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
     #   -r python/requirements/ml/dl-cpu-requirements.txt
-torch-scatter==2.1.2+pt29cpu \
-    --hash=sha256:ff4aa866c5fde07fa153622df4f833af19ec2335736c1072e8c2c1f48f7d5745
-    # via
-    #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
-    #   -r python/requirements/ml/dl-cpu-requirements.txt
-torch-sparse==0.6.18+pt29cpu \
-    --hash=sha256:e1434c9ebe78727576ddbd279b2322a81e97060c31ef97145f47db173d81ef93
-    # via
-    #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
-    #   -r python/requirements/ml/dl-cpu-requirements.txt
-torch-spline-conv==1.2.2+pt29cpu \
-    --hash=sha256:2155b53ae8bf02d40522a4567eb8a7ba8e1c26d605323b3774fd7b0055ec3400
+torch-scatter==2.1.2+cpu.torch.2.9 ; sys_platform == 'linux' \
+    --hash=sha256:2e34f7d83b32512b349e93355b18b1db48e317f30828d7ab717df6628825e000 \
+    --hash=sha256:34a11594df5338600a3fd55986fed088e4186ba56f2524a0a962cc3e40f75a4d \
+    --hash=sha256:51bcef861b61095f1b00f8451fe179fbfa48dc7f03af80dd01f29635090d66eb \
+    --hash=sha256:53ea146be456e3defaec4e70ad482a7c257db9eb8499865dc76ffe8310212cb1 \
+    --hash=sha256:6f9c0cce6e58e94aa9d0db24f9c579c1189973e03e9e1aa57f1e6492694af48d \
+    --hash=sha256:a2ef52eb9376db18986499b226ee54b94e8c1c39bfdf7f0d0a093a95dd3d3f4a \
+    --hash=sha256:b158c84bbff4554fc244f89e920ccfb2a437e13eb905d16d8b53c911dab467ad \
+    --hash=sha256:db5a7d61692c7827de77dfa79a4b18bf158c296e5d1a822bcd4c8ef90f204243 \
+    --hash=sha256:e176fba25b4658fa13ae8e54bcfbc2758b1d45cea78a308ea5562bc42a62f04e \
+    --hash=sha256:ff2a52e3bfd25fc06b8454ade9759506ddb053ea614a36c8b09cb75163075e6f
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
     #   -r python/requirements/ml/dl-cpu-requirements.txt

--- a/python/deplocks/ci/ml-gpubuild-ci_depset_py3.10.lock
+++ b/python/deplocks/ci/ml-gpubuild-ci_depset_py3.10.lock
@@ -1,5 +1,6 @@
 --extra-index-url https://download.pytorch.org/whl/cu128
 --extra-index-url https://wheels.astral.sh/simple/cu128/
+--find-links https://data.pyg.org/whl/torch-2.9.0+cu128.html
 
 about-time==4.2.1 \
     --hash=sha256:6a538862d33ce67d997429d14998310e1dbfda6cb7d9bbfbf799c4709847fece \
@@ -5647,6 +5648,7 @@ scipy==1.14.1 \
     #   statsforecast
     #   statsmodels
     #   torch-geometric
+    #   torch-sparse
 send2trash==2.1.0 \
     --hash=sha256:0da2f112e6d6bb22de6aa6daa7e144831a4febf2a87261451c4ad849fe9a873c \
     --hash=sha256:1c72b39f09457db3c05ce1d19158c2cbef4c32b8bedd02c155e49282b7ea7459
@@ -6163,6 +6165,11 @@ torch-scatter==2.1.2+cu.12.8.torch.2.9 \
     --hash=sha256:c835645d889838a09ca4db931783c9260fb5773c3aa569760aae5b887789ddea \
     --hash=sha256:d60df986a621bd3691e885e814391f38f771de72188a28d930955ff59a78ce83 \
     --hash=sha256:e6388f4e267cea521d04d10040fdb91fc49e47b0e1489f76764e26aecbcf7c48
+    # via
+    #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
+    #   -r python/requirements/ml/dl-gpu-requirements.txt
+torch-sparse==0.6.18+pt29cu128 \
+    --hash=sha256:af0a0ea9a902f868e0d40165e331291063f1ead5a0e07565b9d8f3ebe19f3f9b
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
     #   -r python/requirements/ml/dl-gpu-requirements.txt

--- a/python/deplocks/ci/ml-gpubuild-ci_depset_py3.10.lock
+++ b/python/deplocks/ci/ml-gpubuild-ci_depset_py3.10.lock
@@ -1,5 +1,5 @@
 --extra-index-url https://download.pytorch.org/whl/cu128
---find-links https://data.pyg.org/whl/torch-2.9.0+cu128.html
+--extra-index-url https://wheels.astral.sh/simple/cu128/
 
 about-time==4.2.1 \
     --hash=sha256:6a538862d33ce67d997429d14998310e1dbfda6cb7d9bbfbf799c4709847fece \
@@ -5646,9 +5646,7 @@ scipy==1.14.1 \
     #   scikit-learn
     #   statsforecast
     #   statsmodels
-    #   torch-cluster
     #   torch-geometric
-    #   torch-sparse
 send2trash==2.1.0 \
     --hash=sha256:0da2f112e6d6bb22de6aa6daa7e144831a4febf2a87261451c4ad849fe9a873c \
     --hash=sha256:1c72b39f09457db3c05ce1d19158c2cbef4c32b8bedd02c155e49282b7ea7459
@@ -6139,13 +6137,9 @@ torch==2.9.0+cu128 \
     #   s3torchconnector
     #   timm
     #   torch-optimizer
+    #   torch-scatter
     #   torchmetrics
     #   torchvision
-torch-cluster==1.6.3+pt29cu128 \
-    --hash=sha256:53d269f1fd489709ad047b6fe253fefe3299616c61888047c7365baab83cf620
-    # via
-    #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
-    #   -r python/requirements/ml/dl-gpu-requirements.txt
 torch-geometric==2.5.3 \
     --hash=sha256:8277abfc12600b0e8047e0c3ea2d55cc43f08c1448e73e924de827c15d0b5f85 \
     --hash=sha256:ad0761650c8fa56cdc46ee61c564fd4995f07f079965fe732b3a76d109fd3edc
@@ -6158,18 +6152,17 @@ torch-optimizer==0.1.0 ; python_full_version < '3.12' \
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
     #   mosaicml
-torch-scatter==2.1.2+pt29cu128 \
-    --hash=sha256:7c6d1c2fa5c950593f83f38a6f880a0de70329af39c4d7aa8e51ed80b35f744f
-    # via
-    #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
-    #   -r python/requirements/ml/dl-gpu-requirements.txt
-torch-sparse==0.6.18+pt29cu128 \
-    --hash=sha256:af0a0ea9a902f868e0d40165e331291063f1ead5a0e07565b9d8f3ebe19f3f9b
-    # via
-    #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
-    #   -r python/requirements/ml/dl-gpu-requirements.txt
-torch-spline-conv==1.2.2+pt29cu128 \
-    --hash=sha256:3cd22a139a7f35c57d7297f19a47ca233caf2e86d22d92d2d1a2ee2dd0ccb6b6
+torch-scatter==2.1.2+cu.12.8.torch.2.9 \
+    --hash=sha256:35385c774a1792d719608f132c3d50e941aaa3a697dcec72fe54a715d6f6023c \
+    --hash=sha256:57bc485d4d911ad1c88606cf3e6b246ef8d49a448dfc6f03d8e2d19e9be82242 \
+    --hash=sha256:6893a3b00bd6b13e154edb251edd647f00846ca177c53fcc73e3d49c50e76994 \
+    --hash=sha256:97c513c5fb211ff784e7628666c8da648e0605389f4a8c5c8fac84cf06ea9ca2 \
+    --hash=sha256:97cad80ca9d2639988c57003425f92e01d4f9bda522809d0fd38629a1ce3e7fc \
+    --hash=sha256:a3887cef3f3012dc6e3da88116af3bcabbcaaf70c807085659dd3a8bd74ed503 \
+    --hash=sha256:bbc9402c01238cc5671a0b3ff9f055e983e6d2390ff3b56130a715daf5719f55 \
+    --hash=sha256:c835645d889838a09ca4db931783c9260fb5773c3aa569760aae5b887789ddea \
+    --hash=sha256:d60df986a621bd3691e885e814391f38f771de72188a28d930955ff59a78ce83 \
+    --hash=sha256:e6388f4e267cea521d04d10040fdb91fc49e47b0e1489f76764e26aecbcf7c48
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
     #   -r python/requirements/ml/dl-gpu-requirements.txt

--- a/python/deplocks/ci/ml-gpubuild-ci_depset_py3.12.lock
+++ b/python/deplocks/ci/ml-gpubuild-ci_depset_py3.12.lock
@@ -1,5 +1,6 @@
 --extra-index-url https://download.pytorch.org/whl/cu128
 --extra-index-url https://wheels.astral.sh/simple/cu128/
+--find-links https://data.pyg.org/whl/torch-2.9.0+cu128.html
 
 about-time==4.2.1 \
     --hash=sha256:6a538862d33ce67d997429d14998310e1dbfda6cb7d9bbfbf799c4709847fece \
@@ -5350,6 +5351,7 @@ scipy==1.17.1 \
     #   statsforecast
     #   statsmodels
     #   torch-geometric
+    #   torch-sparse
 send2trash==2.1.0 \
     --hash=sha256:0da2f112e6d6bb22de6aa6daa7e144831a4febf2a87261451c4ad849fe9a873c \
     --hash=sha256:1c72b39f09457db3c05ce1d19158c2cbef4c32b8bedd02c155e49282b7ea7459
@@ -5839,6 +5841,11 @@ torch-scatter==2.1.2+cu.12.8.torch.2.9 \
     --hash=sha256:c835645d889838a09ca4db931783c9260fb5773c3aa569760aae5b887789ddea \
     --hash=sha256:d60df986a621bd3691e885e814391f38f771de72188a28d930955ff59a78ce83 \
     --hash=sha256:e6388f4e267cea521d04d10040fdb91fc49e47b0e1489f76764e26aecbcf7c48
+    # via
+    #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
+    #   -r python/requirements/ml/dl-gpu-requirements.txt
+torch-sparse==0.6.18+pt29cu128 \
+    --hash=sha256:93d7f07210e1316736c09d14c019793bb7627f4b39a4df67ab93166444d25db0
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
     #   -r python/requirements/ml/dl-gpu-requirements.txt

--- a/python/deplocks/ci/ml-gpubuild-ci_depset_py3.12.lock
+++ b/python/deplocks/ci/ml-gpubuild-ci_depset_py3.12.lock
@@ -1,5 +1,5 @@
 --extra-index-url https://download.pytorch.org/whl/cu128
---find-links https://data.pyg.org/whl/torch-2.9.0+cu128.html
+--extra-index-url https://wheels.astral.sh/simple/cu128/
 
 about-time==4.2.1 \
     --hash=sha256:6a538862d33ce67d997429d14998310e1dbfda6cb7d9bbfbf799c4709847fece \
@@ -5349,9 +5349,7 @@ scipy==1.17.1 \
     #   scikit-learn
     #   statsforecast
     #   statsmodels
-    #   torch-cluster
     #   torch-geometric
-    #   torch-sparse
 send2trash==2.1.0 \
     --hash=sha256:0da2f112e6d6bb22de6aa6daa7e144831a4febf2a87261451c4ad849fe9a873c \
     --hash=sha256:1c72b39f09457db3c05ce1d19158c2cbef4c32b8bedd02c155e49282b7ea7459
@@ -5821,31 +5819,26 @@ torch==2.9.0+cu128 \
     #   pytorch-lightning
     #   s3torchconnector
     #   timm
+    #   torch-scatter
     #   torchmetrics
     #   torchvision
-torch-cluster==1.6.3+pt29cu128 \
-    --hash=sha256:0a6fe034d4cd1fddfa930624c4c9a0e10e7eec1c9477af0cf51fa1f2b845111b
-    # via
-    #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
-    #   -r python/requirements/ml/dl-gpu-requirements.txt
 torch-geometric==2.5.3 \
     --hash=sha256:8277abfc12600b0e8047e0c3ea2d55cc43f08c1448e73e924de827c15d0b5f85 \
     --hash=sha256:ad0761650c8fa56cdc46ee61c564fd4995f07f079965fe732b3a76d109fd3edc
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
     #   -r python/requirements/ml/dl-gpu-requirements.txt
-torch-scatter==2.1.2+pt29cu128 \
-    --hash=sha256:06b3c6b95a8fdeef8ffc274919d4b1f68cad14035e667b9eeb4d2934011064b6
-    # via
-    #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
-    #   -r python/requirements/ml/dl-gpu-requirements.txt
-torch-sparse==0.6.18+pt29cu128 \
-    --hash=sha256:93d7f07210e1316736c09d14c019793bb7627f4b39a4df67ab93166444d25db0
-    # via
-    #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
-    #   -r python/requirements/ml/dl-gpu-requirements.txt
-torch-spline-conv==1.2.2+pt29cu128 \
-    --hash=sha256:f648e9bf06bfdcfd3b2ba4927c786be0378ebc2a70e05d47d4c1949af04c3988
+torch-scatter==2.1.2+cu.12.8.torch.2.9 \
+    --hash=sha256:35385c774a1792d719608f132c3d50e941aaa3a697dcec72fe54a715d6f6023c \
+    --hash=sha256:57bc485d4d911ad1c88606cf3e6b246ef8d49a448dfc6f03d8e2d19e9be82242 \
+    --hash=sha256:6893a3b00bd6b13e154edb251edd647f00846ca177c53fcc73e3d49c50e76994 \
+    --hash=sha256:97c513c5fb211ff784e7628666c8da648e0605389f4a8c5c8fac84cf06ea9ca2 \
+    --hash=sha256:97cad80ca9d2639988c57003425f92e01d4f9bda522809d0fd38629a1ce3e7fc \
+    --hash=sha256:a3887cef3f3012dc6e3da88116af3bcabbcaaf70c807085659dd3a8bd74ed503 \
+    --hash=sha256:bbc9402c01238cc5671a0b3ff9f055e983e6d2390ff3b56130a715daf5719f55 \
+    --hash=sha256:c835645d889838a09ca4db931783c9260fb5773c3aa569760aae5b887789ddea \
+    --hash=sha256:d60df986a621bd3691e885e814391f38f771de72188a28d930955ff59a78ce83 \
+    --hash=sha256:e6388f4e267cea521d04d10040fdb91fc49e47b0e1489f76764e26aecbcf7c48
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
     #   -r python/requirements/ml/dl-gpu-requirements.txt

--- a/python/deplocks/ci/ml-lightning1gpubuild-ci_depset_py3.10.lock
+++ b/python/deplocks/ci/ml-lightning1gpubuild-ci_depset_py3.10.lock
@@ -1,5 +1,6 @@
 --extra-index-url https://download.pytorch.org/whl/cu128
 --extra-index-url https://wheels.astral.sh/simple/cu128/
+--find-links https://data.pyg.org/whl/torch-2.9.0+cu128.html
 
 about-time==4.2.1 \
     --hash=sha256:6a538862d33ce67d997429d14998310e1dbfda6cb7d9bbfbf799c4709847fece \
@@ -5617,6 +5618,7 @@ scipy==1.14.1 \
     #   statsforecast
     #   statsmodels
     #   torch-geometric
+    #   torch-sparse
 send2trash==2.1.0 \
     --hash=sha256:0da2f112e6d6bb22de6aa6daa7e144831a4febf2a87261451c4ad849fe9a873c \
     --hash=sha256:1c72b39f09457db3c05ce1d19158c2cbef4c32b8bedd02c155e49282b7ea7459
@@ -6133,6 +6135,11 @@ torch-scatter==2.1.2+cu.12.8.torch.2.9 \
     --hash=sha256:c835645d889838a09ca4db931783c9260fb5773c3aa569760aae5b887789ddea \
     --hash=sha256:d60df986a621bd3691e885e814391f38f771de72188a28d930955ff59a78ce83 \
     --hash=sha256:e6388f4e267cea521d04d10040fdb91fc49e47b0e1489f76764e26aecbcf7c48
+    # via
+    #   -c /tmp/ray-deps/requirements_compiled_py3.13_no_ptl.txt
+    #   -r python/requirements/ml/dl-gpu-requirements.txt
+torch-sparse==0.6.18+pt29cu128 \
+    --hash=sha256:af0a0ea9a902f868e0d40165e331291063f1ead5a0e07565b9d8f3ebe19f3f9b
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.13_no_ptl.txt
     #   -r python/requirements/ml/dl-gpu-requirements.txt

--- a/python/deplocks/ci/ml-lightning1gpubuild-ci_depset_py3.10.lock
+++ b/python/deplocks/ci/ml-lightning1gpubuild-ci_depset_py3.10.lock
@@ -1,5 +1,5 @@
 --extra-index-url https://download.pytorch.org/whl/cu128
---find-links https://data.pyg.org/whl/torch-2.9.0+cu128.html
+--extra-index-url https://wheels.astral.sh/simple/cu128/
 
 about-time==4.2.1 \
     --hash=sha256:6a538862d33ce67d997429d14998310e1dbfda6cb7d9bbfbf799c4709847fece \
@@ -5616,9 +5616,7 @@ scipy==1.14.1 \
     #   scikit-learn
     #   statsforecast
     #   statsmodels
-    #   torch-cluster
     #   torch-geometric
-    #   torch-sparse
 send2trash==2.1.0 \
     --hash=sha256:0da2f112e6d6bb22de6aa6daa7e144831a4febf2a87261451c4ad849fe9a873c \
     --hash=sha256:1c72b39f09457db3c05ce1d19158c2cbef4c32b8bedd02c155e49282b7ea7459
@@ -6109,13 +6107,9 @@ torch==2.9.0+cu128 \
     #   s3torchconnector
     #   timm
     #   torch-optimizer
+    #   torch-scatter
     #   torchmetrics
     #   torchvision
-torch-cluster==1.6.3+pt29cu128 \
-    --hash=sha256:53d269f1fd489709ad047b6fe253fefe3299616c61888047c7365baab83cf620
-    # via
-    #   -c /tmp/ray-deps/requirements_compiled_py3.13_no_ptl.txt
-    #   -r python/requirements/ml/dl-gpu-requirements.txt
 torch-geometric==2.5.3 \
     --hash=sha256:8277abfc12600b0e8047e0c3ea2d55cc43f08c1448e73e924de827c15d0b5f85 \
     --hash=sha256:ad0761650c8fa56cdc46ee61c564fd4995f07f079965fe732b3a76d109fd3edc
@@ -6128,18 +6122,17 @@ torch-optimizer==0.1.0 ; python_full_version < '3.12' \
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.13_no_ptl.txt
     #   mosaicml
-torch-scatter==2.1.2+pt29cu128 \
-    --hash=sha256:7c6d1c2fa5c950593f83f38a6f880a0de70329af39c4d7aa8e51ed80b35f744f
-    # via
-    #   -c /tmp/ray-deps/requirements_compiled_py3.13_no_ptl.txt
-    #   -r python/requirements/ml/dl-gpu-requirements.txt
-torch-sparse==0.6.18+pt29cu128 \
-    --hash=sha256:af0a0ea9a902f868e0d40165e331291063f1ead5a0e07565b9d8f3ebe19f3f9b
-    # via
-    #   -c /tmp/ray-deps/requirements_compiled_py3.13_no_ptl.txt
-    #   -r python/requirements/ml/dl-gpu-requirements.txt
-torch-spline-conv==1.2.2+pt29cu128 \
-    --hash=sha256:3cd22a139a7f35c57d7297f19a47ca233caf2e86d22d92d2d1a2ee2dd0ccb6b6
+torch-scatter==2.1.2+cu.12.8.torch.2.9 \
+    --hash=sha256:35385c774a1792d719608f132c3d50e941aaa3a697dcec72fe54a715d6f6023c \
+    --hash=sha256:57bc485d4d911ad1c88606cf3e6b246ef8d49a448dfc6f03d8e2d19e9be82242 \
+    --hash=sha256:6893a3b00bd6b13e154edb251edd647f00846ca177c53fcc73e3d49c50e76994 \
+    --hash=sha256:97c513c5fb211ff784e7628666c8da648e0605389f4a8c5c8fac84cf06ea9ca2 \
+    --hash=sha256:97cad80ca9d2639988c57003425f92e01d4f9bda522809d0fd38629a1ce3e7fc \
+    --hash=sha256:a3887cef3f3012dc6e3da88116af3bcabbcaaf70c807085659dd3a8bd74ed503 \
+    --hash=sha256:bbc9402c01238cc5671a0b3ff9f055e983e6d2390ff3b56130a715daf5719f55 \
+    --hash=sha256:c835645d889838a09ca4db931783c9260fb5773c3aa569760aae5b887789ddea \
+    --hash=sha256:d60df986a621bd3691e885e814391f38f771de72188a28d930955ff59a78ce83 \
+    --hash=sha256:e6388f4e267cea521d04d10040fdb91fc49e47b0e1489f76764e26aecbcf7c48
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.13_no_ptl.txt
     #   -r python/requirements/ml/dl-gpu-requirements.txt

--- a/python/deplocks/ci/ml-torchft-ci_depset_py3.10.lock
+++ b/python/deplocks/ci/ml-torchft-ci_depset_py3.10.lock
@@ -1,5 +1,5 @@
 --extra-index-url https://download.pytorch.org/whl/cpu
---find-links https://data.pyg.org/whl/torch-2.9.0+cpu.html
+--extra-index-url https://wheels.astral.sh/simple/cpu/
 
 about-time==4.2.1 \
     --hash=sha256:6a538862d33ce67d997429d14998310e1dbfda6cb7d9bbfbf799c4709847fece \
@@ -5620,9 +5620,7 @@ scipy==1.15.3 \
     #   scikit-learn
     #   statsforecast
     #   statsmodels
-    #   torch-cluster
     #   torch-geometric
-    #   torch-sparse
 send2trash==2.1.0 \
     --hash=sha256:0da2f112e6d6bb22de6aa6daa7e144831a4febf2a87261451c4ad849fe9a873c \
     --hash=sha256:1c72b39f09457db3c05ce1d19158c2cbef4c32b8bedd02c155e49282b7ea7459
@@ -6157,15 +6155,11 @@ torch==2.9.0+cpu \
     #   s3torchconnector
     #   timm
     #   torch-optimizer
+    #   torch-scatter
     #   torchft-nightly
     #   torchmetrics
     #   torchtext
     #   torchvision
-torch-cluster==1.6.3+pt29cpu \
-    --hash=sha256:250b7d207623831c03bf162bc45381c57dc19884be9b1b6f2fcaf00749202a42
-    # via
-    #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
-    #   -r python/requirements/ml/dl-cpu-requirements.txt
 torch-geometric==2.5.3 \
     --hash=sha256:8277abfc12600b0e8047e0c3ea2d55cc43f08c1448e73e924de827c15d0b5f85 \
     --hash=sha256:ad0761650c8fa56cdc46ee61c564fd4995f07f079965fe732b3a76d109fd3edc
@@ -6178,18 +6172,17 @@ torch-optimizer==0.1.0 ; python_full_version < '3.12' \
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
     #   mosaicml
-torch-scatter==2.1.2+pt29cpu \
-    --hash=sha256:62a0ad1d9e51da83d3c775b24cb498dc5b94075d18644653a3b24c158f288db6
-    # via
-    #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
-    #   -r python/requirements/ml/dl-cpu-requirements.txt
-torch-sparse==0.6.18+pt29cpu \
-    --hash=sha256:e4b76895717d17a635dbda6880ae46d7e5ef4438d66ffa6c45f85c74f50ea9e3
-    # via
-    #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
-    #   -r python/requirements/ml/dl-cpu-requirements.txt
-torch-spline-conv==1.2.2+pt29cpu \
-    --hash=sha256:d450dae7a383a08fa6ba57a800589becaa79a330fd81700f3255c13d29708283
+torch-scatter==2.1.2+cpu.torch.2.9 ; sys_platform == 'linux' \
+    --hash=sha256:2e34f7d83b32512b349e93355b18b1db48e317f30828d7ab717df6628825e000 \
+    --hash=sha256:34a11594df5338600a3fd55986fed088e4186ba56f2524a0a962cc3e40f75a4d \
+    --hash=sha256:51bcef861b61095f1b00f8451fe179fbfa48dc7f03af80dd01f29635090d66eb \
+    --hash=sha256:53ea146be456e3defaec4e70ad482a7c257db9eb8499865dc76ffe8310212cb1 \
+    --hash=sha256:6f9c0cce6e58e94aa9d0db24f9c579c1189973e03e9e1aa57f1e6492694af48d \
+    --hash=sha256:a2ef52eb9376db18986499b226ee54b94e8c1c39bfdf7f0d0a093a95dd3d3f4a \
+    --hash=sha256:b158c84bbff4554fc244f89e920ccfb2a437e13eb905d16d8b53c911dab467ad \
+    --hash=sha256:db5a7d61692c7827de77dfa79a4b18bf158c296e5d1a822bcd4c8ef90f204243 \
+    --hash=sha256:e176fba25b4658fa13ae8e54bcfbc2758b1d45cea78a308ea5562bc42a62f04e \
+    --hash=sha256:ff2a52e3bfd25fc06b8454ade9759506ddb053ea614a36c8b09cb75163075e6f
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
     #   -r python/requirements/ml/dl-cpu-requirements.txt

--- a/python/deplocks/ci/ml-torchft-ci_depset_py3.10.lock
+++ b/python/deplocks/ci/ml-torchft-ci_depset_py3.10.lock
@@ -1,5 +1,6 @@
 --extra-index-url https://download.pytorch.org/whl/cpu
 --extra-index-url https://wheels.astral.sh/simple/cpu/
+--find-links https://data.pyg.org/whl/torch-2.9.0+cpu.html
 
 about-time==4.2.1 \
     --hash=sha256:6a538862d33ce67d997429d14998310e1dbfda6cb7d9bbfbf799c4709847fece \
@@ -5621,6 +5622,7 @@ scipy==1.15.3 \
     #   statsforecast
     #   statsmodels
     #   torch-geometric
+    #   torch-sparse
 send2trash==2.1.0 \
     --hash=sha256:0da2f112e6d6bb22de6aa6daa7e144831a4febf2a87261451c4ad849fe9a873c \
     --hash=sha256:1c72b39f09457db3c05ce1d19158c2cbef4c32b8bedd02c155e49282b7ea7459
@@ -6183,6 +6185,11 @@ torch-scatter==2.1.2+cpu.torch.2.9 ; sys_platform == 'linux' \
     --hash=sha256:db5a7d61692c7827de77dfa79a4b18bf158c296e5d1a822bcd4c8ef90f204243 \
     --hash=sha256:e176fba25b4658fa13ae8e54bcfbc2758b1d45cea78a308ea5562bc42a62f04e \
     --hash=sha256:ff2a52e3bfd25fc06b8454ade9759506ddb053ea614a36c8b09cb75163075e6f
+    # via
+    #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
+    #   -r python/requirements/ml/dl-cpu-requirements.txt
+torch-sparse==0.6.18+pt29cpu ; sys_platform == 'linux' \
+    --hash=sha256:e4b76895717d17a635dbda6880ae46d7e5ef4438d66ffa6c45f85c74f50ea9e3
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
     #   -r python/requirements/ml/dl-cpu-requirements.txt

--- a/python/deplocks/ci/relaxed_data-ci_depset_py3.10.lock
+++ b/python/deplocks/ci/relaxed_data-ci_depset_py3.10.lock
@@ -1,5 +1,6 @@
 --extra-index-url https://download.pytorch.org/whl/cpu
 --extra-index-url https://wheels.astral.sh/simple/cpu/
+--find-links https://data.pyg.org/whl/torch-2.9.0+cpu.html
 absl-py==2.4.0 \
     --hash=sha256:88476fd881ca8aab94ffa78b7b6c632a782ab3ba1cd19c9bd423abc4fb4cd28d \
     --hash=sha256:8c6af82722b35cf71e0f4d1d47dcaebfff286e27110a99fc359349b247dfb5d4
@@ -4478,6 +4479,7 @@ scipy==1.14.1 \
 #   ray
 #   scikit-learn
 #   torch-geometric
+#   torch-sparse
 shellingham==1.5.4 \
     --hash=sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686 \
     --hash=sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de
@@ -4855,6 +4857,11 @@ torch-scatter==2.1.2+cpu.torch.2.9; sys_platform == "linux" \
     --hash=sha256:db5a7d61692c7827de77dfa79a4b18bf158c296e5d1a822bcd4c8ef90f204243 \
     --hash=sha256:e176fba25b4658fa13ae8e54bcfbc2758b1d45cea78a308ea5562bc42a62f04e \
     --hash=sha256:ff2a52e3bfd25fc06b8454ade9759506ddb053ea614a36c8b09cb75163075e6f
+# via
+#   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
+#   -r python/requirements/ml/dl-cpu-requirements.txt
+torch-sparse==0.6.18+pt29cpu; sys_platform == "linux" \
+    --hash=sha256:e4b76895717d17a635dbda6880ae46d7e5ef4438d66ffa6c45f85c74f50ea9e3
 # via
 #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
 #   -r python/requirements/ml/dl-cpu-requirements.txt

--- a/python/deplocks/ci/relaxed_data-ci_depset_py3.10.lock
+++ b/python/deplocks/ci/relaxed_data-ci_depset_py3.10.lock
@@ -1,5 +1,5 @@
 --extra-index-url https://download.pytorch.org/whl/cpu
---find-links https://data.pyg.org/whl/torch-2.9.0+cpu.html
+--extra-index-url https://wheels.astral.sh/simple/cpu/
 absl-py==2.4.0 \
     --hash=sha256:88476fd881ca8aab94ffa78b7b6c632a782ab3ba1cd19c9bd423abc4fb4cd28d \
     --hash=sha256:8c6af82722b35cf71e0f4d1d47dcaebfff286e27110a99fc359349b247dfb5d4
@@ -4477,9 +4477,7 @@ scipy==1.14.1 \
 #   pymars
 #   ray
 #   scikit-learn
-#   torch-cluster
 #   torch-geometric
-#   torch-sparse
 shellingham==1.5.4 \
     --hash=sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686 \
     --hash=sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de
@@ -4836,32 +4834,27 @@ torch==2.9.0+cpu \
 #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
 #   -r python/requirements/ml/data-test-requirements.txt
 #   -r python/requirements/ml/dl-cpu-requirements.txt
+#   torch-scatter
 #   torchmetrics
 #   torchtext
 #   torchvision
-torch-cluster==1.6.3+pt29cpu \
-    --hash=sha256:250b7d207623831c03bf162bc45381c57dc19884be9b1b6f2fcaf00749202a42
-# via
-#   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
-#   -r python/requirements/ml/dl-cpu-requirements.txt
 torch-geometric==2.5.3 \
     --hash=sha256:8277abfc12600b0e8047e0c3ea2d55cc43f08c1448e73e924de827c15d0b5f85 \
     --hash=sha256:ad0761650c8fa56cdc46ee61c564fd4995f07f079965fe732b3a76d109fd3edc
 # via
 #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
 #   -r python/requirements/ml/dl-cpu-requirements.txt
-torch-scatter==2.1.2+pt29cpu \
-    --hash=sha256:62a0ad1d9e51da83d3c775b24cb498dc5b94075d18644653a3b24c158f288db6
-# via
-#   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
-#   -r python/requirements/ml/dl-cpu-requirements.txt
-torch-sparse==0.6.18+pt29cpu \
-    --hash=sha256:e4b76895717d17a635dbda6880ae46d7e5ef4438d66ffa6c45f85c74f50ea9e3
-# via
-#   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
-#   -r python/requirements/ml/dl-cpu-requirements.txt
-torch-spline-conv==1.2.2+pt29cpu \
-    --hash=sha256:d450dae7a383a08fa6ba57a800589becaa79a330fd81700f3255c13d29708283
+torch-scatter==2.1.2+cpu.torch.2.9; sys_platform == "linux" \
+    --hash=sha256:2e34f7d83b32512b349e93355b18b1db48e317f30828d7ab717df6628825e000 \
+    --hash=sha256:34a11594df5338600a3fd55986fed088e4186ba56f2524a0a962cc3e40f75a4d \
+    --hash=sha256:51bcef861b61095f1b00f8451fe179fbfa48dc7f03af80dd01f29635090d66eb \
+    --hash=sha256:53ea146be456e3defaec4e70ad482a7c257db9eb8499865dc76ffe8310212cb1 \
+    --hash=sha256:6f9c0cce6e58e94aa9d0db24f9c579c1189973e03e9e1aa57f1e6492694af48d \
+    --hash=sha256:a2ef52eb9376db18986499b226ee54b94e8c1c39bfdf7f0d0a093a95dd3d3f4a \
+    --hash=sha256:b158c84bbff4554fc244f89e920ccfb2a437e13eb905d16d8b53c911dab467ad \
+    --hash=sha256:db5a7d61692c7827de77dfa79a4b18bf158c296e5d1a822bcd4c8ef90f204243 \
+    --hash=sha256:e176fba25b4658fa13ae8e54bcfbc2758b1d45cea78a308ea5562bc42a62f04e \
+    --hash=sha256:ff2a52e3bfd25fc06b8454ade9759506ddb053ea614a36c8b09cb75163075e6f
 # via
 #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
 #   -r python/requirements/ml/dl-cpu-requirements.txt

--- a/python/deplocks/ci/relaxed_data-ci_depset_py3.12.lock
+++ b/python/deplocks/ci/relaxed_data-ci_depset_py3.12.lock
@@ -1,5 +1,5 @@
 --extra-index-url https://download.pytorch.org/whl/cpu
---find-links https://data.pyg.org/whl/torch-2.9.0+cpu.html
+--extra-index-url https://wheels.astral.sh/simple/cpu/
 absl-py==2.4.0 \
     --hash=sha256:88476fd881ca8aab94ffa78b7b6c632a782ab3ba1cd19c9bd423abc4fb4cd28d \
     --hash=sha256:8c6af82722b35cf71e0f4d1d47dcaebfff286e27110a99fc359349b247dfb5d4
@@ -4762,9 +4762,7 @@ scipy==1.17.1 \
 #   jaxlib
 #   ray
 #   scikit-learn
-#   torch-cluster
 #   torch-geometric
-#   torch-sparse
 sentry-sdk==2.58.0 \
     --hash=sha256:688d1c704ddecf382ea3326f21a67453d4caa95592d722b7c780a36a9d23109e \
     --hash=sha256:c1144d947352d54e5b7daa63596d9f848adf684989c06c4f5a659f0c85a18f6f
@@ -5106,32 +5104,27 @@ torch==2.9.0+cpu \
 #   -r python/requirements/ml/dl-cpu-requirements.txt
 #   accelerate
 #   lerobot
+#   torch-scatter
 #   torchmetrics
 #   torchtext
 #   torchvision
-torch-cluster==1.6.3+pt29cpu \
-    --hash=sha256:562d2ea316ba0e9173915ae9bc9906eb35455969e6414fa0fe63d08023222a12
-# via
-#   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
-#   -r python/requirements/ml/dl-cpu-requirements.txt
 torch-geometric==2.5.3 \
     --hash=sha256:8277abfc12600b0e8047e0c3ea2d55cc43f08c1448e73e924de827c15d0b5f85 \
     --hash=sha256:ad0761650c8fa56cdc46ee61c564fd4995f07f079965fe732b3a76d109fd3edc
 # via
 #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
 #   -r python/requirements/ml/dl-cpu-requirements.txt
-torch-scatter==2.1.2+pt29cpu \
-    --hash=sha256:ff4aa866c5fde07fa153622df4f833af19ec2335736c1072e8c2c1f48f7d5745
-# via
-#   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
-#   -r python/requirements/ml/dl-cpu-requirements.txt
-torch-sparse==0.6.18+pt29cpu \
-    --hash=sha256:e1434c9ebe78727576ddbd279b2322a81e97060c31ef97145f47db173d81ef93
-# via
-#   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
-#   -r python/requirements/ml/dl-cpu-requirements.txt
-torch-spline-conv==1.2.2+pt29cpu \
-    --hash=sha256:2155b53ae8bf02d40522a4567eb8a7ba8e1c26d605323b3774fd7b0055ec3400
+torch-scatter==2.1.2+cpu.torch.2.9; sys_platform == "linux" \
+    --hash=sha256:2e34f7d83b32512b349e93355b18b1db48e317f30828d7ab717df6628825e000 \
+    --hash=sha256:34a11594df5338600a3fd55986fed088e4186ba56f2524a0a962cc3e40f75a4d \
+    --hash=sha256:51bcef861b61095f1b00f8451fe179fbfa48dc7f03af80dd01f29635090d66eb \
+    --hash=sha256:53ea146be456e3defaec4e70ad482a7c257db9eb8499865dc76ffe8310212cb1 \
+    --hash=sha256:6f9c0cce6e58e94aa9d0db24f9c579c1189973e03e9e1aa57f1e6492694af48d \
+    --hash=sha256:a2ef52eb9376db18986499b226ee54b94e8c1c39bfdf7f0d0a093a95dd3d3f4a \
+    --hash=sha256:b158c84bbff4554fc244f89e920ccfb2a437e13eb905d16d8b53c911dab467ad \
+    --hash=sha256:db5a7d61692c7827de77dfa79a4b18bf158c296e5d1a822bcd4c8ef90f204243 \
+    --hash=sha256:e176fba25b4658fa13ae8e54bcfbc2758b1d45cea78a308ea5562bc42a62f04e \
+    --hash=sha256:ff2a52e3bfd25fc06b8454ade9759506ddb053ea614a36c8b09cb75163075e6f
 # via
 #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
 #   -r python/requirements/ml/dl-cpu-requirements.txt

--- a/python/deplocks/ci/relaxed_data-ci_depset_py3.12.lock
+++ b/python/deplocks/ci/relaxed_data-ci_depset_py3.12.lock
@@ -1,5 +1,6 @@
 --extra-index-url https://download.pytorch.org/whl/cpu
 --extra-index-url https://wheels.astral.sh/simple/cpu/
+--find-links https://data.pyg.org/whl/torch-2.9.0+cpu.html
 absl-py==2.4.0 \
     --hash=sha256:88476fd881ca8aab94ffa78b7b6c632a782ab3ba1cd19c9bd423abc4fb4cd28d \
     --hash=sha256:8c6af82722b35cf71e0f4d1d47dcaebfff286e27110a99fc359349b247dfb5d4
@@ -4763,6 +4764,7 @@ scipy==1.17.1 \
 #   ray
 #   scikit-learn
 #   torch-geometric
+#   torch-sparse
 sentry-sdk==2.58.0 \
     --hash=sha256:688d1c704ddecf382ea3326f21a67453d4caa95592d722b7c780a36a9d23109e \
     --hash=sha256:c1144d947352d54e5b7daa63596d9f848adf684989c06c4f5a659f0c85a18f6f
@@ -5125,6 +5127,11 @@ torch-scatter==2.1.2+cpu.torch.2.9; sys_platform == "linux" \
     --hash=sha256:db5a7d61692c7827de77dfa79a4b18bf158c296e5d1a822bcd4c8ef90f204243 \
     --hash=sha256:e176fba25b4658fa13ae8e54bcfbc2758b1d45cea78a308ea5562bc42a62f04e \
     --hash=sha256:ff2a52e3bfd25fc06b8454ade9759506ddb053ea614a36c8b09cb75163075e6f
+# via
+#   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
+#   -r python/requirements/ml/dl-cpu-requirements.txt
+torch-sparse==0.6.18+pt29cpu; sys_platform == "linux" \
+    --hash=sha256:e1434c9ebe78727576ddbd279b2322a81e97060c31ef97145f47db173d81ef93
 # via
 #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
 #   -r python/requirements/ml/dl-cpu-requirements.txt

--- a/python/deplocks/ci/relaxed_windows-tests-ci_depset_py3.10.lock
+++ b/python/deplocks/ci/relaxed_windows-tests-ci_depset_py3.10.lock
@@ -1,5 +1,5 @@
 --extra-index-url https://download.pytorch.org/whl/cpu
---find-links https://data.pyg.org/whl/torch-2.9.0+cpu.html
+--extra-index-url https://wheels.astral.sh/simple/cpu/
 absl-py==2.4.0 \
     --hash=sha256:88476fd881ca8aab94ffa78b7b6c632a782ab3ba1cd19c9bd423abc4fb4cd28d \
     --hash=sha256:8c6af82722b35cf71e0f4d1d47dcaebfff286e27110a99fc359349b247dfb5d4
@@ -5210,9 +5210,7 @@ scipy==1.15.3 \
 #   mlflow
 #   scikit-learn
 #   skops
-#   torch-cluster
 #   torch-geometric
-#   torch-sparse
 segment-analytics-python==2.2.0 \
     --hash=sha256:b511dce9d22fa31c8a3f1b0e69d15af9705aeeed066fb317bd64bec8b786b0b2 \
     --hash=sha256:d9bbdd554d57fdfc9d8ebe1e5e0a891154aa9c5f5a79b78925861d5bd4789c41
@@ -5549,21 +5547,9 @@ tomlkit==0.13.3 \
 #   torchmetrics
 #   torchtext
 #   torchvision
-# via
-#   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
-#   -r python/requirements/ml/dl-cpu-requirements.txt
 torch-geometric==2.5.3 \
     --hash=sha256:8277abfc12600b0e8047e0c3ea2d55cc43f08c1448e73e924de827c15d0b5f85 \
     --hash=sha256:ad0761650c8fa56cdc46ee61c564fd4995f07f079965fe732b3a76d109fd3edc
-# via
-#   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
-#   -r python/requirements/ml/dl-cpu-requirements.txt
-# via
-#   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
-#   -r python/requirements/ml/dl-cpu-requirements.txt
-# via
-#   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
-#   -r python/requirements/ml/dl-cpu-requirements.txt
 # via
 #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
 #   -r python/requirements/ml/dl-cpu-requirements.txt

--- a/python/deplocks/ci/relaxed_windows-tests-ci_depset_py3.10.lock
+++ b/python/deplocks/ci/relaxed_windows-tests-ci_depset_py3.10.lock
@@ -1,5 +1,6 @@
 --extra-index-url https://download.pytorch.org/whl/cpu
 --extra-index-url https://wheels.astral.sh/simple/cpu/
+--find-links https://data.pyg.org/whl/torch-2.9.0+cpu.html
 absl-py==2.4.0 \
     --hash=sha256:88476fd881ca8aab94ffa78b7b6c632a782ab3ba1cd19c9bd423abc4fb4cd28d \
     --hash=sha256:8c6af82722b35cf71e0f4d1d47dcaebfff286e27110a99fc359349b247dfb5d4

--- a/python/deplocks/ci/rllib-build-ci_depset_py3.10.lock
+++ b/python/deplocks/ci/rllib-build-ci_depset_py3.10.lock
@@ -1,5 +1,6 @@
 --extra-index-url https://download.pytorch.org/whl/cpu
 --extra-index-url https://wheels.astral.sh/simple/cpu/
+--find-links https://data.pyg.org/whl/torch-2.9.0+cpu.html
 
 absl-py==2.4.0 \
     --hash=sha256:88476fd881ca8aab94ffa78b7b6c632a782ab3ba1cd19c9bd423abc4fb4cd28d \
@@ -4497,6 +4498,7 @@ scipy==1.14.1 \
     #   scikit-learn
     #   skops
     #   torch-geometric
+    #   torch-sparse
     #   xgboost
 semantic-version==2.10.0 \
     --hash=sha256:bdabb6d336998cbb378d4b9db3a4b56a1e3235701dc05ea2690d9a997ed5041c \
@@ -4977,6 +4979,11 @@ torch-scatter==2.1.2+cpu.torch.2.9 ; sys_platform == 'linux' \
     --hash=sha256:db5a7d61692c7827de77dfa79a4b18bf158c296e5d1a822bcd4c8ef90f204243 \
     --hash=sha256:e176fba25b4658fa13ae8e54bcfbc2758b1d45cea78a308ea5562bc42a62f04e \
     --hash=sha256:ff2a52e3bfd25fc06b8454ade9759506ddb053ea614a36c8b09cb75163075e6f
+    # via
+    #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
+    #   -r python/requirements/ml/dl-cpu-requirements.txt
+torch-sparse==0.6.18+pt29cpu ; sys_platform == 'linux' \
+    --hash=sha256:e4b76895717d17a635dbda6880ae46d7e5ef4438d66ffa6c45f85c74f50ea9e3
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
     #   -r python/requirements/ml/dl-cpu-requirements.txt

--- a/python/deplocks/ci/rllib-build-ci_depset_py3.10.lock
+++ b/python/deplocks/ci/rllib-build-ci_depset_py3.10.lock
@@ -1,5 +1,5 @@
 --extra-index-url https://download.pytorch.org/whl/cpu
---find-links https://data.pyg.org/whl/torch-2.9.0+cpu.html
+--extra-index-url https://wheels.astral.sh/simple/cpu/
 
 absl-py==2.4.0 \
     --hash=sha256:88476fd881ca8aab94ffa78b7b6c632a782ab3ba1cd19c9bd423abc4fb4cd28d \
@@ -4496,9 +4496,7 @@ scipy==1.14.1 \
     #   ray
     #   scikit-learn
     #   skops
-    #   torch-cluster
     #   torch-geometric
-    #   torch-sparse
     #   xgboost
 semantic-version==2.10.0 \
     --hash=sha256:bdabb6d336998cbb378d4b9db3a4b56a1e3235701dc05ea2690d9a997ed5041c \
@@ -4958,32 +4956,27 @@ torch==2.9.0+cpu \
     #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
     #   -r python/requirements/ml/dl-cpu-requirements.txt
     #   accelerate
+    #   torch-scatter
     #   torchmetrics
     #   torchtext
     #   torchvision
-torch-cluster==1.6.3+pt29cpu \
-    --hash=sha256:250b7d207623831c03bf162bc45381c57dc19884be9b1b6f2fcaf00749202a42
-    # via
-    #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
-    #   -r python/requirements/ml/dl-cpu-requirements.txt
 torch-geometric==2.5.3 \
     --hash=sha256:8277abfc12600b0e8047e0c3ea2d55cc43f08c1448e73e924de827c15d0b5f85 \
     --hash=sha256:ad0761650c8fa56cdc46ee61c564fd4995f07f079965fe732b3a76d109fd3edc
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
     #   -r python/requirements/ml/dl-cpu-requirements.txt
-torch-scatter==2.1.2+pt29cpu \
-    --hash=sha256:62a0ad1d9e51da83d3c775b24cb498dc5b94075d18644653a3b24c158f288db6
-    # via
-    #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
-    #   -r python/requirements/ml/dl-cpu-requirements.txt
-torch-sparse==0.6.18+pt29cpu \
-    --hash=sha256:e4b76895717d17a635dbda6880ae46d7e5ef4438d66ffa6c45f85c74f50ea9e3
-    # via
-    #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
-    #   -r python/requirements/ml/dl-cpu-requirements.txt
-torch-spline-conv==1.2.2+pt29cpu \
-    --hash=sha256:d450dae7a383a08fa6ba57a800589becaa79a330fd81700f3255c13d29708283
+torch-scatter==2.1.2+cpu.torch.2.9 ; sys_platform == 'linux' \
+    --hash=sha256:2e34f7d83b32512b349e93355b18b1db48e317f30828d7ab717df6628825e000 \
+    --hash=sha256:34a11594df5338600a3fd55986fed088e4186ba56f2524a0a962cc3e40f75a4d \
+    --hash=sha256:51bcef861b61095f1b00f8451fe179fbfa48dc7f03af80dd01f29635090d66eb \
+    --hash=sha256:53ea146be456e3defaec4e70ad482a7c257db9eb8499865dc76ffe8310212cb1 \
+    --hash=sha256:6f9c0cce6e58e94aa9d0db24f9c579c1189973e03e9e1aa57f1e6492694af48d \
+    --hash=sha256:a2ef52eb9376db18986499b226ee54b94e8c1c39bfdf7f0d0a093a95dd3d3f4a \
+    --hash=sha256:b158c84bbff4554fc244f89e920ccfb2a437e13eb905d16d8b53c911dab467ad \
+    --hash=sha256:db5a7d61692c7827de77dfa79a4b18bf158c296e5d1a822bcd4c8ef90f204243 \
+    --hash=sha256:e176fba25b4658fa13ae8e54bcfbc2758b1d45cea78a308ea5562bc42a62f04e \
+    --hash=sha256:ff2a52e3bfd25fc06b8454ade9759506ddb053ea614a36c8b09cb75163075e6f
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
     #   -r python/requirements/ml/dl-cpu-requirements.txt

--- a/python/deplocks/ci/rllib-build-ci_depset_py3.12.lock
+++ b/python/deplocks/ci/rllib-build-ci_depset_py3.12.lock
@@ -1,5 +1,6 @@
 --extra-index-url https://download.pytorch.org/whl/cpu
 --extra-index-url https://wheels.astral.sh/simple/cpu/
+--find-links https://data.pyg.org/whl/torch-2.9.0+cpu.html
 
 absl-py==2.4.0 \
     --hash=sha256:88476fd881ca8aab94ffa78b7b6c632a782ab3ba1cd19c9bd423abc4fb4cd28d \
@@ -4285,6 +4286,7 @@ scipy==1.17.1 \
     #   scikit-learn
     #   skops
     #   torch-geometric
+    #   torch-sparse
     #   xgboost
 semantic-version==2.10.0 \
     --hash=sha256:bdabb6d336998cbb378d4b9db3a4b56a1e3235701dc05ea2690d9a997ed5041c \
@@ -4716,6 +4718,11 @@ torch-scatter==2.1.2+cpu.torch.2.9 ; sys_platform == 'linux' \
     --hash=sha256:db5a7d61692c7827de77dfa79a4b18bf158c296e5d1a822bcd4c8ef90f204243 \
     --hash=sha256:e176fba25b4658fa13ae8e54bcfbc2758b1d45cea78a308ea5562bc42a62f04e \
     --hash=sha256:ff2a52e3bfd25fc06b8454ade9759506ddb053ea614a36c8b09cb75163075e6f
+    # via
+    #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
+    #   -r python/requirements/ml/dl-cpu-requirements.txt
+torch-sparse==0.6.18+pt29cpu ; sys_platform == 'linux' \
+    --hash=sha256:e1434c9ebe78727576ddbd279b2322a81e97060c31ef97145f47db173d81ef93
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
     #   -r python/requirements/ml/dl-cpu-requirements.txt

--- a/python/deplocks/ci/rllib-build-ci_depset_py3.12.lock
+++ b/python/deplocks/ci/rllib-build-ci_depset_py3.12.lock
@@ -1,5 +1,5 @@
 --extra-index-url https://download.pytorch.org/whl/cpu
---find-links https://data.pyg.org/whl/torch-2.9.0+cpu.html
+--extra-index-url https://wheels.astral.sh/simple/cpu/
 
 absl-py==2.4.0 \
     --hash=sha256:88476fd881ca8aab94ffa78b7b6c632a782ab3ba1cd19c9bd423abc4fb4cd28d \
@@ -4284,9 +4284,7 @@ scipy==1.17.1 \
     #   ray
     #   scikit-learn
     #   skops
-    #   torch-cluster
     #   torch-geometric
-    #   torch-sparse
     #   xgboost
 semantic-version==2.10.0 \
     --hash=sha256:bdabb6d336998cbb378d4b9db3a4b56a1e3235701dc05ea2690d9a997ed5041c \
@@ -4697,32 +4695,27 @@ torch==2.9.0+cpu \
     #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
     #   -r python/requirements/ml/dl-cpu-requirements.txt
     #   accelerate
+    #   torch-scatter
     #   torchmetrics
     #   torchtext
     #   torchvision
-torch-cluster==1.6.3+pt29cpu \
-    --hash=sha256:562d2ea316ba0e9173915ae9bc9906eb35455969e6414fa0fe63d08023222a12
-    # via
-    #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
-    #   -r python/requirements/ml/dl-cpu-requirements.txt
 torch-geometric==2.5.3 \
     --hash=sha256:8277abfc12600b0e8047e0c3ea2d55cc43f08c1448e73e924de827c15d0b5f85 \
     --hash=sha256:ad0761650c8fa56cdc46ee61c564fd4995f07f079965fe732b3a76d109fd3edc
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
     #   -r python/requirements/ml/dl-cpu-requirements.txt
-torch-scatter==2.1.2+pt29cpu \
-    --hash=sha256:ff4aa866c5fde07fa153622df4f833af19ec2335736c1072e8c2c1f48f7d5745
-    # via
-    #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
-    #   -r python/requirements/ml/dl-cpu-requirements.txt
-torch-sparse==0.6.18+pt29cpu \
-    --hash=sha256:e1434c9ebe78727576ddbd279b2322a81e97060c31ef97145f47db173d81ef93
-    # via
-    #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
-    #   -r python/requirements/ml/dl-cpu-requirements.txt
-torch-spline-conv==1.2.2+pt29cpu \
-    --hash=sha256:2155b53ae8bf02d40522a4567eb8a7ba8e1c26d605323b3774fd7b0055ec3400
+torch-scatter==2.1.2+cpu.torch.2.9 ; sys_platform == 'linux' \
+    --hash=sha256:2e34f7d83b32512b349e93355b18b1db48e317f30828d7ab717df6628825e000 \
+    --hash=sha256:34a11594df5338600a3fd55986fed088e4186ba56f2524a0a962cc3e40f75a4d \
+    --hash=sha256:51bcef861b61095f1b00f8451fe179fbfa48dc7f03af80dd01f29635090d66eb \
+    --hash=sha256:53ea146be456e3defaec4e70ad482a7c257db9eb8499865dc76ffe8310212cb1 \
+    --hash=sha256:6f9c0cce6e58e94aa9d0db24f9c579c1189973e03e9e1aa57f1e6492694af48d \
+    --hash=sha256:a2ef52eb9376db18986499b226ee54b94e8c1c39bfdf7f0d0a093a95dd3d3f4a \
+    --hash=sha256:b158c84bbff4554fc244f89e920ccfb2a437e13eb905d16d8b53c911dab467ad \
+    --hash=sha256:db5a7d61692c7827de77dfa79a4b18bf158c296e5d1a822bcd4c8ef90f204243 \
+    --hash=sha256:e176fba25b4658fa13ae8e54bcfbc2758b1d45cea78a308ea5562bc42a62f04e \
+    --hash=sha256:ff2a52e3bfd25fc06b8454ade9759506ddb053ea614a36c8b09cb75163075e6f
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
     #   -r python/requirements/ml/dl-cpu-requirements.txt

--- a/python/deplocks/ci/rllib-gpubuild-ci_depset_py3.10.lock
+++ b/python/deplocks/ci/rllib-gpubuild-ci_depset_py3.10.lock
@@ -1,5 +1,6 @@
 --extra-index-url https://download.pytorch.org/whl/cu128
 --extra-index-url https://wheels.astral.sh/simple/cu128/
+--find-links https://data.pyg.org/whl/torch-2.9.0+cu128.html
 
 absl-py==2.4.0 \
     --hash=sha256:88476fd881ca8aab94ffa78b7b6c632a782ab3ba1cd19c9bd423abc4fb4cd28d \
@@ -4550,6 +4551,7 @@ scipy==1.14.1 \
     #   scikit-learn
     #   skops
     #   torch-geometric
+    #   torch-sparse
     #   xgboost
 semantic-version==2.10.0 \
     --hash=sha256:bdabb6d336998cbb378d4b9db3a4b56a1e3235701dc05ea2690d9a997ed5041c \
@@ -4984,6 +4986,11 @@ torch-scatter==2.1.2+cu.12.8.torch.2.9 \
     --hash=sha256:c835645d889838a09ca4db931783c9260fb5773c3aa569760aae5b887789ddea \
     --hash=sha256:d60df986a621bd3691e885e814391f38f771de72188a28d930955ff59a78ce83 \
     --hash=sha256:e6388f4e267cea521d04d10040fdb91fc49e47b0e1489f76764e26aecbcf7c48
+    # via
+    #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
+    #   -r python/requirements/ml/dl-gpu-requirements.txt
+torch-sparse==0.6.18+pt29cu128 \
+    --hash=sha256:af0a0ea9a902f868e0d40165e331291063f1ead5a0e07565b9d8f3ebe19f3f9b
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
     #   -r python/requirements/ml/dl-gpu-requirements.txt

--- a/python/deplocks/ci/rllib-gpubuild-ci_depset_py3.10.lock
+++ b/python/deplocks/ci/rllib-gpubuild-ci_depset_py3.10.lock
@@ -1,5 +1,5 @@
 --extra-index-url https://download.pytorch.org/whl/cu128
---find-links https://data.pyg.org/whl/torch-2.9.0+cu128.html
+--extra-index-url https://wheels.astral.sh/simple/cu128/
 
 absl-py==2.4.0 \
     --hash=sha256:88476fd881ca8aab94ffa78b7b6c632a782ab3ba1cd19c9bd423abc4fb4cd28d \
@@ -4549,9 +4549,7 @@ scipy==1.14.1 \
     #   ray
     #   scikit-learn
     #   skops
-    #   torch-cluster
     #   torch-geometric
-    #   torch-sparse
     #   xgboost
 semantic-version==2.10.0 \
     --hash=sha256:bdabb6d336998cbb378d4b9db3a4b56a1e3235701dc05ea2690d9a997ed5041c \
@@ -4967,30 +4965,25 @@ torch==2.9.0+cu128 \
     #   -r python/requirements/ml/dl-gpu-requirements.txt
     #   accelerate
     #   nixl
+    #   torch-scatter
     #   torchvision
-torch-cluster==1.6.3+pt29cu128 \
-    --hash=sha256:53d269f1fd489709ad047b6fe253fefe3299616c61888047c7365baab83cf620
-    # via
-    #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
-    #   -r python/requirements/ml/dl-gpu-requirements.txt
 torch-geometric==2.5.3 \
     --hash=sha256:8277abfc12600b0e8047e0c3ea2d55cc43f08c1448e73e924de827c15d0b5f85 \
     --hash=sha256:ad0761650c8fa56cdc46ee61c564fd4995f07f079965fe732b3a76d109fd3edc
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
     #   -r python/requirements/ml/dl-gpu-requirements.txt
-torch-scatter==2.1.2+pt29cu128 \
-    --hash=sha256:7c6d1c2fa5c950593f83f38a6f880a0de70329af39c4d7aa8e51ed80b35f744f
-    # via
-    #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
-    #   -r python/requirements/ml/dl-gpu-requirements.txt
-torch-sparse==0.6.18+pt29cu128 \
-    --hash=sha256:af0a0ea9a902f868e0d40165e331291063f1ead5a0e07565b9d8f3ebe19f3f9b
-    # via
-    #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
-    #   -r python/requirements/ml/dl-gpu-requirements.txt
-torch-spline-conv==1.2.2+pt29cu128 \
-    --hash=sha256:3cd22a139a7f35c57d7297f19a47ca233caf2e86d22d92d2d1a2ee2dd0ccb6b6
+torch-scatter==2.1.2+cu.12.8.torch.2.9 \
+    --hash=sha256:35385c774a1792d719608f132c3d50e941aaa3a697dcec72fe54a715d6f6023c \
+    --hash=sha256:57bc485d4d911ad1c88606cf3e6b246ef8d49a448dfc6f03d8e2d19e9be82242 \
+    --hash=sha256:6893a3b00bd6b13e154edb251edd647f00846ca177c53fcc73e3d49c50e76994 \
+    --hash=sha256:97c513c5fb211ff784e7628666c8da648e0605389f4a8c5c8fac84cf06ea9ca2 \
+    --hash=sha256:97cad80ca9d2639988c57003425f92e01d4f9bda522809d0fd38629a1ce3e7fc \
+    --hash=sha256:a3887cef3f3012dc6e3da88116af3bcabbcaaf70c807085659dd3a8bd74ed503 \
+    --hash=sha256:bbc9402c01238cc5671a0b3ff9f055e983e6d2390ff3b56130a715daf5719f55 \
+    --hash=sha256:c835645d889838a09ca4db931783c9260fb5773c3aa569760aae5b887789ddea \
+    --hash=sha256:d60df986a621bd3691e885e814391f38f771de72188a28d930955ff59a78ce83 \
+    --hash=sha256:e6388f4e267cea521d04d10040fdb91fc49e47b0e1489f76764e26aecbcf7c48
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
     #   -r python/requirements/ml/dl-gpu-requirements.txt

--- a/python/deplocks/ci/rllib-gpubuild-ci_depset_py3.12.lock
+++ b/python/deplocks/ci/rllib-gpubuild-ci_depset_py3.12.lock
@@ -1,5 +1,5 @@
 --extra-index-url https://download.pytorch.org/whl/cu128
---find-links https://data.pyg.org/whl/torch-2.9.0+cu128.html
+--extra-index-url https://wheels.astral.sh/simple/cu128/
 
 absl-py==2.4.0 \
     --hash=sha256:88476fd881ca8aab94ffa78b7b6c632a782ab3ba1cd19c9bd423abc4fb4cd28d \
@@ -4604,9 +4604,7 @@ scipy==1.17.1 \
     #   ray
     #   scikit-learn
     #   skops
-    #   torch-cluster
     #   torch-geometric
-    #   torch-sparse
     #   xgboost
 semantic-version==2.10.0 \
     --hash=sha256:bdabb6d336998cbb378d4b9db3a4b56a1e3235701dc05ea2690d9a997ed5041c \
@@ -5015,30 +5013,25 @@ torch==2.9.0+cu128 \
     #   -r python/requirements/ml/dl-gpu-requirements.txt
     #   accelerate
     #   nixl
+    #   torch-scatter
     #   torchvision
-torch-cluster==1.6.3+pt29cu128 \
-    --hash=sha256:0a6fe034d4cd1fddfa930624c4c9a0e10e7eec1c9477af0cf51fa1f2b845111b
-    # via
-    #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
-    #   -r python/requirements/ml/dl-gpu-requirements.txt
 torch-geometric==2.5.3 \
     --hash=sha256:8277abfc12600b0e8047e0c3ea2d55cc43f08c1448e73e924de827c15d0b5f85 \
     --hash=sha256:ad0761650c8fa56cdc46ee61c564fd4995f07f079965fe732b3a76d109fd3edc
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
     #   -r python/requirements/ml/dl-gpu-requirements.txt
-torch-scatter==2.1.2+pt29cu128 \
-    --hash=sha256:06b3c6b95a8fdeef8ffc274919d4b1f68cad14035e667b9eeb4d2934011064b6
-    # via
-    #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
-    #   -r python/requirements/ml/dl-gpu-requirements.txt
-torch-sparse==0.6.18+pt29cu128 \
-    --hash=sha256:93d7f07210e1316736c09d14c019793bb7627f4b39a4df67ab93166444d25db0
-    # via
-    #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
-    #   -r python/requirements/ml/dl-gpu-requirements.txt
-torch-spline-conv==1.2.2+pt29cu128 \
-    --hash=sha256:f648e9bf06bfdcfd3b2ba4927c786be0378ebc2a70e05d47d4c1949af04c3988
+torch-scatter==2.1.2+cu.12.8.torch.2.9 \
+    --hash=sha256:35385c774a1792d719608f132c3d50e941aaa3a697dcec72fe54a715d6f6023c \
+    --hash=sha256:57bc485d4d911ad1c88606cf3e6b246ef8d49a448dfc6f03d8e2d19e9be82242 \
+    --hash=sha256:6893a3b00bd6b13e154edb251edd647f00846ca177c53fcc73e3d49c50e76994 \
+    --hash=sha256:97c513c5fb211ff784e7628666c8da648e0605389f4a8c5c8fac84cf06ea9ca2 \
+    --hash=sha256:97cad80ca9d2639988c57003425f92e01d4f9bda522809d0fd38629a1ce3e7fc \
+    --hash=sha256:a3887cef3f3012dc6e3da88116af3bcabbcaaf70c807085659dd3a8bd74ed503 \
+    --hash=sha256:bbc9402c01238cc5671a0b3ff9f055e983e6d2390ff3b56130a715daf5719f55 \
+    --hash=sha256:c835645d889838a09ca4db931783c9260fb5773c3aa569760aae5b887789ddea \
+    --hash=sha256:d60df986a621bd3691e885e814391f38f771de72188a28d930955ff59a78ce83 \
+    --hash=sha256:e6388f4e267cea521d04d10040fdb91fc49e47b0e1489f76764e26aecbcf7c48
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
     #   -r python/requirements/ml/dl-gpu-requirements.txt

--- a/python/deplocks/ci/rllib-gpubuild-ci_depset_py3.12.lock
+++ b/python/deplocks/ci/rllib-gpubuild-ci_depset_py3.12.lock
@@ -1,5 +1,6 @@
 --extra-index-url https://download.pytorch.org/whl/cu128
 --extra-index-url https://wheels.astral.sh/simple/cu128/
+--find-links https://data.pyg.org/whl/torch-2.9.0+cu128.html
 
 absl-py==2.4.0 \
     --hash=sha256:88476fd881ca8aab94ffa78b7b6c632a782ab3ba1cd19c9bd423abc4fb4cd28d \
@@ -4605,6 +4606,7 @@ scipy==1.17.1 \
     #   scikit-learn
     #   skops
     #   torch-geometric
+    #   torch-sparse
     #   xgboost
 semantic-version==2.10.0 \
     --hash=sha256:bdabb6d336998cbb378d4b9db3a4b56a1e3235701dc05ea2690d9a997ed5041c \
@@ -5032,6 +5034,11 @@ torch-scatter==2.1.2+cu.12.8.torch.2.9 \
     --hash=sha256:c835645d889838a09ca4db931783c9260fb5773c3aa569760aae5b887789ddea \
     --hash=sha256:d60df986a621bd3691e885e814391f38f771de72188a28d930955ff59a78ce83 \
     --hash=sha256:e6388f4e267cea521d04d10040fdb91fc49e47b0e1489f76764e26aecbcf7c48
+    # via
+    #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
+    #   -r python/requirements/ml/dl-gpu-requirements.txt
+torch-sparse==0.6.18+pt29cu128 \
+    --hash=sha256:93d7f07210e1316736c09d14c019793bb7627f4b39a4df67ab93166444d25db0
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
     #   -r python/requirements/ml/dl-gpu-requirements.txt

--- a/python/deplocks/ci/windows-tests-ci_depset_py3.10.lock
+++ b/python/deplocks/ci/windows-tests-ci_depset_py3.10.lock
@@ -1,5 +1,6 @@
 --extra-index-url https://download.pytorch.org/whl/cpu
 --extra-index-url https://wheels.astral.sh/simple/cpu/
+--find-links https://data.pyg.org/whl/torch-2.9.0+cpu.html
 
 absl-py==2.4.0 \
     --hash=sha256:88476fd881ca8aab94ffa78b7b6c632a782ab3ba1cd19c9bd423abc4fb4cd28d \

--- a/python/deplocks/ci/windows-tests-ci_depset_py3.10.lock
+++ b/python/deplocks/ci/windows-tests-ci_depset_py3.10.lock
@@ -1,5 +1,5 @@
 --extra-index-url https://download.pytorch.org/whl/cpu
---find-links https://data.pyg.org/whl/torch-2.9.0+cpu.html
+--extra-index-url https://wheels.astral.sh/simple/cpu/
 
 absl-py==2.4.0 \
     --hash=sha256:88476fd881ca8aab94ffa78b7b6c632a782ab3ba1cd19c9bd423abc4fb4cd28d \
@@ -5211,9 +5211,7 @@ scipy==1.15.3 \
     #   mlflow
     #   scikit-learn
     #   skops
-    #   torch-cluster
     #   torch-geometric
-    #   torch-sparse
 segment-analytics-python==2.2.0 \
     --hash=sha256:b511dce9d22fa31c8a3f1b0e69d15af9705aeeed066fb317bd64bec8b786b0b2 \
     --hash=sha256:d9bbdd554d57fdfc9d8ebe1e5e0a891154aa9c5f5a79b78925861d5bd4789c41
@@ -5575,29 +5573,9 @@ torch==2.9.0+cpu \
     #   torchmetrics
     #   torchtext
     #   torchvision
-torch-cluster==1.6.3+pt29cpu \
-    --hash=sha256:9bd316bf3895ebc00e9d366c09f9841174cab03db128016c737c4ab12b7bad19
-    # via
-    #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
-    #   -r python/requirements/ml/dl-cpu-requirements.txt
 torch-geometric==2.5.3 \
     --hash=sha256:8277abfc12600b0e8047e0c3ea2d55cc43f08c1448e73e924de827c15d0b5f85 \
     --hash=sha256:ad0761650c8fa56cdc46ee61c564fd4995f07f079965fe732b3a76d109fd3edc
-    # via
-    #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
-    #   -r python/requirements/ml/dl-cpu-requirements.txt
-torch-scatter==2.1.2+pt29cpu \
-    --hash=sha256:99020f3c093ab8c68027a372e67b2e8c85fe62cc3dbe42cdb8fa119c87f8ecbd
-    # via
-    #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
-    #   -r python/requirements/ml/dl-cpu-requirements.txt
-torch-sparse==0.6.18+pt29cpu \
-    --hash=sha256:49b18df925c8c348d5ce6b437694fb7171c38f8c03ac9a453ceb17181018839e
-    # via
-    #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
-    #   -r python/requirements/ml/dl-cpu-requirements.txt
-torch-spline-conv==1.2.2+pt29cpu \
-    --hash=sha256:131930c5a7bcfa00b6b4c540da2fc3e60bb5a73c9323a88400150adb384f0418
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
     #   -r python/requirements/ml/dl-cpu-requirements.txt

--- a/python/deplocks/ci/windows-tests-torch27-ci_depset_py3.10.lock
+++ b/python/deplocks/ci/windows-tests-torch27-ci_depset_py3.10.lock
@@ -1,6 +1,5 @@
 --extra-index-url https://download.pytorch.org/whl/cpu
---find-links https://data.pyg.org/whl/torch-2.9.0+cpu.html
---find-links https://data.pyg.org/whl/torch-2.7.0+cpu.html
+--extra-index-url https://wheels.astral.sh/simple/cpu/
 
 absl-py==2.4.0 \
     --hash=sha256:88476fd881ca8aab94ffa78b7b6c632a782ab3ba1cd19c9bd423abc4fb4cd28d \
@@ -4995,9 +4994,7 @@ scipy==1.15.3 \
     #   mlflow
     #   scikit-learn
     #   skops
-    #   torch-cluster
     #   torch-geometric
-    #   torch-sparse
 segment-analytics-python==2.2.0 \
     --hash=sha256:b511dce9d22fa31c8a3f1b0e69d15af9705aeeed066fb317bd64bec8b786b0b2 \
     --hash=sha256:d9bbdd554d57fdfc9d8ebe1e5e0a891154aa9c5f5a79b78925861d5bd4789c41
@@ -5325,22 +5322,10 @@ torch==2.7.0+cpu \
     #   torchmetrics
     #   torchtext
     #   torchvision
-torch-cluster==1.6.3+pt27cpu \
-    --hash=sha256:199b35b89f33f700094a9741bc08eaeb480aefea58940b1cba247f281343297e
-    # via -r python/requirements/windows-requirements.txt
 torch-geometric==2.5.3 \
     --hash=sha256:8277abfc12600b0e8047e0c3ea2d55cc43f08c1448e73e924de827c15d0b5f85 \
     --hash=sha256:ad0761650c8fa56cdc46ee61c564fd4995f07f079965fe732b3a76d109fd3edc
     # via -r python/deplocks/ci/relaxed_windows-tests-ci_depset_py3.10.lock
-torch-scatter==2.1.2+pt27cpu \
-    --hash=sha256:4c59964adcfc7223fc18aafefdfaef3453c5ec56808c87b51c667622063f1e0a
-    # via -r python/requirements/windows-requirements.txt
-torch-sparse==0.6.18+pt27cpu \
-    --hash=sha256:7734ebd66e97a2af55e8941cb6657772b5691d09332186914a3b9ccc022a2698
-    # via -r python/requirements/windows-requirements.txt
-torch-spline-conv==1.2.2+pt27cpu \
-    --hash=sha256:d0f5638b6bc49bcaaffedf3e277b245b8d65ba22ac9a88230d2144a92c7e52a2
-    # via -r python/requirements/windows-requirements.txt
 torchmetrics==0.10.3 \
     --hash=sha256:9e6ab66175f2dc13e246c37485b2c27c77931dfe47fc2b81c76217b8efdc1e57 \
     --hash=sha256:b12cf92897545e24a825b0d168888c0f3052700c2901e2d4f7d90b252bc4a343

--- a/python/deplocks/ci/windows-tests-torch27-ci_depset_py3.10.lock
+++ b/python/deplocks/ci/windows-tests-torch27-ci_depset_py3.10.lock
@@ -1,5 +1,6 @@
 --extra-index-url https://download.pytorch.org/whl/cpu
 --extra-index-url https://wheels.astral.sh/simple/cpu/
+--find-links https://data.pyg.org/whl/torch-2.9.0+cpu.html
 
 absl-py==2.4.0 \
     --hash=sha256:88476fd881ca8aab94ffa78b7b6c632a782ab3ba1cd19c9bd423abc4fb4cd28d \

--- a/python/deplocks/docs/doctest_depset_py3.10.lock
+++ b/python/deplocks/docs/doctest_depset_py3.10.lock
@@ -1,5 +1,6 @@
 --extra-index-url https://download.pytorch.org/whl/cpu
 --extra-index-url https://wheels.astral.sh/simple/cpu/
+--find-links https://data.pyg.org/whl/torch-2.9.0+cpu.html
 
 about-time==4.2.1 \
     --hash=sha256:6a538862d33ce67d997429d14998310e1dbfda6cb7d9bbfbf799c4709847fece \
@@ -7375,6 +7376,7 @@ scipy==1.15.3 \
     #   statsforecast
     #   statsmodels
     #   torch-geometric
+    #   torch-sparse
     #   xgboost
 segment-analytics-python==2.2.0 \
     --hash=sha256:b511dce9d22fa31c8a3f1b0e69d15af9705aeeed066fb317bd64bec8b786b0b2 \
@@ -8152,6 +8154,11 @@ torch-scatter==2.1.2+cpu.torch.2.9 ; sys_platform == 'linux' \
     --hash=sha256:db5a7d61692c7827de77dfa79a4b18bf158c296e5d1a822bcd4c8ef90f204243 \
     --hash=sha256:e176fba25b4658fa13ae8e54bcfbc2758b1d45cea78a308ea5562bc42a62f04e \
     --hash=sha256:ff2a52e3bfd25fc06b8454ade9759506ddb053ea614a36c8b09cb75163075e6f
+    # via
+    #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
+    #   -r python/requirements/ml/dl-cpu-requirements.txt
+torch-sparse==0.6.18+pt29cpu ; sys_platform == 'linux' \
+    --hash=sha256:e4b76895717d17a635dbda6880ae46d7e5ef4438d66ffa6c45f85c74f50ea9e3
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
     #   -r python/requirements/ml/dl-cpu-requirements.txt

--- a/python/deplocks/docs/doctest_depset_py3.10.lock
+++ b/python/deplocks/docs/doctest_depset_py3.10.lock
@@ -1,5 +1,5 @@
 --extra-index-url https://download.pytorch.org/whl/cpu
---find-links https://data.pyg.org/whl/torch-2.9.0+cpu.html
+--extra-index-url https://wheels.astral.sh/simple/cpu/
 
 about-time==4.2.1 \
     --hash=sha256:6a538862d33ce67d997429d14998310e1dbfda6cb7d9bbfbf799c4709847fece \
@@ -7374,9 +7374,7 @@ scipy==1.15.3 \
     #   skops
     #   statsforecast
     #   statsmodels
-    #   torch-cluster
     #   torch-geometric
-    #   torch-sparse
     #   xgboost
 segment-analytics-python==2.2.0 \
     --hash=sha256:b511dce9d22fa31c8a3f1b0e69d15af9705aeeed066fb317bd64bec8b786b0b2 \
@@ -8127,14 +8125,10 @@ torch==2.9.0+cpu \
     #   tensordict
     #   timm
     #   torch-optimizer
+    #   torch-scatter
     #   torchmetrics
     #   torchtext
     #   torchvision
-torch-cluster==1.6.3+pt29cpu \
-    --hash=sha256:250b7d207623831c03bf162bc45381c57dc19884be9b1b6f2fcaf00749202a42
-    # via
-    #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
-    #   -r python/requirements/ml/dl-cpu-requirements.txt
 torch-geometric==2.5.3 \
     --hash=sha256:8277abfc12600b0e8047e0c3ea2d55cc43f08c1448e73e924de827c15d0b5f85 \
     --hash=sha256:ad0761650c8fa56cdc46ee61c564fd4995f07f079965fe732b3a76d109fd3edc
@@ -8147,18 +8141,17 @@ torch-optimizer==0.1.0 ; python_full_version < '3.12' \
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
     #   mosaicml
-torch-scatter==2.1.2+pt29cpu \
-    --hash=sha256:62a0ad1d9e51da83d3c775b24cb498dc5b94075d18644653a3b24c158f288db6
-    # via
-    #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
-    #   -r python/requirements/ml/dl-cpu-requirements.txt
-torch-sparse==0.6.18+pt29cpu \
-    --hash=sha256:e4b76895717d17a635dbda6880ae46d7e5ef4438d66ffa6c45f85c74f50ea9e3
-    # via
-    #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
-    #   -r python/requirements/ml/dl-cpu-requirements.txt
-torch-spline-conv==1.2.2+pt29cpu \
-    --hash=sha256:d450dae7a383a08fa6ba57a800589becaa79a330fd81700f3255c13d29708283
+torch-scatter==2.1.2+cpu.torch.2.9 ; sys_platform == 'linux' \
+    --hash=sha256:2e34f7d83b32512b349e93355b18b1db48e317f30828d7ab717df6628825e000 \
+    --hash=sha256:34a11594df5338600a3fd55986fed088e4186ba56f2524a0a962cc3e40f75a4d \
+    --hash=sha256:51bcef861b61095f1b00f8451fe179fbfa48dc7f03af80dd01f29635090d66eb \
+    --hash=sha256:53ea146be456e3defaec4e70ad482a7c257db9eb8499865dc76ffe8310212cb1 \
+    --hash=sha256:6f9c0cce6e58e94aa9d0db24f9c579c1189973e03e9e1aa57f1e6492694af48d \
+    --hash=sha256:a2ef52eb9376db18986499b226ee54b94e8c1c39bfdf7f0d0a093a95dd3d3f4a \
+    --hash=sha256:b158c84bbff4554fc244f89e920ccfb2a437e13eb905d16d8b53c911dab467ad \
+    --hash=sha256:db5a7d61692c7827de77dfa79a4b18bf158c296e5d1a822bcd4c8ef90f204243 \
+    --hash=sha256:e176fba25b4658fa13ae8e54bcfbc2758b1d45cea78a308ea5562bc42a62f04e \
+    --hash=sha256:ff2a52e3bfd25fc06b8454ade9759506ddb053ea614a36c8b09cb75163075e6f
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
     #   -r python/requirements/ml/dl-cpu-requirements.txt

--- a/python/requirements/ml/dl-cpu-requirements.txt
+++ b/python/requirements/ml/dl-cpu-requirements.txt
@@ -14,6 +14,7 @@ tf-keras==2.20.0
 
 --extra-index-url https://download.pytorch.org/whl/cpu  # for CPU versions of torch, torchvision
 --extra-index-url https://wheels.astral.sh/simple/cpu/  # for CPU builds of torch-scatter
+--find-links https://data.pyg.org/whl/torch-2.9.0+cpu.html  # for CPU builds of torch-sparse
 
 torch==2.9.0
 torchmetrics==0.10.3
@@ -24,16 +25,20 @@ torchvision==0.24.0
 # GPU depsets that consume it as a constraint.
 nvidia-nccl-cu12==2.27.5; platform_system == 'Linux' and platform_machine != 'aarch64'
 
-# PyG's own wheel host (data.pyg.org) went dark on 2026-09-02
-# (pyg-team/pyg-lib#719) and was the only place prebuilt wheels for these
-# extensions ever lived; PyPI carries sdists only. torch-scatter now comes from
-# Astral's GPU indexes (https://wheels.astral.sh/), which are PEP 503 indexes
-# rather than flat find-links pages, and which encode the torch minor they were
-# built against in the local version. Astral publishes manylinux wheels only, and
-# nothing in Ray imports torch_scatter, so it is skipped off Linux.
-# torch-sparse, torch-cluster and torch-spline-conv have no remaining wheel
-# source and torch-geometric>=2.3 treats all four as optional, so they are dropped.
+# PyG's wheel host (data.pyg.org) was a dangling CNAME for ~24h on 2026-09-02
+# (pyg-team/pyg-lib#719); PyPI carries sdists only, so it was the sole source of
+# prebuilt wheels for these extensions. torch-scatter now comes from Astral's GPU
+# indexes (https://wheels.astral.sh/), PEP 503 indexes that encode the torch
+# minor in the local version. torch-sparse has no source other than data.pyg.org
+# and is required: torch_geometric.loader.NeighborSampler (used by
+# python/ray/train/examples/pytorch_geometric/distributed_sage_example.py)
+# builds a SparseTensor and raises ImportError without it, and torch_sparse
+# itself imports torch_scatter. Both ship manylinux-only / Linux-tested builds
+# and nothing on Windows or macOS uses PyG, so both are skipped off Linux.
+# torch-cluster and torch-spline-conv are not referenced anywhere in Ray and
+# torch-geometric>=2.3 treats them as optional, so they are dropped.
 torch-scatter==2.1.2+cpu.torch.2.9; sys_platform == 'linux'
+torch-sparse==0.6.18+pt29cpu; sys_platform == 'linux'
 torch-geometric==2.5.3
 
 cupy-cuda12x==13.6.0; sys_platform != 'darwin'

--- a/python/requirements/ml/dl-cpu-requirements.txt
+++ b/python/requirements/ml/dl-cpu-requirements.txt
@@ -13,7 +13,7 @@ tf-keras==2.20.0
 # and to `install-dependencies.sh`!
 
 --extra-index-url https://download.pytorch.org/whl/cpu  # for CPU versions of torch, torchvision
---find-links https://data.pyg.org/whl/torch-2.9.0+cpu.html  # for CPU versions of torch-scatter, torch-sparse, torch-cluster, torch-spline-conv
+--extra-index-url https://wheels.astral.sh/simple/cpu/  # for CPU builds of torch-scatter
 
 torch==2.9.0
 torchmetrics==0.10.3
@@ -24,10 +24,16 @@ torchvision==0.24.0
 # GPU depsets that consume it as a constraint.
 nvidia-nccl-cu12==2.27.5; platform_system == 'Linux' and platform_machine != 'aarch64'
 
-torch-scatter==2.1.2
-torch-sparse==0.6.18
-torch-cluster==1.6.3
-torch-spline-conv==1.2.2
+# PyG's own wheel host (data.pyg.org) went dark on 2026-09-02
+# (pyg-team/pyg-lib#719) and was the only place prebuilt wheels for these
+# extensions ever lived; PyPI carries sdists only. torch-scatter now comes from
+# Astral's GPU indexes (https://wheels.astral.sh/), which are PEP 503 indexes
+# rather than flat find-links pages, and which encode the torch minor they were
+# built against in the local version. Astral publishes manylinux wheels only, and
+# nothing in Ray imports torch_scatter, so it is skipped off Linux.
+# torch-sparse, torch-cluster and torch-spline-conv have no remaining wheel
+# source and torch-geometric>=2.3 treats all four as optional, so they are dropped.
+torch-scatter==2.1.2+cpu.torch.2.9; sys_platform == 'linux'
 torch-geometric==2.5.3
 
 cupy-cuda12x==13.6.0; sys_platform != 'darwin'

--- a/python/requirements/ml/dl-gpu-requirements.txt
+++ b/python/requirements/ml/dl-gpu-requirements.txt
@@ -7,11 +7,13 @@ tf-keras==2.20.0
 
 --extra-index-url https://download.pytorch.org/whl/cu128  # for GPU versions of torch, torchvision
 --extra-index-url https://wheels.astral.sh/simple/cu128/  # for CUDA builds of torch-scatter
+--find-links https://data.pyg.org/whl/torch-2.9.0+cu128.html  # for CUDA builds of torch-sparse
 # specifying explicit plus-notation below so pip overwrites the existing cpu verisons
 torch==2.9.0+cu128
 torchvision==0.24.0+cu128
-# See dl-cpu-requirements.txt for why only torch-scatter remains and where it comes from.
+# See dl-cpu-requirements.txt for which PyG extensions remain and where they come from.
 torch-scatter==2.1.2+cu.12.8.torch.2.9
+torch-sparse==0.6.18+pt29cu128
 torch-geometric==2.5.3
 # Declared explicitly so GPU depsets resolve nccl from cu128 torch
 # transitively rather than being pinned by the CPU-built py3.13 lock.

--- a/python/requirements/ml/dl-gpu-requirements.txt
+++ b/python/requirements/ml/dl-gpu-requirements.txt
@@ -6,14 +6,12 @@ tensorflow-probability==0.24.0
 tf-keras==2.20.0
 
 --extra-index-url https://download.pytorch.org/whl/cu128  # for GPU versions of torch, torchvision
---find-links https://data.pyg.org/whl/torch-2.9.0+cu128.html  # for GPU versions of torch-scatter, torch-sparse, torch-cluster, torch-spline-conv
+--extra-index-url https://wheels.astral.sh/simple/cu128/  # for CUDA builds of torch-scatter
 # specifying explicit plus-notation below so pip overwrites the existing cpu verisons
 torch==2.9.0+cu128
 torchvision==0.24.0+cu128
-torch-scatter==2.1.2+pt29cu128
-torch-sparse==0.6.18+pt29cu128
-torch-cluster==1.6.3+pt29cu128
-torch-spline-conv==1.2.2+pt29cu128
+# See dl-cpu-requirements.txt for why only torch-scatter remains and where it comes from.
+torch-scatter==2.1.2+cu.12.8.torch.2.9
 torch-geometric==2.5.3
 # Declared explicitly so GPU depsets resolve nccl from cu128 torch
 # transitively rather than being pinned by the CPU-built py3.13 lock.

--- a/python/requirements/ml/train-requirements.txt
+++ b/python/requirements/ml/train-requirements.txt
@@ -1,5 +1,13 @@
 accelerate>=0.20.1
-deepspeed>=0.12.3
+# `===` (PEP 440 arbitrary equality) rather than `==`: dl-gpu-requirements.txt
+# adds Astral's cu128 index for torch-scatter, and that index also publishes
+# deepspeed builds with prebuilt CUDA ops as local versions
+# (0.18.9+cu.12.8.torch.2.9). A bare `==0.18.9` matches those too and
+# unsafe-best-match prefers them, which would silently swap deepspeed's build in
+# every GPU depset and pull in nvidia-ml-py. `===` is the only specifier that
+# excludes local versions. Keep in step with requirements_compiled.txt; switch
+# back to `==` to adopt Astral's build deliberately.
+deepspeed===0.18.9
 datasets>=4.0.0,<5.0.0
 huggingface-hub>=1.0,<2.0
 numexpr>=2.8.4

--- a/python/requirements/windows-requirements.txt
+++ b/python/requirements/windows-requirements.txt
@@ -6,16 +6,5 @@
 # pytorch/pytorch#150381). Fixed upstream in torch 2.10 (pytorch/gloo#472).
 # Keep Windows CI on 2.7.0 until the repo-wide torch pin reaches >=2.10, then
 # delete this file and the windows torch2.7 depsets in ci_windows.depsets.yaml.
---find-links https://data.pyg.org/whl/torch-2.7.0+cpu.html
-
 torch==2.7.0
 torchvision==0.22.0
-
-# PyG binary extensions are ABI-coupled to the torch minor version. Pin the
-# +pt27cpu local builds explicitly: the relaxed base lock still emits the
-# torch-2.9.0 find-links, and unsafe-best-match would otherwise prefer the
-# +pt29cpu wheels.
-torch-scatter==2.1.2+pt27cpu
-torch-sparse==0.6.18+pt27cpu
-torch-cluster==1.6.3+pt27cpu
-torch-spline-conv==1.2.2+pt27cpu

--- a/python/requirements_compiled.txt
+++ b/python/requirements_compiled.txt
@@ -1,5 +1,6 @@
 --extra-index-url https://download.pytorch.org/whl/cpu
 --extra-index-url https://wheels.astral.sh/simple/cpu/
+--find-links https://data.pyg.org/whl/torch-2.9.0+cpu.html
 
 about-time==4.2.1
     # via alive-progress
@@ -2136,6 +2137,7 @@ scipy==1.17.1 ; python_version >= "3.11"
     #   statsforecast
     #   statsmodels
     #   torch-geometric
+    #   torch-sparse
     #   xgboost
 segment-analytics-python==2.2.0
     # via -r python/requirements/test-requirements.txt
@@ -2385,6 +2387,8 @@ torch-geometric==2.5.3
 torch-optimizer==0.1.0
     # via mosaicml
 torch-scatter==2.1.2 ; sys_platform == "linux"
+    # via -r python/requirements/ml/dl-cpu-requirements.txt
+torch-sparse==0.6.18 ; sys_platform == "linux"
     # via -r python/requirements/ml/dl-cpu-requirements.txt
 torchmetrics==0.10.3
     # via

--- a/python/requirements_compiled.txt
+++ b/python/requirements_compiled.txt
@@ -1,5 +1,5 @@
 --extra-index-url https://download.pytorch.org/whl/cpu
---find-links https://data.pyg.org/whl/torch-2.9.0+cpu.html
+--extra-index-url https://wheels.astral.sh/simple/cpu/
 
 about-time==4.2.1
     # via alive-progress
@@ -447,7 +447,7 @@ decorator==5.2.1
     #   tensorflow-probability
 decord==0.6.0
     # via -r python/requirements/ml/data-test-requirements.txt
-deepspeed==0.18.9
+deepspeed===0.18.9
     # via -r python/requirements/ml/train-requirements.txt
 defusedxml==0.7.1
     # via
@@ -2135,9 +2135,7 @@ scipy==1.17.1 ; python_version >= "3.11"
     #   skops
     #   statsforecast
     #   statsmodels
-    #   torch-cluster
     #   torch-geometric
-    #   torch-sparse
     #   xgboost
 segment-analytics-python==2.2.0
     # via -r python/requirements/test-requirements.txt
@@ -2378,20 +2376,15 @@ torch==2.9.0
     #   tensordict
     #   timm
     #   torch-optimizer
+    #   torch-scatter
     #   torchmetrics
     #   torchtext
     #   torchvision
-torch-cluster==1.6.3
-    # via -r python/requirements/ml/dl-cpu-requirements.txt
 torch-geometric==2.5.3
     # via -r python/requirements/ml/dl-cpu-requirements.txt
 torch-optimizer==0.1.0
     # via mosaicml
-torch-scatter==2.1.2
-    # via -r python/requirements/ml/dl-cpu-requirements.txt
-torch-sparse==0.6.18
-    # via -r python/requirements/ml/dl-cpu-requirements.txt
-torch-spline-conv==1.2.2
+torch-scatter==2.1.2 ; sys_platform == "linux"
     # via -r python/requirements/ml/dl-cpu-requirements.txt
 torchmetrics==0.10.3
     # via

--- a/python/requirements_compiled_py3.14.txt
+++ b/python/requirements_compiled_py3.14.txt
@@ -1,4 +1,5 @@
 --extra-index-url https://download.pytorch.org/whl/cpu
+--extra-index-url https://wheels.astral.sh/simple/cpu/
 --find-links https://data.pyg.org/whl/torch-2.7.0+cpu.html
 
 about-time==4.2.1
@@ -450,7 +451,7 @@ decorator==5.2.1
     #   tensorflow-probability
 decord==0.6.0
     # via -r python/requirements/ml/py313/data-test-requirements.txt
-deepspeed==0.18.9
+deepspeed===0.18.9
     # via -r python/requirements/ml/py313/train-requirements.txt
 defusedxml==0.7.1
     # via
@@ -2130,7 +2131,6 @@ scipy==1.17.1 ; python_version >= "3.11"
     #   skops
     #   statsforecast
     #   statsmodels
-    #   torch-cluster
     #   torch-geometric
     #   torch-sparse
     #   xgboost
@@ -2381,20 +2381,17 @@ torch==2.7.0
     #   tensordict
     #   timm
     #   torch-optimizer
+    #   torch-scatter
     #   torchmetrics
     #   torchtext
     #   torchvision
-torch-cluster==1.6.3
-    # via -r python/requirements/ml/py313/dl-cpu-requirements.txt
 torch-geometric==2.5.3
     # via -r python/requirements/ml/py313/dl-cpu-requirements.txt
 torch-optimizer==0.1.0
     # via mosaicml
-torch-scatter==2.1.2
+torch-scatter==2.1.2 ; sys_platform == "linux"
     # via -r python/requirements/ml/py313/dl-cpu-requirements.txt
-torch-sparse==0.6.18
-    # via -r python/requirements/ml/py313/dl-cpu-requirements.txt
-torch-spline-conv==1.2.2
+torch-sparse==0.6.18 ; sys_platform == "linux"
     # via -r python/requirements/ml/py313/dl-cpu-requirements.txt
 torchmetrics==0.10.3
     # via

--- a/release/ray_release/byod/requirements_ml_byod_3.10.txt
+++ b/release/ray_release/byod/requirements_ml_byod_3.10.txt
@@ -1,6 +1,5 @@
 --index-url https://pypi.org/simple
 --extra-index-url https://download.pytorch.org/whl/cpu
---find-links https://data.pyg.org/whl/torch-2.7.0+cpu.html
 
 absl-py==1.4.0 \
     --hash=sha256:0d3fe606adfa4f7db64792dd4c7aee4ee0c38ab75dfd353b7a83ed3e957fcb47 \


### PR DESCRIPTION
## Description

`data.pyg.org` — the only host that ever served prebuilt wheels for the PyTorch Geometric extensions — has been a dangling CNAME since 2026-09-02 ([pyg-team/pyg-lib#719](https://github.com/pyg-team/pyg-lib/issues/719)). Every ML/data/rllib/doc/windows depset declared it as `--find-links`, and uv fails eagerly on an unreadable find-links URL, so `raydepsets: compile all dependencies` has been red on master (postmerge 19501, 19507) and was made `soft_fail` in #65880. The same URL is line 2 of every affected lock, so any cache-miss rebuild of the `mlbuild`/`mlgpubuild`/`mllightning1gpubuild` images (and the core/rllib/doc GPU images) fails at `uv pip install -r <lock>` too.

This PR narrows the dependency on `data.pyg.org` to the one package that needs it, sources `torch-scatter` from Astral's index, and re-enables the hard failure:

- **`torch-scatter` now comes from Astral's GPU indexes** (`https://wheels.astral.sh/simple/{cpu,cu128}/`). These are real PEP 503/691 indexes, so the requirement files use `--extra-index-url` instead of a flat find-links page. Versions encode the torch minor: `2.1.2+cpu.torch.2.9` / `2.1.2+cu.12.8.torch.2.9`. Astral publishes manylinux wheels only, so the CPU pin carries `; sys_platform == 'linux'`; nothing in Ray imports `torch_scatter` on any platform.
- **`torch-sparse` stays, still from `data.pyg.org`** (which came back on 2026-09-03; pyg-lib#719 closed). It is required: `torch_geometric.loader.NeighborSampler.__init__` builds a `SparseTensor` from `torch_geometric.typing`, whose stub raises `ImportError: 'SparseTensor' requires 'torch-sparse'` when the package is absent — verified empirically on torch 2.9.0 + torch-geometric 2.5.3 — and `python/ray/train/examples/pytorch_geometric/distributed_sage_example.py` (CI test `distributed_sage_example`, `train_v2_gpu`) uses it. `torch_sparse` also imports `torch_scatter` in 8 modules, so scatter is a hard dependency of sparse. No other wheel source for torch-sparse exists (PyPI is sdist-only; not on Astral, `download.pytorch.org` or `pypi.nvidia.com`; no GitHub release assets), so the `--find-links` for it remains and this PR does **not** remove the dependency on that host — it narrows it to one package. Pinned explicitly (`+pt29cpu` / `+pt29cu128`) so a missing wheel fails loudly instead of falling back to the sdist.
- **`torch-cluster` and `torch-spline-conv` are dropped.** Nothing in `python/`, `rllib/`, `release/` or `doc/` imports them, `torch-geometric==2.5.3` lists none of the four in `requires_dist`, and the example's full path (FakeDataset → RandomNodeSplit → NeighborSampler → SAGEConv) trains with only scatter + sparse installed (run in a glibc-2.36 container against the exact pinned wheels).
- Both remaining extensions are gated on `sys_platform == 'linux'`: Astral ships manylinux wheels only, `torch_sparse` cannot import without `torch_scatter`, and nothing on Windows or macOS uses PyG. Windows therefore loses the four `+pt27cpu` pins, their find-links, and the matching `relaxed_windows_tests` entries.
- **`deepspeed`: `>=0.12.3` → `===0.18.9`** in `train-requirements.txt` (PEP 440 *arbitrary equality*; the compiled constraint follows as `deepspeed==0.18.9` → `deepspeed===0.18.9`). Why: Astral's cu128 index also publishes `deepspeed 0.18.9+cu.12.8.torch.2.9` (prebuilt CUDA ops). Under PEP 440 a bare `==0.18.9` *matches* that local version, and `--index-strategy unsafe-best-match` prefers it, so without this every GPU depset would silently switch to Astral's deepspeed build and pull in `nvidia-ml-py` (verified with `uv pip compile`). `===` is the only specifier that excludes local versions, so deepspeed stays on the PyPI build it uses today; uv honours it as requirement and constraint, and pip-tools writes it through to `requirements_compiled.txt`. The resolved version is unchanged (0.18.9 before and after). If we ever *want* Astral's prebuilt-ops deepspeed, the opt-in is the reverse edit, `===` → `==` — not part of this PR.
- **`ci/ci.sh compile_pip_dependencies`**: the `+cpu`-stripping sed now removes the whole local segment. The compiled file is the GPU depsets' constraint (via the `requirements_compiled_py3.1x.txt` symlinks), and only a bare `torch-scatter==2.1.2` lets `+cu.12.8.torch.2.9` satisfy it; the old `[^\b]*cpu` pattern would have left `2.1.2.torch.2.9`.
- `.buildkite/dependencies.rayci.yml`: `soft_fail` and its comment removed — the job hard-fails again.
- Also: dead `--find-links` removed from `release/ray_release/byod/requirements_ml_byod_3.10.txt` (it pinned none of the four); docs and stale comments updated.

Regenerated: `python/requirements_compiled.txt` (`./ci/ci.sh compile_pip_dependencies`, py3.11 + pip-tools 7.4.1) and all 32 affected locks under `python/deplocks/` (`bazel run //ci/raydepsets:raydepsets -- build --all-configs`). Package-level delta in every lock is only the PyG lines; deepspeed stays `0.18.9`, no new packages. `python/requirements_compiled_py3.14.txt` has no generator (it pins torch 2.7.0, which has no cp314 wheels) and has always been maintained by mirroring the hunks applied to `requirements_compiled.txt` (#65616, #65046, #64056 all changed identical pin counts in both), so the same header/pin deltas were applied to it by hand; its own `torch-2.7.0+cpu` find-links is kept to match its torch pin. That line is only ever read by pip: `requirements_compiled_py${PYTHON_VERSION}.txt` is staged into the `base-deps`/`base-slim` images as `/home/ray/requirements_compiled.txt` (those images install from the rayimg *lock* with uv, not from this file) and then used as `-c` by `ci/docker/ray-image.Dockerfile`, `docker/ray/Dockerfile` and `runtime_env_container/Dockerfile` — all `pip install -c`. pip treats an unreachable `--find-links` in a constraints file as a warning (5 retries, exit 0; verified against an NXDOMAIN host), whereas uv fails eagerly (exit 2; also verified). The only uv consumer is raydepsets, whose pre-hook strips the header lines. So no py3.10–3.14 image build hard-fails on that line even if data.pyg.org goes dark again; the uv exposure is the `--find-links` emitted into the ML/data/rllib/doc *locks*, which this PR narrows to torch-sparse.

Left untouched, flagged for follow-up: `release/ray_release/byod/byod_horovod*.sh` (install torch-2.0.1-era PyG wheels from the same dead host — separate, older problem), `ci/raydepsets/tests/test_cli.py` (fixture strings only).

## Related issues

Follows up #65880 (temporary `soft_fail`). Upstream: pyg-team/pyg-lib#719, pytorch_geometric#10793, pytorch_geometric#10716.

## Additional information

Not a duplicate: no open PR touches `data.pyg.org`, `wheels.astral.sh`, or the PyG pins (searched `pyg`, `astral`, `find-links`, `torch-scatter`, `data.pyg.org`; only unrelated dependabot torch bumps match).

Tests run locally:
- `./ci/ci.sh compile_pip_dependencies` in a py3.11 venv → exit 0; diff vs master is exactly the two header lines, the PyG pins/markers and `deepspeed===`
- `bazel run //ci/raydepsets:raydepsets -- build --all-configs` → exit 0, 107 depsets compiled; the 32 changed locks differ from master only in the PyG lines and the index/find-links header, and the `torch-sparse` hashes are unchanged
- `bazel run //ci/raydepsets:raydepsets -- build --all-configs --check` (CI's exact command) → exit 0, all 107 depsets regenerate byte-identically (including the py3.14-constrained ones against the mirrored snapshot), working tree clean afterwards
- PyG minimal-set check in `python:3.10-bookworm`: the example's path trains with scatter+sparse only; fails without sparse, and sparse fails without scatter
- `pre-commit run --files <changed source files>` → shellcheck, semgrep pass
- `uv pip compile` probes: `torch-scatter==2.1.2+cu.12.8.torch.2.9` resolves from `wheels.astral.sh/simple/cu128/`; `deepspeed==0.18.9` flips to `0.18.9+cu.12.8.torch.2.9` with that index present, `deepspeed===0.18.9` does not.

AI assistance (Claude Code) was used for this change; every changed line was reviewed by the submitter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)