### PR TITLE
[Data] Add consumption API to Data usage collection

### DIFF
--- a/python/ray/data/_internal/execution/streaming_executor.py
+++ b/python/ray/data/_internal/execution/streaming_executor.py
@@ -126,6 +126,9 @@ class StreamingExecutor(Executor, threading.Thread):
         self._final_stats: Optional[DatasetStats] = None
         self._progress_manager: Optional["BaseExecutionProgressManager"] = None
         self._callbacks: List["ExecutionCallback"] = []
+        # Consumption/sink API that triggered this execution, stamped by the
+        # consuming Dataset/DataIterator method for usage collection
+        self._consumption_api = "unknown"
 
         # The executor can be shutdown while still running.
         self._shutdown_lock = threading.RLock()

--- a/python/ray/data/_internal/iterator/stream_split_iterator.py
+++ b/python/ray/data/_internal/iterator/stream_split_iterator.py
@@ -313,8 +313,11 @@ class SplitCoordinator:
                         self._current_executor.shutdown(force=True)
 
                     ds = self._base_dataset
-                    # Re-execute dataset
+                    # Re-execute dataset. The coordinator creates the
+                    # executor directly (not via a consumption method),
+                    # so tag it here for usage collection.
                     self._current_executor = ds._create_executor()
+                    self._current_executor._consumption_api = "streaming_split"
                     self._output_iterator = ds._build_bundle_iterator(
                         self._current_executor
                     )

--- a/python/ray/data/_internal/usage/collector.py
+++ b/python/ray/data/_internal/usage/collector.py
@@ -124,6 +124,7 @@ class UsageInfo:
     workload: WorkloadInfo
     performance: Optional[PipelinePerf] = None
     detected_issues: List[Issue] = field(default_factory=list)
+    consumption_api: str = "unknown"
 
 
 # A callable that records config information for a logical operator.

--- a/python/ray/data/_internal/usage/execution_callback.py
+++ b/python/ray/data/_internal/usage/execution_callback.py
@@ -159,6 +159,14 @@ class UsageCallback(ExecutionCallback):
         # _started_at, and before_execution_starts/_finish set _executor.
         assert self._started_at is not None
         assert self._executor is not None
+        consumption_api = self._executor._consumption_api
+        # A write lands a Write op at the plan root; surface the anonymized
+        # sink (WriteParquet / WriteCustom) rather than the internal
+        # materialize() the write runs through.
+        from ray.data._internal.logical.operators.write_operator import Write
+        root = self._logical_plan.dag
+        if isinstance(root, Write):
+            consumption_api = util.anonymize_op_name(root)
         return UsageInfo(
             id=self._execution_id,
             started_at=self._started_at,
@@ -168,6 +176,7 @@ class UsageCallback(ExecutionCallback):
             detected_issues=collector.collect_issues(
                 self._collect_detected_issues(self._executor)
             ),
+            consumption_api=consumption_api,
         )
 
     def _collect_detected_issues(

--- a/python/ray/data/_internal/usage/execution_callback.py
+++ b/python/ray/data/_internal/usage/execution_callback.py
@@ -166,7 +166,7 @@ class UsageCallback(ExecutionCallback):
         from ray.data._internal.logical.operators.write_operator import Write
         root = self._logical_plan.dag
         if isinstance(root, Write):
-            consumption_api = util.anonymize_op_name(root)
+            consumption_api = self.anonymize_op_name(root)
         return UsageInfo(
             id=self._execution_id,
             started_at=self._started_at,

--- a/python/ray/data/_internal/usage/execution_callback.py
+++ b/python/ray/data/_internal/usage/execution_callback.py
@@ -164,6 +164,7 @@ class UsageCallback(ExecutionCallback):
         # sink (WriteParquet / WriteCustom) rather than the internal
         # materialize() the write runs through.
         from ray.data._internal.logical.operators.write_operator import Write
+
         root = self._logical_plan.dag
         if isinstance(root, Write):
             consumption_api = self.anonymize_op_name(root)

--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -6806,6 +6806,7 @@ class Dataset:
         """
         batch_format = _apply_batch_format(batch_format)
         return self.iterator()._iter_batches(
+            consumption_api="iter_batches",
             prefetch_batches=prefetch_batches,
             batch_size=batch_size,
             batch_format=batch_format,
@@ -7748,7 +7749,7 @@ class Dataset:
         """
         copy = Dataset.copy(self, _deep_copy=True, _as=MaterializedDataset)
 
-        bundle: RefBundle = copy._execute()
+        bundle: RefBundle = copy._execute(consumption_api="materialize")
         blocks_with_metadata = bundle.blocks
 
         # TODO(hchen): Here we generate the same number of blocks as
@@ -8383,7 +8384,9 @@ class Dataset:
         return _CacheMetadataIterator(bundle_iter, executor._topology, self)
 
     @omit_traceback_stdout
-    def _execute(self, preserve_order: bool = False) -> RefBundle:
+    def _execute(
+        self, preserve_order: bool = False, consumption_api: str = "unknown"
+    ) -> RefBundle:
         """Execute this dataset eagerly, returning a RefBundle.
 
         Returns the cached RefBundle if execution has already happened against
@@ -8420,6 +8423,7 @@ class Dataset:
                 )
             else:
                 with self._create_executor() as executor:
+                    executor._consumption_api = consumption_api
                     bundles = self._execute_dag(executor, preserve_order=preserve_order)
                     bundle = RefBundle.merge_ref_bundles(list(bundles))
                     executor.get_stats().set_uuid_recursive(self._uuid)

--- a/python/ray/data/iterator.py
+++ b/python/ray/data/iterator.py
@@ -206,6 +206,7 @@ class DataIterator(abc.ABC):
             An iterable over record batches.
         """
         return self._iter_batches(
+            consumption_api="iter_batches",
             prefetch_batches=prefetch_batches,
             batch_size=batch_size,
             batch_format=batch_format,
@@ -237,6 +238,7 @@ class DataIterator(abc.ABC):
         local_shuffle_seed: Optional[int] = None,
         _collate_fn: Optional[Callable[[DataBatch], "CollatedData"]] = None,
         _finalize_fn: Optional[Callable[[Any], Any]] = None,
+        consumption_api: str = "unknown",
     ) -> Iterable[DataBatch]:
         batch_format = _apply_batch_format(batch_format)
 
@@ -252,6 +254,9 @@ class DataIterator(abc.ABC):
                 stats,
                 executor,
             ) = self._to_ref_bundle_iterator()
+            # Tag the execution with the consuming API for usage telemetry.
+            if executor is not None:
+                executor._consumption_api = consumption_api
 
             dataset_tags = self._get_dataset_tag()
 
@@ -350,7 +355,8 @@ class DataIterator(abc.ABC):
             An iterable over rows of the dataset.
         """
         batch_iterable = self._iter_batches(
-            batch_size=None, batch_format=None, prefetch_batches=1
+            batch_size=None, batch_format=None, prefetch_batches=1,
+            consumption_api="iter_rows",
         )
 
         def _wrapped_iterator():
@@ -588,6 +594,7 @@ class DataIterator(abc.ABC):
             collate_fn = _PinMemoryCollateFnWrapper(collate_fn)
 
         return self._iter_batches(
+            consumption_api="iter_torch_batches",
             prefetch_batches=prefetch_batches,
             batch_size=batch_size,
             batch_format=batch_format,

--- a/python/ray/data/iterator.py
+++ b/python/ray/data/iterator.py
@@ -355,7 +355,9 @@ class DataIterator(abc.ABC):
             An iterable over rows of the dataset.
         """
         batch_iterable = self._iter_batches(
-            batch_size=None, batch_format=None, prefetch_batches=1,
+            batch_size=None,
+            batch_format=None,
+            prefetch_batches=1,
             consumption_api="iter_rows",
         )
 

--- a/python/ray/data/tests/test_streaming_integration.py
+++ b/python/ray/data/tests/test_streaming_integration.py
@@ -11,6 +11,7 @@ import pytest
 import ray
 from ray import cloudpickle
 from ray._common.test_utils import wait_for_condition
+from ray.data._internal.execution.execution_callback import ExecutionCallback
 from ray.data._internal.execution.interfaces import RefBundle
 from ray.data._internal.execution.operators.base_physical_operator import (
     AllToAllOperator,
@@ -22,7 +23,6 @@ from ray.data._internal.execution.operators.map_transformer import (
     MapTransformer,
 )
 from ray.data._internal.execution.operators.output_splitter import OutputSplitter
-from ray.data._internal.execution.execution_callback import ExecutionCallback
 from ray.data._internal.execution.streaming_executor import StreamingExecutor
 from ray.data._internal.execution.util import make_ref_bundles
 from ray.data.context import DataContext

--- a/python/ray/data/tests/test_streaming_integration.py
+++ b/python/ray/data/tests/test_streaming_integration.py
@@ -22,6 +22,7 @@ from ray.data._internal.execution.operators.map_transformer import (
     MapTransformer,
 )
 from ray.data._internal.execution.operators.output_splitter import OutputSplitter
+from ray.data._internal.execution.execution_callback import ExecutionCallback
 from ray.data._internal.execution.streaming_executor import StreamingExecutor
 from ray.data._internal.execution.util import make_ref_bundles
 from ray.data.context import DataContext
@@ -855,6 +856,31 @@ def test_e2e_liveness_with_output_backpressure_edge_case(
     # This will hang forever if the liveness logic is wrong, since the output
     # backpressure will prevent any operators from running at all.
     assert extract_values("id", ds.take_all()) == list(range(10000))
+
+
+def test_streaming_split_consumption_api(ray_start_10_cpus_shared, tmp_path):
+    """Ray Train-style ingest via ``streaming_split`` tags its executor as
+    ``streaming_split``. The executor runs in the remote SplitCoordinator actor,
+    so the callback (defined here so it cloudpickles by value) writes the tag to
+    a shared temp file for the driver to read. ``streaming_split(1)`` keeps it
+    single-consumer, avoiding the multi-shard barrier and its threads."""
+    tag_file = tmp_path / "consumption_api"
+
+    class CaptureConsumptionAPI(ExecutionCallback):
+        def after_execution_succeeds(self, executor):
+            tag_file.write_text(executor._consumption_api)
+
+    ctx = DataContext.get_current()
+    original = list(ctx.custom_execution_callback_classes)
+    ctx.custom_execution_callback_classes.append(CaptureConsumptionAPI)
+    try:
+        (it,) = ray.data.range(1).streaming_split(1)
+        for _ in it.iter_batches():
+            pass
+        wait_for_condition(lambda: tag_file.exists())
+        assert tag_file.read_text() == "streaming_split"
+    finally:
+        ctx.custom_execution_callback_classes[:] = original
 
 
 if __name__ == "__main__":

--- a/python/ray/data/tests/test_usage.py
+++ b/python/ray/data/tests/test_usage.py
@@ -106,9 +106,9 @@ def test_write_consumption_api_from_plan(reset_collector, mock_record, executor)
     """A write execution runs through materialize() internally, so the executor
     carries ``materialize``; build_usage_info overrides it with the anonymized
     sink read from the Write op at the plan root (WriteParquet, WriteCustom)."""
+    from ray.data._internal.datasource.parquet_datasink import ParquetDatasink
     from ray.data._internal.logical.interfaces.logical_plan import LogicalPlan
     from ray.data._internal.logical.operators.write_operator import Write
-    from ray.data._internal.datasource.parquet_datasink import ParquetDatasink
 
     read_ds = ray.data.range(1)
     write_op = Write(

--- a/python/ray/data/tests/test_usage.py
+++ b/python/ray/data/tests/test_usage.py
@@ -29,6 +29,9 @@ def executor():
     # StreamingExecutor the callback receives at runtime.
     executor = MagicMock()
     executor.issue_detector_manager = None
+    # Mirror StreamingExecutor, which declares this slot; otherwise the
+    # MagicMock auto-creates a non-serializable attribute.
+    executor._consumption_api = "unknown"
     return executor
 
 
@@ -70,6 +73,7 @@ def test_round_trip_payload_shape(reset_collector, mock_record, executor):
         (map_batches_usage_id, "MapBatches"),
     ]
     assert entry["workload"]["plan_str"] == "MapBatches\n+- ReadRange\n"
+    assert entry["consumption_api"] == "unknown"
     assert "pyarrow" in entry["env"]
     # Performance carries all four metric fields. Values are None in this
     # hermetic run (no cluster / Prometheus); the delta math is covered by
@@ -82,6 +86,45 @@ def test_round_trip_payload_shape(reset_collector, mock_record, executor):
     }
     # No issues detected in this run; the key is present and empty.
     assert entry["detected_issues"] == []
+
+
+def test_consumption_api_from_executor(reset_collector, mock_record, executor):
+    """The executor's ``_consumption_api`` (set by the consuming method) is
+    carried onto the payload verbatim for non-write executions."""
+    executor._consumption_api = "iter_torch_batches"
+    ds = ray.data.range(1).map_batches(lambda b: b)
+    callback = UsageCallback(ds._logical_plan)
+    callback.before_execution_starts(executor)
+    callback.after_execution_succeeds(executor)
+
+    _, payload_json = mock_record[-1]
+    entry = json.loads(payload_json)["executions"][0]
+    assert entry["consumption_api"] == "iter_torch_batches"
+
+
+def test_write_consumption_api_from_plan(reset_collector, mock_record, executor):
+    """A write execution runs through materialize() internally, so the executor
+    carries ``materialize``; build_usage_info overrides it with the anonymized
+    sink read from the Write op at the plan root (WriteParquet, WriteCustom)."""
+    from ray.data._internal.logical.interfaces.logical_plan import LogicalPlan
+    from ray.data._internal.logical.operators.write_operator import Write
+    from ray.data._internal.datasource.parquet_datasink import ParquetDatasink
+
+    read_ds = ray.data.range(1)
+    write_op = Write(
+        ParquetDatasink("/tmp/does_not_matter"),
+        input_dependencies=[read_ds._logical_plan.dag],
+    )
+    plan = LogicalPlan(write_op, read_ds.context)
+
+    executor._consumption_api = "materialize"  # what the write path really sets
+    callback = UsageCallback(plan)
+    callback.before_execution_starts(executor)
+    callback.after_execution_succeeds(executor)
+
+    _, payload_json = mock_record[-1]
+    entry = json.loads(payload_json)["executions"][0]
+    assert entry["consumption_api"] == "WriteParquet"
 
 
 def test_detected_issues_in_payload(reset_collector, mock_record, monkeypatch):
@@ -97,6 +140,7 @@ def test_detected_issues_in_payload(reset_collector, mock_record, monkeypatch):
         (IssueType.HANGING, "MapBatches"),
         (IssueType.HIGH_MEMORY, "ReadRange"),
     ]
+    executor._consumption_api = "unknown"
     ds = ray.data.range(1).map_batches(lambda b: b)
     callback = UsageCallback(ds._logical_plan)
     callback.before_execution_starts(executor)


### PR DESCRIPTION
## Description
In this PR we add consumption API usage information as part of usage collection. Specifically, we want to record what operator triggered execution (e.g. `iter_batches`, `iter_torch_batches`,`materialize`, `WriteParquet`, `streaming_split`, ...). Custom datasinks are anonymized as with the current usage collection module. The primary motivation of this is so that we have some more visibility into how users are consuming Ray Data pipelines, such as whether a dataset was materialized, iterated for training, or written out to a sink.

## Additional information
We add a new test as part of `test_streaming_integration.py` to ensure we are correctly reporting the consumption API for `streaming_split`.

There are no public API changes.