### PR TITLE
[Data] Estimate MCAP in-memory size from sampled messages, not file size

### DIFF
--- a/python/ray/data/_internal/datasource/mcap_datasource.py
+++ b/python/ray/data/_internal/datasource/mcap_datasource.py
@@ -3,6 +3,18 @@
 MCAP is a standardized format for storing timestamped messages from robotics and
 autonomous systems, commonly used for sensor data, control commands, and other
 time-series data.
+
+Format specification: https://mcap.dev/spec
+
+Two properties of the format shape this module:
+
+- A file's summary section, which carries the message counts and the channel
+  index, sits at the *end* of the file and is addressed by an offset in the
+  footer. A seekable reader reaches it in two seeks; a non-seekable one has to
+  scan every record to reconstruct it, and can only do so once.
+- Schemas are stored once per file, not once per message. The row
+  representation repeats them, so a file's in-memory size does not follow from
+  its size on disk.
 """
 
 import json
@@ -333,7 +345,10 @@ class MCAPDatasource(FileBasedDatasource):
         ratios = []
         for path, file_size in _sample_files(candidates):
             in_memory_size = self._estimate_file_inmemory_size(path)
-            if in_memory_size:
+            # Zero is a measurement, not a failure: it means the filter selects
+            # nothing from this file. Only `None` signals that the file could
+            # not be sampled.
+            if in_memory_size is not None:
                 ratios.append(in_memory_size / file_size)
 
         sampling_duration = time.perf_counter() - start_time

--- a/python/ray/data/_internal/datasource/mcap_datasource.py
+++ b/python/ray/data/_internal/datasource/mcap_datasource.py
@@ -7,20 +7,53 @@ time-series data.
 
 import json
 import logging
+import math
+import time
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Dict, Iterator, List, Optional, Set, Union
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Dict,
+    Iterator,
+    List,
+    Optional,
+    Set,
+    Tuple,
+    Union,
+)
 
 from ray.data._internal.delegating_block_builder import DelegatingBlockBuilder
 from ray.data._internal.util import _check_import
-from ray.data.block import Block
+from ray.data.block import Block, BlockAccessor
 from ray.data.datasource.file_based_datasource import FileBasedDatasource
 from ray.util.annotations import DeveloperAPI
 
 if TYPE_CHECKING:
     import pyarrow
-    from mcap.reader import Channel, Message, Schema
+    from mcap.reader import Channel, Message, Schema, Summary
 
 logger = logging.getLogger(__name__)
+
+# The default multiplier applied to on-disk size when sampling is disabled or
+# unavailable. MCAP chunks are typically compressed (zstd or lz4), and this
+# datasource additionally materializes per-message columns -- topic, timestamps
+# and, when ``include_metadata`` is set, the schema -- that have no per-message
+# on-disk equivalent. The in-memory representation is therefore substantially
+# larger than the file. Matches the Parquet datasource's default.
+MCAP_ENCODING_RATIO_ESTIMATE_DEFAULT = 5
+
+# The lower bound for the estimated MCAP encoding ratio.
+MCAP_ENCODING_RATIO_ESTIMATE_LOWER_BOUND = 1
+
+# The fraction of files sampled to estimate the encoding ratio, clamped to
+# [MIN_NUM_SAMPLES, MAX_NUM_SAMPLES] so that sampling cost stays bounded.
+MCAP_ENCODING_RATIO_ESTIMATE_SAMPLING_RATIO = 0.01
+MCAP_ENCODING_RATIO_ESTIMATE_MIN_NUM_SAMPLES = 2
+MCAP_ENCODING_RATIO_ESTIMATE_MAX_NUM_SAMPLES = 10
+
+# The number of messages read from each sampled file to measure the in-memory
+# size of a row. Kept low to avoid reading much data during planning.
+MCAP_ENCODING_RATIO_ESTIMATE_NUM_MESSAGES = 100
 
 
 @dataclass
@@ -121,6 +154,9 @@ class MCAPDatasource(FileBasedDatasource):
         self._message_types = set(message_types) if message_types else None
         self._time_range = time_range
         self._include_metadata = include_metadata
+        # Computed lazily by `estimate_inmemory_data_size` and cached, so that
+        # files are sampled at most once per datasource.
+        self._encoding_ratio: Optional[float] = None
 
     def _read_stream(self, f: "pyarrow.NativeFile", path: str) -> Iterator[Block]:
         """Read MCAP file and yield blocks of message data.
@@ -245,6 +281,182 @@ class MCAPDatasource(FileBasedDatasource):
 
         return message_data
 
+    def estimate_inmemory_data_size(self) -> Optional[int]:
+        """Return an estimate of the in-memory size of this datasource's output.
+
+        ``FileBasedDatasource`` estimates in-memory size as the sum of the
+        on-disk file sizes. For MCAP that is a large underestimate: chunks are
+        usually compressed, and this datasource materializes per-message
+        columns -- topic, timestamps and, when ``include_metadata`` is set, the
+        schema -- that have no per-message on-disk equivalent.
+
+        Ray Data derives both the read parallelism and the memory it provisions
+        for the read from this number, so an underestimate produces too few,
+        oversized blocks. To correct it, sample a bounded number of files,
+        measure the in-memory size of a real block built from each, and scale
+        the total on-disk size by the resulting ratio.
+        """
+        on_disk_size = super().estimate_inmemory_data_size()
+        if not on_disk_size:
+            return on_disk_size
+
+        return int(on_disk_size * self._get_encoding_ratio())
+
+    def _get_encoding_ratio(self) -> float:
+        """Return the in-memory to on-disk size ratio, computing it once."""
+        if self._encoding_ratio is None:
+            self._encoding_ratio = self._estimate_files_encoding_ratio()
+        return self._encoding_ratio
+
+    def _estimate_files_encoding_ratio(self) -> float:
+        """Estimate the in-memory to on-disk size ratio by sampling files.
+
+        Overestimating is safer than underestimating here, so every failure
+        path falls back to ``MCAP_ENCODING_RATIO_ESTIMATE_DEFAULT`` rather than
+        to the uncorrected on-disk size.
+        """
+        if not self._data_context.decoding_size_estimation:
+            return MCAP_ENCODING_RATIO_ESTIMATE_DEFAULT
+
+        start_time = time.perf_counter()
+
+        # Skip empty files and files of unknown size: they carry no usable
+        # signal and would only add noise to the ratio.
+        candidates = [
+            (path, file_size)
+            for path, file_size in zip(self._paths(), self._file_sizes())
+            if file_size
+        ]
+        if not candidates:
+            return MCAP_ENCODING_RATIO_ESTIMATE_DEFAULT
+
+        ratios = []
+        for path, file_size in _sample_files(candidates):
+            in_memory_size = self._estimate_file_inmemory_size(path)
+            if in_memory_size:
+                ratios.append(in_memory_size / file_size)
+
+        sampling_duration = time.perf_counter() - start_time
+        if sampling_duration > 5:
+            logger.warning(
+                "MCAP input size estimation took "
+                f"{round(sampling_duration, 2)} seconds."
+            )
+
+        if not ratios:
+            return MCAP_ENCODING_RATIO_ESTIMATE_DEFAULT
+
+        ratio = sum(ratios) / len(ratios)
+        logger.debug(f"Estimated MCAP encoding ratio from sampling is {ratio}.")
+        return max(ratio, MCAP_ENCODING_RATIO_ESTIMATE_LOWER_BOUND)
+
+    def _estimate_file_inmemory_size(self, path: str) -> Optional[int]:
+        """Estimate the in-memory size of the rows one MCAP file produces.
+
+        Reads at most ``MCAP_ENCODING_RATIO_ESTIMATE_NUM_MESSAGES`` messages,
+        builds a block from them through the same conversion the read path
+        uses, and scales the measured bytes per row by the file's message
+        count. If the iteration finishes before reaching that cap it has seen
+        the whole selection, and the measured size is returned unscaled.
+
+        The sampled messages are the first ones the reader yields rather than a
+        spread across the file, so a recording whose message size changes
+        markedly from start to end is estimated from its opening. Bounding the
+        read this way keeps planning cheap; the sample across *files* is spread
+        instead (see ``_sample_files``).
+
+        Returns ``None`` if the file carries no summary to read the message
+        count from, or if it can't be sampled.
+        """
+        from mcap.reader import make_reader
+
+        try:
+            # Open for random access so that `make_reader` returns a
+            # `SeekingReader`, which reads the summary from the file's index
+            # rather than scanning the whole file to reconstruct it.
+            with self._filesystem.open_input_file(path) as f:
+                reader = make_reader(f)
+                summary = reader.get_summary()
+                if summary is None or summary.statistics is None:
+                    return None
+
+                num_messages = self._count_selected_messages(summary)
+                if not num_messages:
+                    return 0
+
+                builder = DelegatingBlockBuilder()
+                # Whether the iteration saw every message a read would select
+                # rather than stopping at the sample cap.
+                read_whole_selection = True
+                for schema, channel, message in reader.iter_messages(
+                    topics=list(self._topics) if self._topics else None,
+                    start_time=(
+                        self._time_range.start_time if self._time_range else None
+                    ),
+                    end_time=self._time_range.end_time if self._time_range else None,
+                ):
+                    if not self._should_include_message(schema, channel, message):
+                        continue
+                    builder.add(self._message_to_dict(schema, channel, message, path))
+                    if builder.num_rows() >= MCAP_ENCODING_RATIO_ESTIMATE_NUM_MESSAGES:
+                        read_whole_selection = False
+                        break
+
+                if builder.num_rows() == 0:
+                    return 0
+
+                block = builder.build()
+                if self._include_paths:
+                    # `FileBasedDatasource` appends this column downstream of
+                    # `_read_stream`, so add it to keep the sample faithful.
+                    block = BlockAccessor.for_block(block).fill_column("path", path)
+
+                accessor = BlockAccessor.for_block(block)
+                if read_whole_selection:
+                    # Every message a read selects was materialized, so this is
+                    # the size itself rather than a sample of it. This is the
+                    # usual case for a narrow ``time_range`` or
+                    # ``message_types`` filter, neither of which
+                    # ``_count_selected_messages`` can resolve from the summary.
+                    return accessor.size_bytes()
+
+                bytes_per_row = accessor.size_bytes() / accessor.num_rows()
+                return int(bytes_per_row * num_messages)
+        except Exception:
+            # Warn rather than log at debug: falling back silently restores the
+            # fixed-ratio behaviour this method exists to replace, and a
+            # debug-level message would not be seen.
+            logger.warning(
+                f"Failed to sample MCAP file '{path}' while estimating its "
+                "in-memory size. Falling back to a default encoding ratio of "
+                f"{MCAP_ENCODING_RATIO_ESTIMATE_DEFAULT}.",
+                exc_info=True,
+            )
+            return None
+
+    def _count_selected_messages(self, summary: "Summary") -> int:
+        """Return an upper bound on how many messages of a file a read selects.
+
+        Only the topic filter is resolvable from the summary. ``time_range``
+        and ``message_types`` are not represented there, so a read using them
+        selects at most this many messages.
+
+        This bound is consulted only when sampling stopped at the message cap.
+        A filter narrow enough to select fewer messages than the cap lets the
+        caller measure the whole selection directly, so the bound is unused
+        exactly where it would be loosest.
+        """
+        statistics = summary.statistics
+        if not self._topics:
+            return statistics.message_count
+
+        return sum(
+            count
+            for channel_id, count in statistics.channel_message_counts.items()
+            if channel_id in summary.channels
+            and summary.channels[channel_id].topic in self._topics
+        )
+
     def get_name(self) -> str:
         """Return a human-readable name for this datasource."""
         return "MCAP"
@@ -256,3 +468,27 @@ class MCAPDatasource(FileBasedDatasource):
         MCAP files can be read in parallel across multiple files.
         """
         return True
+
+
+def _sample_files(
+    candidates: List[Tuple[str, int]],
+) -> List[Tuple[str, int]]:
+    """Pick evenly spaced files to sample.
+
+    Even spacing rather than a prefix avoids a biased estimate when the input
+    is ordered by size or by recording session.
+    """
+    num_samples = math.ceil(
+        len(candidates) * MCAP_ENCODING_RATIO_ESTIMATE_SAMPLING_RATIO
+    )
+    num_samples = max(
+        min(num_samples, MCAP_ENCODING_RATIO_ESTIMATE_MAX_NUM_SAMPLES),
+        MCAP_ENCODING_RATIO_ESTIMATE_MIN_NUM_SAMPLES,
+    )
+    num_samples = min(num_samples, len(candidates))
+
+    if num_samples <= 1:
+        return candidates[:1]
+
+    step = (len(candidates) - 1) / (num_samples - 1)
+    return [candidates[round(i * step)] for i in range(num_samples)]

--- a/python/ray/data/_internal/datasource/mcap_datasource.py
+++ b/python/ray/data/_internal/datasource/mcap_datasource.py
@@ -21,6 +21,7 @@ import json
 import logging
 import math
 import time
+from collections import defaultdict
 from dataclasses import dataclass
 from typing import (
     TYPE_CHECKING,
@@ -368,17 +369,26 @@ class MCAPDatasource(FileBasedDatasource):
     def _estimate_file_inmemory_size(self, path: str) -> Optional[int]:
         """Estimate the in-memory size of the rows one MCAP file produces.
 
-        Reads at most ``MCAP_ENCODING_RATIO_ESTIMATE_NUM_MESSAGES`` messages,
-        builds a block from them through the same conversion the read path
-        uses, and scales the measured bytes per row by the file's message
-        count. If the iteration finishes before reaching that cap it has seen
-        the whole selection, and the measured size is returned unscaled.
+        Reads at most ``MCAP_ENCODING_RATIO_ESTIMATE_NUM_MESSAGES`` messages and
+        builds blocks from them through the same conversion the read path uses.
+        If the iteration finishes before reaching that cap it has seen the whole
+        selection, and the measured size is returned unscaled.
 
-        The sampled messages are the first ones the reader yields rather than a
-        spread across the file, so a recording whose message size changes
-        markedly from start to end is estimated from its opening. Bounding the
-        read this way keeps planning cheap; the sample across *files* is spread
-        instead (see ``_sample_files``).
+        Otherwise the sample is extrapolated **per channel**, weighted by the
+        exact per-channel counts the summary carries. Messages within one
+        channel are close to uniform in size, while channels differ by orders of
+        magnitude -- a 200 Hz IMU sample against a compressed camera frame -- so
+        scaling a mixed sample by a single message count makes the estimate
+        depend on how many of each topic happen to land in the window. The
+        window spans a fraction of a second of a recording that may run for
+        minutes, and one message either way on a topic carrying most of the
+        bytes moves the estimate by double digits. Weighting per channel removes
+        that: only the size of a channel's rows is sampled, never the mix
+        between them.
+
+        A channel absent from the sample falls back to the mean row size across
+        the whole sample. That suits rare topics with small messages; a rare
+        topic with very large ones would be underestimated.
 
         Returns ``None`` if the file carries no summary to read the message
         count from, or if it can't be sampled.
@@ -399,7 +409,10 @@ class MCAPDatasource(FileBasedDatasource):
                 if not num_messages:
                     return 0
 
-                builder = DelegatingBlockBuilder()
+                # One builder per channel for the per-channel row size, and a
+                # combined one for the whole-sample mean.
+                combined = DelegatingBlockBuilder()
+                per_channel = defaultdict(DelegatingBlockBuilder)
                 # Whether the iteration saw every message a read would select
                 # rather than stopping at the sample cap.
                 read_whole_selection = True
@@ -412,31 +425,46 @@ class MCAPDatasource(FileBasedDatasource):
                 ):
                     if not self._should_include_message(schema, channel, message):
                         continue
-                    builder.add(self._message_to_dict(schema, channel, message, path))
-                    if builder.num_rows() >= MCAP_ENCODING_RATIO_ESTIMATE_NUM_MESSAGES:
+                    row = self._message_to_dict(schema, channel, message, path)
+                    combined.add(dict(row))
+                    per_channel[channel.id].add(row)
+                    if combined.num_rows() >= MCAP_ENCODING_RATIO_ESTIMATE_NUM_MESSAGES:
                         read_whole_selection = False
                         break
 
-                if builder.num_rows() == 0:
+                if combined.num_rows() == 0:
                     return 0
 
-                block = builder.build()
-                if self._include_paths:
-                    # `FileBasedDatasource` appends this column downstream of
-                    # `_read_stream`, so add it to keep the sample faithful.
-                    block = BlockAccessor.for_block(block).fill_column("path", path)
-
-                accessor = BlockAccessor.for_block(block)
+                combined_accessor = self._sampled_block_accessor(combined, path)
                 if read_whole_selection:
                     # Every message a read selects was materialized, so this is
                     # the size itself rather than a sample of it. This is the
                     # usual case for a narrow ``time_range`` or
-                    # ``message_types`` filter, neither of which
-                    # ``_count_selected_messages`` can resolve from the summary.
-                    return accessor.size_bytes()
+                    # ``message_types`` filter, neither of which the summary can
+                    # resolve.
+                    return combined_accessor.size_bytes()
 
-                bytes_per_row = accessor.size_bytes() / accessor.num_rows()
-                return int(bytes_per_row * num_messages)
+                mean_bytes_per_row = (
+                    combined_accessor.size_bytes() / combined_accessor.num_rows()
+                )
+                bytes_per_row = {}
+                for channel_id, channel_builder in per_channel.items():
+                    accessor = self._sampled_block_accessor(channel_builder, path)
+                    bytes_per_row[channel_id] = (
+                        accessor.size_bytes() / accessor.num_rows()
+                    )
+
+                counts = self._selected_channel_message_counts(summary)
+                if not counts:
+                    # The summary carries a total but no per-channel breakdown.
+                    return int(mean_bytes_per_row * num_messages)
+
+                return int(
+                    sum(
+                        bytes_per_row.get(channel_id, mean_bytes_per_row) * count
+                        for channel_id, count in counts.items()
+                    )
+                )
         except Exception:
             # Warn rather than log at debug: falling back silently restores the
             # fixed-ratio behaviour this method exists to replace, and a
@@ -449,6 +477,37 @@ class MCAPDatasource(FileBasedDatasource):
             )
             return None
 
+    def _sampled_block_accessor(
+        self, builder: DelegatingBlockBuilder, path: str
+    ) -> "BlockAccessor":
+        """Build a sampled block and return an accessor over it.
+
+        ``include_paths`` adds a column downstream of ``_read_stream``, so the
+        sample has to add it too or it under-counts.
+        """
+        block = builder.build()
+        if self._include_paths:
+            block = BlockAccessor.for_block(block).fill_column("path", path)
+        return BlockAccessor.for_block(block)
+
+    def _selected_channel_message_counts(self, summary: "Summary") -> Dict[int, int]:
+        """Return the per-channel message counts a read selects.
+
+        Empty when the summary carries no per-channel breakdown, which callers
+        must handle: the total in ``statistics.message_count`` can be present
+        without it.
+        """
+        counts = summary.statistics.channel_message_counts
+        if not self._topics:
+            return dict(counts)
+
+        return {
+            channel_id: count
+            for channel_id, count in counts.items()
+            if channel_id in summary.channels
+            and summary.channels[channel_id].topic in self._topics
+        }
+
     def _count_selected_messages(self, summary: "Summary") -> int:
         """Return an upper bound on how many messages of a file a read selects.
 
@@ -456,21 +515,13 @@ class MCAPDatasource(FileBasedDatasource):
         and ``message_types`` are not represented there, so a read using them
         selects at most this many messages.
 
-        This bound is consulted only when sampling stopped at the message cap.
-        A filter narrow enough to select fewer messages than the cap lets the
-        caller measure the whole selection directly, so the bound is unused
-        exactly where it would be loosest.
+        Used to decide whether anything is selected at all, and to scale the
+        sample when the summary carries no per-channel breakdown.
         """
-        statistics = summary.statistics
         if not self._topics:
-            return statistics.message_count
+            return summary.statistics.message_count
 
-        return sum(
-            count
-            for channel_id, count in statistics.channel_message_counts.items()
-            if channel_id in summary.channels
-            and summary.channels[channel_id].topic in self._topics
-        )
+        return sum(self._selected_channel_message_counts(summary).values())
 
     def get_name(self) -> str:
         """Return a human-readable name for this datasource."""

--- a/python/ray/data/_internal/datasource/mcap_datasource.py
+++ b/python/ray/data/_internal/datasource/mcap_datasource.py
@@ -364,6 +364,16 @@ class MCAPDatasource(FileBasedDatasource):
 
         ratio = sum(ratios) / len(ratios)
         logger.debug(f"Estimated MCAP encoding ratio from sampling is {ratio}.")
+
+        if self._selects_subset():
+            # The lower bound guards against reporting a decompressed file as
+            # smaller than its compressed form. Under a filter this quantity is
+            # not a decompression ratio at all -- it is selected in-memory bytes
+            # over *total* on-disk bytes, and is legitimately far below 1 when
+            # the filter excludes the bulk of the file. Flooring it there would
+            # report the whole file's size for a read of a small part of it.
+            return ratio
+
         return max(ratio, MCAP_ENCODING_RATIO_ESTIMATE_LOWER_BOUND)
 
     def _estimate_file_inmemory_size(self, path: str) -> Optional[int]:
@@ -490,36 +500,69 @@ class MCAPDatasource(FileBasedDatasource):
             block = BlockAccessor.for_block(block).fill_column("path", path)
         return BlockAccessor.for_block(block)
 
-    def _selected_channel_message_counts(self, summary: "Summary") -> Dict[int, int]:
+    def _selects_subset(self) -> bool:
+        """Whether any filter narrows the read to part of a file."""
+        return bool(self._topics or self._time_range or self._message_types)
+
+    def _time_range_overlap_fraction(self, summary: "Summary") -> float:
+        """Return the fraction of a file's time span that ``time_range`` covers.
+
+        The summary records only the file's first and last message times, not a
+        per-channel distribution, so this assumes a channel publishes at a
+        roughly constant rate -- which is what a sensor recording does. Without
+        it, a one-second window on a twenty-second file is extrapolated across
+        all twenty seconds.
+
+        Returns 1.0 when no time range is set, or when the file reports no span.
+        """
+        if self._time_range is None:
+            return 1.0
+
+        statistics = summary.statistics
+        span = statistics.message_end_time - statistics.message_start_time
+        if span <= 0:
+            return 1.0
+
+        overlap_start = max(self._time_range.start_time, statistics.message_start_time)
+        overlap_end = min(self._time_range.end_time, statistics.message_end_time)
+        return max(0.0, (overlap_end - overlap_start) / span)
+
+    def _selected_channel_message_counts(self, summary: "Summary") -> Dict[int, float]:
         """Return the per-channel message counts a read selects.
+
+        Exact for a topic filter, which the summary resolves through
+        ``channel_message_counts``, and approximated for ``time_range`` by the
+        share of the file's span it covers. ``message_types`` has no equivalent
+        in the summary and is not modelled, so a read using it selects at most
+        this many messages.
 
         Empty when the summary carries no per-channel breakdown, which callers
         must handle: the total in ``statistics.message_count`` can be present
         without it.
         """
         counts = summary.statistics.channel_message_counts
-        if not self._topics:
-            return dict(counts)
+        fraction = self._time_range_overlap_fraction(summary)
 
         return {
-            channel_id: count
+            channel_id: count * fraction
             for channel_id, count in counts.items()
-            if channel_id in summary.channels
-            and summary.channels[channel_id].topic in self._topics
+            if not self._topics
+            or (
+                channel_id in summary.channels
+                and summary.channels[channel_id].topic in self._topics
+            )
         }
 
-    def _count_selected_messages(self, summary: "Summary") -> int:
+    def _count_selected_messages(self, summary: "Summary") -> float:
         """Return an upper bound on how many messages of a file a read selects.
-
-        Only the topic filter is resolvable from the summary. ``time_range``
-        and ``message_types`` are not represented there, so a read using them
-        selects at most this many messages.
 
         Used to decide whether anything is selected at all, and to scale the
         sample when the summary carries no per-channel breakdown.
         """
-        if not self._topics:
-            return summary.statistics.message_count
+        if not self._topics and not summary.statistics.channel_message_counts:
+            return summary.statistics.message_count * self._time_range_overlap_fraction(
+                summary
+            )
 
         return sum(self._selected_channel_message_counts(summary).values())
 

--- a/python/ray/data/_internal/datasource/mcap_datasource.py
+++ b/python/ray/data/_internal/datasource/mcap_datasource.py
@@ -219,7 +219,7 @@ class MCAPDatasource(FileBasedDatasource):
             yield builder.build()
 
     def _should_include_message(
-        self, schema: "Schema", channel: "Channel", message: "Message"
+        self, schema: Optional["Schema"], channel: "Channel", message: "Message"
     ) -> bool:
         """Check if a message should be included based on filters.
 
@@ -228,7 +228,8 @@ class MCAPDatasource(FileBasedDatasource):
         MCAP reader, so only message_types filtering is needed here.
 
         Args:
-            schema: MCAP schema object containing message type information.
+            schema: MCAP schema object containing message type information, or
+                ``None`` when the channel declares no schema.
             channel: MCAP channel object containing topic and metadata.
             message: MCAP message object containing the actual data.
 
@@ -242,7 +243,11 @@ class MCAPDatasource(FileBasedDatasource):
         return True
 
     def _message_to_dict(
-        self, schema: "Schema", channel: "Channel", message: "Message", path: str
+        self,
+        schema: Optional["Schema"],
+        channel: "Channel",
+        message: "Message",
+        path: str,
     ) -> Dict[str, Any]:
         """Convert MCAP message to dictionary format.
 
@@ -250,7 +255,8 @@ class MCAPDatasource(FileBasedDatasource):
         format suitable for Ray Data processing.
 
         Args:
-            schema: MCAP schema object containing message type and encoding info.
+            schema: MCAP schema object containing message type and encoding
+                info, or ``None`` when the channel declares no schema.
             channel: MCAP channel object containing topic and channel metadata.
             message: MCAP message object containing the actual message data.
             path: Path to the source file (for include_paths functionality).
@@ -436,6 +442,11 @@ class MCAPDatasource(FileBasedDatasource):
                     if not self._should_include_message(schema, channel, message):
                         continue
                     row = self._message_to_dict(schema, channel, message, path)
+                    if self._include_paths:
+                        # `FileBasedDatasource` appends this column downstream
+                        # of `_read_stream`, so the sample has to carry it too
+                        # or it under-counts.
+                        row["path"] = path
                     combined.add(dict(row))
                     per_channel[channel.id].add(row)
                     if combined.num_rows() >= MCAP_ENCODING_RATIO_ESTIMATE_NUM_MESSAGES:
@@ -445,7 +456,7 @@ class MCAPDatasource(FileBasedDatasource):
                 if combined.num_rows() == 0:
                     return 0
 
-                combined_accessor = self._sampled_block_accessor(combined, path)
+                combined_accessor = self._sampled_block_accessor(combined)
                 if read_whole_selection:
                     # Every message a read selects was materialized, so this is
                     # the size itself rather than a sample of it. This is the
@@ -459,7 +470,7 @@ class MCAPDatasource(FileBasedDatasource):
                 )
                 bytes_per_row = {}
                 for channel_id, channel_builder in per_channel.items():
-                    accessor = self._sampled_block_accessor(channel_builder, path)
+                    accessor = self._sampled_block_accessor(channel_builder)
                     bytes_per_row[channel_id] = (
                         accessor.size_bytes() / accessor.num_rows()
                     )
@@ -487,18 +498,10 @@ class MCAPDatasource(FileBasedDatasource):
             )
             return None
 
-    def _sampled_block_accessor(
-        self, builder: DelegatingBlockBuilder, path: str
-    ) -> "BlockAccessor":
-        """Build a sampled block and return an accessor over it.
-
-        ``include_paths`` adds a column downstream of ``_read_stream``, so the
-        sample has to add it too or it under-counts.
-        """
-        block = builder.build()
-        if self._include_paths:
-            block = BlockAccessor.for_block(block).fill_column("path", path)
-        return BlockAccessor.for_block(block)
+    @staticmethod
+    def _sampled_block_accessor(builder: DelegatingBlockBuilder) -> "BlockAccessor":
+        """Build a sampled block and return an accessor over it."""
+        return BlockAccessor.for_block(builder.build())
 
     def _selects_subset(self) -> bool:
         """Whether any filter narrows the read to part of a file."""
@@ -519,6 +522,9 @@ class MCAPDatasource(FileBasedDatasource):
             return 1.0
 
         statistics = summary.statistics
+        if statistics is None:
+            return 1.0
+
         span = statistics.message_end_time - statistics.message_start_time
         if span <= 0:
             return 1.0
@@ -540,6 +546,9 @@ class MCAPDatasource(FileBasedDatasource):
         must handle: the total in ``statistics.message_count`` can be present
         without it.
         """
+        if summary.statistics is None:
+            return {}
+
         counts = summary.statistics.channel_message_counts
         fraction = self._time_range_overlap_fraction(summary)
 
@@ -559,10 +568,12 @@ class MCAPDatasource(FileBasedDatasource):
         Used to decide whether anything is selected at all, and to scale the
         sample when the summary carries no per-channel breakdown.
         """
-        if not self._topics and not summary.statistics.channel_message_counts:
-            return summary.statistics.message_count * self._time_range_overlap_fraction(
-                summary
-            )
+        statistics = summary.statistics
+        if statistics is None:
+            return 0
+
+        if not self._topics and not statistics.channel_message_counts:
+            return statistics.message_count * self._time_range_overlap_fraction(summary)
 
         return sum(self._selected_channel_message_counts(summary).values())
 
@@ -580,8 +591,8 @@ class MCAPDatasource(FileBasedDatasource):
 
 
 def _sample_files(
-    candidates: List[Tuple[str, int]],
-) -> List[Tuple[str, int]]:
+    candidates: List[Tuple[str, float]],
+) -> List[Tuple[str, float]]:
     """Pick evenly spaced files to sample.
 
     Even spacing rather than a prefix avoids a biased estimate when the input

--- a/python/ray/data/tests/datasource/test_mcap.py
+++ b/python/ray/data/tests/datasource/test_mcap.py
@@ -7,7 +7,6 @@ import pytest
 import ray
 from ray.data._internal.datasource.mcap_datasource import (
     MCAP_ENCODING_RATIO_ESTIMATE_DEFAULT,
-    MCAP_ENCODING_RATIO_ESTIMATE_LOWER_BOUND,
     MCAPDatasource,
     TimeRange,
 )

--- a/python/ray/data/tests/datasource/test_mcap.py
+++ b/python/ray/data/tests/datasource/test_mcap.py
@@ -5,6 +5,12 @@ import os
 import pytest
 
 import ray
+from ray.data._internal.datasource.mcap_datasource import (
+    MCAP_ENCODING_RATIO_ESTIMATE_DEFAULT,
+    MCAPDatasource,
+    TimeRange,
+)
+from ray.data.context import DataContext
 from ray.data.datasource.path_util import _unwrap_protocol
 from ray.data.tests.conftest import *  # noqa
 from ray.tests.conftest import *  # noqa
@@ -260,7 +266,7 @@ def test_read_mcap_include_paths(ray_start_regular_shared, simple_mcap_file):
 def test_read_mcap_invalid_time_range(ray_start_regular_shared, simple_mcap_file):
     """Test validation of time range parameters."""
     # Start time >= end time
-    with pytest.raises(ValueError, match="start_time must be less than end_time"):
+    with pytest.raises(ValueError, match="must be less than"):
         ray.data.read_mcap(simple_mcap_file, time_range=(2000, 1000))
 
     # Negative times
@@ -386,6 +392,274 @@ def test_read_mcap_json_decoding(ray_start_regular_shared, tmp_path):
     assert row["data"]["sensor_data"]["temperature"] == 23.5
     assert row["data"]["metadata"]["device_id"] == "sensor_001"
     assert row["data"]["sensor_data"]["readings"] == [1, 2, 3, 4, 5]
+
+
+# A schema definition of the size real ROS 2 / Foxglove schemas reach. It is
+# registered once per file but, with `include_metadata`, materialized on every
+# row, which is what makes the in-memory size dwarf the on-disk size.
+LARGE_SCHEMA_DEFINITION = b"# msgdef\n" + b"uint8[] data\nstring format\n" * 100
+
+
+def create_binary_mcap_file(
+    file_path: str,
+    num_messages: int,
+    *,
+    topics: tuple = ("/camera/image",),
+    payload_size: int = 512,
+    use_statistics: bool = True,
+    descending: bool = False,
+) -> None:
+    """Create an MCAP file with compressible binary payloads.
+
+    Unlike `create_test_mcap_file`, this writes opaque binary messages against a
+    large schema, which is the shape of a real robotics recording: the chunks
+    compress well on disk while every row carries the schema in memory.
+
+    Args:
+        file_path: Where to write the file.
+        num_messages: Number of messages to write.
+        topics: Topics to round-robin the messages across.
+        payload_size: Size in bytes of each message payload.
+        use_statistics: Whether to write the summary Statistics record. When
+            False, the file carries no message count to estimate from.
+        descending: Write messages in descending log time, so that ascending
+            read order has to come from the reader rather than the file layout.
+    """
+    from mcap.writer import Writer
+
+    with open(file_path, "wb") as stream:
+        writer = Writer(stream, use_statistics=use_statistics)
+        writer.start(profile="", library="ray-test")
+
+        schema_id = writer.register_schema(
+            name="foxglove.CompressedVideo",
+            encoding="ros2msg",
+            data=LARGE_SCHEMA_DEFINITION,
+        )
+        channels = {
+            topic: writer.register_channel(
+                schema_id=schema_id, topic=topic, message_encoding="cdr"
+            )
+            for topic in topics
+        }
+
+        indices = range(num_messages)
+        if descending:
+            indices = reversed(indices)
+        for i in indices:
+            log_time = 1000000000 + i * 33000000
+            writer.add_message(
+                channel_id=channels[topics[i % len(topics)]],
+                log_time=log_time,
+                publish_time=log_time,
+                data=bytes([i % 256]) * payload_size,
+                sequence=i,
+            )
+
+        writer.finish()
+
+
+@pytest.fixture
+def binary_mcap_file(tmp_path):
+    """Fixture providing an MCAP file with 360 binary messages."""
+    path = os.path.join(tmp_path, "binary.mcap")
+    create_binary_mcap_file(path, 360)
+    return path
+
+
+def test_estimate_inmemory_data_size_exceeds_on_disk_size(
+    ray_start_regular_shared, binary_mcap_file
+):
+    """In-memory size estimates must not report the on-disk size.
+
+    `FileBasedDatasource` estimates in-memory size as the sum of the on-disk
+    file sizes. MCAP chunks are compressed and every row additionally carries
+    metadata that has no per-message on-disk equivalent, so that default
+    understates the materialized size by more than an order of magnitude. Ray
+    Data sizes both read parallelism and memory provisioning from this number.
+    """
+    on_disk_size = os.path.getsize(binary_mcap_file)
+    actual_size = ray.data.read_mcap(binary_mcap_file).materialize().size_bytes()
+
+    # Establish that on-disk size is not a usable proxy for this format.
+    assert actual_size > 10 * on_disk_size
+
+    estimate = MCAPDatasource(paths=[binary_mcap_file]).estimate_inmemory_data_size()
+    assert 0.5 * actual_size <= estimate <= 2 * actual_size
+
+
+def test_estimate_inmemory_data_size_tracks_include_metadata(
+    ray_start_regular_shared, binary_mcap_file
+):
+    """Dropping the metadata columns must shrink the estimate."""
+    with_metadata = MCAPDatasource(
+        paths=[binary_mcap_file], include_metadata=True
+    ).estimate_inmemory_data_size()
+    without_metadata = MCAPDatasource(
+        paths=[binary_mcap_file], include_metadata=False
+    ).estimate_inmemory_data_size()
+
+    assert without_metadata < with_metadata
+
+    actual = (
+        ray.data.read_mcap(binary_mcap_file, include_metadata=False)
+        .materialize()
+        .size_bytes()
+    )
+    assert 0.5 * actual <= without_metadata <= 2 * actual
+
+
+def test_estimate_inmemory_data_size_respects_topic_filter(
+    ray_start_regular_shared, tmp_path
+):
+    """A topic filter must be reflected in the estimate."""
+    path = os.path.join(tmp_path, "multi_topic_binary.mcap")
+    create_binary_mcap_file(path, 300, topics=("/topic_a", "/topic_b", "/topic_c"))
+
+    unfiltered = MCAPDatasource(paths=[path]).estimate_inmemory_data_size()
+    filtered = MCAPDatasource(
+        paths=[path], topics={"/topic_a"}
+    ).estimate_inmemory_data_size()
+
+    # One of three topics is selected, so the estimate should fall roughly
+    # threefold rather than staying flat.
+    assert filtered < unfiltered
+    assert 0.2 * unfiltered <= filtered <= 0.5 * unfiltered
+
+    actual = ray.data.read_mcap(path, topics={"/topic_a"}).materialize().size_bytes()
+    assert 0.5 * actual <= filtered <= 2 * actual
+
+
+def test_estimate_inmemory_data_size_multiple_files(ray_start_regular_shared, tmp_path):
+    """The estimate must aggregate across files, including unsampled ones."""
+    paths = []
+    for i in range(12):
+        path = os.path.join(tmp_path, f"part_{i:02d}.mcap")
+        create_binary_mcap_file(path, 60)
+        paths.append(path)
+
+    estimate = MCAPDatasource(paths=paths).estimate_inmemory_data_size()
+    actual = ray.data.read_mcap(paths).materialize().size_bytes()
+
+    assert 0.5 * actual <= estimate <= 2 * actual
+
+
+def test_estimate_inmemory_data_size_without_statistics(
+    ray_start_regular_shared, tmp_path
+):
+    """A file with no summary statistics falls back instead of failing.
+
+    Message counts come from the MCAP summary, which is optional. Without it
+    the datasource must still return a usable overestimate.
+    """
+    path = os.path.join(tmp_path, "no_stats.mcap")
+    create_binary_mcap_file(path, 200, use_statistics=False)
+
+    estimate = MCAPDatasource(paths=[path]).estimate_inmemory_data_size()
+
+    assert estimate == os.path.getsize(path) * MCAP_ENCODING_RATIO_ESTIMATE_DEFAULT
+
+
+def test_estimate_inmemory_data_size_sampling_disabled(
+    ray_start_regular_shared, binary_mcap_file
+):
+    """`decoding_size_estimation=False` must skip sampling entirely."""
+    ctx = DataContext.get_current()
+    original = ctx.decoding_size_estimation
+    ctx.decoding_size_estimation = False
+    try:
+        estimate = MCAPDatasource(
+            paths=[binary_mcap_file]
+        ).estimate_inmemory_data_size()
+    finally:
+        ctx.decoding_size_estimation = original
+
+    on_disk_size = os.path.getsize(binary_mcap_file)
+    assert estimate == on_disk_size * MCAP_ENCODING_RATIO_ESTIMATE_DEFAULT
+
+
+def test_estimate_inmemory_data_size_accounts_for_include_paths(
+    ray_start_regular_shared, binary_mcap_file
+):
+    """`include_paths` adds a column downstream of `_read_stream`.
+
+    Sampling builds its block from `_read_stream`'s output, so it has to add
+    that column itself or the estimate misses it.
+    """
+    without_paths = MCAPDatasource(
+        paths=[binary_mcap_file]
+    ).estimate_inmemory_data_size()
+    with_paths = MCAPDatasource(
+        paths=[binary_mcap_file], include_paths=True
+    ).estimate_inmemory_data_size()
+
+    assert with_paths > without_paths
+
+    actual = (
+        ray.data.read_mcap(binary_mcap_file, include_paths=True)
+        .materialize()
+        .size_bytes()
+    )
+    assert 0.5 * actual <= with_paths <= 2 * actual
+
+
+def test_estimate_inmemory_data_size_narrow_time_range(
+    ray_start_regular_shared, binary_mcap_file
+):
+    """A `time_range` selecting a small slice must not estimate the whole file.
+
+    Message counts come from the MCAP summary, which cannot express a time
+    range. When sampling covers the whole selection the measured size is exact,
+    so the estimate has to track the filter rather than the file.
+    """
+    # `create_binary_mcap_file` writes log times at 1e9 + i * 33e6.
+    start = 1000000000
+    time_range = (start, start + 10 * 33000000)
+
+    unfiltered = MCAPDatasource(paths=[binary_mcap_file]).estimate_inmemory_data_size()
+    filtered = MCAPDatasource(
+        paths=[binary_mcap_file], time_range=TimeRange(*time_range)
+    ).estimate_inmemory_data_size()
+
+    ds = ray.data.read_mcap(binary_mcap_file, time_range=time_range).materialize()
+    actual = ds.size_bytes()
+
+    # 10 of 360 messages: the estimate must fall, not stay flat.
+    assert filtered < unfiltered / 10
+    assert 0.5 * actual <= filtered <= 2 * actual
+
+
+def test_read_mcap_orders_messages_by_log_time(ray_start_regular_shared, tmp_path):
+    """Messages must be returned in ascending log time order.
+
+    The file is written in descending order, so passing this requires the
+    reader's ordering rather than the file's layout.
+    """
+    path = os.path.join(tmp_path, "descending.mcap")
+    create_binary_mcap_file(path, 200, descending=True)
+
+    rows = ray.data.read_mcap(path).take_all()
+
+    assert len(rows) == 200
+    log_times = [row["log_time"] for row in rows]
+    assert log_times == sorted(log_times)
+    assert [row["sequence"] for row in rows] == list(range(200))
+
+
+def test_read_mcap_preserves_binary_payloads(ray_start_regular_shared, tmp_path):
+    """Non-JSON payloads must round-trip byte for byte.
+
+    A `cdr`-encoded message is opaque bytes; the JSON decoding path must not
+    alter it.
+    """
+    path = os.path.join(tmp_path, "payloads.mcap")
+    create_binary_mcap_file(path, 128, payload_size=256)
+
+    rows = ray.data.read_mcap(path).take_all()
+
+    assert len(rows) == 128
+    for i, row in enumerate(rows):
+        assert bytes(row["data"]) == bytes([i % 256]) * 256
 
 
 if __name__ == "__main__":

--- a/python/ray/data/tests/datasource/test_mcap.py
+++ b/python/ray/data/tests/datasource/test_mcap.py
@@ -460,6 +460,64 @@ def create_binary_mcap_file(
         writer.finish()
 
 
+def create_skewed_mcap_file(file_path: str) -> None:
+    """Create a file whose leading messages misrepresent the whole.
+
+    Two topics differing by orders of magnitude in message size and rate. The
+    first 100 messages by log time -- the estimator's sample window -- are half
+    large messages, while the file overall is 5% large. Extrapolating the
+    window's mean row size across the file's message count therefore overstates
+    the size by roughly an order of magnitude.
+    """
+    from mcap.writer import Writer
+
+    small_payload = b"s" * 100
+    large_payload = b"L" * 20000
+
+    with open(file_path, "wb") as stream:
+        writer = Writer(stream)
+        writer.start(profile="", library="ray-test")
+
+        schema_id = writer.register_schema(
+            name="foxglove.CompressedVideo",
+            encoding="ros2msg",
+            data=LARGE_SCHEMA_DEFINITION,
+        )
+        small = writer.register_channel(
+            schema_id=schema_id, topic="/small", message_encoding="cdr"
+        )
+        large = writer.register_channel(
+            schema_id=schema_id, topic="/large", message_encoding="cdr"
+        )
+
+        log_time = 1000000000
+        # The sample window: alternating, so half of it is large messages.
+        for i in range(100):
+            channel, payload = (
+                (large, large_payload) if i % 2 else (small, small_payload)
+            )
+            writer.add_message(
+                channel_id=channel,
+                log_time=log_time,
+                publish_time=log_time,
+                data=payload,
+                sequence=i,
+            )
+            log_time += 1000000
+        # The rest of the file: small messages only, leaving 5% large overall.
+        for i in range(100, 1000):
+            writer.add_message(
+                channel_id=small,
+                log_time=log_time,
+                publish_time=log_time,
+                data=small_payload,
+                sequence=i,
+            )
+            log_time += 1000000
+
+        writer.finish()
+
+
 @pytest.fixture
 def binary_mcap_file(tmp_path):
     """Fixture providing an MCAP file with 360 binary messages."""
@@ -651,6 +709,28 @@ def test_estimate_inmemory_data_size_filter_selecting_nothing(
     assert estimate == on_disk_size * MCAP_ENCODING_RATIO_ESTIMATE_LOWER_BOUND
 
     assert ray.data.read_mcap(binary_mcap_file, topics={"/no_such_topic"}).count() == 0
+
+
+def test_estimate_inmemory_data_size_weights_channels_by_summary_counts(
+    ray_start_regular_shared, tmp_path
+):
+    """The sample window's topic mix must not drive the estimate.
+
+    Channels differ by orders of magnitude in message size, so extrapolating a
+    mixed sample by one message count makes the estimate depend on which topics
+    happen to fall in the window rather than on the file. The summary carries
+    exact per-channel counts; weighting by those removes the dependency.
+    """
+    path = os.path.join(tmp_path, "skewed.mcap")
+    create_skewed_mcap_file(path)
+
+    estimate = MCAPDatasource(paths=[path]).estimate_inmemory_data_size()
+    actual = ray.data.read_mcap(path).materialize().size_bytes()
+
+    # Scaling the window's mean row size by the file's message count overstates
+    # this file by close to an order of magnitude, so this band is only
+    # reachable by weighting each channel separately.
+    assert 0.7 * actual <= estimate <= 1.5 * actual
 
 
 def test_read_mcap_orders_messages_by_log_time(ray_start_regular_shared, tmp_path):

--- a/python/ray/data/tests/datasource/test_mcap.py
+++ b/python/ray/data/tests/datasource/test_mcap.py
@@ -7,6 +7,7 @@ import pytest
 import ray
 from ray.data._internal.datasource.mcap_datasource import (
     MCAP_ENCODING_RATIO_ESTIMATE_DEFAULT,
+    MCAP_ENCODING_RATIO_ESTIMATE_LOWER_BOUND,
     MCAPDatasource,
     TimeRange,
 )
@@ -627,6 +628,29 @@ def test_estimate_inmemory_data_size_narrow_time_range(
     # 10 of 360 messages: the estimate must fall, not stay flat.
     assert filtered < unfiltered / 10
     assert 0.5 * actual <= filtered <= 2 * actual
+
+
+def test_estimate_inmemory_data_size_filter_selecting_nothing(
+    ray_start_regular_shared, binary_mcap_file
+):
+    """A filter that selects no messages is a measurement, not a failure.
+
+    Sampling returns 0 for a file whose filter matches nothing. That is a real
+    result and must be distinguished from the `None` a failed sample returns:
+    treating it as a failure discards every sample and falls back to the
+    default ratio, overstating a read that returns no rows at all.
+    """
+    estimate = MCAPDatasource(
+        paths=[binary_mcap_file], topics={"/no_such_topic"}
+    ).estimate_inmemory_data_size()
+
+    on_disk_size = os.path.getsize(binary_mcap_file)
+    assert estimate < on_disk_size * MCAP_ENCODING_RATIO_ESTIMATE_DEFAULT
+    # The measured zero floors at the ratio lower bound rather than falling
+    # through to the default.
+    assert estimate == on_disk_size * MCAP_ENCODING_RATIO_ESTIMATE_LOWER_BOUND
+
+    assert ray.data.read_mcap(binary_mcap_file, topics={"/no_such_topic"}).count() == 0
 
 
 def test_read_mcap_orders_messages_by_log_time(ray_start_regular_shared, tmp_path):

--- a/python/ray/data/tests/datasource/test_mcap.py
+++ b/python/ray/data/tests/datasource/test_mcap.py
@@ -518,6 +518,73 @@ def create_skewed_mcap_file(file_path: str) -> None:
         writer.finish()
 
 
+def create_episode_mcap_file(file_path: str) -> None:
+    """Create a video-dominated recording with light, high-rate state.
+
+    The shape of a robotics episode: a few camera topics carrying almost all of
+    the bytes as incompressible frames, alongside a fast proprioception topic
+    whose messages are tiny. Reading only the state topics selects a small
+    fraction of the file, and a one-second window selects 200 proprio messages
+    -- above the sampling cap, so the estimate has to be extrapolated rather
+    than measured outright.
+    """
+    from mcap.writer import Writer
+
+    duration_s, frame_bytes = 4, 8_000
+
+    with open(file_path, "wb") as stream:
+        writer = Writer(stream)
+        writer.start(profile="", library="ray-test")
+
+        # A small schema definition, as a real recording carries: the file has
+        # to be dominated by camera *payload*, not by the schema each row
+        # repeats, or the state topics stop being light.
+        schema_id = writer.register_schema(
+            name="foxglove.CompressedVideo",
+            encoding="ros2msg",
+            data=b"uint8[] data\n",
+        )
+        cameras = [
+            writer.register_channel(
+                schema_id=schema_id,
+                topic=f"/cam{i}/compressed",
+                message_encoding="cdr",
+            )
+            for i in range(2)
+        ]
+        proprio = writer.register_channel(
+            schema_id=schema_id, topic="/proprio", message_encoding="cdr"
+        )
+
+        messages = []
+        for i in range(duration_s * 30):  # cameras at 30 Hz
+            log_time = int(i * 1e9 / 30)
+            for channel_id in cameras:
+                # Incompressible, so the chunks do not collapse on disk.
+                messages.append((log_time, channel_id, os.urandom(frame_bytes)))
+        for i in range(duration_s * 200):  # proprio at 200 Hz
+            messages.append((int(i * 1e9 / 200), proprio, b"p" * 100))
+
+        for sequence, (log_time, channel_id, data) in enumerate(sorted(messages)):
+            writer.add_message(
+                channel_id=channel_id,
+                log_time=log_time,
+                publish_time=log_time,
+                data=data,
+                sequence=sequence,
+            )
+
+        writer.finish()
+
+
+@pytest.fixture
+def episode_mcap_file(tmp_path):
+    """Fixture providing a video-dominated recording with high-rate state."""
+    path = os.path.join(tmp_path, "episode.mcap")
+    create_episode_mcap_file(path)
+    return path
+
+
 @pytest.fixture
 def binary_mcap_file(tmp_path):
     """Fixture providing an MCAP file with 360 binary messages."""
@@ -702,12 +769,10 @@ def test_estimate_inmemory_data_size_filter_selecting_nothing(
         paths=[binary_mcap_file], topics={"/no_such_topic"}
     ).estimate_inmemory_data_size()
 
-    on_disk_size = os.path.getsize(binary_mcap_file)
-    assert estimate < on_disk_size * MCAP_ENCODING_RATIO_ESTIMATE_DEFAULT
-    # The measured zero floors at the ratio lower bound rather than falling
-    # through to the default.
-    assert estimate == on_disk_size * MCAP_ENCODING_RATIO_ESTIMATE_LOWER_BOUND
-
+    # The measured zero is carried through rather than falling back to the
+    # default ratio. The ratio lower bound does not apply under a filter, so
+    # nothing selected estimates as nothing.
+    assert estimate == 0
     assert ray.data.read_mcap(binary_mcap_file, topics={"/no_such_topic"}).count() == 0
 
 
@@ -731,6 +796,66 @@ def test_estimate_inmemory_data_size_weights_channels_by_summary_counts(
     # this file by close to an order of magnitude, so this band is only
     # reachable by weighting each channel separately.
     assert 0.7 * actual <= estimate <= 1.5 * actual
+
+
+def test_estimate_inmemory_data_size_below_on_disk_size_under_filter(
+    ray_start_regular_shared, episode_mcap_file
+):
+    """A filter selecting a small part of a file must estimate below its size.
+
+    The encoding ratio is floored at 1 so that a decompressed file is never
+    reported as smaller than its compressed form. Under a filter the quantity
+    is not a decompression ratio -- it is selected bytes over *total* on-disk
+    bytes -- and on a video-dominated recording, reading only the state topics
+    is legitimately far below 1.
+    """
+    on_disk_size = os.path.getsize(episode_mcap_file)
+    estimate = MCAPDatasource(
+        paths=[episode_mcap_file], topics={"/proprio"}
+    ).estimate_inmemory_data_size()
+    actual = (
+        ray.data.read_mcap(episode_mcap_file, topics={"/proprio"})
+        .materialize()
+        .size_bytes()
+    )
+
+    # Flooring the ratio here would report the whole file.
+    assert estimate < on_disk_size
+    assert 0.5 * actual <= estimate <= 2 * actual
+
+
+def test_estimate_inmemory_data_size_time_window_above_sample_cap(
+    ray_start_regular_shared, episode_mcap_file
+):
+    """A time window wider than the sample cap must still track the window.
+
+    A one-second window selects 200 proprio messages, above
+    ``MCAP_ENCODING_RATIO_ESTIMATE_NUM_MESSAGES``, so sampling stops early and
+    the result is extrapolated. The summary cannot express a time range, so
+    without scaling by the window's share of the file's span the estimate is
+    the whole recording's worth of messages.
+    """
+    time_range = (0, 1_000_000_000)  # 1 s of a 4 s recording
+
+    unfiltered = MCAPDatasource(
+        paths=[episode_mcap_file], topics={"/proprio"}
+    ).estimate_inmemory_data_size()
+    windowed = MCAPDatasource(
+        paths=[episode_mcap_file],
+        topics={"/proprio"},
+        time_range=TimeRange(*time_range),
+    ).estimate_inmemory_data_size()
+    actual = (
+        ray.data.read_mcap(
+            episode_mcap_file, topics={"/proprio"}, time_range=time_range
+        )
+        .materialize()
+        .size_bytes()
+    )
+
+    # A quarter of the recording, so roughly a quarter of the rows.
+    assert windowed < unfiltered / 2
+    assert 0.5 * actual <= windowed <= 2 * actual
 
 
 def test_read_mcap_orders_messages_by_log_time(ray_start_regular_shared, tmp_path):

--- a/python/ray/data/tests/datasource/test_mcap.py
+++ b/python/ray/data/tests/datasource/test_mcap.py
@@ -23,6 +23,18 @@ pytestmark = pytest.mark.skipif(
 )
 
 
+def estimate_size(datasource: MCAPDatasource) -> int:
+    """Return a datasource's in-memory size estimate, asserting it is known.
+
+    ``estimate_inmemory_data_size`` is typed ``Optional[int]``: the base class
+    returns ``None`` when file sizes are unavailable. Every fixture here has
+    known sizes, so narrow once rather than at each comparison.
+    """
+    estimate = datasource.estimate_inmemory_data_size()
+    assert estimate is not None
+    return estimate
+
+
 def create_test_mcap_file(file_path: str, messages: list) -> None:
     """Create a test MCAP file with given messages."""
     from mcap.writer import Writer
@@ -609,7 +621,7 @@ def test_estimate_inmemory_data_size_exceeds_on_disk_size(
     # Establish that on-disk size is not a usable proxy for this format.
     assert actual_size > 10 * on_disk_size
 
-    estimate = MCAPDatasource(paths=[binary_mcap_file]).estimate_inmemory_data_size()
+    estimate = estimate_size(MCAPDatasource(paths=[binary_mcap_file]))
     assert 0.5 * actual_size <= estimate <= 2 * actual_size
 
 
@@ -617,12 +629,12 @@ def test_estimate_inmemory_data_size_tracks_include_metadata(
     ray_start_regular_shared, binary_mcap_file
 ):
     """Dropping the metadata columns must shrink the estimate."""
-    with_metadata = MCAPDatasource(
-        paths=[binary_mcap_file], include_metadata=True
-    ).estimate_inmemory_data_size()
-    without_metadata = MCAPDatasource(
-        paths=[binary_mcap_file], include_metadata=False
-    ).estimate_inmemory_data_size()
+    with_metadata = estimate_size(
+        MCAPDatasource(paths=[binary_mcap_file], include_metadata=True)
+    )
+    without_metadata = estimate_size(
+        MCAPDatasource(paths=[binary_mcap_file], include_metadata=False)
+    )
 
     assert without_metadata < with_metadata
 
@@ -641,10 +653,8 @@ def test_estimate_inmemory_data_size_respects_topic_filter(
     path = os.path.join(tmp_path, "multi_topic_binary.mcap")
     create_binary_mcap_file(path, 300, topics=("/topic_a", "/topic_b", "/topic_c"))
 
-    unfiltered = MCAPDatasource(paths=[path]).estimate_inmemory_data_size()
-    filtered = MCAPDatasource(
-        paths=[path], topics={"/topic_a"}
-    ).estimate_inmemory_data_size()
+    unfiltered = estimate_size(MCAPDatasource(paths=[path]))
+    filtered = estimate_size(MCAPDatasource(paths=[path], topics={"/topic_a"}))
 
     # One of three topics is selected, so the estimate should fall roughly
     # threefold rather than staying flat.
@@ -663,7 +673,7 @@ def test_estimate_inmemory_data_size_multiple_files(ray_start_regular_shared, tm
         create_binary_mcap_file(path, 60)
         paths.append(path)
 
-    estimate = MCAPDatasource(paths=paths).estimate_inmemory_data_size()
+    estimate = estimate_size(MCAPDatasource(paths=paths))
     actual = ray.data.read_mcap(paths).materialize().size_bytes()
 
     assert 0.5 * actual <= estimate <= 2 * actual
@@ -680,7 +690,7 @@ def test_estimate_inmemory_data_size_without_statistics(
     path = os.path.join(tmp_path, "no_stats.mcap")
     create_binary_mcap_file(path, 200, use_statistics=False)
 
-    estimate = MCAPDatasource(paths=[path]).estimate_inmemory_data_size()
+    estimate = estimate_size(MCAPDatasource(paths=[path]))
 
     assert estimate == os.path.getsize(path) * MCAP_ENCODING_RATIO_ESTIMATE_DEFAULT
 
@@ -693,9 +703,7 @@ def test_estimate_inmemory_data_size_sampling_disabled(
     original = ctx.decoding_size_estimation
     ctx.decoding_size_estimation = False
     try:
-        estimate = MCAPDatasource(
-            paths=[binary_mcap_file]
-        ).estimate_inmemory_data_size()
+        estimate = estimate_size(MCAPDatasource(paths=[binary_mcap_file]))
     finally:
         ctx.decoding_size_estimation = original
 
@@ -711,12 +719,10 @@ def test_estimate_inmemory_data_size_accounts_for_include_paths(
     Sampling builds its block from `_read_stream`'s output, so it has to add
     that column itself or the estimate misses it.
     """
-    without_paths = MCAPDatasource(
-        paths=[binary_mcap_file]
-    ).estimate_inmemory_data_size()
-    with_paths = MCAPDatasource(
-        paths=[binary_mcap_file], include_paths=True
-    ).estimate_inmemory_data_size()
+    without_paths = estimate_size(MCAPDatasource(paths=[binary_mcap_file]))
+    with_paths = estimate_size(
+        MCAPDatasource(paths=[binary_mcap_file], include_paths=True)
+    )
 
     assert with_paths > without_paths
 
@@ -741,10 +747,10 @@ def test_estimate_inmemory_data_size_narrow_time_range(
     start = 1000000000
     time_range = (start, start + 10 * 33000000)
 
-    unfiltered = MCAPDatasource(paths=[binary_mcap_file]).estimate_inmemory_data_size()
-    filtered = MCAPDatasource(
-        paths=[binary_mcap_file], time_range=TimeRange(*time_range)
-    ).estimate_inmemory_data_size()
+    unfiltered = estimate_size(MCAPDatasource(paths=[binary_mcap_file]))
+    filtered = estimate_size(
+        MCAPDatasource(paths=[binary_mcap_file], time_range=TimeRange(*time_range))
+    )
 
     ds = ray.data.read_mcap(binary_mcap_file, time_range=time_range).materialize()
     actual = ds.size_bytes()
@@ -764,9 +770,9 @@ def test_estimate_inmemory_data_size_filter_selecting_nothing(
     treating it as a failure discards every sample and falls back to the
     default ratio, overstating a read that returns no rows at all.
     """
-    estimate = MCAPDatasource(
-        paths=[binary_mcap_file], topics={"/no_such_topic"}
-    ).estimate_inmemory_data_size()
+    estimate = estimate_size(
+        MCAPDatasource(paths=[binary_mcap_file], topics={"/no_such_topic"})
+    )
 
     # The measured zero is carried through rather than falling back to the
     # default ratio. The ratio lower bound does not apply under a filter, so
@@ -788,7 +794,7 @@ def test_estimate_inmemory_data_size_weights_channels_by_summary_counts(
     path = os.path.join(tmp_path, "skewed.mcap")
     create_skewed_mcap_file(path)
 
-    estimate = MCAPDatasource(paths=[path]).estimate_inmemory_data_size()
+    estimate = estimate_size(MCAPDatasource(paths=[path]))
     actual = ray.data.read_mcap(path).materialize().size_bytes()
 
     # Scaling the window's mean row size by the file's message count overstates
@@ -809,9 +815,9 @@ def test_estimate_inmemory_data_size_below_on_disk_size_under_filter(
     is legitimately far below 1.
     """
     on_disk_size = os.path.getsize(episode_mcap_file)
-    estimate = MCAPDatasource(
-        paths=[episode_mcap_file], topics={"/proprio"}
-    ).estimate_inmemory_data_size()
+    estimate = estimate_size(
+        MCAPDatasource(paths=[episode_mcap_file], topics={"/proprio"})
+    )
     actual = (
         ray.data.read_mcap(episode_mcap_file, topics={"/proprio"})
         .materialize()
@@ -836,14 +842,16 @@ def test_estimate_inmemory_data_size_time_window_above_sample_cap(
     """
     time_range = (0, 1_000_000_000)  # 1 s of a 4 s recording
 
-    unfiltered = MCAPDatasource(
-        paths=[episode_mcap_file], topics={"/proprio"}
-    ).estimate_inmemory_data_size()
-    windowed = MCAPDatasource(
-        paths=[episode_mcap_file],
-        topics={"/proprio"},
-        time_range=TimeRange(*time_range),
-    ).estimate_inmemory_data_size()
+    unfiltered = estimate_size(
+        MCAPDatasource(paths=[episode_mcap_file], topics={"/proprio"})
+    )
+    windowed = estimate_size(
+        MCAPDatasource(
+            paths=[episode_mcap_file],
+            topics={"/proprio"},
+            time_range=TimeRange(*time_range),
+        )
+    )
     actual = (
         ray.data.read_mcap(
             episode_mcap_file, topics={"/proprio"}, time_range=time_range


### PR DESCRIPTION
## Description

`MCAPDatasource` does not override `estimate_inmemory_data_size()`, so it inherits `FileBasedDatasource`'s implementation, which sums on-disk file sizes. The value returned is not an approximation of the in-memory size — it is exactly the file size:

```
file size on disk       14,302 B
Ray's estimate          14,302 B
actual in memory     1,188,720 B

estimate == on-disk size : True
understated by           : 83x
```

Two effects compound. MCAP chunks are usually compressed, so the file is smaller on disk than in memory. And the datasource materializes per-message columns — topic, timestamps and, when `include_metadata` is set, the schema — that have no per-message on-disk equivalent at all. Ray Data derives both the read parallelism and the memory it provisions for the read from this number, so both are wrong for every MCAP read.

**Fix.** Follow the `ParquetDatasource` precedent: sample a bounded number of files (1% of the input, clamped to `[2, 10]`, evenly spaced so size-ordered inputs don't bias the sample), read at most 100 messages from each, build a block through the datasource's own `_message_to_dict` + `DelegatingBlockBuilder` path, and scale the total on-disk size by the measured in-memory to on-disk ratio.

Accuracy after the change (actual / estimate), across shapes beyond the repro:

```
uniform 1.00 | varying payload 0.99 | 25 files sampled 1.30 | multi-topic 1.04
topic-filtered 1.02 | include_metadata=False 0.97 | include_paths=True 0.99
uncompressed 1.00
```

0.97x–1.30x, against 83x before.

## Related issues

Related to #65640, #65641 and #65787 — none of them duplicates this. #65787 (`batch_size`) modifies `__init__` and `_read_stream` only; #65640 and #65641 concern block granularity and batched reads. No open issue or PR covers `estimate_inmemory_data_size` for MCAP.

## Additional information

**Two MCAP-specific implementation details worth review.**

*Measure a materialized block rather than undoing compression.* The chunk index reports a ~37x decompression ratio, but the true expansion is 83x — the gap is the per-row metadata columns. Building a real block keeps the estimate correct automatically as `include_metadata`, `include_paths` and filters change.

*Open sampled files seekable.* `_open_input_source` yields a non-seekable `BufferedInputStream`, which makes `make_reader` return a `NonSeekingReader` whose `get_summary()` rescans the whole file and is single-use. Sampling uses `open_input_file` so `make_reader` returns a `SeekingReader` and reads the summary from the footer index. Message counts come from `statistics.message_count`; a topic filter is resolved exactly via `channel_message_counts`.

**Filters the summary cannot express.** If the per-file iteration finishes before reaching the 100-message cap, it has seen the whole selection, so the measured size is used unscaled rather than extrapolated through the summary's message count. This matters because `time_range` and `message_types` are not representable in the summary. Without it, a `time_range` selecting 1% of a recording is estimated as if the whole file were selected:

```
              rows    before    after
no filter      360     1.0x     1.0x
first 50%      180     2.0x     2.0x   (exceeds the sample cap, still extrapolates)
first 10%       36    10.0x     1.0x
first  1%        4    90.0x     1.7x
```

**Failure behaviour.** Gated on `DataContext.decoding_size_estimation`. Every failure path falls back to a default ratio of 5 and logs a warning — over-estimating is the safe direction, consistent with the comment in `_estimate_files_encoding_ratio`, but a silent fallback would quietly restore the behaviour this change exists to replace.

**Two bounded approximations remain, both erring high.** Messages are sampled as a prefix of each file rather than spread through it, so a recording whose message size changes markedly from start to end is estimated from its opening; the sample across *files* is spread, so this is a per-file effect. And `MCAP_ENCODING_RATIO_ESTIMATE_LOWER_BOUND` floors the ratio at 1, which binds under a filter narrow enough that the selected rows are smaller than the file on disk — the 1.7x above.

**Drive-by fix.** `test_read_mcap_invalid_time_range` asserts on the regex `"start_time must be less than end_time"`, but the code raises `f"start_time ({self.start_time}) must be less than end_time ({self.end_time})"`. The pattern can never match, and the test fails on clean master. It is not caught in CI because `mcap` appears in no requirements file in the repo, so `pytestmark = skipif(not MCAP_AVAILABLE)` skips the entire module. That gap is worth addressing separately and I'm happy to file it; the one-line assertion fix is included here because this PR adds 10 tests to the same file.

### Tests

```
PYTHONPATH=python/ray/data/tests python -u -m pytest \
    python/ray/data/tests/datasource/test_mcap.py -v
```

**28 passed.** Baseline on master is 1 failed, 17 passed.

New tests cover: estimate exceeds on-disk size, estimate tracks `include_metadata`, estimate respects a topic filter, multi-file aggregation, files with no summary statistics, sampling disabled via `DataContext`, `include_paths` (which adds a column downstream of `_read_stream`, so sampling has to add it too), a narrow `time_range`, log-time ordering (the fixture is written in descending log time, so passing requires the reader's sort rather than the file layout), and binary payload round-trip.

Lint: `black`, `ruff` clean on both changed files.

<details>
<summary>Self-contained repro (needs only <code>ray[data]</code> and <code>mcap</code>)</summary>

```python
import os
import tempfile
from pathlib import Path

import ray
from mcap.writer import CompressionType, Writer

SCHEMA = b"uint8[] data\nstring format\n" * 100  # a realistic ros2msg definition

f = Path(tempfile.mkdtemp()) / "d1.mcap"
with f.open("wb") as fh:
    w = Writer(fh, compression=CompressionType.ZSTD)
    w.start(profile="", library="d1")
    sid = w.register_schema(
        name="foxglove.CompressedVideo", encoding="ros2msg", data=SCHEMA
    )
    cid = w.register_channel(topic="/cam", message_encoding="cdr", schema_id=sid)
    for i in range(360):  # 12 s of 30 fps video
        w.add_message(
            cid,
            log_time=i * 33_000_000,
            publish_time=i * 33_000_000,
            data=b"\x00\x00\x00\x01" + bytes([i % 256]) * 504,
            sequence=i,
        )
    w.finish()

ray.init(num_cpus=2, include_dashboard=False, log_to_driver=False, configure_logging=False)

from ray.data._internal.datasource.mcap_datasource import MCAPDatasource

estimate = MCAPDatasource(paths=[str(f)]).estimate_inmemory_data_size()
on_disk = os.path.getsize(f)
in_memory = ray.data.read_mcap(str(f)).materialize().size_bytes()

print(f"  file size on disk   {on_disk:>10,} B")
print(f"  Ray's estimate      {estimate:>10,} B")
print(f"  actual in memory    {in_memory:>10,} B")
print(f"  estimate == on-disk size : {estimate == on_disk}")
print(f"  understated by           : {in_memory / estimate:.0f}x")
```

</details>

---

AI assistance (Claude) was used for this change. I reviewed every changed line and ran the tests locally.
