### PR TITLE
[Data] Install mcap in CI so the MCAP datasource tests actually run

### DIFF
--- a/python/deplocks/ci/data-base-ci_depset_py3.10.lock
+++ b/python/deplocks/ci/data-base-ci_depset_py3.10.lock
@@ -2208,6 +2208,7 @@ lz4==4.4.5 \
     #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
     #   clickhouse-connect
     #   dask
+    #   mcap
     #   ray
 markdown==3.10.2 \
     --hash=sha256:994d51325d25ad8aa7ce4ebaec003febcce822c3f8c911e3b17c52f7f589f950 \
@@ -2229,6 +2230,10 @@ markupsafe==3.0.3 \
     #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
     #   jinja2
     #   werkzeug
+mcap==1.4.0 \
+    --hash=sha256:0528e2f86a61bfec73779e0628e6cf27af83d01d89e20b27d5ec9f0b556a63ac \
+    --hash=sha256:0b48b1cc951b8d5aabd2599e60d410bae4f1be1819094f54117b7cbf6b3ee2e9
+    # via -r python/requirements/ml/data-test-requirements.txt
 mdit-py-plugins==0.3.5 ; sys_platform != 'win32' \
     --hash=sha256:ca9a0714ea59a24b2b044a1831f48d817dd0c817e84339f20e7889f392d77c4e \
     --hash=sha256:eee0adc7195e5827e17e02d2a258a2ba159944a0748f59c5099a4a27f78fcf6a
@@ -5918,6 +5923,7 @@ zstandard==0.25.0 \
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
     #   clickhouse-connect
+    #   mcap
     #   pyiceberg
 
 # The following packages were excluded from the output:

--- a/python/deplocks/ci/data-base-ci_depset_py3.10.lock
+++ b/python/deplocks/ci/data-base-ci_depset_py3.10.lock
@@ -2233,7 +2233,9 @@ markupsafe==3.0.3 \
 mcap==1.4.0 \
     --hash=sha256:0528e2f86a61bfec73779e0628e6cf27af83d01d89e20b27d5ec9f0b556a63ac \
     --hash=sha256:0b48b1cc951b8d5aabd2599e60d410bae4f1be1819094f54117b7cbf6b3ee2e9
-    # via -r python/requirements/ml/data-test-requirements.txt
+    # via
+    #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
+    #   -r python/requirements/ml/data-test-requirements.txt
 mdit-py-plugins==0.3.5 ; sys_platform != 'win32' \
     --hash=sha256:ca9a0714ea59a24b2b044a1831f48d817dd0c817e84339f20e7889f392d77c4e \
     --hash=sha256:eee0adc7195e5827e17e02d2a258a2ba159944a0748f59c5099a4a27f78fcf6a

--- a/python/deplocks/ci/data-base-ci_depset_py3.11.lock
+++ b/python/deplocks/ci/data-base-ci_depset_py3.11.lock
@@ -2241,7 +2241,9 @@ markupsafe==3.0.3 \
 mcap==1.4.0 \
     --hash=sha256:0528e2f86a61bfec73779e0628e6cf27af83d01d89e20b27d5ec9f0b556a63ac \
     --hash=sha256:0b48b1cc951b8d5aabd2599e60d410bae4f1be1819094f54117b7cbf6b3ee2e9
-    # via -r python/requirements/ml/data-test-requirements.txt
+    # via
+    #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
+    #   -r python/requirements/ml/data-test-requirements.txt
 mdit-py-plugins==0.3.5 ; sys_platform != 'win32' \
     --hash=sha256:ca9a0714ea59a24b2b044a1831f48d817dd0c817e84339f20e7889f392d77c4e \
     --hash=sha256:eee0adc7195e5827e17e02d2a258a2ba159944a0748f59c5099a4a27f78fcf6a

--- a/python/deplocks/ci/data-base-ci_depset_py3.11.lock
+++ b/python/deplocks/ci/data-base-ci_depset_py3.11.lock
@@ -2216,6 +2216,7 @@ lz4==4.4.5 \
     #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
     #   clickhouse-connect
     #   dask
+    #   mcap
     #   ray
 markdown==3.10.2 \
     --hash=sha256:994d51325d25ad8aa7ce4ebaec003febcce822c3f8c911e3b17c52f7f589f950 \
@@ -2237,6 +2238,10 @@ markupsafe==3.0.3 \
     #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
     #   jinja2
     #   werkzeug
+mcap==1.4.0 \
+    --hash=sha256:0528e2f86a61bfec73779e0628e6cf27af83d01d89e20b27d5ec9f0b556a63ac \
+    --hash=sha256:0b48b1cc951b8d5aabd2599e60d410bae4f1be1819094f54117b7cbf6b3ee2e9
+    # via -r python/requirements/ml/data-test-requirements.txt
 mdit-py-plugins==0.3.5 ; sys_platform != 'win32' \
     --hash=sha256:ca9a0714ea59a24b2b044a1831f48d817dd0c817e84339f20e7889f392d77c4e \
     --hash=sha256:eee0adc7195e5827e17e02d2a258a2ba159944a0748f59c5099a4a27f78fcf6a
@@ -5946,6 +5951,7 @@ zstandard==0.25.0 \
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
     #   clickhouse-connect
+    #   mcap
     #   pyiceberg
 
 # The following packages were excluded from the output:

--- a/python/deplocks/ci/data-base-ci_depset_py3.12.lock
+++ b/python/deplocks/ci/data-base-ci_depset_py3.12.lock
@@ -2349,6 +2349,7 @@ lz4==4.4.5 \
     #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
     #   clickhouse-connect
     #   dask
+    #   mcap
     #   ray
 markdown==3.10.2 \
     --hash=sha256:994d51325d25ad8aa7ce4ebaec003febcce822c3f8c911e3b17c52f7f589f950 \
@@ -2370,6 +2371,10 @@ markupsafe==3.0.3 \
     #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
     #   jinja2
     #   werkzeug
+mcap==1.4.0 \
+    --hash=sha256:0528e2f86a61bfec73779e0628e6cf27af83d01d89e20b27d5ec9f0b556a63ac \
+    --hash=sha256:0b48b1cc951b8d5aabd2599e60d410bae4f1be1819094f54117b7cbf6b3ee2e9
+    # via -r python/requirements/ml/data-test-requirements.txt
 mdit-py-plugins==0.3.5 ; sys_platform != 'win32' \
     --hash=sha256:ca9a0714ea59a24b2b044a1831f48d817dd0c817e84339f20e7889f392d77c4e \
     --hash=sha256:eee0adc7195e5827e17e02d2a258a2ba159944a0748f59c5099a4a27f78fcf6a
@@ -6223,6 +6228,7 @@ zstandard==0.25.0 \
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
     #   clickhouse-connect
+    #   mcap
     #   pyiceberg
 
 # The following packages were excluded from the output:

--- a/python/deplocks/ci/data-base-ci_depset_py3.12.lock
+++ b/python/deplocks/ci/data-base-ci_depset_py3.12.lock
@@ -2374,7 +2374,9 @@ markupsafe==3.0.3 \
 mcap==1.4.0 \
     --hash=sha256:0528e2f86a61bfec73779e0628e6cf27af83d01d89e20b27d5ec9f0b556a63ac \
     --hash=sha256:0b48b1cc951b8d5aabd2599e60d410bae4f1be1819094f54117b7cbf6b3ee2e9
-    # via -r python/requirements/ml/data-test-requirements.txt
+    # via
+    #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
+    #   -r python/requirements/ml/data-test-requirements.txt
 mdit-py-plugins==0.3.5 ; sys_platform != 'win32' \
     --hash=sha256:ca9a0714ea59a24b2b044a1831f48d817dd0c817e84339f20e7889f392d77c4e \
     --hash=sha256:eee0adc7195e5827e17e02d2a258a2ba159944a0748f59c5099a4a27f78fcf6a

--- a/python/deplocks/ci/data-mongo-ci_depset_py3.10.lock
+++ b/python/deplocks/ci/data-mongo-ci_depset_py3.10.lock
@@ -2112,6 +2112,7 @@ lz4==4.4.5 \
     # via
     #   -r python/deplocks/ci/relaxed_data-ci_depset_py3.10.lock
     #   clickhouse-connect
+    #   mcap
 markdown==3.10.2 \
     --hash=sha256:994d51325d25ad8aa7ce4ebaec003febcce822c3f8c911e3b17c52f7f589f950 \
     --hash=sha256:e91464b71ae3ee7afd3017d9f358ef0baf158fd9a298db92f1d4761133824c36
@@ -2132,6 +2133,10 @@ markupsafe==3.0.3 \
     #   -r python/deplocks/ci/relaxed_data-ci_depset_py3.10.lock
     #   jinja2
     #   werkzeug
+mcap==1.4.0 \
+    --hash=sha256:0528e2f86a61bfec73779e0628e6cf27af83d01d89e20b27d5ec9f0b556a63ac \
+    --hash=sha256:0b48b1cc951b8d5aabd2599e60d410bae4f1be1819094f54117b7cbf6b3ee2e9
+    # via -r python/deplocks/ci/relaxed_data-ci_depset_py3.10.lock
 mdit-py-plugins==0.3.5 ; sys_platform != 'win32' \
     --hash=sha256:ca9a0714ea59a24b2b044a1831f48d817dd0c817e84339f20e7889f392d77c4e \
     --hash=sha256:eee0adc7195e5827e17e02d2a258a2ba159944a0748f59c5099a4a27f78fcf6a
@@ -5755,6 +5760,7 @@ zstandard==0.25.0 \
     # via
     #   -r python/deplocks/ci/relaxed_data-ci_depset_py3.10.lock
     #   clickhouse-connect
+    #   mcap
     #   pyiceberg
 
 # The following packages were excluded from the output:

--- a/python/deplocks/ci/data-pyarrow-latest-ci_depset_py3.10.lock
+++ b/python/deplocks/ci/data-pyarrow-latest-ci_depset_py3.10.lock
@@ -2129,6 +2129,7 @@ lz4==4.4.5 \
     # via
     #   -r python/deplocks/ci/relaxed_data-ci_depset_py3.10.lock
     #   clickhouse-connect
+    #   mcap
 markdown==3.10.2 \
     --hash=sha256:994d51325d25ad8aa7ce4ebaec003febcce822c3f8c911e3b17c52f7f589f950 \
     --hash=sha256:e91464b71ae3ee7afd3017d9f358ef0baf158fd9a298db92f1d4761133824c36
@@ -2149,6 +2150,10 @@ markupsafe==3.0.3 \
     #   -r python/deplocks/ci/relaxed_data-ci_depset_py3.10.lock
     #   jinja2
     #   werkzeug
+mcap==1.4.0 \
+    --hash=sha256:0528e2f86a61bfec73779e0628e6cf27af83d01d89e20b27d5ec9f0b556a63ac \
+    --hash=sha256:0b48b1cc951b8d5aabd2599e60d410bae4f1be1819094f54117b7cbf6b3ee2e9
+    # via -r python/deplocks/ci/relaxed_data-ci_depset_py3.10.lock
 mdit-py-plugins==0.3.5 ; sys_platform != 'win32' \
     --hash=sha256:ca9a0714ea59a24b2b044a1831f48d817dd0c817e84339f20e7889f392d77c4e \
     --hash=sha256:eee0adc7195e5827e17e02d2a258a2ba159944a0748f59c5099a4a27f78fcf6a
@@ -5703,6 +5708,7 @@ zstandard==0.25.0 \
     # via
     #   -r python/deplocks/ci/relaxed_data-ci_depset_py3.10.lock
     #   clickhouse-connect
+    #   mcap
     #   pyiceberg
 
 # The following packages were excluded from the output:

--- a/python/deplocks/ci/data-pyarrow-latest-ci_depset_py3.12.lock
+++ b/python/deplocks/ci/data-pyarrow-latest-ci_depset_py3.12.lock
@@ -2319,9 +2319,9 @@ markupsafe==3.0.3 \
     #   -r python/deplocks/ci/relaxed_data-ci_depset_py3.12.lock
     #   jinja2
     #   werkzeug
-mcap==1.3.0 \
-    --hash=sha256:5f0d5826ba3b8418508c1d992bada4c5744073f1b3e6d685579f0aca0389fb2f \
-    --hash=sha256:6262a68cd5a9ed7f8fe8fa6330412a87949842782ab42a4800cd033d0f38e4cd
+mcap==1.4.0 \
+    --hash=sha256:0528e2f86a61bfec73779e0628e6cf27af83d01d89e20b27d5ec9f0b556a63ac \
+    --hash=sha256:0b48b1cc951b8d5aabd2599e60d410bae4f1be1819094f54117b7cbf6b3ee2e9
     # via -r python/deplocks/ci/relaxed_data-ci_depset_py3.12.lock
 mdit-py-plugins==0.3.5 ; sys_platform != 'win32' \
     --hash=sha256:ca9a0714ea59a24b2b044a1831f48d817dd0c817e84339f20e7889f392d77c4e \

--- a/python/deplocks/ci/data-pyarrow-latest-ci_depset_py3.12.lock
+++ b/python/deplocks/ci/data-pyarrow-latest-ci_depset_py3.12.lock
@@ -2298,6 +2298,7 @@ lz4==4.4.5 \
     # via
     #   -r python/deplocks/ci/relaxed_data-ci_depset_py3.12.lock
     #   clickhouse-connect
+    #   mcap
 markdown==3.10.2 \
     --hash=sha256:994d51325d25ad8aa7ce4ebaec003febcce822c3f8c911e3b17c52f7f589f950 \
     --hash=sha256:e91464b71ae3ee7afd3017d9f358ef0baf158fd9a298db92f1d4761133824c36
@@ -2318,6 +2319,10 @@ markupsafe==3.0.3 \
     #   -r python/deplocks/ci/relaxed_data-ci_depset_py3.12.lock
     #   jinja2
     #   werkzeug
+mcap==1.3.0 \
+    --hash=sha256:5f0d5826ba3b8418508c1d992bada4c5744073f1b3e6d685579f0aca0389fb2f \
+    --hash=sha256:6262a68cd5a9ed7f8fe8fa6330412a87949842782ab42a4800cd033d0f38e4cd
+    # via -r python/deplocks/ci/relaxed_data-ci_depset_py3.12.lock
 mdit-py-plugins==0.3.5 ; sys_platform != 'win32' \
     --hash=sha256:ca9a0714ea59a24b2b044a1831f48d817dd0c817e84339f20e7889f392d77c4e \
     --hash=sha256:eee0adc7195e5827e17e02d2a258a2ba159944a0748f59c5099a4a27f78fcf6a
@@ -6079,6 +6084,7 @@ zstandard==0.25.0 \
     # via
     #   -r python/deplocks/ci/relaxed_data-ci_depset_py3.12.lock
     #   clickhouse-connect
+    #   mcap
     #   pyiceberg
 
 # The following packages were excluded from the output:

--- a/python/deplocks/ci/data-pyarrow-nightly-ci_depset_py3.10.lock
+++ b/python/deplocks/ci/data-pyarrow-nightly-ci_depset_py3.10.lock
@@ -2119,6 +2119,7 @@ lz4==4.4.5 \
     # via
     #   -r python/deplocks/ci/relaxed_data-ci_depset_py3.10.lock
     #   clickhouse-connect
+    #   mcap
 markdown==3.10.2 \
     --hash=sha256:994d51325d25ad8aa7ce4ebaec003febcce822c3f8c911e3b17c52f7f589f950 \
     --hash=sha256:e91464b71ae3ee7afd3017d9f358ef0baf158fd9a298db92f1d4761133824c36
@@ -2139,6 +2140,10 @@ markupsafe==3.0.3 \
     #   -r python/deplocks/ci/relaxed_data-ci_depset_py3.10.lock
     #   jinja2
     #   werkzeug
+mcap==1.4.0 \
+    --hash=sha256:0528e2f86a61bfec73779e0628e6cf27af83d01d89e20b27d5ec9f0b556a63ac \
+    --hash=sha256:0b48b1cc951b8d5aabd2599e60d410bae4f1be1819094f54117b7cbf6b3ee2e9
+    # via -r python/deplocks/ci/relaxed_data-ci_depset_py3.10.lock
 mdit-py-plugins==0.3.5 ; sys_platform != 'win32' \
     --hash=sha256:ca9a0714ea59a24b2b044a1831f48d817dd0c817e84339f20e7889f392d77c4e \
     --hash=sha256:eee0adc7195e5827e17e02d2a258a2ba159944a0748f59c5099a4a27f78fcf6a
@@ -5687,6 +5692,7 @@ zstandard==0.25.0 \
     # via
     #   -r python/deplocks/ci/relaxed_data-ci_depset_py3.10.lock
     #   clickhouse-connect
+    #   mcap
     #   pyiceberg
 
 # The following packages were excluded from the output:

--- a/python/deplocks/ci/data-pyarrow-v17-ci_depset_py3.10.lock
+++ b/python/deplocks/ci/data-pyarrow-v17-ci_depset_py3.10.lock
@@ -2144,6 +2144,7 @@ lz4==4.4.5 \
     # via
     #   -r python/deplocks/ci/relaxed_data-ci_depset_py3.10.lock
     #   clickhouse-connect
+    #   mcap
 markdown==3.10.2 \
     --hash=sha256:994d51325d25ad8aa7ce4ebaec003febcce822c3f8c911e3b17c52f7f589f950 \
     --hash=sha256:e91464b71ae3ee7afd3017d9f358ef0baf158fd9a298db92f1d4761133824c36
@@ -2164,6 +2165,10 @@ markupsafe==3.0.3 \
     #   -r python/deplocks/ci/relaxed_data-ci_depset_py3.10.lock
     #   jinja2
     #   werkzeug
+mcap==1.4.0 \
+    --hash=sha256:0528e2f86a61bfec73779e0628e6cf27af83d01d89e20b27d5ec9f0b556a63ac \
+    --hash=sha256:0b48b1cc951b8d5aabd2599e60d410bae4f1be1819094f54117b7cbf6b3ee2e9
+    # via -r python/deplocks/ci/relaxed_data-ci_depset_py3.10.lock
 mdit-py-plugins==0.3.5 ; sys_platform != 'win32' \
     --hash=sha256:ca9a0714ea59a24b2b044a1831f48d817dd0c817e84339f20e7889f392d77c4e \
     --hash=sha256:eee0adc7195e5827e17e02d2a258a2ba159944a0748f59c5099a4a27f78fcf6a
@@ -5719,6 +5724,7 @@ zstandard==0.25.0 \
     # via
     #   -r python/deplocks/ci/relaxed_data-ci_depset_py3.10.lock
     #   clickhouse-connect
+    #   mcap
     #   pyiceberg
 
 # The following packages were excluded from the output:

--- a/python/deplocks/ci/relaxed_data-ci_depset_py3.10.lock
+++ b/python/deplocks/ci/relaxed_data-ci_depset_py3.10.lock
@@ -2191,6 +2191,7 @@ lz4==4.4.5 \
 #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
 #   clickhouse-connect
 #   dask
+#   mcap
 #   ray
 markdown==3.10.2 \
     --hash=sha256:994d51325d25ad8aa7ce4ebaec003febcce822c3f8c911e3b17c52f7f589f950 \
@@ -2212,6 +2213,10 @@ markupsafe==3.0.3 \
 #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
 #   jinja2
 #   werkzeug
+mcap==1.4.0 \
+    --hash=sha256:0528e2f86a61bfec73779e0628e6cf27af83d01d89e20b27d5ec9f0b556a63ac \
+    --hash=sha256:0b48b1cc951b8d5aabd2599e60d410bae4f1be1819094f54117b7cbf6b3ee2e9
+# via -r python/requirements/ml/data-test-requirements.txt
 mdit-py-plugins==0.3.5; sys_platform != "win32" \
     --hash=sha256:ca9a0714ea59a24b2b044a1831f48d817dd0c817e84339f20e7889f392d77c4e \
     --hash=sha256:eee0adc7195e5827e17e02d2a258a2ba159944a0748f59c5099a4a27f78fcf6a
@@ -5711,6 +5716,7 @@ zstandard==0.25.0 \
 # via
 #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
 #   clickhouse-connect
+#   mcap
 #   pyiceberg
 # The following packages were excluded from the output:
 # setuptools

--- a/python/deplocks/ci/relaxed_data-ci_depset_py3.10.lock
+++ b/python/deplocks/ci/relaxed_data-ci_depset_py3.10.lock
@@ -2216,7 +2216,9 @@ markupsafe==3.0.3 \
 mcap==1.4.0 \
     --hash=sha256:0528e2f86a61bfec73779e0628e6cf27af83d01d89e20b27d5ec9f0b556a63ac \
     --hash=sha256:0b48b1cc951b8d5aabd2599e60d410bae4f1be1819094f54117b7cbf6b3ee2e9
-# via -r python/requirements/ml/data-test-requirements.txt
+# via
+#   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
+#   -r python/requirements/ml/data-test-requirements.txt
 mdit-py-plugins==0.3.5; sys_platform != "win32" \
     --hash=sha256:ca9a0714ea59a24b2b044a1831f48d817dd0c817e84339f20e7889f392d77c4e \
     --hash=sha256:eee0adc7195e5827e17e02d2a258a2ba159944a0748f59c5099a4a27f78fcf6a

--- a/python/deplocks/ci/relaxed_data-ci_depset_py3.12.lock
+++ b/python/deplocks/ci/relaxed_data-ci_depset_py3.12.lock
@@ -2354,7 +2354,7 @@ markupsafe==3.0.3 \
 #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
 #   jinja2
 #   werkzeug
-mcap==1.3.0 \
+mcap==1.4.0 \
     --hash=sha256:0528e2f86a61bfec73779e0628e6cf27af83d01d89e20b27d5ec9f0b556a63ac \
     --hash=sha256:0b48b1cc951b8d5aabd2599e60d410bae4f1be1819094f54117b7cbf6b3ee2e9
 # via -r python/requirements/ml/data-test-requirements.txt

--- a/python/deplocks/ci/relaxed_data-ci_depset_py3.12.lock
+++ b/python/deplocks/ci/relaxed_data-ci_depset_py3.12.lock
@@ -2357,7 +2357,9 @@ markupsafe==3.0.3 \
 mcap==1.4.0 \
     --hash=sha256:0528e2f86a61bfec73779e0628e6cf27af83d01d89e20b27d5ec9f0b556a63ac \
     --hash=sha256:0b48b1cc951b8d5aabd2599e60d410bae4f1be1819094f54117b7cbf6b3ee2e9
-# via -r python/requirements/ml/data-test-requirements.txt
+# via
+#   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
+#   -r python/requirements/ml/data-test-requirements.txt
 mdit-py-plugins==0.3.5; sys_platform != "win32" \
     --hash=sha256:ca9a0714ea59a24b2b044a1831f48d817dd0c817e84339f20e7889f392d77c4e \
     --hash=sha256:eee0adc7195e5827e17e02d2a258a2ba159944a0748f59c5099a4a27f78fcf6a

--- a/python/deplocks/ci/relaxed_data-ci_depset_py3.12.lock
+++ b/python/deplocks/ci/relaxed_data-ci_depset_py3.12.lock
@@ -2332,6 +2332,7 @@ lz4==4.4.5 \
 #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
 #   clickhouse-connect
 #   dask
+#   mcap
 #   ray
 markdown==3.10.2 \
     --hash=sha256:994d51325d25ad8aa7ce4ebaec003febcce822c3f8c911e3b17c52f7f589f950 \
@@ -2353,6 +2354,10 @@ markupsafe==3.0.3 \
 #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
 #   jinja2
 #   werkzeug
+mcap==1.3.0 \
+    --hash=sha256:0528e2f86a61bfec73779e0628e6cf27af83d01d89e20b27d5ec9f0b556a63ac \
+    --hash=sha256:0b48b1cc951b8d5aabd2599e60d410bae4f1be1819094f54117b7cbf6b3ee2e9
+# via -r python/requirements/ml/data-test-requirements.txt
 mdit-py-plugins==0.3.5; sys_platform != "win32" \
     --hash=sha256:ca9a0714ea59a24b2b044a1831f48d817dd0c817e84339f20e7889f392d77c4e \
     --hash=sha256:eee0adc7195e5827e17e02d2a258a2ba159944a0748f59c5099a4a27f78fcf6a
@@ -6016,6 +6021,7 @@ zstandard==0.25.0 \
 # via
 #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
 #   clickhouse-connect
+#   mcap
 #   pyiceberg
 # The following packages were excluded from the output:
 # setuptools

--- a/python/ray/data/_internal/datasource/mcap_datasource.py
+++ b/python/ray/data/_internal/datasource/mcap_datasource.py
@@ -170,7 +170,7 @@ class MCAPDatasource(FileBasedDatasource):
             yield builder.build()
 
     def _should_include_message(
-        self, schema: "Schema", channel: "Channel", message: "Message"
+        self, schema: Optional["Schema"], channel: "Channel", message: "Message"
     ) -> bool:
         """Check if a message should be included based on filters.
 
@@ -179,7 +179,8 @@ class MCAPDatasource(FileBasedDatasource):
         MCAP reader, so only message_types filtering is needed here.
 
         Args:
-            schema: MCAP schema object containing message type information.
+            schema: MCAP schema object containing message type information, or
+                ``None`` when the channel declares no schema.
             channel: MCAP channel object containing topic and metadata.
             message: MCAP message object containing the actual data.
 
@@ -193,7 +194,11 @@ class MCAPDatasource(FileBasedDatasource):
         return True
 
     def _message_to_dict(
-        self, schema: "Schema", channel: "Channel", message: "Message", path: str
+        self,
+        schema: Optional["Schema"],
+        channel: "Channel",
+        message: "Message",
+        path: str,
     ) -> Dict[str, Any]:
         """Convert MCAP message to dictionary format.
 
@@ -201,7 +206,8 @@ class MCAPDatasource(FileBasedDatasource):
         format suitable for Ray Data processing.
 
         Args:
-            schema: MCAP schema object containing message type and encoding info.
+            schema: MCAP schema object containing message type and encoding
+                info, or ``None`` when the channel declares no schema.
             channel: MCAP channel object containing topic and channel metadata.
             message: MCAP message object containing the actual message data.
             path: Path to the source file (for include_paths functionality).

--- a/python/ray/data/tests/datasource/test_mcap.py
+++ b/python/ray/data/tests/datasource/test_mcap.py
@@ -260,7 +260,7 @@ def test_read_mcap_include_paths(ray_start_regular_shared, simple_mcap_file):
 def test_read_mcap_invalid_time_range(ray_start_regular_shared, simple_mcap_file):
     """Test validation of time range parameters."""
     # Start time >= end time
-    with pytest.raises(ValueError, match="start_time must be less than end_time"):
+    with pytest.raises(ValueError, match="must be less than"):
         ray.data.read_mcap(simple_mcap_file, time_range=(2000, 1000))
 
     # Negative times

--- a/python/requirements/ml/data-test-requirements.txt
+++ b/python/requirements/ml/data-test-requirements.txt
@@ -24,6 +24,10 @@ clickhouse-connect
 confluent-kafka
 pybase64
 hudi==0.4.0
+# ray.data.read_mcap. Without this, python/ray/data/tests/datasource/test_mcap.py
+# skips every test through its module-level skipif and the //python/ray/data:test_mcap
+# target passes without running anything.
+mcap
 datasketches
 testcontainers[kafka]
 obstore

--- a/python/requirements/ml/data-test-requirements.txt
+++ b/python/requirements/ml/data-test-requirements.txt
@@ -24,9 +24,6 @@ clickhouse-connect
 confluent-kafka
 pybase64
 hudi==0.4.0
-# ray.data.read_mcap. Without this, python/ray/data/tests/datasource/test_mcap.py
-# skips every test through its module-level skipif and the //python/ray/data:test_mcap
-# target passes without running anything.
 mcap
 datasketches
 testcontainers[kafka]

--- a/python/requirements_compiled.txt
+++ b/python/requirements_compiled.txt
@@ -1058,6 +1058,7 @@ lz4==4.4.5
     #   -r python/requirements/test-requirements.txt
     #   clickhouse-connect
     #   dask
+    #   mcap
 mako==1.3.11
     # via alembic
 markdown==3.10.2
@@ -1089,6 +1090,8 @@ matplotlib-inline==0.2.1
     # via
     #   ipykernel
     #   ipython
+mcap==1.4.0
+    # via -r python/requirements/ml/data-test-requirements.txt
 mdit-py-plugins==0.3.5
     # via
     #   jupytext
@@ -2706,6 +2709,7 @@ zoopt==0.4.1
 zstandard==0.25.0
     # via
     #   clickhouse-connect
+    #   mcap
     #   pyiceberg
 
 # The following packages are considered to be unsafe in a requirements file:


### PR DESCRIPTION
## Description

`python/ray/data/tests/datasource/test_mcap.py` guards its whole module with
`pytestmark = skipif(not MCAP_AVAILABLE)`, and `mcap` appears in no requirements file
anywhere in the repo. `//python/ray/data:test_mcap` has therefore reported success
since the datasource landed in #55716 without executing a single one of its 18 tests.

This PR adds `mcap` to `python/requirements/ml/data-test-requirements.txt` — the file
consumed by the Data CI image (`ci/env/install-dependencies.sh:303`, `ci/ci.sh:60`) and
by `ci/raydepsets/configs/ci_data.depsets.yaml:19` — and regenerates the locks that
depend on it.

## Related issues

Related to #65912, which fixes `estimate_inmemory_data_size` for this datasource. The
two PRs are independent: both carry the identical one-line fix to
`test_read_mcap_invalid_time_range`, deliberately, so neither blocks the other. Being
byte-identical, whichever lands second should rebase without a conflict.

Related to #61222 (audit and refactor file-based datasource tests), which covers
adjacent ground but not this.

## Additional information

### What turning the tests on exposed

Three defects were sitting behind that skip. Each is fixed in its own commit here,
because without them the target goes red on its first real run:

1. **`test_read_mcap_invalid_time_range` can never pass.** It searches for
   `"start_time must be less than end_time"`; the code raises
   `"start_time (2000) must be less than end_time (1000)"`. Fails on unmodified master.

2. **`_should_include_message` and `_message_to_dict` annotate `schema` as a bare
   `Schema`,** but `McapReader.iter_messages()` yields
   `Tuple[Optional[Schema], Channel, Message]` — a channel may declare no schema. Both
   bodies already guard with `if schema else None`, so this is an annotation fix only.
   It was invisible while `mcap` was absent: pyrefly could not resolve `mcap.reader`,
   treated the return as `Any`, and reported nothing. With the package installed its
   `py.typed` annotations apply and `ci/lint/pyrefly-check.sh` fails on the two
   pre-existing call sites in `_read_stream`.

3. **`python/requirements_compiled.txt` was missing `mcap`.** That file is a separate
   lock from `python/deplocks/`, compiled by `compile_pip_dependencies` in `ci/ci.sh`
   from an input list that includes `data-test-requirements.txt`.

### The dependency itself costs the image nothing

The regenerated locks introduce exactly one package:

```
mcap==1.4.0 \
    --hash=sha256:0528e2f86a61bfec73779e0628e6cf27af83d01d89e20b27d5ec9f0b556a63ac \
    --hash=sha256:0b48b1cc951b8d5aabd2599e60d410bae4f1be1819094f54117b7cbf6b3ee2e9
    # via -r python/requirements/ml/data-test-requirements.txt
```

mcap's own dependencies, `lz4` and `zstandard`, are already present via
`clickhouse-connect`, `dask`, `ray` and `pyiceberg`. Every other changed line across the
ten `python/deplocks/ci/*.lock` files and `requirements_compiled.txt` is a `# via`
comment recording mcap as a new consumer.

### How the locks were produced

`python/deplocks/*.lock` with the repo's own tooling, using the same command the
`raydepsets: compile all dependencies` job runs:

```
bazelisk run //ci/raydepsets:raydepsets -- build --all-configs
bazelisk run //ci/raydepsets:raydepsets -- build --all-configs --check
# Lock files are up to date.
```

`python/requirements_compiled.txt` could not be regenerated locally:
`compile_pip_dependencies` returns early on arm64 (`ci/ci.sh:20-27`). Its four added
lines were reconstructed from the `dependencies` job's own diff and land at the exact
line numbers it reported — mcap at 1093–1094, zstandard's `# via` entry at 2712.

**Worth knowing for anyone adding a dependency here:** the two lock systems are coupled
through a symlink. `python/requirements_compiled_py3.10` … `py3.13` are all symlinks to
`requirements_compiled.txt` (only `py3.14` is a real file), and
`ci/raydepsets/pre_hooks/remove-compiled-headers.sh` copies
`python/requirements_compiled_py3.13.txt` into `/tmp/ray-deps/`, where it becomes the
constraint the data depsets compile against. So adding a package to
`requirements_compiled.txt` changes the `# via` provenance recorded in
`python/deplocks/ci/*.lock` — uv then lists the package as coming from both the
constraint and `data-test-requirements.txt`. Regenerating one lock system without the
other leaves the tree inconsistent, which is why this PR has a separate commit for it.

### Tests

With `mcap` installed on unmodified master, the previously-skipped module runs and one
test fails — what the target would have been reporting all along:

```
1 failed, 17 passed in 15.50s
FAILED test_read_mcap_invalid_time_range
E   AssertionError: Regex pattern did not match.
E    Regex: 'start_time must be less than end_time'
E    Input: 'start_time (2000) must be less than end_time (1000)'
```

With the fixes in this PR:

```
PYTHONPATH=python/ray/data/tests python -u -m pytest \
    python/ray/data/tests/datasource/test_mcap.py -v
18 passed in 10.95s
```

pyrefly, run exactly as `ci/lint/pyrefly-check.sh` does, reports no errors in
`mcap_datasource.py`. Lint hooks `black`, `ruff`, `pydoclint`, `docstyle`, `check-ast`,
`check-import-order`, `trailing-whitespace` and `end-of-file-fixer` all pass on the
changed files.

`size = "small"` is left as-is: the 18 tests take ~11s, and `test_json` is `small` with
58 tests, so the 60-second budget has ample headroom.

---

AI assistance (Claude) was used for this change. I reviewed every changed line and ran
the commands above locally.
