### PR TITLE
[Data] Surface MCAP channel metadata as a map column

### DIFF
--- a/python/ray/data/_internal/datasource/mcap_datasource.py
+++ b/python/ray/data/_internal/datasource/mcap_datasource.py
@@ -8,7 +8,17 @@ time-series data.
 import json
 import logging
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Dict, Iterator, List, Optional, Set, Union
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Dict,
+    Iterator,
+    List,
+    Optional,
+    Set,
+    Tuple,
+    Union,
+)
 
 from ray.data._internal.delegating_block_builder import DelegatingBlockBuilder
 from ray.data._internal.util import _check_import
@@ -155,6 +165,14 @@ class MCAPDatasource(FileBasedDatasource):
         )
 
         builder = DelegatingBlockBuilder()
+        # Collected alongside the builder rather than inside `_message_to_dict`:
+        # Arrow infers `struct` from a Python dict, and a struct's fields are
+        # the union of the keys it happens to see, so two files with different
+        # metadata keys yield blocks that will not concatenate.
+        # `_add_channel_metadata` builds a `map` column instead.
+        channel_metadata: Optional[List[List[Tuple[str, str]]]] = (
+            [] if self._include_metadata else None
+        )
 
         for schema, channel, message in messages:
             # Apply filters that couldn't be pushed down to MCAP level
@@ -164,10 +182,12 @@ class MCAPDatasource(FileBasedDatasource):
             # Convert message to dictionary format
             message_data = self._message_to_dict(schema, channel, message, path)
             builder.add(message_data)
+            if channel_metadata is not None:
+                channel_metadata.append(list(channel.metadata.items()))
 
         # Yield the block if we have any messages
         if builder.num_rows() > 0:
-            yield builder.build()
+            yield _add_channel_metadata(builder.build(), channel_metadata)
 
     def _should_include_message(
         self, schema: "Schema", channel: "Channel", message: "Message"
@@ -256,3 +276,37 @@ class MCAPDatasource(FileBasedDatasource):
         MCAP files can be read in parallel across multiple files.
         """
         return True
+
+
+CHANNEL_METADATA_COLUMN = "channel_metadata"
+
+
+def _add_channel_metadata(
+    block: Block, values: Optional[List[List[Tuple[str, str]]]]
+) -> Block:
+    """Attach each message's channel metadata as a ``map<string, string>`` column.
+
+    A Channel record carries a ``metadata`` field of type ``Map<string, string>``
+    (MCAP specification, op=0x04) holding whatever the recorder chose to record
+    about the topic. ROS 2 writes ``offered_qos_profiles`` there, and rigs
+    commonly add sensor serials or calibration identifiers. No message record
+    reproduces it, so without this column that information is not reachable from
+    the dataset at all.
+
+    The column is typed explicitly rather than inferred. Arrow reads a Python
+    dict as a ``struct`` whose fields are the union of the keys it happens to
+    see: blocks from two files recording different keys then carry different
+    types and fail to concatenate, and a channel that never had a key becomes
+    indistinguishable from one whose value is null. A ``map`` matches the
+    specification's own type, keeps the block schema stable whatever the keys
+    are, and concatenates across files.
+    """
+    import pyarrow as pa
+
+    if values is None or not isinstance(block, pa.Table):
+        # `include_metadata=False`, or a pandas block, which
+        # `DelegatingBlockBuilder` produces for row values Arrow cannot hold.
+        return block
+
+    column = pa.array(values, type=pa.map_(pa.string(), pa.string()))
+    return block.append_column(CHANNEL_METADATA_COLUMN, column)

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -3281,7 +3281,12 @@ def read_mcap(
         message_types: Optional list or set of message type names (schema names) to
             include. Only messages with matching schema names will be read.
         include_metadata: Whether to include MCAP metadata fields in the output.
-            Defaults to True. When True, includes schema, channel, and message metadata.
+            Defaults to True. When True, adds ``channel_id``, ``message_encoding``,
+            ``schema_name``, ``schema_encoding``, ``schema_data`` and
+            ``channel_metadata``. ``channel_metadata`` is the Channel record's
+            ``Map<string, string>``, typed as ``map<string, string>``: ROS 2 records
+            ``offered_qos_profiles`` there, and recorders commonly add sensor serials
+            or calibration identifiers.
         filesystem: The PyArrow filesystem implementation to read from.
         parallelism: This argument is deprecated. Use ``override_num_blocks`` argument.
         num_cpus: The number of CPUs to reserve for each parallel read worker.

--- a/python/ray/data/tests/datasource/test_mcap.py
+++ b/python/ray/data/tests/datasource/test_mcap.py
@@ -2,6 +2,7 @@ import importlib.util
 import json
 import os
 
+import pyarrow as pa
 import pytest
 
 import ray
@@ -386,6 +387,118 @@ def test_read_mcap_json_decoding(ray_start_regular_shared, tmp_path):
     assert row["data"]["sensor_data"]["temperature"] == 23.5
     assert row["data"]["metadata"]["device_id"] == "sensor_001"
     assert row["data"]["sensor_data"]["readings"] == [1, 2, 3, 4, 5]
+
+
+def create_mcap_file_with_channel_metadata(
+    file_path: str, channels: dict, num_messages: int = 3
+) -> None:
+    """Write an MCAP whose channels carry metadata.
+
+    ``channels`` maps a topic to the ``Map<string, string>`` recorded on its
+    Channel record.
+    """
+    from mcap.writer import Writer
+
+    with open(file_path, "wb") as stream:
+        writer = Writer(stream)
+        writer.start(profile="", library="ray-test")
+        schema_id = writer.register_schema(
+            name="test_schema", encoding="jsonschema", data=b"{}"
+        )
+        registered = {
+            topic: writer.register_channel(
+                schema_id=schema_id,
+                topic=topic,
+                message_encoding="json",
+                metadata=metadata,
+            )
+            for topic, metadata in channels.items()
+        }
+        for i in range(num_messages):
+            for topic, channel_id in registered.items():
+                writer.add_message(
+                    channel_id=channel_id,
+                    log_time=1000 + i,
+                    publish_time=1000 + i,
+                    data=json.dumps({"i": i}).encode(),
+                )
+        writer.finish()
+
+
+def test_read_mcap_includes_channel_metadata(ray_start_regular_shared, tmp_path):
+    """A Channel record's metadata must be reachable from the dataset.
+
+    No message record reproduces it, so without this column the information is
+    unreachable. ROS 2 records `offered_qos_profiles` here and recorders
+    commonly add sensor serials.
+    """
+    path = os.path.join(tmp_path, "channel_metadata.mcap")
+    create_mcap_file_with_channel_metadata(
+        path,
+        {
+            "/camera": {"serial": "cam-7", "offered_qos_profiles": ""},
+            "/imu": {"serial": "imu-2", "offered_qos_profiles": ""},
+        },
+    )
+
+    ds = ray.data.read_mcap(path)
+
+    column_types = dict(zip(ds.schema().names, ds.schema().types))
+    assert pa.types.is_map(column_types["channel_metadata"])
+
+    by_topic = {row["topic"]: dict(row["channel_metadata"]) for row in ds.take_all()}
+    assert by_topic == {
+        "/camera": {"serial": "cam-7", "offered_qos_profiles": ""},
+        "/imu": {"serial": "imu-2", "offered_qos_profiles": ""},
+    }
+
+
+def test_read_mcap_channel_metadata_requires_include_metadata(
+    ray_start_regular_shared, tmp_path
+):
+    """`include_metadata=False` must omit the column entirely."""
+    path = os.path.join(tmp_path, "no_metadata.mcap")
+    create_mcap_file_with_channel_metadata(path, {"/camera": {"serial": "cam-7"}})
+
+    ds = ray.data.read_mcap(path, include_metadata=False)
+
+    assert "channel_metadata" not in ds.schema().names
+
+
+def test_read_mcap_channel_metadata_keys_may_differ_across_files(
+    ray_start_regular_shared, tmp_path
+):
+    """Blocks must concatenate when files record different metadata keys.
+
+    This is why the column is a `map` rather than the `struct` Arrow infers from
+    a Python dict: a struct's fields are the union of the keys it happens to
+    see, so blocks from these two files would carry different types and fail to
+    concatenate, and a channel that never recorded a key would be
+    indistinguishable from one whose value is null.
+    """
+    first = os.path.join(tmp_path, "first.mcap")
+    second = os.path.join(tmp_path, "second.mcap")
+    create_mcap_file_with_channel_metadata(first, {"/a": {"serial": "cam-7"}})
+    create_mcap_file_with_channel_metadata(second, {"/b": {"rate_hz": "200"}})
+
+    ds = ray.data.read_mcap([first, second]).materialize()
+    blocks = [ray.get(ref) for ref in ds.to_arrow_refs()]
+
+    # Would raise ArrowInvalid on differing struct fields.
+    assert pa.concat_tables(blocks).num_rows == ds.count()
+
+    by_topic = {row["topic"]: dict(row["channel_metadata"]) for row in ds.take_all()}
+    assert by_topic == {"/a": {"serial": "cam-7"}, "/b": {"rate_hz": "200"}}
+
+
+def test_read_mcap_channel_metadata_absent(ray_start_regular_shared, tmp_path):
+    """A channel recording no metadata yields an empty map, not a failure."""
+    path = os.path.join(tmp_path, "empty_metadata.mcap")
+    create_mcap_file_with_channel_metadata(path, {"/camera": {}})
+
+    rows = ray.data.read_mcap(path).take_all()
+
+    assert all(dict(row["channel_metadata"]) == {} for row in rows)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

A Channel record carries a `metadata` field of type `Map<string, string>` — [MCAP specification](https://mcap.dev/spec), op=0x04, *"Metadata about this channel"* — holding whatever the recorder chose to record about the topic. ROS 2 writes `offered_qos_profiles` there, and rigs commonly add sensor serials or calibration identifiers.

No message record reproduces it, so today it is not reachable from the dataset at all. `include_metadata=True` adds `channel_id`, `message_encoding`, `schema_name`, `schema_encoding` and `schema_data` — the schema and the channel's *id*, but not the channel's own metadata map. A caller who needs it has to re-open the file with the `mcap` library alongside the Ray Data read.

This adds a `channel_metadata` column under the existing `include_metadata` flag.

## The column is typed, not inferred

Arrow reads a Python dict as a `struct` whose fields are the union of the keys it happens to see. Two consequences, both verified:

```
file A: struct<serial: string>
file B: struct<offered_qos_profiles: string>
pa.concat_tables([A, B]) -> ArrowInvalid: Schema at index 1 was different
```

- Blocks from two files recording different keys carry different types and fail to concatenate (only `promote_options="permissive"` gets past it).
- A channel that never recorded a key becomes indistinguishable from one whose value is null, because the union fills the missing field with `None`.

A `map<string, string>` matches the specification's own type, keeps the block schema stable whatever the keys are, and concatenates across files without promotion. It is built explicitly in `_add_channel_metadata` rather than added in `_message_to_dict`, since the builder would otherwise infer the struct.

## Verified on a real recording

A FAST-LIVO ROS 2 recording (Livox IMU + lidar + two compressed camera streams):

```
dtype: map<string, string>
  /left_camera/image/compressed    {'offered_qos_profiles': ''}
  /livox/imu                       {'offered_qos_profiles': ''}
  /livox/lidar                     {'offered_qos_profiles': ''}
  /right_camera/image/compressed   {'offered_qos_profiles': ''}

concat across files: 1457 rows from 40 blocks
```

Every rosbag2-produced MCAP populates this field, so this is the common case rather than a corner one.

## Why this is not a duplicate

I checked issues and PRs for `mcap`, `channel_metadata` and `metadata` in all states.

- **#65913** (dictionary-encode `schema_data`) — closest overlap, and it touches the same two files. Its diff contains no reference to `channel_metadata` or `channel.metadata`; it deduplicates a column that already exists rather than adding one. **It will conflict textually** with this PR on the `yield` at the end of `_read_stream`, where both wrap `builder.build()`. The two compose — `_dictionary_encode_schema_data(_add_channel_metadata(builder.build(), channel_metadata))` — and whichever lands second, I'll rebase.
- **#65787** (`batch_size`) modifies `__init__` and `_read_stream`'s iteration, not the row contents.
- **#65912** (in-memory size estimation) does not change the output schema.
- **#65914** (install `mcap` in CI) is test infrastructure.
- **#58403** (file-level predicate pushdown and metadata filtering) is closed and was about filtering by metadata, not surfacing it.
- **#65640**, **#65641** concern block granularity.

## Compatibility

`include_metadata=True` is the default, so this adds a column to the default output. It is additive — existing code selecting named columns is unaffected — but code asserting an exact schema will see the new column. `read_mcap` is `@PublicAPI(stability="alpha")`. Happy to move it behind a separate flag if maintainers prefer.

## Tests

```
PYTHONPATH=python/ray/data/tests python -u -m pytest \
    python/ray/data/tests/datasource/test_mcap.py -v
```

**21 passed, 1 failed.** The failure is `test_read_mcap_invalid_time_range`, which fails identically on clean master — its regex omits the values the error message interpolates, so it can never match. #65912 fixes it; it is untouched here. (It is not caught in CI because `mcap` is in no requirements file, which is what #65914 addresses.)

Four new tests: the column carries the channel's metadata and is typed `map`; `include_metadata=False` omits it; blocks from files with **different** metadata keys still concatenate (the reason for map over struct); and a channel recording no metadata yields an empty map rather than failing.

Lint: `black`, `ruff` clean on all three files.

## AI assistance

AI assistance (Claude) was used for this change. I reviewed every changed line and ran the tests locally.
