### PR TITLE
[Data] Decode MCAP video topics inside the read task

### DIFF
--- a/python/ray/data/_internal/datasource/mcap_datasource.py
+++ b/python/ray/data/_internal/datasource/mcap_datasource.py
@@ -8,7 +8,17 @@ time-series data.
 import json
 import logging
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Dict, Iterator, List, Optional, Set, Union
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Dict,
+    Iterator,
+    List,
+    Optional,
+    Set,
+    Tuple,
+    Union,
+)
 
 from ray.data._internal.delegating_block_builder import DelegatingBlockBuilder
 from ray.data._internal.util import _check_import
@@ -21,6 +31,23 @@ if TYPE_CHECKING:
     from mcap.reader import Channel, Message, Schema
 
 logger = logging.getLogger(__name__)
+
+# Payload magic numbers. MCAP is codec-agnostic and the schema often does not say
+# what a video payload is, so the encoding is sniffed from the bytes.
+_JPEG_SOI = b"\xff\xd8\xff"
+_PNG_SIGNATURE = b"\x89PNG\r\n\x1a\n"
+_ANNEXB_START_4 = b"\x00\x00\x00\x01"
+_ANNEXB_START_3 = b"\x00\x00\x01"
+
+# H.264 NAL unit types that can begin a decode: IDR slice, sequence parameter
+# set, picture parameter set. See ITU-T H.264 table 7-1.
+_ANNEXB_KEYFRAME_NAL_TYPES = frozenset({5, 7, 8})
+
+# How far into a payload to look for a JPEG start-of-image marker. A ROS 2
+# sensor_msgs/CompressedImage puts a header in front of the JPEG.
+_EMBEDDED_JPEG_SEARCH_WINDOW = 256
+
+_STILL_IMAGE_KINDS = frozenset({"jpeg", "png", "jpeg_embedded"})
 
 
 @dataclass
@@ -94,6 +121,9 @@ class MCAPDatasource(FileBasedDatasource):
         time_range: Optional[TimeRange] = None,
         message_types: Optional[Union[List[str], Set[str]]] = None,
         include_metadata: bool = True,
+        decode_video: bool = False,
+        fps: Optional[int] = None,
+        resize: Optional[Tuple[int, int]] = None,
         **file_based_datasource_kwargs,
     ):
         """Initialize MCAP datasource.
@@ -121,6 +151,24 @@ class MCAPDatasource(FileBasedDatasource):
         self._message_types = set(message_types) if message_types else None
         self._time_range = time_range
         self._include_metadata = include_metadata
+        self._decode_video = decode_video
+        self._fps = fps
+        self._resize = resize
+
+        if decode_video:
+            _check_import(self, module="av", package="av")
+            _check_import(self, module="PIL", package="Pillow")
+        if fps is not None and (not isinstance(fps, int) or fps <= 0):
+            raise ValueError(f"Expected `fps` to be a positive integer, got {fps}.")
+        if resize is not None and (
+            len(resize) != 2 or any(not isinstance(v, int) or v <= 0 for v in resize)
+        ):
+            raise ValueError(
+                f"Expected `resize` to be a (height, width) pair of positive "
+                f"integers, got {resize}."
+            )
+        if (fps is not None or resize is not None) and not decode_video:
+            raise ValueError("`fps` and `resize` only apply when `decode_video=True`.")
 
     def _read_stream(self, f: "pyarrow.NativeFile", path: str) -> Iterator[Block]:
         """Read MCAP file and yield blocks of message data.
@@ -142,6 +190,10 @@ class MCAPDatasource(FileBasedDatasource):
         from mcap.reader import make_reader
 
         reader = make_reader(f)
+        if self._decode_video:
+            yield from self._read_video_stream(reader, path)
+            return
+
         # Note: MCAP summaries are optional and iter_messages works without them
         # We don't need to validate the summary since it's not required
 
@@ -168,6 +220,92 @@ class MCAPDatasource(FileBasedDatasource):
         # Yield the block if we have any messages
         if builder.num_rows() > 0:
             yield builder.build()
+
+    def _read_video_stream(self, reader: Any, path: str) -> Iterator[Block]:
+        """Decode video topics inside the read task and yield frames as rows.
+
+        `read_videos` establishes this contract for container formats: decoding
+        happens where the decoder can hold state for a whole file, so the rows
+        that reach a block are self-contained frames. MCAP needs the same, for
+        the same reason -- an H.264 access unit is meaningless without the group
+        of pictures it belongs to, and Ray Data splits rows into blocks at
+        positions that have nothing to do with those groups.
+
+        A `time_range` is deliberately *not* pushed down to the reader here. The
+        first access unit at or after `start_time` is usually not a keyframe, so
+        decoding has to begin at the last keyframe before it; those earlier
+        frames are decoded as context and never emitted. The scan before the
+        window costs I/O but no decoding.
+        """
+        start_time = self._time_range.start_time if self._time_range else None
+        end_time = self._time_range.end_time if self._time_range else None
+
+        decoders: Dict[int, _ChannelVideoDecoder] = {}
+        builder = DelegatingBlockBuilder()
+
+        for schema, channel, message in reader.iter_messages(
+            topics=list(self._topics) if self._topics else None,
+            start_time=None,
+            end_time=end_time,
+            log_time_order=True,
+            reverse=False,
+        ):
+            if not self._should_include_message(schema, channel, message):
+                continue
+
+            decoder = decoders.get(message.channel_id)
+            if decoder is None:
+                decoder = _ChannelVideoDecoder(
+                    kind=_extract_kind(
+                        message.data,
+                        channel.message_encoding,
+                        schema.name if schema else "",
+                    ),
+                    schema=schema,
+                    channel=channel,
+                    fps=self._fps,
+                    resize=self._resize,
+                    start_time=start_time,
+                )
+                decoders[message.channel_id] = decoder
+
+            for source, frame in decoder.feed(message):
+                builder.add(
+                    self._frame_to_dict(
+                        decoder.schema, decoder.channel, source, frame, path
+                    )
+                )
+
+        for decoder in decoders.values():
+            for source, frame in decoder.flush():
+                builder.add(
+                    self._frame_to_dict(
+                        decoder.schema, decoder.channel, source, frame, path
+                    )
+                )
+
+        if builder.num_rows() > 0:
+            yield builder.build()
+
+    def _frame_to_dict(
+        self,
+        schema: "Schema",
+        channel: "Channel",
+        message: "Message",
+        frame: Any,
+        path: str,
+    ) -> Dict[str, Any]:
+        """Build a row for a decoded frame.
+
+        The same columns a message row carries, with the undecoded `data`
+        payload replaced by the decoded `frame`. Keeping both would double the
+        memory for no benefit: `data` is unusable once decoded, and a decoded
+        frame is orders of magnitude larger than the payload it came from.
+        """
+        row = self._message_to_dict(schema, channel, message, path)
+        row.pop("data", None)
+        row["frame"] = frame
+        return row
 
     def _should_include_message(
         self, schema: "Schema", channel: "Channel", message: "Message"
@@ -256,3 +394,207 @@ class MCAPDatasource(FileBasedDatasource):
         MCAP files can be read in parallel across multiple files.
         """
         return True
+
+
+def _extract_kind(payload: bytes, message_encoding: str, schema_name: str) -> str:
+    """Classify a video payload by its leading bytes.
+
+    Sniffing beats trusting metadata here. MCAP is codec-agnostic, rigs log video
+    under several schemas, and the schema is frequently absent or unhelpful, so
+    the bytes are the only reliable signal.
+    """
+    if payload.startswith(_JPEG_SOI):
+        return "jpeg"
+    if payload.startswith(_PNG_SIGNATURE):
+        return "png"
+    if payload.startswith(_ANNEXB_START_4) or payload.startswith(_ANNEXB_START_3):
+        return "h264_annexb"
+    # A ROS 2 sensor_msgs/CompressedImage wraps the JPEG behind a header, so the
+    # marker appears a little way in rather than at offset 0.
+    if payload.find(_JPEG_SOI, 0, _EMBEDDED_JPEG_SEARCH_WINDOW) > 0:
+        return "jpeg_embedded"
+    raise ValueError(
+        "Cannot decode this payload as video: "
+        f"message_encoding={message_encoding!r}, schema={schema_name!r}, "
+        f"first bytes {payload[:16].hex()}. `decode_video=True` only supports "
+        "JPEG, PNG and H.264 Annex-B payloads. Pass `topics=[...]` to select "
+        "only the video topics of this recording."
+    )
+
+
+def _annexb_nal_types(payload: bytes) -> List[int]:
+    """Return the H.264 NAL unit types present in an Annex-B buffer."""
+    types: List[int] = []
+    index, size = 0, len(payload)
+    while index < size - 3:
+        if payload[index] == 0 and payload[index + 1] == 0:
+            if payload[index + 2] == 1:
+                header = index + 3
+            elif (
+                payload[index + 2] == 0 and index + 3 < size and payload[index + 3] == 1
+            ):
+                header = index + 4
+            else:
+                index += 1
+                continue
+            if header < size:
+                types.append(payload[header] & 0x1F)
+            index = header + 1
+            continue
+        index += 1
+    return types
+
+
+def _is_annexb_keyframe(payload: bytes) -> bool:
+    """Whether this access unit can begin a decode.
+
+    True when it carries an IDR slice or the parameter sets a decoder needs to
+    interpret what follows. An H.264 stream that starts anywhere else cannot be
+    decoded, which is why `_ChannelVideoDecoder` rewinds to one of these before
+    a `time_range`.
+    """
+    return any(t in _ANNEXB_KEYFRAME_NAL_TYPES for t in _annexb_nal_types(payload))
+
+
+class _ChannelVideoDecoder:
+    """Decodes one channel's payloads into frames.
+
+    One per channel, because topics interleave in log-time order: the decoder for
+    a camera topic has to survive IMU messages arriving between two of its own
+    frames, and inter-frame video cannot be decoded without that continuity.
+
+    Holding the decoder here -- inside the read task -- is the point of the whole
+    feature. Blocks then carry decoded frames, which are self-contained, so no
+    downstream block boundary or re-batching can produce an undecodable unit.
+    """
+
+    def __init__(
+        self,
+        kind: str,
+        schema: "Schema",
+        channel: "Channel",
+        fps: Optional[int],
+        resize: Optional[Tuple[int, int]],
+        start_time: Optional[int],
+    ):
+        self.kind = kind
+        self.schema = schema
+        self.channel = channel
+        self._resize = resize
+        self._start_time = start_time
+        self._min_interval_ns = int(1e9 / fps) if fps else None
+        self._last_emit_ns: Optional[int] = None
+        self._codec = None
+        # Access units since the last keyframe, held only until the window opens.
+        self._gop: List["Message"] = []
+        self._primed = False
+
+    # -- public ------------------------------------------------------------
+
+    def feed(self, message: "Message") -> Iterator[Tuple["Message", Any]]:
+        """Yield ``(message, frame)`` for every frame this payload completes."""
+        if self.kind in _STILL_IMAGE_KINDS:
+            if self._before_window(message.log_time) or not self._due(message.log_time):
+                return
+            self._last_emit_ns = message.log_time
+            yield message, self._decode_still(message.data)
+            return
+
+        if not self._primed:
+            # Before the window opens, keep only the current group of pictures.
+            # Those are exactly the packets the decoder needs to produce the
+            # first frame inside the window, and no more.
+            if _is_annexb_keyframe(message.data):
+                self._gop = [message]
+            else:
+                self._gop.append(message)
+            if self._start_time is not None and message.log_time < self._start_time:
+                return
+            self._primed = True
+            backlog, self._gop = self._gop, []
+            for buffered in backlog:
+                yield from self._decode_packet(buffered)
+            return
+
+        yield from self._decode_packet(message)
+
+    def flush(self) -> Iterator[Tuple["Message", Any]]:
+        """Drain frames the decoder is still holding."""
+        if self._codec is None:
+            return
+        for frame in self._codec.decode(None):
+            yield from self._emit(self._last_packet, frame)
+
+    # -- internals ---------------------------------------------------------
+
+    def _before_window(self, log_time: int) -> bool:
+        return self._start_time is not None and log_time < self._start_time
+
+    def _due(self, log_time: int) -> bool:
+        """Whether enough time has passed since the last emitted frame.
+
+        `read_videos` strides by frame index, which assumes a constant frame
+        rate. An MCAP topic has no such guarantee -- messages are timestamped and
+        can be irregular -- so `fps` is honoured against log time instead.
+        """
+        if self._min_interval_ns is None or self._last_emit_ns is None:
+            return True
+        return log_time - self._last_emit_ns >= self._min_interval_ns
+
+    def _decode_packet(self, message: "Message") -> Iterator[Tuple["Message", Any]]:
+        import av
+
+        if self._codec is None:
+            self._codec = av.CodecContext.create("h264", "r")
+        self._last_packet = message
+        packet = av.packet.Packet(message.data)
+        packet.pts = message.log_time
+        try:
+            frames = self._codec.decode(packet)
+        except av.error.InvalidDataError:
+            # A truncated or mid-GOP access unit. Skipping keeps the rest of the
+            # topic readable; failing here would lose the whole file.
+            logger.debug(
+                f"Undecodable access unit on {self.channel.topic!r} at "
+                f"log_time {message.log_time}.",
+            )
+            return
+        for frame in frames:
+            yield from self._emit(message, frame)
+
+    def _emit(self, message: "Message", frame) -> Iterator[Tuple["Message", Any]]:
+        log_time = message.log_time
+        if self._before_window(log_time):
+            # Decoded only as context for the first frame inside the window.
+            return
+        if not self._due(log_time):
+            return
+        self._last_emit_ns = log_time
+        yield message, self._to_array(frame)
+
+    def _to_array(self, frame):
+        if self._resize is not None:
+            height, width = self._resize
+            # One libswscale pass does the colour conversion and the scale
+            # together; converting first and scaling after costs more for the
+            # same output.
+            frame = frame.reformat(width=width, height=height, format="rgb24")
+            return frame.to_ndarray()
+        return frame.to_ndarray(format="rgb24")
+
+    def _decode_still(self, payload: bytes):
+        import io
+
+        import numpy as np
+        from PIL import Image
+
+        if self.kind == "jpeg_embedded":
+            payload = payload[payload.find(_JPEG_SOI) :]
+        image = Image.open(io.BytesIO(payload)).convert("RGB")
+        if self._resize is not None:
+            height, width = self._resize
+            if image.size != (width, height):
+                # An already-coded still gives libswscale nothing to fuse with,
+                # so this path stays on PIL.
+                image = image.resize((width, height), Image.BILINEAR)
+        return np.asarray(image)

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -3199,6 +3199,9 @@ def read_mcap(
     time_range: Optional[Union[Tuple[int, int], TimeRange]] = None,
     message_types: Optional[Union[List[str], Set[str]]] = None,
     include_metadata: bool = True,
+    decode_video: bool = False,
+    fps: Optional[int] = None,
+    resize: Optional[Tuple[int, int]] = None,
     filesystem: Optional["pyarrow.fs.FileSystem"] = None,
     parallelism: int = -1,
     num_cpus: Optional[float] = None,
@@ -3282,6 +3285,30 @@ def read_mcap(
             include. Only messages with matching schema names will be read.
         include_metadata: Whether to include MCAP metadata fields in the output.
             Defaults to True. When True, includes schema, channel, and message metadata.
+        decode_video: Whether to decode video topics into frames. Defaults to
+            ``False``, which returns the raw message payload in a ``data`` column.
+            When ``True``, each row instead carries a decoded RGB frame in a
+            ``frame`` column, and ``data`` is dropped.
+
+            Decoding happens inside the read task, matching :func:`read_videos`.
+            This matters for inter-frame codecs: an H.264 access unit cannot be
+            decoded without the group of pictures it belongs to, and Ray Data
+            splits rows into blocks at positions unrelated to those groups. A
+            pipeline that reads raw payloads and decodes them downstream will
+            silently drop the frames of any block that does not begin on a
+            keyframe. Decoding here means blocks carry self-contained frames.
+
+            Supports JPEG, PNG, and H.264 Annex-B payloads, including the
+            JPEG-behind-a-header layout that ROS 2 ``sensor_msgs/CompressedImage``
+            uses. Requires the ``av`` and ``Pillow`` packages. Pass ``topics`` to
+            select the video topics; a non-video payload raises ``ValueError``.
+        fps: Subsample decoded frames to approximately this rate. Only valid with
+            ``decode_video=True``. Unlike :func:`read_videos`, which strides by
+            frame index, this is applied against message log time, because an MCAP
+            topic carries timestamps and is not guaranteed to be constant-rate.
+        resize: Resize decoded frames to this ``(height, width)``. Only valid with
+            ``decode_video=True``. For H.264 the colour conversion and the scale
+            happen in a single libswscale pass.
         filesystem: The PyArrow filesystem implementation to read from.
         parallelism: This argument is deprecated. Use ``override_num_blocks`` argument.
         num_cpus: The number of CPUs to reserve for each parallel read worker.
@@ -3344,6 +3371,9 @@ def read_mcap(
         time_range=time_range,
         message_types=message_types,
         include_metadata=include_metadata,
+        decode_video=decode_video,
+        fps=fps,
+        resize=resize,
         filesystem=filesystem,
         meta_provider=DefaultFileMetadataProvider(),
         partition_filter=partition_filter,

--- a/python/ray/data/tests/datasource/test_mcap.py
+++ b/python/ray/data/tests/datasource/test_mcap.py
@@ -5,12 +5,20 @@ import os
 import pytest
 
 import ray
+from ray.data._internal.datasource.mcap_datasource import (
+    _annexb_nal_types,
+    _is_annexb_keyframe,
+)
 from ray.data.datasource.path_util import _unwrap_protocol
 from ray.data.tests.conftest import *  # noqa
 from ray.tests.conftest import *  # noqa
 
 # Skip all tests if mcap is not available
 MCAP_AVAILABLE = importlib.util.find_spec("mcap") is not None
+AV_AVAILABLE = importlib.util.find_spec("av") is not None
+requires_av = pytest.mark.skipif(
+    not AV_AVAILABLE, reason="av not available. Install with: pip install av"
+)
 pytestmark = pytest.mark.skipif(
     not MCAP_AVAILABLE,
     reason="mcap module not available. Install with: pip install mcap",
@@ -392,3 +400,208 @@ if __name__ == "__main__":
     import sys
 
     sys.exit(pytest.main(["-v", __file__]))
+
+
+# ---------------------------------------------------------------------------
+# Video decoding
+# ---------------------------------------------------------------------------
+
+GOP_SIZE = 10
+
+
+def _encode_h264(num_frames: int, width: int = 64, height: int = 48):
+    """Encode frames to H.264 Annex-B access units, one per returned packet."""
+    import io
+
+    import av
+    import numpy as np
+
+    container = av.open(io.BytesIO(), mode="w", format="h264")
+    stream = container.add_stream("libx264", rate=30)
+    stream.width, stream.height, stream.pix_fmt = width, height, "yuv420p"
+    # A fixed GOP with no B-frames keeps the keyframe positions predictable, so
+    # a test can open a window at a known offset from one.
+    stream.options = {"g": str(GOP_SIZE), "bf": "0", "tune": "zerolatency"}
+
+    packets = []
+    for i in range(num_frames):
+        array = np.full((height, width, 3), i * 8 % 256, dtype=np.uint8)
+        array[:, :, 1] = (i * 3) % 256
+        frame = av.VideoFrame.from_ndarray(array, format="rgb24")
+        packets.extend(bytes(p) for p in stream.encode(frame))
+    packets.extend(bytes(p) for p in stream.encode())
+    return packets
+
+
+def _write_payload_mcap(path, payloads, *, schema_name, topic="/camera"):
+    from mcap.writer import Writer
+
+    with open(path, "wb") as stream:
+        writer = Writer(stream)
+        writer.start(profile="", library="ray-test")
+        schema_id = writer.register_schema(
+            name=schema_name, encoding="ros2msg", data=b"video\n"
+        )
+        channel_id = writer.register_channel(
+            schema_id=schema_id, topic=topic, message_encoding="cdr"
+        )
+        for i, payload in enumerate(payloads):
+            writer.add_message(
+                channel_id=channel_id,
+                log_time=i * 33000000,
+                publish_time=i * 33000000,
+                data=payload,
+                sequence=i,
+            )
+        writer.finish()
+
+
+@pytest.fixture
+def h264_mcap_file(tmp_path):
+    """30 H.264 access units with a keyframe every `GOP_SIZE` frames."""
+    path = os.path.join(tmp_path, "h264.mcap")
+    _write_payload_mcap(path, _encode_h264(30), schema_name="foxglove.CompressedVideo")
+    return path
+
+
+@pytest.fixture
+def jpeg_mcap_file(tmp_path):
+    """10 JPEGs behind a header, the ROS 2 sensor_msgs/CompressedImage layout."""
+    import io
+
+    import numpy as np
+    from PIL import Image
+
+    payloads = []
+    for i in range(10):
+        array = np.full((48, 64, 3), i * 20 % 256, dtype=np.uint8)
+        buffer = io.BytesIO()
+        Image.fromarray(array).save(buffer, format="JPEG")
+        # A CDR header in front of the JPEG, so the SOI marker is not at offset 0.
+        payloads.append(b"\x00\x01\x00\x00" + b"header" * 4 + buffer.getvalue())
+    _write_payload_mcap(
+        path=os.path.join(tmp_path, "jpeg.mcap"),
+        payloads=payloads,
+        schema_name="sensor_msgs/msg/CompressedImage",
+    )
+    return os.path.join(tmp_path, "jpeg.mcap")
+
+
+@requires_av
+def test_annexb_keyframe_detection(ray_start_regular_shared):
+    """Keyframes must be found at the encoder's GOP boundaries.
+
+    Everything about seeking depends on this, so it is asserted directly rather
+    than only through a decode.
+    """
+    packets = _encode_h264(30)
+    keyframes = [i for i, p in enumerate(packets) if _is_annexb_keyframe(p)]
+
+    assert keyframes == list(range(0, len(packets), GOP_SIZE))
+    # An IDR access unit carries the parameter sets; an inter frame does not.
+    assert set(_annexb_nal_types(packets[0])) >= {5, 7, 8}
+    assert not _is_annexb_keyframe(packets[1])
+
+
+@requires_av
+def test_read_mcap_decode_video_yields_frames(ray_start_regular_shared, h264_mcap_file):
+    """`decode_video` replaces the undecoded payload with a decoded frame."""
+    raw = ray.data.read_mcap(h264_mcap_file).materialize()
+    assert "data" in raw.take(1)[0]
+
+    decoded = ray.data.read_mcap(h264_mcap_file, decode_video=True).materialize()
+    row = decoded.take(1)[0]
+
+    assert decoded.count() == 30
+    assert "frame" in row and "data" not in row
+    assert row["frame"].shape == (48, 64, 3)
+    assert row["frame"].dtype.name == "uint8"
+    # The message columns survive; only the payload is replaced.
+    assert {"topic", "log_time", "publish_time", "sequence"} <= set(row)
+
+
+@requires_av
+def test_read_mcap_decode_video_seeks_to_keyframe(
+    ray_start_regular_shared, h264_mcap_file
+):
+    """A `time_range` opening mid-GOP must still decode.
+
+    The first access unit at or after `start_time` is an inter frame, which
+    cannot be decoded alone. Decoding has to begin at the preceding keyframe and
+    discard the frames before the window. Without that, this window yields
+    nothing -- which is exactly what a downstream decoder handed a mid-GOP block
+    would produce, silently.
+    """
+    start_frame = GOP_SIZE + GOP_SIZE // 2  # deliberately not a keyframe
+    end_frame = start_frame + 5
+    time_range = (start_frame * 33000000, end_frame * 33000000)
+
+    decoded = ray.data.read_mcap(
+        h264_mcap_file, decode_video=True, time_range=time_range
+    ).materialize()
+    sequences = sorted(row["sequence"] for row in decoded.take_all())
+
+    assert sequences == list(range(start_frame, end_frame))
+
+
+@requires_av
+def test_read_mcap_decode_video_resize(ray_start_regular_shared, h264_mcap_file):
+    """`resize` takes (height, width), matching `read_videos`."""
+    decoded = ray.data.read_mcap(
+        h264_mcap_file, decode_video=True, resize=(24, 32)
+    ).materialize()
+
+    assert decoded.take(1)[0]["frame"].shape == (24, 32, 3)
+    assert decoded.count() == 30
+
+
+@requires_av
+def test_read_mcap_decode_video_fps(ray_start_regular_shared, h264_mcap_file):
+    """`fps` subsamples against log time, not frame index."""
+    full = ray.data.read_mcap(h264_mcap_file, decode_video=True).materialize()
+    # 30 frames 33 ms apart is just under a second, so 10 fps keeps roughly ten.
+    thinned = ray.data.read_mcap(
+        h264_mcap_file, decode_video=True, fps=10
+    ).materialize()
+
+    assert 0 < thinned.count() < full.count()
+    times = sorted(row["log_time"] for row in thinned.take_all())
+    assert all(b - a >= 1e9 / 10 for a, b in zip(times, times[1:]))
+
+
+@requires_av
+def test_read_mcap_decode_video_embedded_jpeg(ray_start_regular_shared, jpeg_mcap_file):
+    """A JPEG behind a header decodes; sniffing finds the marker past offset 0."""
+    decoded = ray.data.read_mcap(jpeg_mcap_file, decode_video=True).materialize()
+
+    assert decoded.count() == 10
+    assert decoded.take(1)[0]["frame"].shape == (48, 64, 3)
+
+
+@requires_av
+def test_read_mcap_decode_video_rejects_non_video(
+    ray_start_regular_shared, simple_mcap_file
+):
+    """A payload that is not video must fail loudly, naming the way out."""
+    with pytest.raises(Exception, match="Cannot decode this payload as video"):
+        ray.data.read_mcap(simple_mcap_file, decode_video=True).materialize()
+
+
+def test_read_mcap_fps_and_resize_require_decode_video(
+    ray_start_regular_shared, simple_mcap_file
+):
+    """`fps` and `resize` are meaningless without decoding, so they are refused."""
+    with pytest.raises(ValueError, match="only apply when `decode_video=True`"):
+        ray.data.read_mcap(simple_mcap_file, fps=5)
+    with pytest.raises(ValueError, match="only apply when `decode_video=True`"):
+        ray.data.read_mcap(simple_mcap_file, resize=(10, 10))
+
+
+@requires_av
+def test_read_mcap_decode_video_validates_arguments(
+    ray_start_regular_shared, h264_mcap_file
+):
+    with pytest.raises(ValueError, match="positive integer"):
+        ray.data.read_mcap(h264_mcap_file, decode_video=True, fps=0)
+    with pytest.raises(ValueError, match="height, width"):
+        ray.data.read_mcap(h264_mcap_file, decode_video=True, resize=(10, 0))


### PR DESCRIPTION
## Description

`read_mcap` returns the raw message payload in a `data` column. For an inter-frame video topic that payload is an H.264 access unit — which the [MCAP spec](https://mcap.dev/spec) describes as *"Message data, to be decoded according to the schema of the channel"* — and it is meaningless without the group of pictures it belongs to.

Ray Data then splits those rows into blocks at positions that have nothing to do with GOP boundaries. A pipeline that reads payloads and decodes them downstream therefore drops the frames of every block that does not begin on a keyframe. **No rows are lost** — every message is returned intact — but the frames never decode, and how many are lost depends on where the boundaries happened to fall.

`read_videos` already solves this for container formats, and notably *not* with a block guarantee:

```python
def _read_stream(self, f, path):
    reader = VideoReader(f, **decord_load_args)   # whole file, one read task
    for frame_index, frame in enumerate(reader):
        item = {"frame": frame.asnumpy(), "frame_index": frame_index}
        yield builder.build()                     # rows are DECODED frames
```

It decodes inside the read task, so the rows reaching a block are self-contained frames and no boundary — or downstream re-batching — can produce an undecodable unit. This PR gives MCAP the same contract.

## Related issues

Related to #65640, which asks for file-level MCAP output; this addresses the same underlying problem from the `read_videos` direction rather than through block granularity. No open issue or PR covers video decoding for MCAP.

## Additional information

**API.** `decode_video=True` replaces the `data` column with a decoded RGB `frame`, keeping every other message column. `data` is dropped rather than kept alongside: it is unusable once decoded, and a decoded frame is far larger than the payload it came from.

**Payload sniffing.** The kind is read from the leading bytes rather than the schema, because MCAP is codec-agnostic and rigs log video under schemas that frequently do not say what the payload is. Supported: JPEG, PNG, H.264 Annex-B, and the JPEG-behind-a-header layout that ROS 2 `sensor_msgs/CompressedImage` uses (verified against a real FAST-LIVO recording, where the payload begins `0001000075e2…` and the SOI marker is some bytes in). A payload that matches none of these raises, naming `topics` as the way to select video topics.

**One decoder per channel.** Topics interleave in log-time order, so a camera decoder has to survive IMU messages arriving between two of its own frames.

**Keyframe seeking.** A `time_range` is deliberately *not* pushed down to the MCAP reader when decoding. The first access unit at or after `start_time` is usually an inter frame, so decoding begins at the preceding keyframe and those earlier frames are decoded as context and never emitted. Only the current group of pictures is buffered, so the memory cost is one GOP rather than the file.

Measured on a 30-frame fixture with a keyframe every 10, opening a window five frames past a keyframe:

```
whole file          -> 30 frames
time_range [15,20)  ->  5 frames, sequences [15, 16, 17, 18, 19]
naive, no rewind    ->  0 frames   <- what a downstream decoder gets
```

**`fps` and `resize`** mirror `read_videos`, which they need to — a decoded 1024×1280 frame from the sample recording is roughly 40× the compressed payload, and a 13-frame block goes from 2.8 MB to 51 MB decoded, or 0.77 MB at `resize=(120, 160)`. `fps` is applied against **log time** rather than frame index: unlike a video container, an MCAP topic carries timestamps and is not guaranteed to be constant-rate.

**Dependencies.** `av` is already in `python/requirements/ml/data-test-requirements.txt` (added for the lerobot datasource), so this adds no new CI dependency. Both `av` and `Pillow` are gated behind `_check_import`, the same way `read_videos` gates `decord`.

**Not handled.** H.265 — its NAL header layout differs from H.264's and it can follow separately.

## Tests

```
PYTHONPATH=python/ray/data/tests python -u -m pytest \
    python/ray/data/tests/datasource/test_mcap.py -v
```

**26 passed, 1 failed.** The failure is `test_read_mcap_invalid_time_range`, which fails identically on clean master — its regex omits the values the error message interpolates, so it can never match. It is fixed in #65912, not here. Baseline on master is 1 failed, 17 passed.

Nine new tests: keyframe detection at encoder GOP boundaries (asserted directly, since all seeking depends on it), frames replacing payloads, mid-GOP `time_range` seeking, `resize`, `fps` spacing against log time, the embedded-JPEG layout, rejection of non-video payloads, and argument validation.

Lint: `black`, `ruff` clean.

## AI assistance

AI assistance (Claude) was used for this change. I reviewed every changed line and ran the tests locally.
