### PR TITLE
[tune] Stop ASHA crashing when a trial reports None for the metric

### DIFF
--- a/python/ray/tune/schedulers/async_hyperband.py
+++ b/python/ray/tune/schedulers/async_hyperband.py
@@ -145,6 +145,13 @@ class AsyncHyperBandScheduler(FIFOScheduler):
         idx = np.random.choice(len(self._brackets), p=normalized)
         self._trial_info[trial.trial_id] = self._brackets[idx]
 
+    def _reward(self, result: Dict) -> Optional[float]:
+        # A trial can report the metric as None. _Bracket.on_result already handles that by
+        # warning and leaving the trial running, so keep None intact instead of failing here
+        # on the metric_op multiplication.
+        value = result[self._metric]
+        return None if value is None else self._metric_op * value
+
     def on_trial_result(
         self, tune_controller: "TuneController", trial: Trial, result: Dict
     ) -> str:
@@ -156,7 +163,7 @@ class AsyncHyperBandScheduler(FIFOScheduler):
         else:
             bracket = self._trial_info[trial.trial_id]
             action = bracket.on_result(
-                trial, result[self._time_attr], self._metric_op * result[self._metric]
+                trial, result[self._time_attr], self._reward(result)
             )
         if action == TrialScheduler.STOP:
             self._num_stopped += 1
@@ -168,9 +175,7 @@ class AsyncHyperBandScheduler(FIFOScheduler):
         if self._time_attr not in result or self._metric not in result:
             return
         bracket = self._trial_info[trial.trial_id]
-        bracket.on_result(
-            trial, result[self._time_attr], self._metric_op * result[self._metric]
-        )
+        bracket.on_result(trial, result[self._time_attr], self._reward(result))
         del self._trial_info[trial.trial_id]
 
     def on_trial_remove(self, tune_controller: "TuneController", trial: Trial):
@@ -258,15 +263,15 @@ class _Bracket:
             if cur_iter < milestone or trial.trial_id in recorded:
                 continue
             else:
-                cutoff = self.cutoff(recorded)
-                if cutoff is not None and cur_rew < cutoff:
-                    action = TrialScheduler.STOP
                 if cur_rew is None:
                     logger.warning(
                         "Reward attribute is None! Consider"
                         " reporting using a different field."
                     )
                 else:
+                    cutoff = self.cutoff(recorded)
+                    if cutoff is not None and cur_rew < cutoff:
+                        action = TrialScheduler.STOP
                     recorded[trial.trial_id] = cur_rew
                 break
         return action

--- a/python/ray/tune/tests/test_trial_scheduler.py
+++ b/python/ray/tune/tests/test_trial_scheduler.py
@@ -2356,6 +2356,42 @@ class AsyncHyperBandSuite(unittest.TestCase):
             scheduler.on_trial_result(None, t3, result(2, 260)), TrialScheduler.STOP
         )
 
+    def testAsyncHBNoneMetric(self):
+        # A trial reporting None for the metric must not crash the scheduler: _Bracket.on_result
+        # warns and leaves the trial running, and the None is not recorded as a rung result.
+        scheduler = AsyncHyperBandScheduler(
+            metric="episode_reward_mean",
+            mode="max",
+            grace_period=1,
+            max_t=10,
+            reduction_factor=2,
+            brackets=1,
+        )
+        t1 = Trial(MOCK_TRAINABLE_NAME)
+        scheduler.on_trial_add(None, t1)
+        scheduler.on_trial_result(None, t1, result(1, 450))
+
+        t2 = Trial(MOCK_TRAINABLE_NAME)
+        scheduler.on_trial_add(None, t2)
+        self.assertEqual(
+            scheduler.on_trial_result(None, t2, result(1, None)),
+            TrialScheduler.CONTINUE,
+        )
+        for _, recorded in scheduler._brackets[0]._rungs:
+            self.assertNotIn(t2.trial_id, recorded)
+
+        # on_trial_complete goes through the same path
+        t3 = Trial(MOCK_TRAINABLE_NAME)
+        scheduler.on_trial_add(None, t3)
+        scheduler.on_trial_complete(None, t3, result(1, None))
+
+        # and a genuinely underperforming trial is still stopped
+        t4 = Trial(MOCK_TRAINABLE_NAME)
+        scheduler.on_trial_add(None, t4)
+        self.assertEqual(
+            scheduler.on_trial_result(None, t4, result(1, 0)), TrialScheduler.STOP
+        )
+
     def testAsyncHBSaveRestore(self):
         _, tmpfile = tempfile.mkstemp()
 


### PR DESCRIPTION
Reopening #65008, which the stale bot closed on 2026-09-04 for inactivity rather than on review. GitHub refuses to reopen it, so this is the same branch as a fresh PR.

## Why are these changes needed?

`AsyncHyperBandScheduler` raises `TypeError` when a trial reports `None` for the metric, even though `_Bracket.on_result` already contains handling for exactly that case:

```python
cutoff = self.cutoff(recorded)
if cutoff is not None and cur_rew < cutoff:
    action = TrialScheduler.STOP
if cur_rew is None:
    logger.warning("Reward attribute is None! Consider reporting using a different field.")
else:
    recorded[trial.trial_id] = cur_rew
```

That branch cannot be reached, for two separate reasons.

1. Both callers apply the metric op first: `bracket.on_result(trial, result[self._time_attr], self._metric_op * result[self._metric])`. `self._metric_op` is `1.0` or `-1.0`, so a `None` metric dies on the multiplication.
2. Even reaching the bracket directly, `cur_rew < cutoff` is evaluated above the `cur_rew is None` check, so it raises for any rung that already holds a recorded result.

This change keeps `None` intact through a small `_reward` helper and moves the cutoff comparison inside the `else`, which is where it was always meant to sit.

## Still current

`python/ray/tune/schedulers/async_hyperband.py` has not changed since I opened #65008: its master blob sha is still `a6394aec8a6becdcee9b0570d91e6699105f176e`, byte identical to this diff's pre-image, and the newest commit touching the file is `b33bf69d` (2026-06-02), docs only.

## Not a duplicate

Re-checked today, per `AGENTS.md`:

```
gh search prs --repo ray-project/ray --state open "async_hyperband"   -> no matches
gh search prs --repo ray-project/ray --state open "AsyncHyperBand"    -> no matches
gh search prs --repo ray-project/ray --state open "ASHA"              -> #64577, #64053, both Serve, unrelated
```

No open PR or issue covers the `None`-metric crash in ASHA.

## Tests run and results

`testAsyncHBNoneMetric` in `python/ray/tune/tests/test_trial_scheduler.py`, added next to the existing NaN/Inf coverage in `AsyncHyperBandSuite`. It drives `None` through both `on_trial_result` and `on_trial_complete`, asserts the trial continues and is not written into any rung, and keeps a genuinely underperforming trial as the control that must still be stopped.

Re-verified today by applying this diff to an installed `ray==2.56.1`, whose copy of the file is git-blob identical to master:

```
                  before                                                    after
None metric       TypeError: unsupported operand type(s) for *: ...         action=CONTINUE
None complete     TypeError: unsupported operand type(s) for *: ...         ok
underperformer    action=STOP                                              action=STOP   (control, unchanged)
```

`black` and `ruff` are clean on both changed files. The patch applies to current master with a 3 line offset in the test file only, from #65250 landing elsewhere in it.

## AI assistance

AI assistance was used in preparing this change, disclosed per `AGENTS.md`.