### PR TITLE
[Data] Move read release tests to 4 m5.24xlarge workers

### DIFF
--- a/release/nightly_tests/dataset/read_benchmark_compute.yaml
+++ b/release/nightly_tests/dataset/read_benchmark_compute.yaml
@@ -1,0 +1,14 @@
+cloud: {{env["ANYSCALE_CLOUD_NAME"]}}
+
+advanced_instance_config:
+    IamInstanceProfile: {"Name": "ray-autoscaler-v1"}
+
+head_node:
+    # Default head node type on Anyscale workspaces.
+    instance_type: m5.2xlarge
+
+worker_nodes:
+    - instance_type: m5.24xlarge
+      min_nodes: 4
+      max_nodes: 4
+      market_type: ON_DEMAND

--- a/release/release_data_tests.yaml
+++ b/release/release_data_tests.yaml
@@ -45,7 +45,7 @@
         # Footer read tuning.
         - RAY_DATA_PARQUET_BIN_PACKING_BYTES=67108864
     anyscale_sdk_2026: true
-    cluster_compute: fixed_size_cpu_compute.yaml
+    cluster_compute: read_benchmark_compute.yaml
 
   run:
     timeout: 3600
@@ -70,7 +70,7 @@
         # Footer read tuning.
         - RAY_DATA_PARQUET_BIN_PACKING_BYTES=1073741824
     anyscale_sdk_2026: true
-    cluster_compute: fixed_size_cpu_compute.yaml
+    cluster_compute: read_benchmark_compute.yaml
 
   run:
     timeout: 3600
@@ -88,7 +88,7 @@
   python: "3.10"
   cluster:
     anyscale_sdk_2026: true
-    cluster_compute: fixed_size_cpu_compute.yaml
+    cluster_compute: read_benchmark_compute.yaml
 
   run:
     timeout: 3600
@@ -112,6 +112,7 @@
         # Footer read tuning.
         - RAY_DATA_PARQUET_BIN_PACKING_BYTES=67108864
     anyscale_sdk_2026: true
+    cluster_compute: read_benchmark_compute.yaml
   run:
     timeout: 3600
     script: >
@@ -123,7 +124,7 @@
   python: "3.10"
   cluster:
     anyscale_sdk_2026: true
-    cluster_compute: fixed_size_cpu_compute.yaml
+    cluster_compute: read_benchmark_compute.yaml
 
   run:
     timeout: 5400


### PR DESCRIPTION
### Summary

- Add a dedicated compute configuration with four on-demand `m5.24xlarge` workers.
- Run the five existing read release tests on the new configuration.
- Keep the shared compute configuration unchanged.

This only changes the cluster configuration. The workloads and benchmark code are unchanged.


---

Closes #65920

Part of #65919