### PR TITLE
[Core] Look up the retry task in the args-ready callback instead of pointing at it

### DIFF
--- a/src/ray/core_worker/task_execution/ordered_actor_task_execution_queue.cc
+++ b/src/ray/core_worker/task_execution/ordered_actor_task_execution_queue.cc
@@ -98,9 +98,8 @@ void OrderedActorTaskExecutionQueue::EnqueueTask(int64_t seq_no,
 
   const bool is_retry = task_spec.IsRetry();
 
-  TaskToExecute *retry_task = nullptr;
   if (is_retry) {
-    retry_task = &group_state.pending_retry_tasks.emplace_back(std::move(task));
+    group_state.pending_retry_tasks.emplace_back(std::move(task));
   } else {
     RAY_CHECK(group_state.pending_tasks.emplace(seq_no, std::move(task)).second);
   }
@@ -138,20 +137,30 @@ void OrderedActorTaskExecutionQueue::EnqueueTask(int64_t seq_no,
         /*include_task_info=*/false);
     waiter_.OnArgsReady(
         TaskAttempt{task_spec.TaskId(), task_spec.AttemptNumber()},
-        [this, seq_no, is_retry, retry_task, group]() {
+        [this,
+         seq_no,
+         is_retry,
+         task_id = task_spec.TaskId(),
+         attempt_number = task_spec.AttemptNumber(),
+         group]() {
+          // The queued task may already be gone by the time its args arrive, and
+          // nothing deregisters this callback.
+          auto &group_state_in = group_states_.at(group);
           TaskToExecute *ready_task = nullptr;
           if (is_retry) {
-            // retry_task is guaranteed to be a valid pointer for retries
-            // because it won't be erased from the retry list until its
-            // dependencies are fetched and ExecuteRequest happens.
-            ready_task = retry_task;
+            auto it =
+                std::find_if(group_state_in.pending_retry_tasks.begin(),
+                             group_state_in.pending_retry_tasks.end(),
+                             [&task_id, attempt_number](const TaskToExecute &queued) {
+                               return queued.TaskID() == task_id &&
+                                      queued.TaskSpec().AttemptNumber() == attempt_number;
+                             });
+            if (it != group_state_in.pending_retry_tasks.end()) {
+              ready_task = &*it;
+            }
           } else {
-            auto &group_state_in = group_states_.at(group);
             auto it = group_state_in.pending_tasks.find(seq_no);
             if (it != group_state_in.pending_tasks.end()) {
-              // For non-retry tasks, we need to check if the task is
-              // still in the map because it can be erased due to being
-              // canceled via a higher `client_processed_up_to`.
               ready_task = &it->second;
             }
           }

--- a/src/ray/core_worker/task_execution/tests/actor_task_execution_queue_test.cc
+++ b/src/ray/core_worker/task_execution/tests/actor_task_execution_queue_test.cc
@@ -673,6 +673,97 @@ TEST(OrderedActorTaskExecutionQueueTest, TestRetryInOrderOrderedActorTaskExecuti
   queue.Stop();
 }
 
+// Stop() cancels the queued retry while its args-ready callback stays registered with
+// the waiter, so the callback runs after the entry is gone and must find nothing. The
+// stale-entry version instead recorded a task event for it.
+TEST(OrderedActorTaskExecutionQueueTest, TestRetryArgsReadyAfterStop) {
+  instrumented_io_context io_service;
+  MockWaiter waiter;
+  MockTaskEventBuffer task_event_buffer;
+  [[maybe_unused]] ray::observability::FakeRayEventRecorder ray_task_event_recorder;
+  std::vector<ConcurrencyGroup> concurrency_groups{ConcurrencyGroup{"io", 1, {}}};
+  auto pool_manager =
+      std::make_shared<ConcurrencyGroupManager<BoundedExecutor>>(concurrency_groups);
+
+  int n_accept = 0;
+  int n_reject = 0;
+  auto execute_task = [&n_accept](TaskToExecute &task) { n_accept++; };
+  auto cancel_task = [&n_reject](const TaskToExecute &task, const Status &status) {
+    n_reject++;
+  };
+
+  OrderedActorTaskExecutionQueue queue(io_service,
+                                       waiter,
+                                       task_event_buffer,
+                                       ray_task_event_recorder,
+                                       pool_manager,
+                                       2,
+                                       execute_task,
+                                       cancel_task);
+
+  auto retry_spec = CreateActorTaskSpec(0, /*is_retry=*/true, /*dependency=*/true);
+  EnqueueWithFetch(queue, waiter, 0, -1, MakeTaskToExecute(retry_spec));
+  ASSERT_EQ(n_accept, 0);
+
+  queue.Stop();
+  ASSERT_EQ(n_reject, 1);
+
+  const size_t events_before_args_ready = task_event_buffer.task_events.size();
+  waiter.Complete(0);
+
+  ASSERT_EQ(task_event_buffer.task_events.size(), events_before_args_ready);
+  ASSERT_EQ(n_accept, 0);
+}
+
+// Two retries wait for their args at once and become ready in reverse order. Each
+// callback must resolve its own task, not whichever retry is at the head of the list.
+TEST(OrderedActorTaskExecutionQueueTest, TestConcurrentRetryArgsReadyOutOfOrder) {
+  instrumented_io_context io_service;
+  MockWaiter waiter;
+  MockTaskEventBuffer task_event_buffer;
+  [[maybe_unused]] ray::observability::FakeRayEventRecorder ray_task_event_recorder;
+  std::vector<ConcurrencyGroup> concurrency_groups{ConcurrencyGroup{"io", 1, {}}};
+  auto pool_manager =
+      std::make_shared<ConcurrencyGroupManager<BoundedExecutor>>(concurrency_groups);
+
+  std::vector<int64_t> accept_seq_nos;
+  std::atomic<int> n_accept = 0;
+  auto execute_task = [&accept_seq_nos, &n_accept](TaskToExecute &task) {
+    accept_seq_nos.push_back(task.TaskSpec().ConcurrencyGroupSequenceNumber());
+    n_accept++;
+  };
+  auto cancel_task = [](const TaskToExecute &, const Status &) { FAIL(); };
+
+  OrderedActorTaskExecutionQueue queue(io_service,
+                                       waiter,
+                                       task_event_buffer,
+                                       ray_task_event_recorder,
+                                       pool_manager,
+                                       2,
+                                       execute_task,
+                                       cancel_task);
+
+  // CreateActorTaskSpec leaves the task id nil, and the retries share an attempt
+  // number, so give them distinct ids to tell the two attempts apart.
+  JobID job_id = JobID::FromInt(1);
+  for (int64_t seq_no : {0, 1}) {
+    auto spec = CreateActorTaskSpec(seq_no, /*is_retry=*/true, /*dependency=*/true);
+    spec.GetMutableMessage().set_task_id(TaskID::FromRandom(job_id).Binary());
+    EnqueueWithFetch(queue, waiter, seq_no, -1, MakeTaskToExecute(spec));
+  }
+  ASSERT_EQ(n_accept, 0);
+
+  waiter.Complete(1);
+  ASSERT_TRUE(WaitForCondition([&n_accept]() { return n_accept == 1; }, 1000));
+  waiter.Complete(0);
+  ASSERT_TRUE(WaitForCondition([&n_accept]() { return n_accept == 2; }, 1000));
+
+  pool_manager->GetDefaultExecutor()->Join();
+  ASSERT_EQ(accept_seq_nos, (std::vector<int64_t>{1, 0}));
+
+  queue.Stop();
+}
+
 TEST(OrderedActorTaskExecutionQueueTest, TestPerConcurrencyGroupOrdering) {
   // Test that tasks in different concurrency groups are sequenced independently.
   // group "b" tasks should execute even when group "a" is waiting for a missing seq_no.


### PR DESCRIPTION
## Description

`EnqueueTask` kept a raw pointer to the retry entry it had just pushed onto the group's `pending_retry_tasks` and captured it in the args-ready callback, on the assumption stated there: the entry is not erased until its dependencies are fetched and it executes. `CancelAllQueuedTasks` breaks that. It pops every queued retry, and it runs from `Stop()`, so it can drop an entry whose dependencies are still in flight. Nothing takes the callback back out either: `ActorTaskExecutionArgWaiterInterface` has no deregistration API and `MarkReady` invokes whatever was registered. So a notification arriving after `Stop()` read the freed entry's spec to record a task event and then wrote through `MarkDependenciesResolved()`.

The callback now looks the entry up by (task id, attempt number) and does nothing when it is gone, which is what the in-order branch below it already did with `pending_tasks`. That key is the one the waiter is itself keyed on, so the lookup is exactly as unique as the registration: `task_receiver.cc` documents that each attempt is sent once and that every resubmission bumps the attempt number, and a second `OnArgsReady` for a live key `RAY_CHECK`-fails before any callback can run.

The window is reachable during actor shutdown. `task_receiver_->Stop()` runs in the `CoreWorker.DrainAndShutdown` handler, while `task_execution_service_.stop()` only runs in the later `CoreWorker.Shutdown` handler that the same chain posts, so a `MarkReady` already queued in between still executes. `CoreWorker::HandleActorCallArgWaitComplete` also lacks the `IsExiting()` check that both branches of `HandlePushTask` have. That is worth its own look, but it would not make the pointer valid, so the validation belongs in the callback.

## Related issues

Fixes #65927

Not a duplicate: searches for `ordered actor task execution queue`, `OnArgsReady` and `pending_retry_tasks` turn up no open PR on this path, and no open issue describes it. The one open PR that touches this file, #63765, is marked DO NOT MERGE, has not moved since 2026-07-08, and does not touch the pointer.

## Additional information

The first new test pins the behaviour: one retry carrying a dependency, `Stop()`, then the args-ready callback. With the production change reverted it dies with SIGSEGV; with it, the callback finds nothing and records no event. The second covers the lookup itself, with two retries waiting on dependencies at once and becoming ready in reverse order: matching on position instead of identity would resolve the wrong entry and execute them in the wrong order. No existing test had two dependency-carrying retries in one group. It passes either way.

This touches the same file as #65786, in a different function, with no textual overlap.

```
bazel test --dynamic_mode=off \
  --copt=-Wno-error=deprecated-builtins \
  --host_copt=-Wno-error=deprecated-builtins \
  //src/ray/core_worker/task_execution/tests:all
```

```
//src/ray/core_worker/task_execution/tests:actor_task_execution_queue_test PASSED in 4.4s
//src/ray/core_worker/task_execution/tests:concurrency_group_manager_test PASSED in 0.5s
//src/ray/core_worker/task_execution/tests:fiber_state_test              PASSED in 1.5s
//src/ray/core_worker/task_execution/tests:normal_task_execution_queue_test PASSED in 0.5s
//src/ray/core_worker/task_execution/tests:task_receiver_test            PASSED in 1.8s
//src/ray/core_worker/task_execution/tests:thread_pool_test              PASSED in 0.7s

Executed 6 out of 6 tests: 6 tests pass.
```

`actor_task_execution_queue_test` is 16 tests, 14 of them pre-existing and unchanged. macOS 26.5 / arm64, Apple clang 21; the two extra flags work around a deprecated builtin in the pinned absl on that toolchain, not this change. `pre-commit run clang-format` and `pre-commit run cpplint` pass on both files.

## AI assistance

AI assistance was used for this change and for reviewing it. I have read every changed line and run the commands above locally.
