### PR TITLE
[Core] Decline an idle exit request before recording that shutdown started

### DIFF
--- a/src/ray/core_worker/core_worker_shutdown_executor.cc
+++ b/src/ray/core_worker/core_worker_shutdown_executor.cc
@@ -269,17 +269,14 @@ void CoreWorkerShutdownExecutor::ExecuteExitIfIdle(std::string_view exit_type,
   RAY_LOG(INFO) << "Executing handle exit: " << exit_type << " - " << detail
                 << " (timeout: " << timeout_ms.count() << "ms)";
 
-  if (ShouldWorkerIdleExit()) {
-    auto actual_timeout = timeout_ms;
-    if (actual_timeout.count() == -1) {
-      actual_timeout = std::chrono::milliseconds{10000};  // 10s default
-    }
-
-    ExecuteExit(exit_type, detail, actual_timeout, nullptr);
-  } else {
-    RAY_LOG(INFO) << "Worker not idle, ignoring exit request: " << detail;
-    NotifyComplete();
+  // RequestShutdown declines an idle exit while the worker is busy, so by the time this
+  // runs the state machine has committed to shutting down and there is no way back.
+  auto actual_timeout = timeout_ms;
+  if (actual_timeout.count() == -1) {
+    actual_timeout = std::chrono::milliseconds{10000};  // 10s default
   }
+
+  ExecuteExit(exit_type, detail, actual_timeout, nullptr);
 }
 
 void CoreWorkerShutdownExecutor::KillChildProcessesImmediately() {

--- a/src/ray/core_worker/shutdown_coordinator.cc
+++ b/src/ray/core_worker/shutdown_coordinator.cc
@@ -26,6 +26,14 @@ namespace ray {
 
 namespace core {
 
+namespace {
+
+bool IsIdleExitReason(ShutdownReason reason) {
+  return reason == ShutdownReason::kIdleTimeout || reason == ShutdownReason::kJobFinished;
+}
+
+}  // namespace
+
 ShutdownCoordinator::ShutdownCoordinator(
     std::unique_ptr<ShutdownExecutorInterface> executor, rpc::WorkerType worker_type)
     : executor_(std::move(executor)), worker_type_(worker_type) {
@@ -42,6 +50,13 @@ bool ShutdownCoordinator::RequestShutdown(
     std::string_view detail,
     std::chrono::milliseconds timeout_ms,
     const std::shared_ptr<LocalMemoryBuffer> &creation_task_exception_pb_bytes) {
+  // An idle exit is declined when the worker turns out not to be idle, and the state
+  // machine has no way back to kRunning, so ask before recording that shutdown started.
+  if (!force_shutdown && IsIdleExitReason(reason) && !executor_->ShouldWorkerIdleExit()) {
+    RAY_LOG(INFO) << "Declining idle exit request, worker is not idle: " << detail;
+    return false;
+  }
+
   bool should_execute = false;
   bool execute_force = force_shutdown;
   {
@@ -225,8 +240,7 @@ void ShutdownCoordinator::ExecuteWorkerShutdown(
     TryTransitionToDisconnecting();
     executor_->ExecuteExit(
         GetExitTypeString(), detail, timeout_ms, creation_task_exception_pb_bytes);
-  } else if (reason == ShutdownReason::kIdleTimeout ||
-             reason == ShutdownReason::kJobFinished) {
+  } else if (IsIdleExitReason(reason)) {
     TryTransitionToDisconnecting();
     executor_->ExecuteExitIfIdle(GetExitTypeString(), detail, timeout_ms);
   } else {

--- a/src/ray/core_worker/tests/shutdown_coordinator_test.cc
+++ b/src/ray/core_worker/tests/shutdown_coordinator_test.cc
@@ -279,10 +279,37 @@ TEST_F(ShutdownCoordinatorTest, Worker_ExecuteWorkerExit_OnUserError) {
 }
 
 TEST_F(ShutdownCoordinatorTest, Worker_HandleExit_OnIdleTimeout) {
-  auto coordinator = CreateCoordinator(rpc::WorkerType::WORKER);
+  auto fake = std::make_unique<FakeShutdownExecutor>();
+  auto *fake_ptr = fake.get();
+  fake_ptr->idle_exit_allowed = true;
+  auto coordinator =
+      std::make_unique<ShutdownCoordinator>(std::move(fake), rpc::WorkerType::WORKER);
 
   EXPECT_TRUE(coordinator->RequestShutdown(false,  // graceful
                                            ShutdownReason::kIdleTimeout));
+  EXPECT_EQ(fake_ptr->handle_exit_calls.load(), 1);
+}
+
+// A worker that is not idle declines the request rather than half-committing to it. The
+// state machine has no transition back to kRunning, so a worker left in kDisconnecting
+// would neither exit nor accept a later graceful shutdown.
+TEST_F(ShutdownCoordinatorTest, Worker_IdleTimeout_WhenNotIdle_StaysRunning) {
+  auto fake = std::make_unique<FakeShutdownExecutor>();
+  auto *fake_ptr = fake.get();
+  fake_ptr->idle_exit_allowed = false;
+  auto coordinator =
+      std::make_unique<ShutdownCoordinator>(std::move(fake), rpc::WorkerType::WORKER);
+
+  EXPECT_FALSE(coordinator->RequestShutdown(false,  // graceful
+                                            ShutdownReason::kIdleTimeout));
+
+  EXPECT_EQ(coordinator->GetState(), ShutdownState::kRunning);
+  EXPECT_EQ(coordinator->GetReason(), ShutdownReason::kNone);
+  EXPECT_FALSE(coordinator->ShouldEarlyExit());
+  EXPECT_EQ(fake_ptr->handle_exit_calls.load(), 0);
+
+  EXPECT_TRUE(coordinator->RequestShutdown(false, ShutdownReason::kGracefulExit));
+  EXPECT_EQ(fake_ptr->worker_exit_calls.load(), 1);
 }
 
 TEST_F(ShutdownCoordinatorTest, StringRepresentations_StateAndReason_AreReadable) {
@@ -314,7 +341,9 @@ TEST_F(ShutdownCoordinatorTest, ExitTypeStringMapping_OOM_IsNODE_OUT_OF_MEMORY) 
 
 TEST_F(ShutdownCoordinatorTest,
        ExitTypeStringMapping_IdleTimeout_IsINTENDED_SYSTEM_EXIT) {
-  auto coordinator = CreateCoordinator();
+  auto fake = std::make_unique<FakeShutdownExecutor>();
+  fake->idle_exit_allowed = true;
+  auto coordinator = std::make_unique<ShutdownCoordinator>(std::move(fake));
   coordinator->RequestShutdown(false, ShutdownReason::kIdleTimeout);
   EXPECT_EQ(coordinator->GetExitTypeString(), "INTENDED_SYSTEM_EXIT");
 }


### PR DESCRIPTION
## Description

`RequestShutdown` wrote `state_ = kShuttingDown` for a `kIdleTimeout` request, `ExecuteWorkerShutdown` then committed `kDisconnecting`, and only after that did the executor ask whether the worker is idle. When it is not, `ExecuteExitIfIdle` logs and returns without exiting, and there is no transition back to `kRunning`, so the worker was left permanently non-running: `IsExiting()` stays true, and every later graceful `RequestShutdown` returns false at the `state_ != kRunning` check, including the one the 10ms `CoreWorker.CheckSignal` timer makes for SIGTERM.

The check now runs at the top of `RequestShutdown`, before any state is written, and a worker that is not idle declines the request. That is the only place a check helps: the first commit happens in `RequestShutdown` itself, so a guard inside `ExecuteWorkerShutdown` would still leave the worker in `kShuttingDown`, which is just as non-running. `ShouldWorkerIdleExit()` is already on `ShutdownExecutorInterface`; until now the coordinator never called it, and the executor called it from inside the branch that could no longer act on the answer.

Both call sites ignore the return value, and the reply the raylet already has is `success = is_idle || force_exit`, so a worker left in `kRunning` is what that reply describes. The ordinary not-idle case never reaches the new guard at all, since `HandleExit`'s callback returns early when `will_exit` is false. What reaches it is the worker turning busy between the reply and the check, and the fallback callback on a failed reply, which asks for an idle-timeout shutdown without looking at `is_idle`.

The executor's own check is gone, so the decision has a single owner. That check could not close the loop from where it sat: by the time `ExecuteExitIfIdle` runs, `kDisconnecting` is already committed, and declining there is exactly what wedged the worker. A worker that turns busy between the guard and the exit now exits anyway, which is what the reply the raylet already has says, and the raylet has by then dropped it from the idle pool and marked it dead (`!status.ok() || r.success()` in `WorkerPool::KillIdleWorker`). The 10s default that branch computed is only ever logged, since `ExecuteExit` never reads its `timeout_ms`.

## Related issues

Fixes #65929

Not a duplicate: searches for `shutdown coordinator`, `idle exit worker` and `ExecuteExitIfIdle` turn up no open PR on this path, and no open issue describes it.

## Additional information

The new test asks a fake executor that reports the worker as busy for an idle-timeout shutdown, then asserts the state, the reason, `ShouldEarlyExit()`, that the executor was not asked to exit, and that a following graceful request still succeeds. With the production change reverted all five expectations fail, the last one showing that the worker can no longer be shut down.

Two existing tests were requesting an idle-timeout shutdown from a fake whose `idle_exit_allowed` is false, so they were relying on the request being accepted by a worker that is not idle. Both now set the flag, which is what their names describe, and both pass with and without the production change, so they are not covering for the new one.

```
bazel test --dynamic_mode=off \
  --copt=-Wno-error=deprecated-builtins \
  --host_copt=-Wno-error=deprecated-builtins \
  //src/ray/core_worker/tests:shutdown_coordinator_test
```

```
//src/ray/core_worker/tests:shutdown_coordinator_test PASSED in 0.6s

Executed 1 out of 1 test: 1 test passes.
```

19 tests, 17 of them pre-existing. `shutdown_coordinator_test.cc` is the only test file that touches `ShutdownCoordinator`, and nothing unit-tests `CoreWorkerShutdownExecutor`, which needs a live `CoreWorker`, so the executor side of this change is verified by reading and by compiling `//src/ray/core_worker:core_worker_lib`. macOS 26.5 / arm64, Apple clang 21; the two extra flags work around a deprecated builtin in the pinned absl on that toolchain, not this change. `pre-commit run clang-format` and `pre-commit run cpplint` pass on all three files.

## AI assistance

AI assistance was used for this change and for reviewing it. I have read every changed line and run the commands above locally.
