### PR TITLE
[ci] Scope docs-only deplock changes off the wheel/image build matrix

### DIFF
--- a/.buildkite/dependencies.rayci.yml
+++ b/.buildkite/dependencies.rayci.yml
@@ -21,7 +21,14 @@ steps:
 
   - label: ":tapioca: build: raydepsets: compile all dependencies"
     key: raydepsets_compile_all_dependencies
-    tags: python_dependencies
+    # `deplock_check` lets a docs-only deplock change reach this lock-consistency
+    # verification without also triggering the wheel/image build matrix that
+    # `python_dependencies` fans out to. Ordinary dependency changes still emit
+    # `python_dependencies` and run this job through that tag. See the docs
+    # deplock rule and the `deplock_check` declaration in test.rules.txt.
+    tags:
+      - python_dependencies
+      - deplock_check
     instance_type: small
     commands:
       - bazel run //ci/raydepsets:raydepsets -- build --all-configs --check

--- a/.buildkite/test.rules.test.txt
+++ b/.buildkite/test.rules.test.txt
@@ -229,8 +229,13 @@ doc/test_myst_doc.py: core_doc
 doc/source/_intersphinx/python.inv: doc
 doc/source/_intersphinx/refresh.py: doc
 doc/source/_intersphinx/README.md:
-python/deplocks/docs/docbuild_depset_py3.11.lock: doc doc_api python_dependencies
-ci/raydepsets/configs/docs.depsets.yaml: doc doc_api python_dependencies
+# A docs-only deplock change runs the docbuild, the API-consistency checks, and
+# the `raydepsets --check` lock-consistency job (via `deplock_check`), but not
+# the wheel/image build matrix: the docs lock feeds only the Sphinx docbuild
+# image and is never installed into a Ray wheel, so it emits `deplock_check`
+# rather than `python_dependencies`.
+python/deplocks/docs/docbuild_depset_py3.11.lock: doc doc_api deplock_check
+ci/raydepsets/configs/docs.depsets.yaml: doc doc_api deplock_check
 # Redirect YAML selects the dedicated lightweight check and nothing else: no
 # docbuild, no API checks, no per-team doc tests. The README beside it is prose
 # and stays unrouted, which is what the second case locks in.

--- a/.buildkite/test.rules.txt
+++ b/.buildkite/test.rules.txt
@@ -36,7 +36,7 @@
 ! core_python cpp core_cpp java workflow cgraphs_direct_transport dashboard
 ! ray_client runtime_env_container
 ! data dask serve ml tune train train_gpu llm rllib rllib_gpu rllib_directly
-! linux_wheels macos_wheels docker doc doc_api doc_redirects python_dependencies min_build tools windows
+! linux_wheels macos_wheels docker doc doc_api doc_redirects python_dependencies deplock_check min_build tools windows
 ! release_tests spark_on_ray rocksdb_tests redis_tests sandbox_tests
 ! core_doc data_doc ml_doc rllib_doc serve_doc
 
@@ -177,9 +177,18 @@ python/deplocks/ci/macos_depset_py*
 # change can alter stub generation and therefore what the API-consistency
 # checks see. Emit `doc_api` as well so those checks run on a docs dependency
 # bump.
+#
+# Emit `deplock_check`, not `python_dependencies`. The docs deplock feeds only
+# the Sphinx docbuild image; it is never installed into any Ray wheel or image,
+# so the wheel/image build matrix (which `python_dependencies` fans out to)
+# cannot be affected by a docs-only lock change. `deplock_check` triggers just
+# the `raydepsets --check` lock-consistency job in dependencies.rayci.yml, which
+# validates `--all-configs` (docs included). Every real dependency rule still
+# emits `python_dependencies`, and that job carries both tags, so lock
+# consistency is still verified on ordinary dependency changes.
 python/deplocks/docs/*.lock
 ci/raydepsets/configs/docs.depsets.yaml
-@ doc doc_api python_dependencies
+@ doc doc_api deplock_check
 ;
 
 # Raydepsets-generated lock files and raydepsets configs that drive


### PR DESCRIPTION
## Problem

A docs-only dependency change — `doc/requirements-doc.txt` plus its regenerated `python/deplocks/docs/*.lock` — triggers the full wheel and image build matrix across architectures on premerge. That is heavy for a change that cannot affect any shipped artifact: the docs deplock feeds only the Sphinx docbuild image and is never installed into a Ray wheel or image.

Observed on #65875 (a `setuptools` docs pin bump): https://buildkite.com/ray-project/premerge/builds/72805

We expect these docs dependency bumps to become frequent (a docs dependency staleness/security cleanup is underway), so each one currently pays for the whole matrix.

## Mechanism

`.buildkite/test.rules.txt` maps the docs deplock to tags:

```
python/deplocks/docs/*.lock
ci/raydepsets/configs/docs.depsets.yaml
@ doc doc_api python_dependencies
```

The over-trigger is `python_dependencies`. Nearly every wheel and image build step (`build.rayci.yml`, `linux_aarch64.rayci.yml`, `macos.rayci.yml`, `_images.rayci.yml`) carries it, because for a *real* requirements change it means "dependencies changed, rebuild and retest wheels." The `doc` / `doc_api` tags already cover everything a docs-deplock change can actually affect (docbuild, RtD, the two API-consistency checks).

The subtlety: `python_dependencies` does double duty. It also triggers the `raydepsets --check` lock-consistency job (`raydepsets_compile_all_dependencies` in `dependencies.rayci.yml`), which *should* run when any deplock changes. A blind "drop `python_dependencies` from the docs rule" would also drop that check.

## This change

Split the two concerns **additively**, so no existing dependency rule changes behavior:

- Declare a `deplock_check` tag.
- Carry `deplock_check` on `raydepsets_compile_all_dependencies` **alongside** `python_dependencies`. Real dependency changes still reach it via `python_dependencies` (unchanged); a docs-deplock change reaches it via `deplock_check` without the matrix.
- The docs-deplock rule emits `@ doc doc_api deplock_check` instead of `@ doc doc_api python_dependencies`.

`pip_compile_dependencies` is deliberately left on `python_dependencies` only — it verifies `python/requirements_compiled.txt`, which a docs deplock never touches.

### Why not tag the check with `doc`

An alternative is to give the lock-check job a `doc`-or-narrower trigger. But `raydepsets --check` runs `--all-configs`, and `doc` fires on nearly every prose docs PR, so the check (a manylinux build) would run on every `.md`/`.rst` edit. The dedicated `deplock_check` tag fires only when a lock or depset config actually changes.

## Verification

Local dry-run against the edited rules (Ray's in-repo reference evaluator, `ci/pipeline/determine_tests_to_run.py`):

- `python/deplocks/docs/docbuild_depset_py3.11.lock` → `doc doc_api deplock_check` (no `python_dependencies`).
- `ci/raydepsets/configs/docs.depsets.yaml` → `doc doc_api deplock_check`.
- Control — real dependency files (`python/requirements.txt`, `python/deplocks/ci/*.lock`, `python/deplocks/llm/*.lock`, depset configs) still emit the full `python_dependencies` fan-out, unchanged.

Step-dependency trace (tags are a lower bound; `markDeps` pulls in `depends_on` chains regardless of tags): the surviving `doc` / `doc_api` / `deplock_check` steps depend only on `docbuild` (which installs the docs lock via `REQUIREMENTS_FILE`), `ray-core-build(py3.11)`, base CI images, and `manylinux` / `forge` — none of the `python_dependencies` wheel/image matrix steps. So the matrix genuinely drops, while the docbuild rebuild that must pick up the new lock still runs.

`.buildkite/test.rules.test.txt` is updated with the new expected tags; the `test-rules` premerge check validates it authoritatively.

## For Ray CI review

`test.rules.txt` and the `python_dependencies` tag are shared CI surface, so this needs a Ray CI call on the tag design — flagging @elliot-barn (REEf). Open questions:

1. Is `deplock_check` the tag name/shape you want, or would you prefer splitting `python_dependencies` itself into "verify locks" vs "rebuild wheels"?
2. `deplock_check` is on `raydepsets_compile_all_dependencies` only; `pip_compile_dependencies` stays `python_dependencies`-only. Agree that's the right boundary for a docs deplock?

Holding this as a **draft** pending that sign-off and a green premerge that shows the wheel/image matrix dropping on a real docs-deplock change (this PR touches the rules, not a docs lock, so a follow-up test push or a check on the next real docs-deplock PR confirms it end to end).

## Done when

A docs-only dependency change (`requirements-doc.txt` + docs deplock) runs the doc build, the API-consistency checks, and the lock-consistency check — but not the wheel/image build matrix — verified on a real premerge build.
