### PR TITLE
[ci] DO NOT MERGE: docs-deplock CI routing demo for #65934

### DIFF
--- a/python/deplocks/docs/docbuild_depset_py3.11.lock
+++ b/python/deplocks/docs/docbuild_depset_py3.11.lock
@@ -1,3 +1,5 @@
+# CI routing demonstration for #65934 — DO NOT MERGE. This no-op comment exists
+# only to make this a docs-deplock change so premerge shows the new tag routing.
 absl-py==2.4.0 \
     --hash=sha256:88476fd881ca8aab94ffa78b7b6c632a782ab3ba1cd19c9bd423abc4fb4cd28d \
     --hash=sha256:8c6af82722b35cf71e0f4d1d47dcaebfff286e27110a99fc359349b247dfb5d4


### PR DESCRIPTION
**DO NOT MERGE.** Throwaway branch to give #65934 a real premerge run. Stacked on `doc-1646-scope-docs-deplock-ci`, so the diff here is a single no-op comment added to `python/deplocks/docs/docbuild_depset_py3.11.lock` — enough to make premerge treat this as a docs-only deplock change and route it through the new tags.

## What to look at

The **pipeline shape**, not the pass/fail of any single step:

- **No wheel/image build matrix.** The steps that carry `python_dependencies` (`build.rayci.yml` wheels, `_images.rayci.yml` image matrix, `linux_aarch64.rayci.yml`, `macos`) should be **absent**. That's the whole point of #65934.
- **Present:** `doc: build`, the two API-consistency checks (`doc_api`), and `raydepsets: compile all dependencies` (the lock-consistency check, now reachable via the new `deplock_check` tag).

## Expected red, and why it's fine

`raydepsets: compile all dependencies` is **expected to fail** here. The comment this PR adds is stripped when the lock is regenerated, so `--check` sees a diff. That red is the demonstration working: it proves `deplock_check` wired up and the lock-consistency check ran on a docs-deplock change. A real docs-deplock PR (a genuine resolver-driven regeneration) would be green.

`doc: build` installs the lock and ignores `#` comments, so it should stay green.

## Base

Based on the `doc-1646-scope-docs-deplock-ci` branch (PR #65934), not `master`, so the routing is evaluated with that PR's rules in effect and the diff stays to the one lock file. Close this once #65934's design is settled.

cc @elliot-barn
