### PR TITLE
[CI] Fix deepspeed astral's cu128 index incompatible with Torch 2.9

### DIFF
--- a/ci/docker/docgpu.build.Dockerfile
+++ b/ci/docker/docgpu.build.Dockerfile
@@ -17,7 +17,9 @@ RUN <<EOF
 
 set -euo pipefail
 
-uv pip install -r /home/ray/python_depset.lock --no-deps --system --index-strategy unsafe-best-match
+# --no-binary deepspeed: the GPU locks resolve against Astral's cu128 index, which publishes prebuilt deepspeed wheels
+#   as local versions (0.18.9+cu.12.8.torch.2.11), however, currently we use torch 2.9 which is incompatible
+uv pip install -r /home/ray/python_depset.lock --no-deps --system --index-strategy unsafe-best-match --no-binary deepspeed
 
 # Remove installed ray so the source overlay at /rayci/ is used at test time
 pip uninstall -y ray

--- a/ci/docker/ml.build.Dockerfile
+++ b/ci/docker/ml.build.Dockerfile
@@ -41,7 +41,9 @@ mkdir -p python/ray/thirdparty_files
 uv pip install -r /home/ray/thirdparty_depset.lock --no-deps --target=python/ray/thirdparty_files
 
 # Install Python dependencies from depset lock file
-uv pip install -r /home/ray/python_depset.lock --no-deps --system --index-strategy unsafe-best-match
+# --no-binary deepspeed: the GPU locks resolve against Astral's cu128 index, which publishes prebuilt deepspeed wheels
+#   as local versions (0.18.9+cu.12.8.torch.2.11), however, currently we use torch 2.9 which is incompatible
+uv pip install -r /home/ray/python_depset.lock --no-deps --system --index-strategy unsafe-best-match --no-binary deepspeed
 
 # Inject our own mirror for the CIFAR10 dataset
 SITE_PACKAGES=$(python -c 'from distutils.sysconfig import get_python_lib; print(get_python_lib())')


### PR DESCRIPTION
## Description
https://github.com/ray-project/ray/pull/65899 added astral's cu128 index for torch-scatter support, however, at the same time, started pulling in a DeepSpeed wheel that was compiled with torch 2.11
This wheel is incompatible with our torch 2.9 install causing
```
RuntimeError: PyTorch version mismatch! DeepSpeed ops were compiled and installed with a different version than what is being used at runtime. Please re-install DeepSpeed or switch torch versions. Install torch version=2.11, Runtime torch version=2.9 
```

This PR fixes it through adding `--no-binary` to `uv` for `deepspeed` to ensure that deepspeed is built locally using the current torch version. In this future this could be removed. 
 