### PR TITLE
[raylet] Release pinned lease args in HandleReturnWorkerLease

### DIFF
--- a/python/ray/tests/test_basic.py
+++ b/python/ray/tests/test_basic.py
@@ -191,7 +191,9 @@ def test_hung_worker_releases_pinned_lease_args(shutdown_only):
         total = 0
         for path in glob.glob(os.path.join(session_dir, "logs", "debug_state*.txt")):
             with open(path) as f:
-                m = re.search(r"Total size of pinned lease arguments:\s*(\d+)", f.read())
+                m = re.search(
+                    r"Total size of pinned lease arguments:\s*(\d+)", f.read()
+                )
             if m:
                 total += int(m.group(1))
         return total
@@ -218,14 +220,14 @@ def test_hung_worker_releases_pinned_lease_args(shutdown_only):
         payload = ray.put(np.zeros(15 * 1024 * 1024 // 8, dtype=np.int64))
         ref = hanging_task.remote(payload)
         if i == 0:
-            assert wait_until(lambda v: v >= 10 * 1024 * 1024) > 0, (
-                "raylet did not pin the lease arg; test precondition broken"
-            )
+            assert (
+                wait_until(lambda v: v >= 10 * 1024 * 1024) > 0
+            ), "raylet did not pin the lease arg; test precondition broken"
         keepalive.append(ray.get(ref, timeout=30))
         del payload
-        assert wait_until(lambda v: v == 0) == 0, (
-            f"pinned bytes did not return to 0 after iteration {i}"
-        )
+        assert (
+            wait_until(lambda v: v == 0) == 0
+        ), f"pinned bytes did not return to 0 after iteration {i}"
     keepalive.clear()
 
 

--- a/python/ray/tests/test_basic.py
+++ b/python/ray/tests/test_basic.py
@@ -213,7 +213,8 @@ def test_hung_worker_releases_pinned_lease_args(shutdown_only):
 
     keepalive = []
     for i in range(3):
-        # 15MB > inline threshold → plasma-backed lease arg.
+        # Use a 15MB plasma object so the lease argument is pinned by the
+        # raylet rather than inlined in the task spec.
         payload = ray.put(np.zeros(15 * 1024 * 1024 // 8, dtype=np.int64))
         ref = hanging_task.remote(payload)
         if i == 0:

--- a/python/ray/tests/test_basic.py
+++ b/python/ray/tests/test_basic.py
@@ -173,6 +173,65 @@ def test_max_calls_releases_resources(shutdown_only):
         ray.get(f.remote())  # This will hang if GPU resources aren't released.
 
 
+def test_hung_worker_releases_pinned_lease_args(shutdown_only):
+    """E2E: max_calls + hung DrainAndShutdown must release pinned lease args.
+
+    C++ ``ReturnWorkerLeaseWithWorkerExitingReleasesPinnedArgs`` is the
+    primary unit test. This checks the real worker path via debug_state.
+    """
+    import glob
+
+    import numpy as np
+
+    ctx = ray.init(
+        num_cpus=2,
+        object_store_memory=400 * 1024 * 1024,
+        # Observe pin while the task still holds it (released on return).
+        _system_config={"debug_dump_period_milliseconds": 1000},
+    )
+    session_dir = ctx.address_info["session_dir"]
+
+    def read_pinned_bytes():
+        total = 0
+        for path in glob.glob(os.path.join(session_dir, "logs", "debug_state*.txt")):
+            with open(path) as f:
+                m = re.search(r"Total size of pinned lease arguments:\s*(\d+)", f.read())
+            if m:
+                total += int(m.group(1))
+        return total
+
+    def wait_until(predicate, timeout=15):
+        deadline = time.monotonic() + timeout
+        value = read_pinned_bytes()
+        while time.monotonic() < deadline and not predicate(value):
+            time.sleep(0.5)
+            value = read_pinned_bytes()
+        return value
+
+    @ray.remote(max_calls=1)
+    def hanging_task(payload):
+        # sleep: cover one debug dump while pinned. ray.put return: keep
+        # worker in DrainAndShutdown (no DisconnectClient).
+        time.sleep(3)
+        return ray.put({"m": 1})
+
+    keepalive = []
+    for i in range(3):
+        # 15MB > inline threshold → plasma-backed lease arg.
+        payload = ray.put(np.zeros(15 * 1024 * 1024 // 8, dtype=np.int64))
+        ref = hanging_task.remote(payload)
+        if i == 0:
+            assert wait_until(lambda v: v >= 10 * 1024 * 1024) > 0, (
+                "raylet did not pin the lease arg; test precondition broken"
+            )
+        keepalive.append(ray.get(ref, timeout=30))
+        del payload
+        assert wait_until(lambda v: v == 0) == 0, (
+            f"pinned bytes did not return to 0 after iteration {i}"
+        )
+    keepalive.clear()
+
+
 # https://github.com/ray-project/ray/issues/7263
 def test_grpc_message_size(shutdown_only):
     ray.init(num_cpus=1)

--- a/python/ray/tests/test_basic.py
+++ b/python/ray/tests/test_basic.py
@@ -174,11 +174,7 @@ def test_max_calls_releases_resources(shutdown_only):
 
 
 def test_hung_worker_releases_pinned_lease_args(shutdown_only):
-    """E2E: max_calls + hung DrainAndShutdown must release pinned lease args.
-
-    C++ ``ReturnWorkerLeaseWithWorkerExitingReleasesPinnedArgs`` is the
-    primary unit test. This checks the real worker path via debug_state.
-    """
+    """E2E: max_calls + hung DrainAndShutdown must release pinned lease args."""
     import glob
 
     import numpy as np

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -2245,9 +2245,8 @@ void NodeManager::HandleReturnWorkerLease(rpc::ReturnWorkerLeaseRequest request,
       // unblock RPC by unblocking it immediately (unblock is idempotent).
       HandleNotifyWorkerUnblocked(worker);
     }
-    // Release resources first to match the reuse-path teardown order, then
-    // release pinned lease args now: a worker that hangs in shutdown never
-    // triggers DisconnectClient, so deferred release would leak.
+    // Release pinned lease args now: a worker that hangs in shutdown
+    // never triggers DisconnectClient, so deferred release would leak.
     local_lease_manager_.ReleaseWorkerResources(worker);
     if (!worker->GetGrantedLeaseId().IsNil()) {
       CleanupLease(worker);

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -2245,9 +2245,14 @@ void NodeManager::HandleReturnWorkerLease(rpc::ReturnWorkerLeaseRequest request,
       // unblock RPC by unblocking it immediately (unblock is idempotent).
       HandleNotifyWorkerUnblocked(worker);
     }
+    // Release pinned lease args now: a worker that hangs in shutdown
+    // never triggers DisconnectClient, so deferred release would leak.
+    if (!worker->GetGrantedLeaseId().IsNil()) {
+      CleanupLease(worker);
+    }
     local_lease_manager_.ReleaseWorkerResources(worker);
-    // If the worker is exiting, don't add it to our pool. The worker will cleanup
-    // and terminate itself.
+    // If the worker is exiting, don't add it to our pool. The worker will
+    // cleanup and terminate itself.
     if (!request.worker_exiting()) {
       HandleWorkerAvailable(worker);
     }

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -2251,8 +2251,8 @@ void NodeManager::HandleReturnWorkerLease(rpc::ReturnWorkerLeaseRequest request,
       CleanupLease(worker);
     }
     local_lease_manager_.ReleaseWorkerResources(worker);
-    // If the worker is exiting, don't add it to our pool. The worker will
-    // cleanup and terminate itself.
+    // If the worker is exiting, don't add it to our pool. The worker will cleanup
+    // and terminate itself.
     if (!request.worker_exiting()) {
       HandleWorkerAvailable(worker);
     }

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -2245,12 +2245,13 @@ void NodeManager::HandleReturnWorkerLease(rpc::ReturnWorkerLeaseRequest request,
       // unblock RPC by unblocking it immediately (unblock is idempotent).
       HandleNotifyWorkerUnblocked(worker);
     }
-    // Release pinned lease args now: a worker that hangs in shutdown
-    // never triggers DisconnectClient, so deferred release would leak.
+    // Release resources first to match the reuse-path teardown order, then
+    // release pinned lease args now: a worker that hangs in shutdown never
+    // triggers DisconnectClient, so deferred release would leak.
+    local_lease_manager_.ReleaseWorkerResources(worker);
     if (!worker->GetGrantedLeaseId().IsNil()) {
       CleanupLease(worker);
     }
-    local_lease_manager_.ReleaseWorkerResources(worker);
     // If the worker is exiting, don't add it to our pool. The worker will cleanup
     // and terminate itself.
     if (!request.worker_exiting()) {

--- a/src/ray/raylet/scheduling/local_lease_manager.h
+++ b/src/ray/raylet/scheduling/local_lease_manager.h
@@ -183,6 +183,9 @@ class LocalLeaseManager : public LocalLeaseManagerInterface {
     return num_unschedulable_lease_spilled_;
   }
 
+  /// Bytes currently pinned as granted-lease arguments. For tests / debug.
+  size_t GetPinnedLeaseArgumentsBytes() const { return pinned_lease_arguments_bytes_; }
+
   bool IsLeaseQueued(const SchedulingClass &scheduling_class,
                      const LeaseID &lease_id) const override;
 

--- a/src/ray/raylet/tests/node_manager_test.cc
+++ b/src/ray/raylet/tests/node_manager_test.cc
@@ -1726,7 +1726,7 @@ INSTANTIATE_TEST_SUITE_P(ReleaseUnusedBundlesRetriesVariations,
 
 // Regression: HandleReturnWorkerLease with worker_exiting=true must release
 // pinned lease args without waiting on DisconnectClient.
-TEST_F(NodeManagerTest, ReturnWorkerLeaseWithWorkerExitingReleasesPinnedArgs) {
+TEST_F(NodeManagerTest, TestExitingWorkerReleasesPinnedLeaseArgs) {
   auto [lease_id, worker] = GrantLeaseWithPinnedArg(/*arg_bytes=*/1024);
   ASSERT_GT(local_lease_manager_->GetPinnedLeaseArgumentsBytes(), 0);
   ASSERT_EQ(leased_workers_.size(), 1u);

--- a/src/ray/raylet/tests/node_manager_test.cc
+++ b/src/ray/raylet/tests/node_manager_test.cc
@@ -477,8 +477,7 @@ class NodeManagerTest : public ::testing::Test {
       size_t arg_bytes) {
     auto lease_spec = BuildLeaseSpec({});
     ObjectID object_dep = ObjectID::FromRandom();
-    lease_spec.GetMutableMessage().add_dependencies()->set_object_id(
-        object_dep.Binary());
+    lease_spec.GetMutableMessage().add_dependencies()->set_object_id(object_dep.Binary());
 
     rpc::Address owner_addr;
     RAY_UNUSED(mock_store_client_->TryCreateImmediately(
@@ -1727,8 +1726,7 @@ INSTANTIATE_TEST_SUITE_P(ReleaseUnusedBundlesRetriesVariations,
 
 // Regression: HandleReturnWorkerLease with worker_exiting=true must release
 // pinned lease args without waiting on DisconnectClient.
-TEST_F(NodeManagerTest,
-       ReturnWorkerLeaseWithWorkerExitingReleasesPinnedArgs) {
+TEST_F(NodeManagerTest, ReturnWorkerLeaseWithWorkerExitingReleasesPinnedArgs) {
   auto [lease_id, worker] = GrantLeaseWithPinnedArg(/*arg_bytes=*/1024);
   ASSERT_GT(local_lease_manager_->GetPinnedLeaseArgumentsBytes(), 0);
   ASSERT_EQ(leased_workers_.size(), 1u);

--- a/src/ray/raylet/tests/node_manager_test.cc
+++ b/src/ray/raylet/tests/node_manager_test.cc
@@ -522,10 +522,6 @@ class NodeManagerTest : public ::testing::Test {
     return {lease_id, worker};
   }
 
-  size_t PinnedLeaseArgBytes() const {
-    return local_lease_manager_->GetPinnedLeaseArgumentsBytes();
-  }
-
   instrumented_io_context io_service_;
   rpc::ClientCallManager client_call_manager_;
   rpc::CoreWorkerClientPool worker_rpc_pool_;
@@ -1734,7 +1730,7 @@ INSTANTIATE_TEST_SUITE_P(ReleaseUnusedBundlesRetriesVariations,
 TEST_F(NodeManagerTest,
        ReturnWorkerLeaseWithWorkerExitingReleasesPinnedArgs) {
   auto [lease_id, worker] = GrantLeaseWithPinnedArg(/*arg_bytes=*/1024);
-  ASSERT_GT(PinnedLeaseArgBytes(), 0);
+  ASSERT_GT(local_lease_manager_->GetPinnedLeaseArgumentsBytes(), 0);
   ASSERT_EQ(leased_workers_.size(), 1u);
 
   rpc::ReturnWorkerLeaseRequest request;
@@ -1748,7 +1744,7 @@ TEST_F(NodeManagerTest,
       });
 
   EXPECT_EQ(leased_workers_.size(), 0u);
-  EXPECT_EQ(PinnedLeaseArgBytes(), 0);
+  EXPECT_EQ(local_lease_manager_->GetPinnedLeaseArgumentsBytes(), 0);
 }
 
 }  // namespace ray::raylet

--- a/src/ray/raylet/tests/node_manager_test.cc
+++ b/src/ray/raylet/tests/node_manager_test.cc
@@ -471,6 +471,61 @@ class NodeManagerTest : public ::testing::Test {
         fake_clock_);
   }
 
+  // Grant a lease that carries one plasma dependency of `arg_bytes` so the
+  // LocalLeaseManager pins it as a lease argument. Returns (lease_id, worker).
+  std::pair<LeaseID, std::shared_ptr<MockWorker>> GrantLeaseWithPinnedArg(
+      size_t arg_bytes) {
+    auto lease_spec = BuildLeaseSpec({});
+    ObjectID object_dep = ObjectID::FromRandom();
+    lease_spec.GetMutableMessage().add_dependencies()->set_object_id(
+        object_dep.Binary());
+
+    rpc::Address owner_addr;
+    RAY_UNUSED(mock_store_client_->TryCreateImmediately(
+        object_dep,
+        owner_addr,
+        arg_bytes,
+        nullptr,
+        arg_bytes,
+        nullptr,
+        plasma::flatbuf::ObjectSource::CreatedByWorker,
+        0));
+
+    LeaseID lease_id = LeaseID::FromRandom();
+    lease_spec.GetMutableMessage().set_lease_id(lease_id.Binary());
+    rpc::RequestWorkerLeaseRequest request;
+    rpc::RequestWorkerLeaseReply reply;
+    request.mutable_lease_spec()->CopyFrom(lease_spec.GetMessage());
+    request.set_backlog_size(1);
+    request.set_grant_or_reject(true);
+    request.set_is_selected_based_on_locality(true);
+
+    EXPECT_CALL(*mock_object_manager_, Pull(_, _, _))
+        .Times(::testing::AnyNumber())
+        .WillRepeatedly(Return(1));
+
+    auto worker = std::make_shared<MockWorker>(WorkerID::FromRandom(), 10, clock_);
+    PopWorkerCallback pop_cb;
+    EXPECT_CALL(mock_worker_pool_, PopWorker(_, _))
+        .Times(1)
+        .WillOnce([&](const LeaseSpecification &, const PopWorkerCallback &cb) {
+          pop_cb = cb;
+        });
+    node_manager_->HandleRequestWorkerLease(
+        request, &reply, [](Status s, std::function<void()>, std::function<void()>) {
+          ASSERT_TRUE(s.ok());
+        });
+    auto ready = lease_dependency_manager_->HandleObjectLocal(object_dep);
+    local_lease_manager_->LeasesUnblocked(ready);
+    RAY_CHECK(pop_cb);
+    pop_cb(worker, PopWorkerStatus::OK, "");
+    return {lease_id, worker};
+  }
+
+  size_t PinnedLeaseArgBytes() const {
+    return local_lease_manager_->GetPinnedLeaseArgumentsBytes();
+  }
+
   instrumented_io_context io_service_;
   rpc::ClientCallManager client_call_manager_;
   rpc::CoreWorkerClientPool worker_rpc_pool_;
@@ -1673,5 +1728,27 @@ TEST_P(ReleaseUnusedBundlesRetriesTest, TestHandleReleaseUnusedBundlesRetries) {
 INSTANTIATE_TEST_SUITE_P(ReleaseUnusedBundlesRetriesVariations,
                          ReleaseUnusedBundlesRetriesTest,
                          ::testing::Bool());
+
+// Regression: HandleReturnWorkerLease with worker_exiting=true must release
+// pinned lease args without waiting on DisconnectClient.
+TEST_F(NodeManagerTest,
+       ReturnWorkerLeaseWithWorkerExitingReleasesPinnedArgs) {
+  auto [lease_id, worker] = GrantLeaseWithPinnedArg(/*arg_bytes=*/1024);
+  ASSERT_GT(PinnedLeaseArgBytes(), 0);
+  ASSERT_EQ(leased_workers_.size(), 1u);
+
+  rpc::ReturnWorkerLeaseRequest request;
+  rpc::ReturnWorkerLeaseReply reply;
+  request.set_lease_id(lease_id.Binary());
+  request.set_worker_exiting(true);
+  request.set_disconnect_worker(false);
+  node_manager_->HandleReturnWorkerLease(
+      request, &reply, [](Status s, std::function<void()>, std::function<void()>) {
+        ASSERT_TRUE(s.ok());
+      });
+
+  EXPECT_EQ(leased_workers_.size(), 0u);
+  EXPECT_EQ(PinnedLeaseArgBytes(), 0);
+}
 
 }  // namespace ray::raylet


### PR DESCRIPTION
## Description
- A `max_calls` worker can hang in `DrainAndShutdown` when the driver still borrows a worker-owned return ref (e.g. `return ray.put(...)`), so `DisconnectClient` never runs and pinned lease-arg bytes leak until new leases stall in `WAITING_FOR_AVAILABLE_PLASMA_MEMORY`.
- Release those pins in `HandleReturnWorkerLease` by calling `CleanupLease` before reuse/exit handling (idempotent with the normal reuse path).


## Tests

- C++ (`ReturnWorkerLeaseWithWorkerExitingReleasesPinnedArgs`): grants a lease with a pinned plasma arg, returns the worker with `worker_exiting=true` / `disconnect_worker=false`, and asserts pinned lease-arg bytes drop to 0.
- Python e2e (`test_hung_worker_releases_pinned_lease_args`): runs `max_calls=1` tasks that `return ray.put(...)` so the worker hangs in `DrainAndShutdown`, parses `Total size of pinned lease arguments` from `session/logs/debug_state*.txt`, and asserts that value returns to 0 after each iteration.