### PR TITLE
[Data][LLM] Support unary ServeDeploymentProcessor responses

### DIFF
--- a/python/ray/data/llm.py
+++ b/python/ray/data/llm.py
@@ -328,6 +328,10 @@ class ServeDeploymentProcessorConfig(_ServeDeploymentProcessorConfig, ProcessorC
     Args:
         deployment_name: The name of the serve deployment to use.
         app_name: The name of the serve application to use.
+        stream: Whether the serve deployment returns a streaming response. If True
+            (default), the processor consumes the deployment's streaming response.
+            If False, the processor supports an ordinary non-streaming or unary
+            serve deployment.
         batch_size: The batch size to send to the serve deployment. Large batch sizes are
             likely to saturate the compute resources and could achieve higher throughput.
             On the other hand, small batch sizes are more fault-tolerant and could

--- a/python/ray/llm/_internal/batch/processor/serve_deployment_proc.py
+++ b/python/ray/llm/_internal/batch/processor/serve_deployment_proc.py
@@ -24,6 +24,7 @@ class ServeDeploymentProcessorConfig(ProcessorConfig):
         description="The name of the serve application to use.",
         default="default",
     )
+    stream: bool = True
     dtype_mapping: Dict[str, Type[Any]] = Field(
         description="A dictionary mapping data type names to their corresponding request classes for the serve deployment.",
         default=None,
@@ -79,6 +80,7 @@ def build_serve_deployment_processor(
             fn_constructor_kwargs=dict(
                 deployment_name=config.deployment_name,
                 app_name=config.app_name,
+                stream=config.stream,
                 dtype_mapping=config.dtype_mapping,
                 should_continue_on_error=config.should_continue_on_error,
                 request_timeout_s=config.request_timeout_s,

--- a/python/ray/llm/_internal/batch/stages/serve_deployment_stage.py
+++ b/python/ray/llm/_internal/batch/stages/serve_deployment_stage.py
@@ -40,6 +40,7 @@ class ServeDeploymentStageUDF(StatefulStageUDF):
         deployment_name: str,
         app_name: str,
         dtype_mapping: Dict[str, Type[Any]],
+        stream: bool = True,
         should_continue_on_error: bool = False,
         request_timeout_s: Optional[float] = None,
     ):
@@ -52,6 +53,7 @@ class ServeDeploymentStageUDF(StatefulStageUDF):
             deployment_name: The name of the deployment.
             app_name: The name of the deployment app.
             dtype_mapping: The mapping of the request class name to the request class.
+            stream: Whether the deployment returns a streaming response.
             should_continue_on_error: If True, continue processing when inference
                 fails for a row instead of raising. Failed rows will have
                 '__inference_error__' set to the error message.
@@ -63,14 +65,14 @@ class ServeDeploymentStageUDF(StatefulStageUDF):
         """
         super().__init__(data_column, expected_input_keys)
         self._dtype_mapping = dtype_mapping
+        self.stream = stream
         self.should_continue_on_error = should_continue_on_error
         self.request_timeout_s = request_timeout_s
 
-        # Using stream=True as LLM serve deployments return async generators.
-        # TODO (Kourosh): Generalize this to support non-streaming deployments.
-        self._dh = serve.get_deployment_handle(deployment_name, app_name).options(
-            stream=True
-        )
+        self._dh = serve.get_deployment_handle(deployment_name, app_name)
+        if self.stream:
+            # LLM serve deployments return async generators.
+            self._dh = self._dh.options(stream=True)
         self.request_id = 0
 
     def _prepare_request(
@@ -129,11 +131,12 @@ class ServeDeploymentStageUDF(StatefulStageUDF):
 
         t = time.perf_counter()
         # Directly using anext() requires python3.10 and above
-        response_gen = getattr(self._dh, method).remote(request_obj)
+        response = getattr(self._dh, method).remote(request_obj)
+        response_awaitable = response.__anext__() if self.stream else response
         if self.request_timeout_s is not None:
             try:
                 output_data = await asyncio.wait_for(
-                    response_gen.__anext__(), timeout=self.request_timeout_s
+                    response_awaitable, timeout=self.request_timeout_s
                 )
             except asyncio.TimeoutError as e:
                 raise TimeoutError(
@@ -141,7 +144,7 @@ class ServeDeploymentStageUDF(StatefulStageUDF):
                     f"for deployment '{method}' to return a response."
                 ) from e
         else:
-            output_data = await response_gen.__anext__()
+            output_data = await response_awaitable
         time_taken = time.perf_counter() - t
 
         # Convert the output data to a dict if it is a Pydantic model.

--- a/python/ray/llm/tests/batch/gpu/processor/test_serve_deployment_proc.py
+++ b/python/ray/llm/tests/batch/gpu/processor/test_serve_deployment_proc.py
@@ -14,7 +14,10 @@ from ray.serve.llm.openai_api_models import ChatCompletionRequest, CompletionReq
 @pytest.mark.parametrize(
     "dtype_mapping", [None, {"CompletionRequest": CompletionRequest}]
 )
-def test_serve_deployment_processor(dtype_mapping):
+@pytest.mark.parametrize(
+    "stream_config,expected_stream", [(None, True), (False, False)]
+)
+def test_serve_deployment_processor(dtype_mapping, stream_config, expected_stream):
     app_name = "test_serve_deployment_processor_app"
     deployment_name = "test_serve_deployment_name"
 
@@ -24,6 +27,8 @@ def test_serve_deployment_processor(dtype_mapping):
         batch_size=16,
         concurrency=1,
     )
+    if stream_config is not None:
+        config_kwargs["stream"] = stream_config
     if dtype_mapping is not None:
         config_kwargs["dtype_mapping"] = dtype_mapping
     config = ServeDeploymentProcessorConfig(**config_kwargs)
@@ -37,6 +42,7 @@ def test_serve_deployment_processor(dtype_mapping):
     assert stage.fn_constructor_kwargs == {
         "deployment_name": deployment_name,
         "app_name": app_name,
+        "stream": expected_stream,
         "dtype_mapping": dtype_mapping,
         "should_continue_on_error": False,
         "request_timeout_s": None,
@@ -87,6 +93,39 @@ def test_simple_serve_deployment(serve_cleanup):
     outs = ds.take_all()
     assert len(outs) == 60
     assert all("resp" in out for out in outs)
+    assert all(out["resp"] == out["id"] + 1 for out in outs)
+
+
+def test_simple_unary_serve_deployment(serve_cleanup):
+    @serve.deployment
+    class SimpleUnaryServeDeployment:
+        async def add(self, request: Dict[str, Any]):
+            return {"result": request["x"] + 1}
+
+    app_name = "simple_unary_serve_deployment_app"
+    deployment_name = "SimpleUnaryServeDeployment"
+
+    serve.run(SimpleUnaryServeDeployment.bind(), name=app_name)
+
+    config = ServeDeploymentProcessorConfig(
+        deployment_name=deployment_name,
+        app_name=app_name,
+        stream=False,
+        batch_size=4,
+        concurrency=1,
+    )
+    processor = build_processor(
+        config,
+        preprocess=lambda row: dict(
+            method="add",
+            dtype=None,
+            request_kwargs=dict(x=row["id"]),
+        ),
+        postprocess=lambda row: dict(resp=row["result"], id=row["id"]),
+    )
+
+    outs = processor(ray.data.range(4)).take_all()
+    assert len(outs) == 4
     assert all(out["resp"] == out["id"] + 1 for out in outs)
 
 

--- a/python/ray/llm/tests/batch/gpu/stages/test_serve_deployment_stage.py
+++ b/python/ray/llm/tests/batch/gpu/stages/test_serve_deployment_stage.py
@@ -107,6 +107,40 @@ async def test_serve_deployment_udf_methods(
     assert getattr(mock_serve_deployment_handle, method).remote.call_count == len(
         test_data
     )
+    mock_serve_deployment_handle.options.assert_called_once_with(stream=True)
+
+
+@pytest.mark.asyncio
+async def test_serve_deployment_udf_unary_response(mock_serve_deployment_handle):
+    async def mock_response():
+        return {"test": "unary response"}
+
+    mock_serve_deployment_handle.completions.remote.return_value = mock_response()
+    udf = ServeDeploymentStageUDF(
+        data_column="__data",
+        expected_input_keys=["method", "request_kwargs"],
+        deployment_name="test_deployment",
+        app_name="test_app",
+        stream=False,
+        dtype_mapping={"CompletionRequest": CompletionRequest},
+    )
+
+    responses = []
+    async for response in udf(
+        {
+            "__data": [
+                {
+                    "method": "completions",
+                    "dtype": "CompletionRequest",
+                    "request_kwargs": {"prompt": "Hello"},
+                }
+            ]
+        }
+    ):
+        responses.append(response)
+
+    assert responses[0]["__data"][0]["test"] == "unary response"
+    mock_serve_deployment_handle.options.assert_not_called()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Description

Adds support for non-streaming (unary) Serve deployments in `ServeDeploymentProcessor`.

`ServeDeploymentStageUDF` previously always configured the deployment handle with `stream=True` and consumed responses with `__anext__()`. That works for streaming deployments, but fails for unary deployments that return a regular `DeploymentResponse`.

This PR adds a `stream: bool = True` option to `ServeDeploymentProcessorConfig`.

* `stream=True` remains the default and preserves the existing streaming behavior.
* `stream=False` uses the normal deployment handle and awaits the returned `DeploymentResponse` directly.

The option is threaded through the existing processor → stage → UDF configuration path.

Regression coverage includes:

* default streaming configuration
* explicit unary configuration
* config propagation
* streaming handle behavior
* unary response processing
* processor-level execution against a unary Serve deployment

Local validation completed:

* Python compilation passed for all changed files
* `git diff --check` passed

The focused Ray tests could not run in this Windows source checkout because the compiled `ray._raylet` extension is unavailable, so runtime validation is left to Ray CI.

## Related issues

Closes #65937

## Additional information

This is additive and backward-compatible because `stream=True` remains the default.

No changes were made to Ray Serve internals or existing streaming semantics.
