### PR TITLE
[serve][doc] Move the Serve CLI reference to its own page

### DIFF
--- a/doc/source/serve/api/cli.md
+++ b/doc/source/serve/api/cli.md
@@ -1,0 +1,16 @@
+---
+myst:
+  html_meta:
+    description: "Ray Serve command line interface (CLI) reference: the serve command for deploying, inspecting, and managing Serve applications."
+---
+
+(serve-cli)=
+# Serve CLI
+
+The `serve` command line interface (CLI) lets you deploy, inspect, and manage Serve applications from the command line.
+
+```{eval-rst}
+.. click:: ray.serve.scripts:cli
+   :prog: serve
+   :nested: full
+```

--- a/doc/source/serve/api/index.md
+++ b/doc/source/serve/api/index.md
@@ -7,6 +7,12 @@ myst:
 (serve-api)=
 # Ray Serve API
 
+```{toctree}
+:hidden:
+
+Serve CLI <cli>
+```
+
 ## Python API
 
 (core-apis)=
@@ -180,15 +186,9 @@ The deprecated `RayServeHandle` and `RayServeSyncHandle` APIs have been fully re
 ```
 
 
-(serve-cli)=
-
 ## Command Line Interface (CLI)
 
-```{eval-rst}
-.. click:: ray.serve.scripts:cli
-   :prog: serve
-   :nested: full
-```
+The `serve` command line interface deploys, inspects, and manages Serve applications from the command line. See the [Serve CLI reference](serve-cli) for the full command list.
 
 (serve-rest-api)=
 


### PR DESCRIPTION
## Why are these changes needed?

The [Ray Serve API reference](https://docs.ray.io/en/latest/serve/api/index.html) embeds the entire `serve` CLI reference inline via a `.. click:: :nested: full` dump. This makes the Serve API landing page an outlier among the library API references. Every other library's API landing page is a hub that links out to a dedicated CLI page rather than inlining it:

- Ray Core — `ray-core/api/cli.rst`
- Ray Tune — `tune/api/cli.rst`
- Ray Observability — `ray-observability/reference/cli.rst`
- Cluster / Jobs — `cluster/cli.rst`, `cluster/.../job-submission/cli.rst`

This change brings Serve in line with that pattern:

- Adds a dedicated `doc/source/serve/api/cli.md` page holding the `serve` CLI reference.
- Replaces the inline CLI section on the API index with a one-line pointer and wires the new page into a hidden toctree so it's navigable from the sidebar.
- Moves the `serve-cli` cross-reference target to the new page. Because the label travels with the content, the existing links to it (in `serve/architecture.md` and `advanced-guides/dev-workflow.md`) keep resolving.

No CLI content changes — the `serve` command reference renders identically, just on its own page.

## Related issue number

N/A

## Checks

- [ ] I've signed off every commit (by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
