### PR TITLE
[doc] Track Ray Data's tested pyarrow in the docs build instead of a separate pin

### DIFF
--- a/ci/raydepsets/configs/docs.depsets.yaml
+++ b/ci/raydepsets/configs/docs.depsets.yaml
@@ -17,8 +17,11 @@ depsets:
     # Pin pyarrow to the version Ray Data tests against instead of hand-maintaining
     # a separate pin in requirements-doc.txt. pyarrow is in the docs build only
     # because rendered Ray Data docstrings import it, so it should track Ray Data's
-    # tested version. This file's other entries (pandas, modin, ...) are inert here
-    # because the docs build doesn't resolve them.
+    # tested version. This file also pins pandas, modin, and others; they're inert
+    # here today because the docs build doesn't resolve them, but if it ever pulls
+    # one in, it would be constrained to Ray Data's tested version too. That's the
+    # same intent, but keep it in mind before adding a heavy Ray Data package to the
+    # docs build, and prefer a pyarrow-only constraint file if the coupling grows.
     constraints:
       - python/requirements/data/pyarrow-latest.txt
     output: python/deplocks/docs/docbuild_depset_py${PYTHON_VERSION}.lock

--- a/ci/raydepsets/configs/docs.depsets.yaml
+++ b/ci/raydepsets/configs/docs.depsets.yaml
@@ -14,6 +14,13 @@ depsets:
       - ray_img_depset_${PYTHON_SHORT}
     requirements:
       - doc/requirements-doc.txt
+    # Pin pyarrow to the version Ray Data tests against instead of hand-maintaining
+    # a separate pin in requirements-doc.txt. pyarrow is in the docs build only
+    # because rendered Ray Data docstrings import it, so it should track Ray Data's
+    # tested version. This file's other entries (pandas, modin, ...) are inert here
+    # because the docs build doesn't resolve them.
+    constraints:
+      - python/requirements/data/pyarrow-latest.txt
     output: python/deplocks/docs/docbuild_depset_py${PYTHON_VERSION}.lock
     append_flags:
       - --python-version=${PYTHON_VERSION}

--- a/doc/requirements-doc.txt
+++ b/doc/requirements-doc.txt
@@ -48,9 +48,8 @@ requests==2.34.2
 tensorflow==2.20.0
 tf-keras==2.20.1
 xmltodict==0.13.0
-# Kept aligned with the pyarrow version Ray Data tests against
-# (python/requirements/data/pyarrow-latest.txt), not the newest release. Ray Data
-# supports pyarrow >= 17 but only tests up to this version, so the docs build
-# shouldn't run ahead of what the examples it renders are exercised on. 23.0.1
-# also clears the version scanners flag for CVE-2026-25087; bump deliberately.
-pyarrow==23.0.1
+# pyarrow is needed because rendered Ray Data docstrings import it. The version is
+# constrained to Ray Data's tested pyarrow (python/requirements/data/pyarrow-latest.txt)
+# by the docbuild depset in ci/raydepsets/configs/docs.depsets.yaml, so leave this
+# unversioned and let that constraint track Ray Data rather than pinning it here.
+pyarrow

--- a/doc/requirements-doc.txt
+++ b/doc/requirements-doc.txt
@@ -52,4 +52,6 @@ xmltodict==0.13.0
 # constrained to Ray Data's tested pyarrow (python/requirements/data/pyarrow-latest.txt)
 # by the docbuild depset in ci/raydepsets/configs/docs.depsets.yaml, so leave this
 # unversioned and let that constraint track Ray Data rather than pinning it here.
+# Installing this file directly (pip install -r) resolves pyarrow unconstrained;
+# install the compiled lock in python/deplocks/docs/ to match the CI docs build.
 pyarrow

--- a/python/deplocks/docs/docbuild_depset_py3.11.lock
+++ b/python/deplocks/docs/docbuild_depset_py3.11.lock
@@ -1183,7 +1183,9 @@ pyarrow==23.0.1 \
     --hash=sha256:f4b0dbfa124c0bb161f8b5ebb40f1a680b70279aa0c9901d44a2b5a20806039f \
     --hash=sha256:fa8e51cb04b9f8c9c5ace6bab63af9a1f88d35c0d6cbf53e8c17c098552285e1 \
     --hash=sha256:fed7020203e9ef273360b9e45be52a2a47d3103caf156a30ace5247ffb51bdbd
-    # via -r doc/requirements-doc.txt
+    # via
+    #   -c python/requirements/data/pyarrow-latest.txt
+    #   -r doc/requirements-doc.txt
 pydantic==2.12.4 \
     --hash=sha256:0f8cb9555000a4b5b617f66bfd2566264c4984b27589d3b845685983e8ea85ac \
     --hash=sha256:92d3d202a745d46f9be6df459ac5a064fdaa3c1c4cd8adcfa332ccf3c05f871e


### PR DESCRIPTION
## Summary

Makes the docs build **track Ray Data's tested `pyarrow`** instead of carrying a separate hand-maintained pin. Follow-up to the pin bump in #65946.

`pyarrow` is in the docs build only because rendered Ray Data docstrings import it — drop the line from `doc/requirements-doc.txt` and pyarrow disappears from the docbuild lock entirely. So its version should follow Ray Data. Today it doesn't: it's an independent pin that merely parallels Ray Data's, which is how it drifted to 19.0.1 while Ray Data sat at 23.0.1.

The docbuild depset lists `depsets: [ray_img_depset_311]`, which looks like it layers on Ray Data's stack — but raydepsets only honors `depsets:` for `expand`/`subset` operations. The docbuild depset is a `compile`, so that field is inert and Ray Data's pin never feeds in.

## What changed

- `ci/raydepsets/configs/docs.depsets.yaml`: add a `constraints:` entry on `docbuild_depset` pointing at `python/requirements/data/pyarrow-latest.txt` (Ray Data's tested-latest). raydepsets passes `constraints:` to uv as `-c` for a compile.
- `doc/requirements-doc.txt`: `pyarrow==23.0.1` → unversioned `pyarrow`; the constraint dictates the version.
- `docbuild_depset_py3.11.lock`: regenerated. Resolves to the same `pyarrow==23.0.1`; the only change is the `# via` provenance line now citing the constraint.

The constraint file's other entries (`pandas==2.3.3`, `modin`, `hudi`, `pylance`, `delta-sharing`) are inert here — the docs build doesn't resolve any of them, so only the pyarrow bound bites. Verified those packages are absent from the docbuild lock.

## Result

When Ray Data bumps `pyarrow-latest.txt`, the docs build follows on the next regeneration — no hand bump, no drift. The pyarrow Dependabot signal moves to Ray Data's file, where it belongs.

## Verification

- `raydepsets ... --check` on the full `docs.depsets.yaml`: `Lock files are up to date.`
- The resolved lock is byte-identical to #65946's (same `pyarrow==23.0.1`, same hashes) apart from the `# via` annotation, so the installed docs environment is unchanged and #65946's clean `make -C doc rtd-build` still stands. This change is source-side wiring only; it doesn't change what gets installed.

## Notes for review

- `pyarrow-latest.txt` is Ray Data's *tested*-latest, updated occasionally (last touched 2026-04), not true PyPI-latest. Following it means the docs build tracks Ray Data's test cadence — intended, but it can sit behind the newest pyarrow release.
- This is a raydepsets config change on a shared CI surface, so it wants a Ray CI look, separate from the security bump it stacks on.

## Stacking

Stacked on #65946 and targets its branch (`doc-1643-pyarrow-bump`); merge after it.
