### PR TITLE
[doc] Lift the urllib3 docs-build ceiling to 2.x (2.7.0)

### DIFF
--- a/doc/requirements-doc.txt
+++ b/doc/requirements-doc.txt
@@ -37,8 +37,14 @@ myst-nb==1.4.0
 # Jupyter conversion
 jupytext==1.15.2
 
-# Pin urllib to avoid downstream ssl incompatibility issues
-urllib3 < 1.27
+# The old <1.27 ceiling was botocore's pre-Python-3.10 urllib3 cap (its
+# `python_version < "3.10"` requirement, the "downstream ssl incompatibility").
+# This docs build runs on Python 3.11, where botocore requires urllib3
+# !=2.2.0,<3 and requests requires <3, so nothing here still caps urllib3 at the
+# 1.x line. Moving to 2.x clears the 1.26.x advisories the scanners flag (all
+# fixed only in the 2.x line). Kept pinned for deterministic deplock
+# regeneration and Dependabot bumps; bump it deliberately rather than removing.
+urllib3==2.7.0
 
 # External dependencies such as ML libraries should be mocked out, not added here.
 # See doc/source/conf.py for examples of how to mock out external dependencies.

--- a/python/deplocks/docs/docbuild_depset_py3.11.lock
+++ b/python/deplocks/docs/docbuild_depset_py3.11.lock
@@ -1978,9 +1978,9 @@ typing-inspection==0.4.2 \
     # via
     #   pydantic
     #   pydantic-settings
-urllib3==1.26.20 \
-    --hash=sha256:0ed14ccfbf1c30a9072c7ca157e4319b70d65f623e91e7b32fadb2853431016e \
-    --hash=sha256:40c2dc0c681e47eb8f90e7e27bf6ff7df2e677421fd46756da1161c39ca70d32
+urllib3==2.7.0 \
+    --hash=sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c \
+    --hash=sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897
     # via
     #   -r doc/requirements-doc.txt
     #   botocore


### PR DESCRIPTION
## Why

`doc/requirements-doc.txt` pinned `urllib3 < 1.27` with a comment citing "downstream ssl incompatibility." That ceiling was botocore's **pre-Python-3.10** urllib3 cap (its `python_version < "3.10"` requirement). The docs build runs on **Python 3.11**, where:

- botocore requires `urllib3 !=2.2.0, <3`
- requests requires `urllib3 <3`
- `ray_img_depset_311` adds no urllib3 constraint

So nothing in the docbuild resolve still caps urllib3 at the 1.x line. The old ceiling only held back security fixes: the current `urllib3==1.26.20` carries advisories that are fixed only in the 2.x line.

## What

- Replace the `urllib3 < 1.27` pin with `urllib3==2.7.0` (latest 2.x; requires Python >= 3.10) and rewrite the comment to explain the resolved constraint, in the same style as the neighboring `setuptools` and `pyarrow` pins.
- Regenerate `python/deplocks/docs/docbuild_depset_py3.11.lock`. **Only urllib3 moves** (1.26.20 → 2.7.0); no transitive churn.

## Scope

`doc/requirements-doc.txt` feeds only `docbuild_depset_311`. The `doctest_depset_310` lock still pins urllib3 1.26.20, but that comes from the repo-wide compiled constraints (`requirements_compiled_py3.13.txt`), not this file — confirmed by `raydepsets --check` regenerating it unchanged. That surface is out of scope here.

## Verification

- `raydepsets build ci/raydepsets/configs/docs.depsets.yaml --check` → "Lock files are up to date."
- Fresh venv from `doc/requirements-doc.lock.txt` installs `urllib3 2.7.0`.
- Full `make -C doc rtd-build` → `build succeeded.` with zero warnings under `-W` (the same gate as Read the Docs' `fail_on_warning: true`).

## Supersedes

This replaces the Dependabot security-update PRs against the doc build for urllib3 (`urllib3-2.7.0`, `urllib3-2.6.x`), which edit only the source file and leave the deplock un-regenerated, so they can't land as-is.

## Note for reviewers

This PR is stacked on top of the pyarrow docs-build bump; its base branch is `doc-1643-pyarrow-bump`, not `master`. Review just the top commit here.
