### PR TITLE
[ci] DEMO (do not merge): route dependencies.rayci.yml through the deplock_check rule

### DIFF
--- a/.buildkite/dependencies.rayci.yml
+++ b/.buildkite/dependencies.rayci.yml
@@ -34,3 +34,7 @@ steps:
       - bazel run //ci/raydepsets:raydepsets -- build --all-configs --check
     job_env: manylinux-x86_64
     depends_on: manylinux-x86_64
+
+# CI routing demonstration for #65941 (throwaway; DO NOT MERGE). This no-op
+# comment makes the pipeline file the only source change, so premerge routes it
+# through the new dependencies.rayci.yml rule in test.rules.txt.

--- a/.buildkite/test.rules.test.txt
+++ b/.buildkite/test.rules.test.txt
@@ -65,6 +65,9 @@ ci/raydepsets/raydepsets.py: tools python_dependencies
 .buildkite/ml.rayci.yml: ml train train_gpu tune
 .buildkite/core.rayci.yml: core_python core_cpp
 .buildkite/others.rayci.yml: java
+# The dependency pipeline routes to its own lock-consistency check via
+# `deplock_check`, not the `.buildkite/*.rayci.yml` -> java catch-all.
+.buildkite/dependencies.rayci.yml: deplock_check
 .buildkite/lint.rayci.yml: tools
 .buildkite/macos.rayci.yml: macos_wheels
 .buildkite/base.rayci.yml: docker linux_wheels tools

--- a/.buildkite/test.rules.txt
+++ b/.buildkite/test.rules.txt
@@ -682,6 +682,17 @@ ci/ci.sh
 @ llm
 ;
 
+# The dependency pipeline is not a library suite, so the `@ java` catch-all
+# below is the wrong default: editing it should run the jobs it defines, not an
+# unrelated Java worker suite. Emit `deplock_check`, the tag on its
+# `raydepsets_compile_all_dependencies` lock-consistency job, so a change to the
+# pipeline runs that check without fanning out to the wheel/image matrix that
+# `python_dependencies` carries. Must precede the `.buildkite/*.rayci.yml`
+# fallback.
+.buildkite/dependencies.rayci.yml
+@ deplock_check
+;
+
 .buildkite/*.rayci.yml
 @ java
 ;


### PR DESCRIPTION
## Throwaway evidence branch for #65941 — DO NOT MERGE

Stacked on #65941 (`doc-1648-dependencies-rayci-deplock`). It adds a single no-op comment to `.buildkite/dependencies.rayci.yml` so premerge routes the change through the new `dependencies.rayci.yml` rule that #65941 adds to `test.rules.txt`.

## What to read in the premerge build

- **The Java worker suite should be absent.** Before #65941, editing `dependencies.rayci.yml` fell through to the `.buildkite/*.rayci.yml` → `java` catch-all and ran the Java worker suite. With the new rule it emits `deplock_check` instead.
- **`raydepsets: compile all dependencies` should run and pass**, reached via `deplock_check`. This is the lock-consistency job the pipeline file defines. Because the no-op lives in the pipeline YAML rather than a lock file, the `raydepsets --check` has nothing to flag, so it should be green.
- **`test-rules` and lint (`tools`)** run because this branch also carries #65941's `test.rules.txt` / `test.rules.test.txt` edits. Expected, and unrelated to the java-vs-deplock_check point.

Close this once the pipeline shape has been reviewed; the fix itself is #65941.
