### PR TITLE
[ci] Split doc CI routing into a docs-owned doc.rules.txt fragment

### DIFF
--- a/.buildkite/BUILD.bazel
+++ b/.buildkite/BUILD.bazel
@@ -2,8 +2,13 @@ load("@py_deps_py310//:requirements.bzl", ci_require = "requirement")
 load("@rules_python//python:defs.bzl", "py_binary")
 
 # Consumed by //ci/pipeline:test_doc_api_rules_sync, which reads the doc_api
-# rule out of this file to keep it in sync with the API-page set.
-exports_files(["test.rules.txt"])
+# rule out of these files to keep it in sync with the API-page set. The doc_api
+# routing lives in doc.rules.txt; test.rules.txt is read too because rayci unions
+# the two files' tags and the docs deplock rule that emits doc_api stays there.
+exports_files([
+    "test.rules.txt",
+    "doc.rules.txt",
+])
 
 py_binary(
     name = "copy_files",

--- a/.buildkite/doc.rules.test.txt
+++ b/.buildkite/doc.rules.test.txt
@@ -1,0 +1,61 @@
+# Unit tests for doc.rules.txt
+#
+# Format: file_path: tag1 tag2 tag3
+#
+# Run by `rayci test-rules`, which pairs each *.rules.txt in this directory with
+# its *.rules.test.txt companion by name. Each rules file is evaluated on its
+# own, so the tags expected below are the ones doc.rules.txt emits by itself. In
+# a real build these union with test.rules.txt (which skips doc/ paths) and
+# always.rules.txt (which adds `always`/`lint`); those are covered by their own
+# companions. An empty expected tag set (`path:`) asserts a doc-only skip.
+
+# === API reference pages (doc_api, ahead of the prose skip) ===
+doc/source/data/api/ray.data.Dataset.rst: doc_api
+doc/source/ray-observability/reference/api.rst: doc_api
+
+# === Prose and image assets skip premerge ===
+doc/source/data/user-guide.md:
+doc/source/serve/index.rst:
+doc/source/rllib/images/arch.svg:
+doc/README.md:
+
+# === Autodoc / API machinery (doc doc_api, + tools for api_sidebar) ===
+doc/source/conf.py: doc doc_api
+doc/source/custom_directives.py: doc doc_api
+doc/source/_ext/gallery_directive.py: doc doc_api
+doc/requirements-doc.txt: doc doc_api
+doc/source/_ext/api_sidebar.py: doc doc_api tools
+
+# === Redirect YAML (doc_redirects alone) ===
+doc/redirects/serve.yaml: doc_redirects
+
+# === Render-only doc infra (doc) ===
+doc/load_doc_cache.py: doc
+doc/source/data/examples.yml: doc
+doc/source/ray-core/examples/highly_parallel.ipynb: doc
+doc/source/_intersphinx/refresh.py: doc
+
+# === Per-library executable doc assets route to one <lib>_doc step ===
+doc/source/data/working_with_datasets.py: data_doc
+doc/source/serve/doc_code/deployment.py: serve_doc
+doc/source/rllib/doc_code/getting_started.py: rllib_doc
+doc/source/train/doc_code/trainer.py: ml_doc
+doc/source/tune/doc_code/tuner.py: ml_doc
+doc/source/ray-core/doc_code/actors.py: core_doc
+doc/source/ray-core/examples/plot_pong_example.ipynb: ml_doc
+doc/external/pytorch_tutorial.py: ml_doc
+
+# === LLM doc assets route to the llm step, ahead of data_doc ===
+doc/source/llm/serving.py: llm
+doc/source/data/doc_code/working-with-llms/batch.py: llm
+
+# === doc/BUILD.bazel exercises every library's example step ===
+doc/BUILD.bazel: core_doc data_doc ml_doc rllib_doc serve_doc llm
+
+# === doc/*.py catch-all lands on core_doc ===
+doc/test_myst_doc.py: core_doc
+doc/source/ray-contribute/writing-code-snippets.ipynb: core_doc
+
+# === Starter templates and unrouted doc files skip ===
+doc/source/templates/01_batch_inference/start.py:
+doc/source/some_config.json:

--- a/.buildkite/doc.rules.txt
+++ b/.buildkite/doc.rules.txt
@@ -1,0 +1,300 @@
+# Ray CI conditional testing rules -- documentation routing fragment.
+#
+# Same format and evaluation model as test.rules.txt (see its header). rayci
+# discovers every .buildkite/*.rules.txt, evaluates each on its own with
+# first-match-wins, and unions the emitted tags across files. This file carries
+# the doc/-scoped routing that used to live in test.rules.txt so the docs team
+# can own it without a seat on the repo-wide rule files.
+#
+# What stays in test.rules.txt on purpose: rules that touch shared, non-doc/
+# surfaces -- the docs deplock (python/deplocks/docs, above the general
+# python/deplocks/ rule), .buildkite/doc.rayci.yml, .readthedocs.yaml, and
+# ci/ray_ci/doc/. Those keep repo-wide blast radius and stay REEf-owned.
+#
+# Rules whose paths are entirely under doc/ were MOVED here. A few shared skip
+# rules that also match non-doc/ paths (the prose/image skip, the doc/source/llm
+# route, the render-infra rule, and the terminal doc/ skip) are DUPLICATED as
+# doc-only copies: the full rule stays in test.rules.txt for its non-doc paths,
+# and the copy here reproduces first-match order for doc/ paths. Both copies of a
+# skip emit nothing, so the union is unchanged. Order matters here exactly as it
+# does in test.rules.txt.
+#
+# Verified tag-preserving over every tracked file in the repo; keep the
+# .buildkite/doc.rules.test.txt companion in sync when editing.
+
+! doc doc_api doc_redirects tools
+! core_doc data_doc ml_doc rllib_doc serve_doc llm
+
+# Per-team API reference pages. Editing these can change the documented public
+# API surface, so they must be able to trigger the API-consistency checks
+# ("doc: check API annotations" and "doc: check API doc consistency" in
+# doc.rayci.yml), which cross-check every @PublicAPI symbol against these
+# autosummary pages. Emit a dedicated "doc_api" tag, ahead of the narrative
+# prose skip rule below so these pages aren't swallowed as prose.
+#
+# This tag is the whole trigger mechanism for those two checks: they carry no
+# `if:` label guard, so what runs is decided here and nowhere else. Keep that
+# in mind when editing the rules below -- an API surface that stops emitting
+# doc_api stops being checked, silently.
+#
+# The six per-team dirs match the API-page set in doc/source/_ext/api_sidebar.py
+# (API_PATH_PREFIXES). ray-observability/reference/ is here too because the Ray
+# Core landing (ray-core/api/index.md) toctrees into its api.rst, so those
+# pages are part of the Core API surface the check walks despite living outside
+# ray-core/api/. //ci/pipeline:test_doc_api_rules_sync enforces this alignment,
+# so adding a library's API dir to API_PATH_PREFIXES without adding it here (or
+# vice versa) fails CI.
+doc/source/data/api/
+doc/source/serve/api/
+doc/source/ray-core/api/
+doc/source/train/api/
+doc/source/tune/api/
+doc/source/rllib/package_ref/
+doc/source/ray-observability/reference/
+@ doc_api
+;
+
+# Doc-only copy of the prose/image skip (the full rule, which also
+# covers repo-root .claude/, stays in test.rules.txt). Leads the fragment
+# so prose and images skip before the routing rules below can match them.
+doc/.claude/
+doc/*.md
+doc/*.rst
+doc/*.png
+doc/*.svg
+doc/*.jpg
+doc/*.jpeg
+doc/*.gif
+doc/*.webp
+;
+
+# Doc-only copy of the llm route (full rule stays in test.rules.txt).
+# Keeps doc/source/llm and the llm data_code examples on the llm docs
+# example step, ahead of the data_doc rule below.
+doc/source/llm/
+doc/source/data/doc_code/working-with-llms/
+@ llm
+;
+
+# api_sidebar.py is autodoc machinery like the rest of doc/source/_ext/ below,
+# but it needs `tools` on top. Its `API_PATH_PREFIXES` is one half of the pair
+# that //ci/pipeline:test_doc_api_rules_sync compares; the other half is the
+# doc_api rule block at the top of this file. That test is a ci_unit target, and
+# ci_unit is selected by `tools`, not by `doc` or `doc_api`. Without `tools`
+# here the guard would run on an edit to the rules side (this file emits
+# `tools`) but not on an edit to the prefixes side -- so growing
+# API_PATH_PREFIXES without adding the matching rule, which is exactly the drift
+# the guard exists to catch, would never execute it. First match wins, so this
+# rule has to precede the doc/source/_ext/ directory entry in part 1.
+doc/source/_ext/api_sidebar.py
+@ doc doc_api tools
+;
+
+# Documentation validation infra, part 1 of 2: the autodoc machinery. These
+# files determine what the API reference *contains*, so a change here can alter
+# the documented public API surface just as an API page edit can. They emit
+# `doc_api` alongside `doc` so both the documentation build and the two
+# API-consistency checks run.
+#
+# Why each one is autodoc machinery, not just build config:
+#   - conf.py             the autodoc, autosummary, and intersphinx
+#                         configuration, and the importer of the four modules
+#                         below
+#   - api_autogen.py      generates the autosummary stub .rst files that
+#                         `lint.sh api_policy_check` reads; `AUTOGEN_FILES` here
+#                         is what decides which stubs exist at all
+#   - api_mock_imports.py the mocked-module list; mocking a package changes
+#                         which symbols autodoc can resolve, and therefore what
+#                         the check sees as documented
+#   - custom_directives.py imported by conf.py and registers directives the API
+#                         templates render through
+#   - doc/source/_ext/    the in-repo Sphinx extensions, including
+#                         api_sidebar.py, whose `API_PATH_PREFIXES` is the
+#                         source of truth for "this page documents public API"
+#                         (//ci/pipeline:test_doc_api_rules_sync enforces that
+#                         alignment)
+#   - requirements-doc.txt pins Sphinx and the autodoc/autosummary extensions;
+#                         a version bump can change stub generation output
+#
+# The `doc/source/*.py` modules are enumerated one by one on purpose, here and
+# in part 2. A `doc/source/*.py` pattern would NOT work: `*` in these patterns
+# is fnmatch and crosses `/`, so it would also swallow every example script
+# under `doc/source/<lib>/doc_code/` and stop those from reaching the
+# per-library rules below. Add a module to one of these two blocks when
+# `conf.py` grows a new import -- part 1 if it can affect the API surface,
+# part 2 if it only affects rendering.
+doc/source/conf.py
+doc/source/api_autogen.py
+doc/source/api_mock_imports.py
+doc/source/custom_directives.py
+doc/source/_ext/
+doc/requirements-doc.txt
+@ doc doc_api
+;
+
+# Redirect YAML under doc/redirects/ gets a dedicated, credential-free premerge
+# check (rtd-redirects validate + diff-file). Today these files match no rule at
+# all: `.yaml` isn't covered by the leading prose-and-image skip, nor by the
+# `doc/*.py`/`doc/*.ipynb` catch-all further down, so they fall through to the
+# broad `doc/` pass rule and trigger nothing. This rule is purely additive.
+#
+# It emits `doc_redirects` alone, and deliberately not `doc` or `doc_api`. A
+# redirect edit can't change the documented API surface, and it doesn't need the
+# documentation build: the check parses the YAML and diffs it against the base
+# ref. Keep this rule ahead of the `doc/` pass rule at the bottom of the doc
+# section, or redirect YAML goes back to matching nothing.
+doc/redirects/*.yaml
+@ doc_redirects
+;
+
+# Doc-only copy of the render-infra rule (part 2; full rule, which also
+# covers .vale config, stays in test.rules.txt). Emits doc for build-only
+# doc inputs, ahead of the per-library and doc/*.py rules below.
+doc/source/template_collections.py
+doc/source/preprocess_github_markdown.py
+doc/source/llms_txt_summary.txt
+doc/load_doc_cache.py
+doc/update_cache_env.py
+doc/rtd_doctor.py
+doc/test_no_new_rst.py
+doc/test_llms_txt.py
+doc/source/data/examples.yml
+doc/source/serve/examples.yml
+doc/source/train/examples.yml
+doc/source/ray-core/examples/highly_parallel.ipynb
+doc/source/templates/05_dreambooth_finetuning/
+doc/source/cluster/doc_code/
+doc/source/ray-contribute/doc_code/
+@ doc
+;
+
+# The root doc/BUILD.bazel defines the example and doctest targets for every
+# library, so a change there exercises all of them. Route it to every
+# library's docs example step.
+doc/BUILD.bazel
+@ core_doc data_doc ml_doc rllib_doc serve_doc llm
+;
+
+# Executable doc assets route to the owning library's docs example test step
+# via a dedicated <lib>_doc tag, so a one-library doc change runs only that
+# library's example tests instead of fanning out to every team. Prose
+# (.md/.rst) is skipped by the leading rule; the llm doc assets are routed to
+# `llm` earlier. Each directory rule also covers that library's example
+# BUILD.bazel files.
+doc/source/data/
+doc/source/ray-more-libs/
+@ data_doc
+;
+
+doc/source/serve/
+@ serve_doc
+;
+
+doc/source/rllib/
+@ rllib_doc
+;
+
+doc/source/train/
+doc/source/tune/
+doc/source/ray-air/
+@ ml_doc
+;
+
+# These four notebooks live under ray-core/ but their targets in
+# doc/BUILD.bazel are tagged `team:ml`, and the team argument to
+# ci/ray_ci:test_in_docker filters targets by `team:<team>`
+# (ci/ray_ci/tester.py:372). So the core step would not execute them: routing
+# them to core_doc would run a step that tests everything under ray-core/
+# except the file that changed. They route to ml_doc, the step that actually
+# owns the targets, and carry no tag the step excludes. Re-tagging the targets
+# `team:core` in doc/BUILD.bazel would be the alternative fix and would let
+# these lines go away. Their fifth sibling, highly_parallel.ipynb, is routed to
+# `doc` above: no step executes it at all.
+doc/source/ray-core/examples/plot_hyperparameter.ipynb
+doc/source/ray-core/examples/batch_prediction.ipynb
+doc/source/ray-core/examples/plot_parameter_server.ipynb
+doc/source/ray-core/examples/plot_pong_example.ipynb
+@ ml_doc
+;
+
+doc/source/ray-core/
+doc/source/ray-observability/
+@ core_doc
+;
+
+# doc/external/ holds a vendored PyTorch tutorial and the test that guards it
+# against upstream drift. The same cross-team miss applies: `test_external_hashes`
+# in doc/BUILD.bazel is tagged `team:ml`, so the core step would filter it out.
+# Route the whole directory rather than the test file alone, because the tutorial
+# script is the test's `data` and editing it is what the hash check exists to
+# catch. Without this rule both files fall through to the `doc/*.py` catch-all
+# below, since `*` in these patterns crosses `/`.
+doc/external/
+@ ml_doc
+;
+
+# Committed intersphinx inventory snapshots and the script that refreshes them.
+# The `.inv` files are live build inputs: `intersphinx_mapping` in
+# doc/source/conf.py resolves each target's local `_intersphinx/<name>.inv`
+# ahead of its remote URL, so a truncated or stale snapshot changes what
+# cross-references resolve. But they are read as inventories, not as pages --
+# `exclude_patterns` drops `_intersphinx/**` from the source tree -- and no
+# bazel target names this directory, so there is nothing here for a docs
+# example step to execute. Route the whole directory to `doc`, the tag that
+# selects the documentation build, and to nothing else.
+#
+# Two things were wrong before this rule existed. `refresh.py` fell through to
+# the `doc/*.py` catch-all below, whose `*` crosses `/`, and so started the core
+# docs example step -- a large-instance, three-invocation bazel run -- for a
+# standalone maintenance script that nothing imports and no target covers. The
+# `.inv` files fell past it to the broad `doc/` skip and emitted no tag at all,
+# so refreshing an inventory, which is the routine maintenance this directory
+# exists for, triggered no build. The premerge gate for an inventory change is
+# the Read the Docs `-W` build, which runs outside tag selection; `doc` is what
+# gives the postmerge documentation build coverage here.
+#
+# README.md is already skipped by the `doc/*.md` prose rule further up, so this
+# rule only ever sees the snapshots and the script.
+doc/source/_intersphinx/
+@ doc
+;
+
+# Starter-template sources and the notebook authoring boilerplate. Sphinx never
+# reads any of these: `exclude_patterns` in doc/source/conf.py drops
+# `templates/*` from the build outright, and `_templates/template.ipynb` is a
+# file contributors copy, not a page. Nothing includes them either -- 01 through
+# 03 have no reference anywhere in the repo, and 04 is cited only as a GitHub
+# URL, from train/deepspeed.rst, train/huggingface-accelerate.rst, and the train
+# examples gallery, none of which any build step resolves. They also back no bazel target: doc/BUILD.bazel names
+# source/templates/ exactly once, as a doctest exclusion. So the catch-all was
+# starting the core docs example step for files that step cannot run and the
+# build does not read. 05_dreambooth_finetuning is the exception and is routed
+# to `doc` above, because a rendered Train page literalincludes it.
+doc/source/templates/
+doc/source/_templates/
+# pass
+;
+
+# Any remaining executable doc asset (other unowned doc dirs, and any example
+# BUILD.bazel outside the library dirs above) falls to the core docs example
+# step as the catch-all owner.
+#
+# `doc/test_myst_doc.py` lands here too. It is the shared notebook runner behind
+# every library's example targets, so a change to it could in principle break
+# any of them, and routing it to all five `<lib>_doc` tags the way
+# `doc/BUILD.bazel` does would be the maximal-coverage choice. One library's
+# worth of execution is deliberately treated as a sufficient smoke signal
+# instead: the runner is shared, so a break shows up in core as readily as
+# anywhere, and the post-merge documentation build covers the rest. Widen this
+# only if a harness regression actually escapes core.
+doc/*.py
+doc/*.ipynb
+doc/*/BUILD.bazel
+@ core_doc
+;
+
+# Doc-only copy of the terminal doc/ skip (full rule, which also covers
+# examples/ dev/ kubernetes/ site/, stays in test.rules.txt). Anything
+# under doc/ not matched above skips here, mirroring test.rules.txt.
+doc/
+;

--- a/.buildkite/test.rules.test.txt
+++ b/.buildkite/test.rules.test.txt
@@ -89,28 +89,13 @@ docker/Dockerfile.ray: docker linux_wheels
 # Executable doc assets route to the owning library's docs example step via a
 # dedicated <lib>_doc tag, instead of the blanket `doc` tag, so a one-library
 # doc change no longer fans out to every team.
-doc/source/serve/doc_code/example.py: serve_doc
-doc/source/serve/examples/example.ipynb: serve_doc
-doc/source/data/doc_code/example.py: data_doc
-doc/source/ray-more-libs/example.py: data_doc
-doc/source/train/examples/example.py: ml_doc
-doc/source/tune/examples/example.py: ml_doc
-doc/source/rllib/doc_code/example.py: rllib_doc
-doc/source/ray-core/examples/example.ipynb: core_doc
-doc/source/ray-observability/example.py: core_doc
 # The four ray-core notebooks whose targets are tagged team:ml route to ml_doc,
 # because the core step filters targets by team and would not execute them.
-doc/source/ray-core/examples/plot_hyperparameter.ipynb: ml_doc
-doc/source/ray-core/examples/batch_prediction.ipynb: ml_doc
-doc/source/ray-core/examples/plot_parameter_server.ipynb: ml_doc
-doc/source/ray-core/examples/plot_pong_example.ipynb: ml_doc
 # highly_parallel.ipynb is the exception: the ml docs example step excludes its
 # tag, so no step runs it. It routes to the build instead.
 doc/source/ray-core/examples/highly_parallel.ipynb: doc
 # doc/external/ is the same team:ml case: the hash-guard test and the vendored
 # tutorial it covers both route to the step that owns the target.
-doc/external/test_hashes.py: ml_doc
-doc/external/pytorch_tutorials_hyperparameter_tuning_tutorial.py: ml_doc
 # Claude Code skills and agent files trigger nothing, matching the RtD guard.
 # This holds for both the doc subtree and the repo-root .claude/.
 doc/.claude/skills/sphinx-fix/sphinx_fix.py:
@@ -119,13 +104,8 @@ doc/.claude/agents/reviewer.md:
 .claude/settings.json:
 doc/source/llm/doc_code/example.py: llm
 # Unowned doc dirs and doc-root executables fall to the core docs example step.
-doc/source/cluster/example.py: core_doc
-doc/code.py: core_doc
-doc/example.ipynb: core_doc
 # A library's example BUILD.bazel routes to that library; the root doc
 # BUILD.bazel defines every library's targets, so it routes to all of them.
-doc/source/serve/examples/BUILD.bazel: serve_doc
-doc/BUILD.bazel: core_doc data_doc ml_doc rllib_doc serve_doc llm
 # Prose and static images under a library doc dir are skipped, not routed to
 # that library's docs example step. The per-library rules match whole
 # directories, so these cases lock in that the leading skip rule wins first.
@@ -137,7 +117,6 @@ doc/source/train/images/overview.jpg:
 doc/source/tune/images/tune-flow.gif:
 # Config and script assets a doc example consumes can change what the test
 # does, so under a library doc dir they keep routing to that library.
-doc/source/serve/doc_code/config.yaml: serve_doc
 # Under an unowned dir the asset is not a test input at all -- no bazel target
 # covers doc/source/cluster/doc_code/ -- but a rendered page literalincludes it,
 # so it routes to the build. This asserts the whole directory lands on `doc`
@@ -166,26 +145,12 @@ doc/source/templates/05_dreambooth_finetuning/README.md:
 # scripts build the docs, so they route to the `doc` build and validation only,
 # never to a library's doctest or example execution.
 .readthedocs.yaml: doc
-doc/source/data/api/api.md: doc_api
-doc/source/serve/api/index.md: doc_api
-doc/source/ray-core/api/index.md: doc_api
-doc/source/train/api/api.md: doc_api
-doc/source/tune/api/api.rst: doc_api
-doc/source/rllib/package_ref/index.rst: doc_api
-doc/source/ray-observability/reference/api.rst: doc_api
 # A nested leaf page under an API dir must also emit doc_api: directory rules
 # match recursively, so a change to any page below the dir triggers the checks,
 # not just the top-level index. Guards against a rule or matcher change that
 # would only catch top-level pages.
-doc/source/rllib/package_ref/env/single_agent_episode.rst: doc_api
 .vale.ini: doc
 .vale/styles/config/vocabularies/Core/accept.txt: doc
-doc/requirements-doc.txt: doc doc_api
-doc/source/conf.py: doc doc_api
-doc/source/_ext/llms_txt.py: doc doc_api
-doc/source/custom_directives.py: doc doc_api
-doc/source/api_autogen.py: doc doc_api
-doc/source/api_mock_imports.py: doc doc_api
 # doc.rayci.yml declares the redirect-validation step as well as the two API
 # checks, so it emits doc_redirects on top of doc and doc_api. An edit to a step
 # definition has to be able to select the step it edits.
@@ -194,7 +159,6 @@ doc/source/api_mock_imports.py: doc doc_api
 # dir rule's tags, because //ci/pipeline:test_doc_api_rules_sync is a ci_unit
 # target and ci_unit is selected by `tools`. This case is what keeps the drift
 # guard executing on an API_PATH_PREFIXES edit.
-doc/source/_ext/api_sidebar.py: doc doc_api tools
 # The autodoc machinery above emits doc_api so the two API-consistency checks
 # run on it: these files decide what the API reference contains. The rendering
 # half of the doc infra must NOT, or every Vale vocabulary tweak pays for a
@@ -209,7 +173,6 @@ doc/source/serve/examples.yml: doc
 doc/source/train/examples.yml: doc
 # A sibling .yml under the same dir still routes to the library, so the gallery
 # rule is a targeted exception rather than a blanket .yml skip.
-doc/source/data/doc_code/some_config.yml: data_doc
 doc/load_doc_cache.py: doc
 doc/update_cache_env.py: doc
 doc/rtd_doctor.py: doc
@@ -221,13 +184,10 @@ doc/test_llms_txt.py: doc
 doc/source/llms_txt_summary.txt: doc
 # The shared notebook runner stays on the catch-all core step by design; see
 # the comment on the catch-all rule in test.rules.txt.
-doc/test_myst_doc.py: core_doc
 # Intersphinx snapshots are build inputs, so they route to the build. refresh.py
 # is the case the dedicated rule exists for: without it the `doc/*.py` catch-all
 # claimed it and started the core docs example step. README.md beside them is
 # prose and stays unrouted, which is what the third case locks in.
-doc/source/_intersphinx/python.inv: doc
-doc/source/_intersphinx/refresh.py: doc
 doc/source/_intersphinx/README.md:
 # A docs-only deplock change runs the docbuild, the API-consistency checks, and
 # the `raydepsets --check` lock-consistency job (via `deplock_check`), but not
@@ -239,7 +199,6 @@ ci/raydepsets/configs/docs.depsets.yaml: doc doc_api deplock_check
 # Redirect YAML selects the dedicated lightweight check and nothing else: no
 # docbuild, no API checks, no per-team doc tests. The README beside it is prose
 # and stays unrouted, which is what the second case locks in.
-doc/redirects/current.yaml: doc_redirects
 doc/redirects/README.md:
 
 # === Release ===

--- a/.buildkite/test.rules.txt
+++ b/.buildkite/test.rules.txt
@@ -40,35 +40,6 @@
 ! release_tests spark_on_ray rocksdb_tests redis_tests sandbox_tests
 ! core_doc data_doc ml_doc rllib_doc serve_doc
 
-# Per-team API reference pages. Editing these can change the documented public
-# API surface, so they must be able to trigger the API-consistency checks
-# ("doc: check API annotations" and "doc: check API doc consistency" in
-# doc.rayci.yml), which cross-check every @PublicAPI symbol against these
-# autosummary pages. Emit a dedicated "doc_api" tag, ahead of the narrative
-# prose skip rule below so these pages aren't swallowed as prose.
-#
-# This tag is the whole trigger mechanism for those two checks: they carry no
-# `if:` label guard, so what runs is decided here and nowhere else. Keep that
-# in mind when editing the rules below -- an API surface that stops emitting
-# doc_api stops being checked, silently.
-#
-# The six per-team dirs match the API-page set in doc/source/_ext/api_sidebar.py
-# (API_PATH_PREFIXES). ray-observability/reference/ is here too because the Ray
-# Core landing (ray-core/api/index.md) toctrees into its api.rst, so those
-# pages are part of the Core API surface the check walks despite living outside
-# ray-core/api/. //ci/pipeline:test_doc_api_rules_sync enforces this alignment,
-# so adding a library's API dir to API_PATH_PREFIXES without adding it here (or
-# vice versa) fails CI.
-doc/source/data/api/
-doc/source/serve/api/
-doc/source/ray-core/api/
-doc/source/train/api/
-doc/source/tune/api/
-doc/source/rllib/package_ref/
-doc/source/ray-observability/reference/
-@ doc_api
-;
-
 # Documentation prose (.md and .rst) and static image assets do not block
 # premerge. A content-only change to narrative docs or a diagram swap triggers
 # no library test steps: neither can change tested code, and the post-merge
@@ -276,62 +247,6 @@ docker/
 @ doc
 ;
 
-# api_sidebar.py is autodoc machinery like the rest of doc/source/_ext/ below,
-# but it needs `tools` on top. Its `API_PATH_PREFIXES` is one half of the pair
-# that //ci/pipeline:test_doc_api_rules_sync compares; the other half is the
-# doc_api rule block at the top of this file. That test is a ci_unit target, and
-# ci_unit is selected by `tools`, not by `doc` or `doc_api`. Without `tools`
-# here the guard would run on an edit to the rules side (this file emits
-# `tools`) but not on an edit to the prefixes side -- so growing
-# API_PATH_PREFIXES without adding the matching rule, which is exactly the drift
-# the guard exists to catch, would never execute it. First match wins, so this
-# rule has to precede the doc/source/_ext/ directory entry in part 1.
-doc/source/_ext/api_sidebar.py
-@ doc doc_api tools
-;
-
-# Documentation validation infra, part 1 of 2: the autodoc machinery. These
-# files determine what the API reference *contains*, so a change here can alter
-# the documented public API surface just as an API page edit can. They emit
-# `doc_api` alongside `doc` so both the documentation build and the two
-# API-consistency checks run.
-#
-# Why each one is autodoc machinery, not just build config:
-#   - conf.py             the autodoc, autosummary, and intersphinx
-#                         configuration, and the importer of the four modules
-#                         below
-#   - api_autogen.py      generates the autosummary stub .rst files that
-#                         `lint.sh api_policy_check` reads; `AUTOGEN_FILES` here
-#                         is what decides which stubs exist at all
-#   - api_mock_imports.py the mocked-module list; mocking a package changes
-#                         which symbols autodoc can resolve, and therefore what
-#                         the check sees as documented
-#   - custom_directives.py imported by conf.py and registers directives the API
-#                         templates render through
-#   - doc/source/_ext/    the in-repo Sphinx extensions, including
-#                         api_sidebar.py, whose `API_PATH_PREFIXES` is the
-#                         source of truth for "this page documents public API"
-#                         (//ci/pipeline:test_doc_api_rules_sync enforces that
-#                         alignment)
-#   - requirements-doc.txt pins Sphinx and the autodoc/autosummary extensions;
-#                         a version bump can change stub generation output
-#
-# The `doc/source/*.py` modules are enumerated one by one on purpose, here and
-# in part 2. A `doc/source/*.py` pattern would NOT work: `*` in these patterns
-# is fnmatch and crosses `/`, so it would also swallow every example script
-# under `doc/source/<lib>/doc_code/` and stop those from reaching the
-# per-library rules below. Add a module to one of these two blocks when
-# `conf.py` grows a new import -- part 1 if it can affect the API surface,
-# part 2 if it only affects rendering.
-doc/source/conf.py
-doc/source/api_autogen.py
-doc/source/api_mock_imports.py
-doc/source/custom_directives.py
-doc/source/_ext/
-doc/requirements-doc.txt
-@ doc doc_api
-;
-
 # The doc pipeline definition gets its own rule because it declares the redirect
 # step as well as the two API-consistency checks, so it needs a tag the machinery
 # block above must not emit: a conf.py edit shouldn't run the redirect check.
@@ -343,21 +258,6 @@ doc/requirements-doc.txt
 # pin, which lives in that step's commands, so a version bump re-runs the check.
 .buildkite/doc.rayci.yml
 @ doc doc_api doc_redirects
-;
-
-# Redirect YAML under doc/redirects/ gets a dedicated, credential-free premerge
-# check (rtd-redirects validate + diff-file). Today these files match no rule at
-# all: `.yaml` isn't covered by the leading prose-and-image skip, nor by the
-# `doc/*.py`/`doc/*.ipynb` catch-all further down, so they fall through to the
-# broad `doc/` pass rule and trigger nothing. This rule is purely additive.
-#
-# It emits `doc_redirects` alone, and deliberately not `doc` or `doc_api`. A
-# redirect edit can't change the documented API surface, and it doesn't need the
-# documentation build: the check parses the YAML and diffs it against the base
-# ref. Keep this rule ahead of the `doc/` pass rule at the bottom of the doc
-# section, or redirect YAML goes back to matching nothing.
-doc/redirects/*.yaml
-@ doc_redirects
 ;
 
 # Documentation validation infra, part 2 of 2: rendering and validation only.
@@ -424,131 +324,6 @@ doc/source/templates/05_dreambooth_finetuning/
 doc/source/cluster/doc_code/
 doc/source/ray-contribute/doc_code/
 @ doc
-;
-
-# The root doc/BUILD.bazel defines the example and doctest targets for every
-# library, so a change there exercises all of them. Route it to every
-# library's docs example step.
-doc/BUILD.bazel
-@ core_doc data_doc ml_doc rllib_doc serve_doc llm
-;
-
-# Executable doc assets route to the owning library's docs example test step
-# via a dedicated <lib>_doc tag, so a one-library doc change runs only that
-# library's example tests instead of fanning out to every team. Prose
-# (.md/.rst) is skipped by the leading rule; the llm doc assets are routed to
-# `llm` earlier. Each directory rule also covers that library's example
-# BUILD.bazel files.
-doc/source/data/
-doc/source/ray-more-libs/
-@ data_doc
-;
-
-doc/source/serve/
-@ serve_doc
-;
-
-doc/source/rllib/
-@ rllib_doc
-;
-
-doc/source/train/
-doc/source/tune/
-doc/source/ray-air/
-@ ml_doc
-;
-
-# These four notebooks live under ray-core/ but their targets in
-# doc/BUILD.bazel are tagged `team:ml`, and the team argument to
-# ci/ray_ci:test_in_docker filters targets by `team:<team>`
-# (ci/ray_ci/tester.py:372). So the core step would not execute them: routing
-# them to core_doc would run a step that tests everything under ray-core/
-# except the file that changed. They route to ml_doc, the step that actually
-# owns the targets, and carry no tag the step excludes. Re-tagging the targets
-# `team:core` in doc/BUILD.bazel would be the alternative fix and would let
-# these lines go away. Their fifth sibling, highly_parallel.ipynb, is routed to
-# `doc` above: no step executes it at all.
-doc/source/ray-core/examples/plot_hyperparameter.ipynb
-doc/source/ray-core/examples/batch_prediction.ipynb
-doc/source/ray-core/examples/plot_parameter_server.ipynb
-doc/source/ray-core/examples/plot_pong_example.ipynb
-@ ml_doc
-;
-
-doc/source/ray-core/
-doc/source/ray-observability/
-@ core_doc
-;
-
-# doc/external/ holds a vendored PyTorch tutorial and the test that guards it
-# against upstream drift. The same cross-team miss applies: `test_external_hashes`
-# in doc/BUILD.bazel is tagged `team:ml`, so the core step would filter it out.
-# Route the whole directory rather than the test file alone, because the tutorial
-# script is the test's `data` and editing it is what the hash check exists to
-# catch. Without this rule both files fall through to the `doc/*.py` catch-all
-# below, since `*` in these patterns crosses `/`.
-doc/external/
-@ ml_doc
-;
-
-# Committed intersphinx inventory snapshots and the script that refreshes them.
-# The `.inv` files are live build inputs: `intersphinx_mapping` in
-# doc/source/conf.py resolves each target's local `_intersphinx/<name>.inv`
-# ahead of its remote URL, so a truncated or stale snapshot changes what
-# cross-references resolve. But they are read as inventories, not as pages --
-# `exclude_patterns` drops `_intersphinx/**` from the source tree -- and no
-# bazel target names this directory, so there is nothing here for a docs
-# example step to execute. Route the whole directory to `doc`, the tag that
-# selects the documentation build, and to nothing else.
-#
-# Two things were wrong before this rule existed. `refresh.py` fell through to
-# the `doc/*.py` catch-all below, whose `*` crosses `/`, and so started the core
-# docs example step -- a large-instance, three-invocation bazel run -- for a
-# standalone maintenance script that nothing imports and no target covers. The
-# `.inv` files fell past it to the broad `doc/` skip and emitted no tag at all,
-# so refreshing an inventory, which is the routine maintenance this directory
-# exists for, triggered no build. The premerge gate for an inventory change is
-# the Read the Docs `-W` build, which runs outside tag selection; `doc` is what
-# gives the postmerge documentation build coverage here.
-#
-# README.md is already skipped by the `doc/*.md` prose rule further up, so this
-# rule only ever sees the snapshots and the script.
-doc/source/_intersphinx/
-@ doc
-;
-
-# Starter-template sources and the notebook authoring boilerplate. Sphinx never
-# reads any of these: `exclude_patterns` in doc/source/conf.py drops
-# `templates/*` from the build outright, and `_templates/template.ipynb` is a
-# file contributors copy, not a page. Nothing includes them either -- 01 through
-# 03 have no reference anywhere in the repo, and 04 is cited only as a GitHub
-# URL, from train/deepspeed.rst, train/huggingface-accelerate.rst, and the train
-# examples gallery, none of which any build step resolves. They also back no bazel target: doc/BUILD.bazel names
-# source/templates/ exactly once, as a doctest exclusion. So the catch-all was
-# starting the core docs example step for files that step cannot run and the
-# build does not read. 05_dreambooth_finetuning is the exception and is routed
-# to `doc` above, because a rendered Train page literalincludes it.
-doc/source/templates/
-doc/source/_templates/
-# pass
-;
-
-# Any remaining executable doc asset (other unowned doc dirs, and any example
-# BUILD.bazel outside the library dirs above) falls to the core docs example
-# step as the catch-all owner.
-#
-# `doc/test_myst_doc.py` lands here too. It is the shared notebook runner behind
-# every library's example targets, so a change to it could in principle break
-# any of them, and routing it to all five `<lib>_doc` tags the way
-# `doc/BUILD.bazel` does would be the maximal-coverage choice. One library's
-# worth of execution is deliberately treated as a sufficient smoke signal
-# instead: the runner is shared, so a break shows up in core as readily as
-# anywhere, and the post-merge documentation build covers the rest. Widen this
-# only if a harness regression actually escapes core.
-doc/*.py
-doc/*.ipynb
-doc/*/BUILD.bazel
-@ core_doc
 ;
 
 ci/docker/doctest.build.Dockerfile

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -129,6 +129,13 @@
 /.buildkite/test.rules.txt @ray-project/ray-ci
 /.buildkite/always.rules.txt @ray-project/ray-ci
 
+# Documentation routing fragment. Carries only doc/-scoped routing (its tags
+# union with test.rules.txt at build time), so ray-docs owns it and can iterate
+# on doc CI routing without a seat on the repo-wide rule files above; ray-ci
+# co-owns and ray-docs-reviewers is a silent fallback for backup approval.
+/.buildkite/doc.rules.txt @ray-project/ray-docs @ray-project/ray-ci @ray-project/ray-docs-reviewers
+/.buildkite/doc.rules.test.txt @ray-project/ray-docs @ray-project/ray-ci @ray-project/ray-docs-reviewers
+
 # Compiled dependency lockfile. Gates the build and test environment.
 /python/requirements_compiled.txt @ray-project/ray-ci
 

--- a/ci/pipeline/BUILD.bazel
+++ b/ci/pipeline/BUILD.bazel
@@ -15,6 +15,7 @@ py_test(
     ],
     data = [
         "//:.rayciversion",
+        "//.buildkite:doc.rules.txt",
         "//.buildkite:test.rules.txt",
         "//doc:doc_source_modules",
         "//doc:source/_ext/api_sidebar.py",

--- a/ci/pipeline/test_doc_api_rules_sync.py
+++ b/ci/pipeline/test_doc_api_rules_sync.py
@@ -1,11 +1,20 @@
 """Keep the ``doc_api`` conditional-testing rule in sync with the API-page set.
 
-The ``doc_api`` tag in ``.buildkite/test.rules.txt`` selects the API-consistency
-CI checks ("doc: check API annotations" and "doc: check API doc consistency" in
-``.buildkite/doc.rayci.yml``). It covers two populations: the API reference
-pages, and the autodoc machinery that determines what those pages contain
-(``conf.py``, ``api_autogen.py``, ``api_mock_imports.py``, the in-repo Sphinx
-extensions, and the docs dependency locks).
+The ``doc_api`` tag selects the API-consistency CI checks ("doc: check API
+annotations" and "doc: check API doc consistency" in ``.buildkite/doc.rayci.yml``).
+It covers two populations: the API reference pages, and the autodoc machinery
+that determines what those pages contain (``conf.py``, ``api_autogen.py``,
+``api_mock_imports.py``, the in-repo Sphinx extensions, and the docs dependency
+locks).
+
+The rules that emit ``doc_api`` for those two populations live in the
+``.buildkite/doc.rules.txt`` documentation fragment (the docs deplock rule, which
+also touches ``python/deplocks/``, stays in ``.buildkite/test.rules.txt``). rayci
+evaluates each ``.buildkite/*.rules.txt`` file on its own and unions the emitted
+tags, so this test reads both files and unions their tags to match what a real
+build sees. Merging the two files into one rule set would be wrong: a skip rule
+in one file cannot suppress a match in another, but it would in a single merged
+first-match-wins pass.
 
 This test polices the first population only. Its directory list must track
 ``API_PATH_PREFIXES`` in ``doc/source/_ext/api_sidebar.py``, which is the source
@@ -127,24 +136,51 @@ def _api_path_prefixes(root: Path) -> set:
     raise AssertionError("API_PATH_PREFIXES not found in api_sidebar.py")
 
 
+def _doc_api_rulesets(root: Path) -> list:
+    """The per-file rule sets whose ``doc_api`` tags rayci unions.
+
+    doc_api routing lives in the doc.rules.txt fragment; the docs deplock rule,
+    which also touches python/deplocks/, stays in test.rules.txt. Read both, and
+    keep them as separate rule sets so tag matching unions across files rather
+    than merging into a single first-match-wins pass (see the module docstring).
+    """
+    return [
+        TagRuleSet((root / ".buildkite" / "test.rules.txt").read_text()),
+        TagRuleSet((root / ".buildkite" / "doc.rules.txt").read_text()),
+    ]
+
+
+def _match_tags_union(rulesets: list, path: str) -> set:
+    """Union of the tags each rule set emits for ``path`` -- rayci's model."""
+    tags = set()
+    for rules in rulesets:
+        matched, _ = rules.match_tags(path)
+        tags |= set(matched)
+    return tags
+
+
 def _doc_api_rule_dirs(root: Path) -> set:
-    """Directories that emit the ``doc_api`` tag in test.rules.txt, normalized
-    to be relative to doc/source/ so they compare against API_PATH_PREFIXES."""
-    rules = TagRuleSet((root / ".buildkite" / "test.rules.txt").read_text())
+    """Directories that emit the ``doc_api`` tag across the doc routing rules,
+    normalized to be relative to doc/source/ so they compare against
+    API_PATH_PREFIXES. Enumerates every rule in both files (union of rule dirs),
+    which is order-independent, unlike tag matching."""
     dirs = set()
-    for rule in rules.rules:
-        if "doc_api" not in rule.tags:
-            continue
-        for d in rule.dirs:  # stored without a trailing slash
-            if d in _NON_PAGE_DOC_API_DIRS:
-                # Not an API page (e.g. the checker's own source); intentionally
-                # outside the page<->API_PATH_PREFIXES alignment this test checks.
+    for rules in _doc_api_rulesets(root):
+        for rule in rules.rules:
+            if "doc_api" not in rule.tags:
                 continue
-            assert d.startswith(_DOC_SOURCE), (
-                f"doc_api rule directory {d!r} is not under {_DOC_SOURCE!r}; the "
-                "sync check assumes API reference pages live under doc/source/."
-            )
-            dirs.add(d[len(_DOC_SOURCE) :] + "/")
+            for d in rule.dirs:  # stored without a trailing slash
+                if d in _NON_PAGE_DOC_API_DIRS:
+                    # Not an API page (e.g. the checker's own source);
+                    # intentionally outside the page<->API_PATH_PREFIXES
+                    # alignment this test checks.
+                    continue
+                assert d.startswith(_DOC_SOURCE), (
+                    f"doc_api rule directory {d!r} is not under {_DOC_SOURCE!r}; "
+                    "the sync check assumes API reference pages live under "
+                    "doc/source/."
+                )
+                dirs.add(d[len(_DOC_SOURCE) :] + "/")
     return dirs
 
 
@@ -158,9 +194,9 @@ def test_doc_api_rule_matches_api_path_prefixes():
     extra_in_rule = actual - expected
 
     assert not missing_from_rule and not extra_in_rule, (
-        "The doc_api rule in .buildkite/test.rules.txt has drifted from "
+        "The doc_api rule in .buildkite/doc.rules.txt has drifted from "
         "API_PATH_PREFIXES in doc/source/_ext/api_sidebar.py.\n"
-        f"  API pages with no doc_api rule (add these dirs to test.rules.txt so "
+        f"  API pages with no doc_api rule (add these dirs to doc.rules.txt so "
         f"the API checks fire on them): {sorted(missing_from_rule)}\n"
         f"  doc_api rule dirs not in API_PATH_PREFIXES (remove them, or, if the "
         f"divergence is intentional, add them to the documented exception list "
@@ -199,7 +235,7 @@ def _conf_py_local_imports(root: Path) -> set:
 def test_conf_py_imports_route_to_doc_api():
     """Every local module conf.py imports is classified, not left to a catch-all.
 
-    The autodoc machinery block in test.rules.txt is a hand-enumerated list, and
+    The autodoc machinery block in doc.rules.txt is a hand-enumerated list, and
     a `doc/source/*.py` pattern can't replace it (fnmatch `*` crosses `/`, so it
     would swallow every example script under doc/source/<lib>/doc_code/). That
     makes the list drift-prone in a way that fails silently and badly: a new
@@ -212,7 +248,7 @@ def test_conf_py_imports_route_to_doc_api():
     exception.
     """
     root = _find_ray_root()
-    rules = TagRuleSet((root / ".buildkite" / "test.rules.txt").read_text())
+    rulesets = _doc_api_rulesets(root)
 
     found = _conf_py_local_imports(root)
     missing_floor = _MACHINERY_IMPORT_FLOOR - found
@@ -231,17 +267,17 @@ def test_conf_py_imports_route_to_doc_api():
         if module in _CONF_IMPORTS_NOT_API_MACHINERY:
             continue
         path = f"doc/source/{module.replace('.', '/')}.py"
-        tags, _ = rules.match_tags(path)
+        tags = _match_tags_union(rulesets, path)
         if "doc_api" not in tags:
             unclassified[path] = sorted(tags)
 
     assert not unclassified, (
-        "conf.py imports these modules, but test.rules.txt does not route them "
-        "to doc_api, so editing them would not run the API-consistency "
+        "conf.py imports these modules, but the doc routing rules do not route "
+        "them to doc_api, so editing them would not run the API-consistency "
         "checks:\n"
         + "\n".join(f"  {p} currently emits {t}" for p, t in unclassified.items())
         + "\n\nAdd each one to the autodoc machinery block in "
-        ".buildkite/test.rules.txt, or, if it genuinely cannot affect the "
+        ".buildkite/doc.rules.txt, or, if it genuinely cannot affect the "
         "documented API surface, to _CONF_IMPORTS_NOT_API_MACHINERY in this "
         "test with a comment saying why."
     )


### PR DESCRIPTION
## What

Splits the `doc/`-scoped change-detection rules out of `.buildkite/test.rules.txt` into a new `.buildkite/doc.rules.txt` that `@ray-project/ray-docs` co-owns.

rayci discovers every `.buildkite/*.rules.txt`, evaluates each on its own with first-match-wins, and unions the emitted tags across files. So a dedicated doc fragment is picked up with **no rayci change** — this is a rules-file-only change. It lets the docs team iterate on doc CI routing without a review seat on `test.rules.txt`/`always.rules.txt`, which route CI for the whole repo.

## How

- **Moved** the 15 rules whose paths are entirely under `doc/` into `doc.rules.txt` (the `doc_api` page block, the autodoc/`conf.py` infra, `doc/redirects`, `doc/BUILD.bazel`, the per-library `<lib>_doc` routing, `_intersphinx`, templates, the `doc/*.py` catch-all).
- **Duplicated** 4 shared skip rules that also match non-`doc/` paths (the prose/image skip, which also covers repo-root `.claude/`; the `doc/source/llm` route; the render-infra rule, which also covers `.vale`; and the terminal `doc/` skip). The full rule stays in `test.rules.txt` for its non-doc paths; a doc-only copy leads/orders the fragment so `doc/` paths resolve the same first-match.
- **Left** the rules that touch shared, non-`doc/` surfaces in `test.rules.txt`: the docs deplock (which must win first-match above the general `python/deplocks/` rule), `.buildkite/doc.rayci.yml`, `.readthedocs.yaml`, and `ci/ray_ci/doc/`. Those keep repo-wide blast radius.
- Added a `.buildkite/doc.rules.test.txt` companion and re-homed the doc cases out of `test.rules.test.txt`.
- Added `@ray-project/ray-docs` co-ownership of the fragment in CODEOWNERS, mirroring the existing `.readthedocs.yaml` pattern; the repo-wide rule files stay `@ray-project/ray-ci`.

This is a no-op on what CI runs. It only changes which file the doc routing lives in and who can review a doc-routing edit.

## Testing

- **Tag-preservation, repo-wide:** using rayci's own union evaluator (`loadTagRuleConfigs` + `tagsForChangedFiles`), the emitted tag set is **identical before and after the split for all 10,389 tracked files** (1,677 under `doc/`). 0 mismatches.
- **`rayci test-rules` passes** with the new `doc.rules.test.txt` companion and the trimmed `test.rules.test.txt`.
- **`pre-commit run --files`** on all changed files passes (trailing-whitespace, end-of-files, large-files; the rest are not-applicable to rules files).

## Not a duplicate

No open PR touches `doc.rules.txt` or splits doc routing. The adjacent open PRs (#65941, #65950) route `dependencies.rayci.yml` through `deplock_check` — a different rule and concern.

## Note for reviewers

This is an ownership-boundary change on a shared CI surface, so it's up as a **draft pending REEf alignment** on the boundary before merge. The intent is that docs owns only the `doc/`-scoped fragment and gains no authority over the repo-wide rule files or the shared dependency/CI surfaces. @elliot-barn — this is the doc-routing-ownership split we discussed; the extraction is verified tag-preserving so the review is about the boundary, not the routing.

AI assistance (Claude) was used to author and verify this change.
