### PR TITLE
[tune] Stop Repeater raising KeyError on unknown trial IDs

### DIFF
--- a/python/ray/tune/search/repeater.py
+++ b/python/ray/tune/search/repeater.py
@@ -162,6 +162,7 @@ class Repeater(Searcher):
                 "Trial {} not in group; cannot report score. "
                 "Seen trials: {}".format(trial_id, list(self._trial_id_to_group))
             )
+            return
         trial_group = self._trial_id_to_group[trial_id]
         if not result or self.searcher.metric not in result:
             score = np.nan

--- a/python/ray/tune/tests/test_searcher_utils.py
+++ b/python/ray/tune/tests/test_searcher_utils.py
@@ -128,6 +128,42 @@ def test_set_get_repeater():
     assert new_repeater.searcher.returned_result[-1] == {"result": 3}
 
 
+def test_repeater_ignores_unknown_trial():
+    """Reporting a trial the Repeater never suggested should not raise.
+
+    On resume, Tune can restore a trial that was suggested after the last
+    search algorithm checkpoint was written. Such a trial is missing from the
+    restored ``_trial_id_to_group`` mapping, and completing it used to raise a
+    ``KeyError`` that tore down the whole experiment.
+    """
+
+    class TestSuggestion(Searcher):
+        def __init__(self):
+            self.returned_result = []
+            super().__init__(metric="result", mode="max")
+
+        def suggest(self, trial_id):
+            return {"score": 1}
+
+        def on_trial_complete(self, trial_id, result=None, **kwargs):
+            self.returned_result.append(result)
+
+    searcher = TestSuggestion()
+    repeater = Repeater(searcher, repeat=2, set_index=False)
+    repeater.suggest("known_1")
+
+    # A trial that is absent from the restored group mapping is skipped
+    # instead of aborting the experiment.
+    repeater.on_trial_complete("unknown", {"result": 8})
+    assert searcher.returned_result == []
+
+    # Groups the Repeater does know about still report normally.
+    repeater.suggest("known_2")
+    repeater.on_trial_complete("known_1", {"result": 1})
+    repeater.on_trial_complete("known_2", {"result": 3})
+    assert searcher.returned_result == [{"result": 2.0}]
+
+
 def test_set_get_limiter():
     class TestSuggestion(Searcher):
         def __init__(self, index):


### PR DESCRIPTION
## Why are these changes needed?

`Repeater.on_trial_complete` guards against a trial that is missing from its
`_trial_id_to_group` mapping, logs `"Trial {} not in group; cannot report score"`,
and then immediately indexes that same mapping anyway:

```python
if trial_id not in self._trial_id_to_group:
    logger.error(
        "Trial {} not in group; cannot report score. "
        "Seen trials: {}".format(trial_id, list(self._trial_id_to_group))
    )
trial_group = self._trial_id_to_group[trial_id]   # KeyError
```

The log message says the score cannot be reported, but there is no `return`, so
the next line raises `KeyError` and the exception propagates up through
`SearchGenerator.on_trial_complete` into `_process_trial`, taking down the whole
experiment rather than skipping the one trial.

This is reachable on resume. Tune checkpoints the search algorithm and the trial
state on separate cadences, so a trial suggested after the last search algorithm
checkpoint is still restored from the trial state while being absent from the
restored `_trial_id_to_group`. When it completes, `Repeater` has never seen the
ID. That matches the original report, where resume fails when the last trial
before the interruption was incomplete.

This change adds the missing `return` so the trial is skipped, which is the
behavior the existing log message already describes. The group bookkeeping for
trials the `Repeater` does know about is unchanged.

Worth noting for reviewers: the 2020 comment on the issue suggested the cause was
that `save`/`restore` were not implemented for `Repeater`. That is no longer the
case. `SearchGenerator.save_to_dir` / `restore_from_dir` walk the wrapper chain
and call `get_state()` / `set_state()` on each wrapper, so `Repeater` state is
checkpointed today. What remains is only the missing early return on the
unknown-trial path.

## Related issue number

Closes #11918

## Not a duplicate

- `gh pr list --repo ray-project/ray --state open --search "11918 in:body"` → no results
- `gh pr list --repo ray-project/ray --state all --search "repeater in:title"` → no results
- The issue has no linked PR and no open cross-referenced PR.

## Checks

Environment: Python 3.11.16, `ray[tune]` 2.58.0 in a venv, with `python/ray/tune`
symlinked to this branch via `python/ray/setup-dev.py -y --allow tune`.

Added `test_repeater_ignores_unknown_trial`, which reproduces the reported
failure. Before the fix it fails with the same signature as the issue report:

```
ERROR repeater.py:161 -- Trial unknown not in group; cannot report score. Seen trials: ['known_1']
>       trial_group = self._trial_id_to_group[trial_id]
E       KeyError: 'unknown'
```

After the fix:

```
$ pytest ray/tune/tests/test_searcher_utils.py -q
...........                                                              [100%]
11 passed in 0.02s

$ pytest ray/tune/tests/execution/test_controller_search_alg_integration.py -q
........ss.........                                                      [100%]
17 passed, 2 skipped in 45.90s
```

Lint:

```
$ pre-commit run --files python/ray/tune/search/repeater.py python/ray/tune/tests/test_searcher_utils.py
# all hooks pass
```

Commit is DCO signed off.

## AI assistance

Per `AGENTS.md`: AI assistance (Claude Code) was used for this change. The
diagnosis, the fix, and the regression test were reviewed and the tests were run
locally as shown above before opening this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QtvvymoPBWrpb7JZQ4zEBc
