### PR TITLE
[runtime_env][docs] Document uv environment variable expansion

### DIFF
--- a/doc/source/ray-core/handling-dependencies.rst
+++ b/doc/source/ray-core/handling-dependencies.rst
@@ -594,6 +594,13 @@ The ``runtime_env`` is a Python dictionary or a Python class :class:`ray.runtime
 
   - Example: ``{"packages":["tensorflow", "requests"], "uv_version": "==0.4.0;python_version=='3.8.11'"}``
 
+  Before running ``uv pip install``, Ray expands ``$VAR`` and ``${VAR}`` references in
+  ``packages`` and ``uv_pip_install_options`` entries using the environment available
+  during runtime environment creation, including variables set in
+  ``runtime_env["env_vars"]``. When ``working_dir`` is set,
+  ``${RAY_RUNTIME_ENV_CREATE_WORKING_DIR}`` resolves to its prepared local directory.
+  References to variables that aren't defined remain unchanged.
+
   When specifying a path to a ``requirements.txt`` file, the file must be present on your local machine and it must be a valid absolute path or relative filepath relative to your local current working directory, *not* relative to the ``working_dir`` specified in the ``runtime_env``.
   Furthermore, referencing local files *within* a ``requirements.txt`` file isn't directly supported (e.g., ``-r ./my-laptop/more-requirements.txt``, ``./my-pkg.whl``). Instead, use the ``${RAY_RUNTIME_ENV_CREATE_WORKING_DIR}`` environment variable in the creation process. For example, use ``-r ${RAY_RUNTIME_ENV_CREATE_WORKING_DIR}/my-laptop/more-requirements.txt`` or ``${RAY_RUNTIME_ENV_CREATE_WORKING_DIR}/my-pkg.whl`` to reference local files, while ensuring they're in the ``working_dir``.
 


### PR DESCRIPTION
## Description

Documents the environment-variable expansion behavior added in #65767 for the low-level `uv` runtime environment plugin:

- `$VAR` and `${VAR}` references are expanded in `packages` and `uv_pip_install_options`.
- Values include variables supplied through `runtime_env["env_vars"]`.
- `RAY_RUNTIME_ENV_CREATE_WORKING_DIR` points to the prepared working directory when one is configured.
- Undefined references remain unchanged.

This is the documentation follow-up requested by @edoakes in the approving review on #65767. It does not change runtime behavior.

## Related issues

Follow-up to #65767.

## Additional information

Validation:

- `git diff --check` — passed.
- `sphinx-lint` baseline comparison — no new findings; the patched and base files have the same four pre-existing findings.
- `test_install_uv_packages_expands_env_vars_from_install_env` — `1 passed in 0.07s` against source matching current `master`.

A full Sphinx build was not run because the local environment does not have the Ray docs dependencies installed. The changed page is explicitly excluded from `doctest[core]`; upstream docs CI is still required.

AI assistance was used to prepare this documentation follow-up. I reviewed the proposed text against the merged implementation and its regression tests.
