### PR TITLE
[tune] Do not count a trial with no usable running mean as a median sample

### DIFF
--- a/python/ray/tune/schedulers/median_stopping_rule.py
+++ b/python/ray/tune/schedulers/median_stopping_rule.py
@@ -146,7 +146,17 @@ class MedianStoppingRule(FIFOScheduler):
         trials = self._trials_beyond_time(time)
         trials.remove(trial)
 
-        if len(trials) < self._min_samples_required:
+        # A trial is only a usable sample if it has a real running mean at `time`. It does not when
+        # it reported nothing inside [grace_period, time] (`np.mean` of an empty window is nan) or
+        # when its own reports were nan. One nan makes the median nan, and nan compares worse than
+        # every real score under both modes, so a single such trial stops every other trial.
+        running_means = [
+            running_mean
+            for running_mean in (self._running_mean(other, time) for other in trials)
+            if np.isfinite(running_mean)
+        ]
+
+        if len(running_means) < self._min_samples_required:
             action = self._on_insufficient_samples(tune_controller, trial, time)
             if action == TrialScheduler.PAUSE:
                 self._last_pause[trial] = time
@@ -156,12 +166,12 @@ class MedianStoppingRule(FIFOScheduler):
             logger.debug(
                 "MedianStoppingRule: insufficient samples={} to evaluate "
                 "trial {} at t={}. {}".format(
-                    len(trials), trial.trial_id, time, action_str
+                    len(running_means), trial.trial_id, time, action_str
                 )
             )
             return action
 
-        median_result = self._median_result(trials, time)
+        median_result = np.median(running_means)
         best_result = self._best_result(trial)
         logger.debug(
             "Trial {} best res={} vs median res={} at t={}".format(
@@ -209,7 +219,12 @@ class MedianStoppingRule(FIFOScheduler):
         return trials
 
     def _median_result(self, trials: List[Trial], time: float):
-        return np.median([self._running_mean(trial, time) for trial in trials])
+        running_means = [
+            running_mean
+            for running_mean in (self._running_mean(trial, time) for trial in trials)
+            if np.isfinite(running_mean)
+        ]
+        return np.median(running_means) if running_means else np.nan
 
     def _running_mean(self, trial: Trial, time: float) -> np.ndarray:
         results = self._results[trial]
@@ -218,6 +233,9 @@ class MedianStoppingRule(FIFOScheduler):
         scoped_results = [
             r for r in results if self._grace_period <= r[self._time_attr] <= time
         ]
+        if not scoped_results:
+            # Sparse reporting can skip the window entirely; `np.mean([])` is nan plus a warning.
+            return np.nan
         return np.mean([r[self._metric] for r in scoped_results])
 
     def _best_result(self, trial):

--- a/python/ray/tune/tests/test_trial_scheduler.py
+++ b/python/ray/tune/tests/test_trial_scheduler.py
@@ -175,6 +175,46 @@ class EarlyStoppingSuite(unittest.TestCase):
             rule.on_trial_result(runner, t3, result(2, 260)), TrialScheduler.STOP
         )
 
+    def testMedianStoppingSparseReportsAreNotSamples(self):
+        # A trial that reported nothing inside [grace_period, time] has no running mean there:
+        # `np.mean` of the empty window is nan, which made the median nan and stopped every trial.
+        rule = MedianStoppingRule(
+            metric="episode_reward_mean",
+            mode="max",
+            grace_period=10,
+            min_samples_required=1,
+        )
+        runner = mock_tune_controller()
+        sparse = Trial(MOCK_TRAINABLE_NAME)
+        rule.on_trial_result(runner, sparse, result(5, 0))
+        rule.on_trial_complete(runner, sparse, result(100, 0))
+
+        best = Trial(MOCK_TRAINABLE_NAME)
+        # `sparse` is the only other trial beyond t=10 and it never reported inside [10, 10],
+        # so there is no sample to compare against and the best trial must keep running.
+        self.assertEqual(
+            rule.on_trial_result(runner, best, result(10, 1000)), TrialScheduler.CONTINUE
+        )
+
+    def testMedianStoppingNanReportsAreNotSamples(self):
+        # Same shape via a nan metric (issue #24809): the offending trial is excluded instead of
+        # making the median nan.
+        rule = MedianStoppingRule(
+            metric="episode_reward_mean",
+            mode="max",
+            grace_period=0,
+            min_samples_required=1,
+        )
+        runner = mock_tune_controller()
+        poisoned = Trial(MOCK_TRAINABLE_NAME)
+        rule.on_trial_result(runner, poisoned, result(1, float("nan")))
+        rule.on_trial_complete(runner, poisoned, result(2, float("nan")))
+
+        best = Trial(MOCK_TRAINABLE_NAME)
+        self.assertEqual(
+            rule.on_trial_result(runner, best, result(2, 1000)), TrialScheduler.CONTINUE
+        )
+
     def testMedianStoppingSoftStop(self):
         rule = MedianStoppingRule(
             metric="episode_reward_mean",

--- a/python/ray/tune/tests/test_trial_scheduler.py
+++ b/python/ray/tune/tests/test_trial_scheduler.py
@@ -193,7 +193,8 @@ class EarlyStoppingSuite(unittest.TestCase):
         # `sparse` is the only other trial beyond t=10 and it never reported inside [10, 10],
         # so there is no sample to compare against and the best trial must keep running.
         self.assertEqual(
-            rule.on_trial_result(runner, best, result(10, 1000)), TrialScheduler.CONTINUE
+            rule.on_trial_result(runner, best, result(10, 1000)),
+            TrialScheduler.CONTINUE,
         )
 
     def testMedianStoppingNanReportsAreNotSamples(self):


### PR DESCRIPTION
## Why this is not a duplicate

```
gh pr list --repo ray-project/ray --state open --search "MedianStoppingRule"   -> none
gh pr list --repo ray-project/ray --state open --search "median stopping"      -> none
gh pr list --repo ray-project/ray --state all  --search "median_stopping_rule" -> none touching this code
```

Issue #24809 reports the same user-visible symptom ("the scheduler seems to stop ALL trials") from one of the two causes below, the nan metric. It was closed in 2026 by the pending-cleanup bot with no fix, has no linked PR, and the code is unchanged on master.

## What is wrong

`MedianStoppingRule._running_mean` averages a trial's results over `[grace_period, time]`. Two cases give it a nan:

1. The trial reported nothing inside that window. `_trials_beyond_time` only checks that the trial's **last** result is at or past `time`, so a trial that reports every N iterations is included while having no result in the window. `np.mean([])` is nan, with a `RuntimeWarning: Mean of empty slice`.
2. The trial's own reports were nan (issue #24809).

One nan makes `np.median` nan, and `max(nan, x)` / `min(nan, x)` both return nan, so `self._compare_op(median_result, best_result) != best_result` is true and the trial is stopped, however good it is.

Three trials scoring `0.0`, one scoring `100.0`, `grace_period=60`, `mode="max"`:

```
other trials report every   1 iterations -> never stopped (correct)
other trials report every   5 iterations -> never stopped (correct)
other trials report every  20 iterations -> never stopped (correct)
other trials report every  25 iterations -> stopped at t=60, median of the others = nan
other trials report every  50 iterations -> stopped at t=60, median of the others = nan
other trials report every 100 iterations -> stopped at t=60, median of the others = nan
```

## What changed

Drop non-finite running means before the `min_samples_required` check. A trial with no usable running mean is not a sample, so the rule falls back to its existing insufficient-samples path instead of stopping everything. `_running_mean` now returns `np.nan` explicitly for an empty window rather than going through `np.mean([])` and its warning.

## Tests run and their results

```
pytest python/ray/tune/tests/test_trial_scheduler.py -k testMedianStopping
  master, pristine test file:                     7 passed
  master, with the two new tests:                 2 failed, 7 passed
  this branch, with the two new tests:            9 passed
```

The two new tests are `testMedianStoppingSparseReportsAreNotSamples` and `testMedianStoppingNanReportsAreNotSamples` in `EarlyStoppingSuite`. Ray cannot be built on this machine, so the scheduler module under test was the installed `ray==2.56.1` copy after confirming it is git-blob identical to master (`33fadfb9817a5c3f29db7a84e54fb86b5d3c16af`), patched in place and restored afterwards.

## AI assistance

AI assistance was used for this change.
