### PR TITLE
[Data] Add a network bandwidth assertion to `read_parquet_fixed_size` release test

### DIFF
--- a/release/nightly_tests/dataset/benchmark.py
+++ b/release/nightly_tests/dataset/benchmark.py
@@ -16,6 +16,8 @@ from ray.util.state import list_runtime_envs
 logger = logging.getLogger(__name__)
 
 PROMETHEUS_QUERY_TIMEOUT_S = 30
+BITS_PER_BYTE = 8
+BITS_PER_GIGABIT = 1_000_000_000
 
 
 def _query_prometheus(query: str, timestamp: float):
@@ -39,7 +41,7 @@ def _query_prometheus(query: str, timestamp: float):
             )
         except asyncio.TimeoutError as exc:
             raise RuntimeError(
-                "Prometheus head-node memory query timed out after "
+                "Prometheus query timed out after "
                 f"{PROMETHEUS_QUERY_TIMEOUT_S} seconds."
             ) from exc
         finally:
@@ -96,6 +98,69 @@ def _get_peak_head_node_memory_used_bytes(
     return peak_memory_bytes
 
 
+@dataclasses.dataclass(frozen=True)
+class WorkerNetworkReceiveStats:
+    total_bytes_per_second: float
+    average_bytes_per_second: float
+    node_count: int
+
+
+def _get_worker_network_receive_stats(
+    start_unix_time: float, end_unix_time: float
+) -> WorkerNetworkReceiveStats:
+    """Return worker network receive throughput averaged over a benchmark case."""
+    assert start_unix_time <= end_unix_time, (start_unix_time, end_unix_time)
+
+    session_name = ray.get_runtime_context().get_session_name()
+    metric_selector = (
+        "ray_node_network_receive_speed{"
+        f'RayNodeType="worker",SessionName={json.dumps(session_name)}'
+        "}"
+    )
+
+    # Prometheus requires a positive range, so use 1 ms for a zero-duration case.
+    duration_ms = max(1, math.ceil((end_unix_time - start_unix_time) * 1000))
+    results = _query_prometheus(
+        f"avg_over_time({metric_selector}[{duration_ms}ms])",
+        end_unix_time,
+    )
+    if results is None:
+        raise RuntimeError(
+            "Failed to query Prometheus for worker network receive throughput."
+        )
+    if not results:
+        raise RuntimeError(
+            "Prometheus returned no worker network receive throughput results."
+        )
+
+    worker_bytes_per_second = []
+    for result in results:
+        try:
+            _, raw_value = result["value"]
+            bytes_per_second = float(raw_value)
+        except (KeyError, TypeError, ValueError) as exc:
+            raise RuntimeError(
+                "Prometheus returned an invalid worker network receive throughput "
+                "value."
+            ) from exc
+
+        if not math.isfinite(bytes_per_second) or bytes_per_second < 0:
+            raise RuntimeError(
+                "Prometheus returned an invalid worker network receive throughput "
+                "value."
+            )
+        worker_bytes_per_second.append(bytes_per_second)
+
+    total_bytes_per_second = sum(worker_bytes_per_second)
+    return WorkerNetworkReceiveStats(
+        total_bytes_per_second=total_bytes_per_second,
+        average_bytes_per_second=(
+            total_bytes_per_second / len(worker_bytes_per_second)
+        ),
+        node_count=len(worker_bytes_per_second),
+    )
+
+
 def _get_spilled_bytes_total(state) -> float:
     """Get the total number of spilled bytes across the cluster."""
     return get_memory_info_reply(state).store_stats.spilled_bytes_total
@@ -103,6 +168,10 @@ def _get_spilled_bytes_total(state) -> float:
 
 def _bytes_to_gb(b: float) -> float:
     return round(b / (1024**3), 4)
+
+
+def _bytes_per_second_to_gbps(bytes_per_second: float) -> float:
+    return bytes_per_second * BITS_PER_BYTE / BITS_PER_GIGABIT
 
 
 class ObjectStoreMemorySampler:
@@ -260,6 +329,9 @@ class BenchmarkMetric(Enum):
     OBJECT_STORE_MEMORY_USED_PEAK_GB = "object_store_memory_used_peak_gb"
     OBJECT_STORE_MEMORY_UTILIZATION_PEAK = "object_store_memory_utilization_peak"
     HEAD_NODE_MEMORY_USED_PEAK_GB = "head_node_memory_used_peak_gb"
+    WORKER_NETWORK_RECEIVE_TOTAL_GBPS = "worker_network_receive_total_gbps"
+    WORKER_NETWORK_RECEIVE_AVERAGE_GBPS = "worker_network_receive_average_gbps"
+    WORKER_NETWORK_RECEIVE_NODE_COUNT = "worker_network_receive_node_count"
 
 
 class Benchmark:
@@ -268,6 +340,9 @@ class Benchmark:
     Args:
         max_head_node_memory_bytes: If set, query Prometheus after each case and fail
             if peak physical memory used on the head node exceeds this limit.
+        min_total_worker_network_receive_gbps: If set, fail if worker network receive
+            bandwidth, averaged over the case and summed across workers, is below this
+            limit.
 
     Here's an example of typical usage:
 
@@ -294,12 +369,27 @@ class Benchmark:
         {"short": {"time": 1.0, "sleep_s": 1}, "long": {"time": 10.0 "sleep_s": 10}}
     """
 
-    def __init__(self, *, max_head_node_memory_bytes: Optional[int] = None):
+    def __init__(
+        self,
+        *,
+        max_head_node_memory_bytes: Optional[int] = None,
+        min_total_worker_network_receive_gbps: Optional[float] = None,
+    ):
         if max_head_node_memory_bytes is not None and max_head_node_memory_bytes <= 0:
             raise ValueError("max_head_node_memory_bytes must be greater than 0.")
+        if (
+            min_total_worker_network_receive_gbps is not None
+            and min_total_worker_network_receive_gbps <= 0
+        ):
+            raise ValueError(
+                "min_total_worker_network_receive_gbps must be greater than 0."
+            )
 
         self.result = {}
         self._max_head_node_memory_bytes = max_head_node_memory_bytes
+        self._min_total_worker_network_receive_gbps = (
+            min_total_worker_network_receive_gbps
+        )
 
     def run_fn(
         self,
@@ -373,6 +463,31 @@ class Benchmark:
                 BenchmarkMetric.HEAD_NODE_MEMORY_USED_PEAK_GB.value
             ] = _bytes_to_gb(peak_head_node_memory_bytes)
 
+        min_total_worker_network_receive_gbps = (
+            self._min_total_worker_network_receive_gbps
+        )
+        worker_network_receive_stats = None
+        total_worker_network_receive_gbps = None
+        if min_total_worker_network_receive_gbps is not None:
+            worker_network_receive_stats = _get_worker_network_receive_stats(
+                start_unix_time, end_unix_time
+            )
+            total_worker_network_receive_gbps = _bytes_per_second_to_gbps(
+                worker_network_receive_stats.total_bytes_per_second
+            )
+            average_worker_network_receive_gbps = _bytes_per_second_to_gbps(
+                worker_network_receive_stats.average_bytes_per_second
+            )
+            curr_case_metrics[
+                BenchmarkMetric.WORKER_NETWORK_RECEIVE_TOTAL_GBPS.value
+            ] = round(total_worker_network_receive_gbps, 4)
+            curr_case_metrics[
+                BenchmarkMetric.WORKER_NETWORK_RECEIVE_AVERAGE_GBPS.value
+            ] = round(average_worker_network_receive_gbps, 4)
+            curr_case_metrics[
+                BenchmarkMetric.WORKER_NETWORK_RECEIVE_NODE_COUNT.value
+            ] = worker_network_receive_stats.node_count
+
         print(f"Result of case {name}: {curr_case_metrics}")
 
         if (
@@ -385,6 +500,22 @@ class Benchmark:
                 f"({_bytes_to_gb(peak_head_node_memory_bytes)} GiB) exceeded the "
                 f"configured limit "
                 f"({_bytes_to_gb(max_head_node_memory_bytes)} GiB)."
+            )
+
+        if (
+            total_worker_network_receive_gbps is not None
+            and min_total_worker_network_receive_gbps is not None
+            and total_worker_network_receive_gbps
+            < min_total_worker_network_receive_gbps
+        ):
+            assert worker_network_receive_stats is not None
+            raise AssertionError(
+                f"Benchmark case {name!r} worker network receive throughput "
+                f"({total_worker_network_receive_gbps:.4f} Gbps total, "
+                f"{_bytes_per_second_to_gbps(worker_network_receive_stats.average_bytes_per_second):.4f} "
+                f"Gbps per worker across {worker_network_receive_stats.node_count} "
+                f"workers) was below the configured minimum "
+                f"({min_total_worker_network_receive_gbps:.4f} Gbps total)."
             )
 
     def write_result(self):

--- a/release/nightly_tests/dataset/benchmark.py
+++ b/release/nightly_tests/dataset/benchmark.py
@@ -103,17 +103,23 @@ class WorkerNetworkReceiveStats:
     total_bytes_per_second: float
     average_bytes_per_second: float
     node_count: int
+    per_node_bytes_per_second: Dict[str, float] = dataclasses.field(
+        default_factory=dict
+    )
 
 
-def _get_worker_network_receive_stats(
-    start_unix_time: float, end_unix_time: float
-) -> WorkerNetworkReceiveStats:
-    """Return worker network receive throughput averaged over a benchmark case."""
+def _get_worker_metric_averages(
+    metric_name: str,
+    metric_description: str,
+    start_unix_time: float,
+    end_unix_time: float,
+) -> Dict[str, float]:
+    """Return a Prometheus metric averaged by worker over a benchmark case."""
     assert start_unix_time <= end_unix_time, (start_unix_time, end_unix_time)
 
     session_name = ray.get_runtime_context().get_session_name()
     metric_selector = (
-        "ray_node_network_receive_speed{"
+        f"{metric_name}{{"
         f'RayNodeType="worker",SessionName={json.dumps(session_name)}'
         "}"
     )
@@ -125,39 +131,70 @@ def _get_worker_network_receive_stats(
         end_unix_time,
     )
     if results is None:
-        raise RuntimeError(
-            "Failed to query Prometheus for worker network receive throughput."
-        )
+        raise RuntimeError(f"Failed to query Prometheus for {metric_description}.")
     if not results:
-        raise RuntimeError(
-            "Prometheus returned no worker network receive throughput results."
-        )
+        raise RuntimeError(f"Prometheus returned no {metric_description} results.")
 
-    worker_bytes_per_second = []
+    per_node_values = {}
     for result in results:
         try:
+            node_ip = result["metric"]["ip"]
             _, raw_value = result["value"]
-            bytes_per_second = float(raw_value)
+            value = float(raw_value)
         except (KeyError, TypeError, ValueError) as exc:
             raise RuntimeError(
-                "Prometheus returned an invalid worker network receive throughput "
-                "value."
+                f"Prometheus returned an invalid {metric_description} result."
             ) from exc
 
-        if not math.isfinite(bytes_per_second) or bytes_per_second < 0:
+        if not isinstance(node_ip, str) or not node_ip:
             raise RuntimeError(
-                "Prometheus returned an invalid worker network receive throughput "
-                "value."
+                f"Prometheus returned an invalid {metric_description} worker IP."
             )
-        worker_bytes_per_second.append(bytes_per_second)
+        if not math.isfinite(value) or value < 0:
+            raise RuntimeError(
+                f"Prometheus returned an invalid {metric_description} value."
+            )
+        if node_ip in per_node_values:
+            raise RuntimeError(
+                f"Prometheus returned multiple {metric_description} results for "
+                f"worker {node_ip}."
+            )
+        per_node_values[node_ip] = value
 
-    total_bytes_per_second = sum(worker_bytes_per_second)
+    return dict(sorted(per_node_values.items()))
+
+
+def _get_worker_network_receive_stats(
+    start_unix_time: float, end_unix_time: float
+) -> WorkerNetworkReceiveStats:
+    """Return worker network receive throughput averaged over a benchmark case."""
+    per_node_bytes_per_second = _get_worker_metric_averages(
+        "ray_node_network_receive_speed",
+        "worker network receive throughput",
+        start_unix_time,
+        end_unix_time,
+    )
+
+    total_bytes_per_second = sum(per_node_bytes_per_second.values())
     return WorkerNetworkReceiveStats(
         total_bytes_per_second=total_bytes_per_second,
         average_bytes_per_second=(
-            total_bytes_per_second / len(worker_bytes_per_second)
+            total_bytes_per_second / len(per_node_bytes_per_second)
         ),
-        node_count=len(worker_bytes_per_second),
+        node_count=len(per_node_bytes_per_second),
+        per_node_bytes_per_second=per_node_bytes_per_second,
+    )
+
+
+def _get_worker_cpu_utilization(
+    start_unix_time: float, end_unix_time: float
+) -> Dict[str, float]:
+    """Return CPU utilization averaged by worker over a benchmark case."""
+    return _get_worker_metric_averages(
+        "ray_node_cpu_utilization",
+        "worker CPU utilization",
+        start_unix_time,
+        end_unix_time,
     )
 
 
@@ -332,6 +369,8 @@ class BenchmarkMetric(Enum):
     WORKER_NETWORK_RECEIVE_TOTAL_GBPS = "worker_network_receive_total_gbps"
     WORKER_NETWORK_RECEIVE_AVERAGE_GBPS = "worker_network_receive_average_gbps"
     WORKER_NETWORK_RECEIVE_NODE_COUNT = "worker_network_receive_node_count"
+    WORKER_NETWORK_RECEIVE_GBPS_BY_NODE = "worker_network_receive_gbps_by_node"
+    WORKER_CPU_UTILIZATION_PERCENT_BY_NODE = "worker_cpu_utilization_percent_by_node"
 
 
 class Benchmark:
@@ -416,9 +455,9 @@ class Benchmark:
         state = get_state_from_address(ray.get_runtime_context().gcs_address)
 
         with ObjectStoreMemorySampler(state) as memory_sampler:
+            start_spilled_bytes = _get_spilled_bytes_total(state)
             start_unix_time = time.time()
             start_time = time.perf_counter()
-            start_spilled_bytes = _get_spilled_bytes_total(state)
 
             try:
                 fn_output = fn(*fn_args, **fn_kwargs)
@@ -472,6 +511,9 @@ class Benchmark:
             worker_network_receive_stats = _get_worker_network_receive_stats(
                 start_unix_time, end_unix_time
             )
+            worker_cpu_utilization = _get_worker_cpu_utilization(
+                start_unix_time, end_unix_time
+            )
             total_worker_network_receive_gbps = _bytes_per_second_to_gbps(
                 worker_network_receive_stats.total_bytes_per_second
             )
@@ -487,6 +529,45 @@ class Benchmark:
             curr_case_metrics[
                 BenchmarkMetric.WORKER_NETWORK_RECEIVE_NODE_COUNT.value
             ] = worker_network_receive_stats.node_count
+            worker_network_receive_gbps_by_node = {
+                node_ip: round(_bytes_per_second_to_gbps(bytes_per_second), 4)
+                for node_ip, bytes_per_second in (
+                    worker_network_receive_stats.per_node_bytes_per_second.items()
+                )
+            }
+            worker_cpu_utilization_percent_by_node = {
+                node_ip: round(cpu_utilization, 2)
+                for node_ip, cpu_utilization in worker_cpu_utilization.items()
+            }
+            curr_case_metrics[
+                BenchmarkMetric.WORKER_NETWORK_RECEIVE_GBPS_BY_NODE.value
+            ] = worker_network_receive_gbps_by_node
+            curr_case_metrics[
+                BenchmarkMetric.WORKER_CPU_UTILIZATION_PERCENT_BY_NODE.value
+            ] = worker_cpu_utilization_percent_by_node
+
+            print("Worker averages during the benchmark:")
+            for node_ip in sorted(
+                set(worker_network_receive_gbps_by_node)
+                | set(worker_cpu_utilization_percent_by_node)
+            ):
+                network_gbps = worker_network_receive_gbps_by_node.get(node_ip)
+                cpu_percent = worker_cpu_utilization_percent_by_node.get(node_ip)
+                network_text = (
+                    f"{network_gbps:.4f} Gbps"
+                    if network_gbps is not None
+                    else "network unavailable"
+                )
+                cpu_text = (
+                    f"{cpu_percent:.2f}% CPU"
+                    if cpu_percent is not None
+                    else "CPU unavailable"
+                )
+                print(f"  {node_ip}: {network_text}, {cpu_text}")
+            print(
+                "Total worker network receive: "
+                f"{total_worker_network_receive_gbps:.4f} Gbps"
+            )
 
         print(f"Result of case {name}: {curr_case_metrics}")
 

--- a/release/nightly_tests/dataset/read_and_consume_benchmark.py
+++ b/release/nightly_tests/dataset/read_and_consume_benchmark.py
@@ -31,6 +31,12 @@ def parse_args() -> argparse.Namespace:
         default=None,
         help="Logical memory in bytes to pass to the read.",
     )
+    parser.add_argument(
+        "--min-total-worker-network-receive-gbps",
+        type=float,
+        default=None,
+        help="Fail if the workers receive less than this many Gbps in total, on average.",
+    )
 
     consume_group = parser.add_mutually_exclusive_group()
     consume_group.add_argument("--count", action="store_true")
@@ -71,7 +77,11 @@ def parse_args() -> argparse.Namespace:
 
 
 def main(args):
-    benchmark = Benchmark()
+    benchmark = Benchmark(
+        min_total_worker_network_receive_gbps=(
+            args.min_total_worker_network_receive_gbps
+        )
+    )
 
     def benchmark_fn():
         read_fn = get_read_fn(args)

--- a/release/nightly_tests/dataset/read_and_consume_benchmark.py
+++ b/release/nightly_tests/dataset/read_and_consume_benchmark.py
@@ -37,6 +37,12 @@ def parse_args() -> argparse.Namespace:
         default=None,
         help="Fail if the workers receive less than this many Gbps in total, on average.",
     )
+    parser.add_argument(
+        "--repeat-reads",
+        type=int,
+        default=1,
+        help="Number of times to read and consume the input.",
+    )
 
     consume_group = parser.add_mutually_exclusive_group()
     consume_group.add_argument("--count", action="store_true")
@@ -73,6 +79,8 @@ def parse_args() -> argparse.Namespace:
         parser.error(
             "--write-delta-mode/--write-delta-partition-by require --write-delta."
         )
+    if args.repeat_reads < 1:
+        parser.error("--repeat-reads must be at least 1.")
     return args
 
 
@@ -87,8 +95,9 @@ def main(args):
         read_fn = get_read_fn(args)
         consume_fn = get_consume_fn(args)
 
-        ds = read_fn(args.path)
-        consume_fn(ds)
+        for _ in range(args.repeat_reads):
+            ds = read_fn(args.path)
+            consume_fn(ds)
 
         # Report arguments for the benchmark.
         return vars(args)

--- a/release/nightly_tests/dataset/read_and_consume_benchmark.py
+++ b/release/nightly_tests/dataset/read_and_consume_benchmark.py
@@ -37,13 +37,6 @@ def parse_args() -> argparse.Namespace:
         default=None,
         help="Fail if the workers receive less than this many Gbps in total, on average.",
     )
-    parser.add_argument(
-        "--repeat-reads",
-        type=int,
-        default=1,
-        help="Number of times to read and consume the input.",
-    )
-
     consume_group = parser.add_mutually_exclusive_group()
     consume_group.add_argument("--count", action="store_true")
     consume_group.add_argument("--iter-bundles", action="store_true")
@@ -79,8 +72,6 @@ def parse_args() -> argparse.Namespace:
         parser.error(
             "--write-delta-mode/--write-delta-partition-by require --write-delta."
         )
-    if args.repeat_reads < 1:
-        parser.error("--repeat-reads must be at least 1.")
     return args
 
 
@@ -95,9 +86,8 @@ def main(args):
         read_fn = get_read_fn(args)
         consume_fn = get_consume_fn(args)
 
-        for _ in range(args.repeat_reads):
-            ds = read_fn(args.path)
-            consume_fn(ds)
+        ds = read_fn(args.path)
+        consume_fn(ds)
 
         # Report arguments for the benchmark.
         return vars(args)

--- a/release/nightly_tests/dataset/read_and_consume_benchmark.py
+++ b/release/nightly_tests/dataset/read_and_consume_benchmark.py
@@ -37,6 +37,12 @@ def parse_args() -> argparse.Namespace:
         default=None,
         help="Fail if the workers receive less than this many Gbps in total, on average.",
     )
+    parser.add_argument(
+        "--repeat-reads",
+        type=int,
+        default=1,
+        help="Number of times to read and consume the input.",
+    )
     consume_group = parser.add_mutually_exclusive_group()
     consume_group.add_argument("--count", action="store_true")
     consume_group.add_argument("--iter-bundles", action="store_true")
@@ -72,6 +78,8 @@ def parse_args() -> argparse.Namespace:
         parser.error(
             "--write-delta-mode/--write-delta-partition-by require --write-delta."
         )
+    if args.repeat_reads < 1:
+        parser.error("--repeat-reads must be at least 1.")
     return args
 
 
@@ -86,8 +94,9 @@ def main(args):
         read_fn = get_read_fn(args)
         consume_fn = get_consume_fn(args)
 
-        ds = read_fn(args.path)
-        consume_fn(ds)
+        for _ in range(args.repeat_reads):
+            ds = read_fn(args.path)
+            consume_fn(ds)
 
         # Report arguments for the benchmark.
         return vars(args)

--- a/release/nightly_tests/dataset/read_and_consume_benchmark.py
+++ b/release/nightly_tests/dataset/read_and_consume_benchmark.py
@@ -1,5 +1,6 @@
 import argparse
 import functools
+import time
 import uuid
 from typing import Callable
 
@@ -37,12 +38,6 @@ def parse_args() -> argparse.Namespace:
         default=None,
         help="Fail if the workers receive less than this many Gbps in total, on average.",
     )
-    parser.add_argument(
-        "--repeat-reads",
-        type=int,
-        default=1,
-        help="Number of times to read and consume the input.",
-    )
     consume_group = parser.add_mutually_exclusive_group()
     consume_group.add_argument("--count", action="store_true")
     consume_group.add_argument("--iter-bundles", action="store_true")
@@ -78,8 +73,6 @@ def parse_args() -> argparse.Namespace:
         parser.error(
             "--write-delta-mode/--write-delta-partition-by require --write-delta."
         )
-    if args.repeat_reads < 1:
-        parser.error("--repeat-reads must be at least 1.")
     return args
 
 
@@ -94,12 +87,23 @@ def main(args):
         read_fn = get_read_fn(args)
         consume_fn = get_consume_fn(args)
 
-        for _ in range(args.repeat_reads):
-            ds = read_fn(args.path)
-            consume_fn(ds)
+        start_time = time.perf_counter()
+        ds = read_fn(args.path)
+        dataset_creation_time_s = time.perf_counter() - start_time
+
+        start_time = time.perf_counter()
+        consume_fn(ds)
+        dataset_consumption_time_s = time.perf_counter() - start_time
+
+        if args.min_total_worker_network_receive_gbps is not None:
+            print(f"Ray Dataset stats:\n{ds.stats()}")
 
         # Report arguments for the benchmark.
-        return vars(args)
+        return {
+            **vars(args),
+            "dataset_creation_time_s": round(dataset_creation_time_s, 4),
+            "dataset_consumption_time_s": round(dataset_consumption_time_s, 4),
+        }
 
     if args.write_delta and args.write_delta_mode == "overwrite":
         # Populate the table once first (same source/scale as the timed run

--- a/release/nightly_tests/dataset/read_benchmark_compute.yaml
+++ b/release/nightly_tests/dataset/read_benchmark_compute.yaml
@@ -1,0 +1,14 @@
+cloud: {{env["ANYSCALE_CLOUD_NAME"]}}
+
+advanced_instance_config:
+    IamInstanceProfile: {"Name": "ray-autoscaler-v1"}
+
+head_node:
+    # Default head node type on Anyscale workspaces.
+    instance_type: m5.2xlarge
+
+worker_nodes:
+    - instance_type: m5.24xlarge
+      min_nodes: 4
+      max_nodes: 4
+      market_type: ON_DEMAND

--- a/release/nightly_tests/dataset/read_from_uris_benchmark.py
+++ b/release/nightly_tests/dataset/read_from_uris_benchmark.py
@@ -12,7 +12,7 @@ from benchmark import Benchmark
 BUCKET = "anyscale-imagenet"
 # This Parquet file contains the keys of images in the 'anyscale-imagenet' bucket.
 METADATA_PATH = "s3://anyscale-imagenet/metadata.parquet"
-MIN_TOTAL_WORKER_NETWORK_RECEIVE_GBPS = 50
+MIN_TOTAL_WORKER_NETWORK_RECEIVE_GBPS = 0.001
 
 
 def main():

--- a/release/nightly_tests/dataset/read_from_uris_benchmark.py
+++ b/release/nightly_tests/dataset/read_from_uris_benchmark.py
@@ -12,10 +12,13 @@ from benchmark import Benchmark
 BUCKET = "anyscale-imagenet"
 # This Parquet file contains the keys of images in the 'anyscale-imagenet' bucket.
 METADATA_PATH = "s3://anyscale-imagenet/metadata.parquet"
+MIN_TOTAL_WORKER_NETWORK_RECEIVE_GBPS = 50
 
 
 def main():
-    benchmark = Benchmark()
+    benchmark = Benchmark(
+        min_total_worker_network_receive_gbps=MIN_TOTAL_WORKER_NETWORK_RECEIVE_GBPS
+    )
     benchmark.run_fn("main", benchmark_fn)
     benchmark.write_result()
 

--- a/release/release_data_tests.yaml
+++ b/release/release_data_tests.yaml
@@ -52,7 +52,7 @@
     script: >
       python read_and_consume_benchmark.py
       s3://ray-benchmark-data-internal-us-west-2/imagenet/parquet --format parquet
-      --iter-bundles --min-total-worker-network-receive-gbps 50
+      --iter-bundles --min-total-worker-network-receive-gbps 0.001
 
 - name: "read_large_parquet_fixed_size"
   python: "3.10"
@@ -83,7 +83,7 @@
       python read_and_consume_benchmark.py
       s3://ray-benchmark-data-internal-us-west-2/large-parquet/ --format parquet
       --iter-bundles --memory 3650722201
-      --min-total-worker-network-receive-gbps 50
+      --min-total-worker-network-receive-gbps 0.001
 
 - name: "read_images_fixed_size"
   python: "3.10"
@@ -96,7 +96,7 @@
     script: >
       python read_and_consume_benchmark.py
       s3://anyscale-imagenet/ILSVRC/Data/CLS-LOC/ --format image --iter-bundles
-      --min-total-worker-network-receive-gbps 50
+      --min-total-worker-network-receive-gbps 0.001
 
 - name: read_tfrecords
   python: "3.10"
@@ -120,7 +120,7 @@
     script: >
       python read_and_consume_benchmark.py
       s3://ray-benchmark-data-internal-us-west-2/imagenet/tfrecords --format tfrecords
-      --iter-bundles --min-total-worker-network-receive-gbps 50
+      --iter-bundles --min-total-worker-network-receive-gbps 0.001
 
 - name: "read_from_uris_fixed_size"
   python: "3.10"

--- a/release/release_data_tests.yaml
+++ b/release/release_data_tests.yaml
@@ -45,7 +45,7 @@
         # Footer read tuning.
         - RAY_DATA_PARQUET_BIN_PACKING_BYTES=67108864
     anyscale_sdk_2026: true
-    cluster_compute: fixed_size_cpu_compute.yaml
+    cluster_compute: read_benchmark_compute.yaml
 
   run:
     timeout: 3600
@@ -70,7 +70,7 @@
         # Footer read tuning.
         - RAY_DATA_PARQUET_BIN_PACKING_BYTES=1073741824
     anyscale_sdk_2026: true
-    cluster_compute: fixed_size_cpu_compute.yaml
+    cluster_compute: read_benchmark_compute.yaml
 
   run:
     timeout: 3600
@@ -88,7 +88,7 @@
   python: "3.10"
   cluster:
     anyscale_sdk_2026: true
-    cluster_compute: fixed_size_cpu_compute.yaml
+    cluster_compute: read_benchmark_compute.yaml
 
   run:
     timeout: 3600
@@ -112,6 +112,7 @@
         # Footer read tuning.
         - RAY_DATA_PARQUET_BIN_PACKING_BYTES=67108864
     anyscale_sdk_2026: true
+    cluster_compute: read_benchmark_compute.yaml
   run:
     timeout: 3600
     script: >
@@ -123,7 +124,7 @@
   python: "3.10"
   cluster:
     anyscale_sdk_2026: true
-    cluster_compute: fixed_size_cpu_compute.yaml
+    cluster_compute: read_benchmark_compute.yaml
 
   run:
     timeout: 5400

--- a/release/release_data_tests.yaml
+++ b/release/release_data_tests.yaml
@@ -52,7 +52,7 @@
     script: >
       python read_and_consume_benchmark.py
       s3://ray-benchmark-data-internal-us-west-2/imagenet/parquet --format parquet
-      --iter-bundles
+      --iter-bundles --min-total-worker-network-receive-gbps 50
 
 - name: "read_large_parquet_fixed_size"
   python: "3.10"
@@ -83,6 +83,7 @@
       python read_and_consume_benchmark.py
       s3://ray-benchmark-data-internal-us-west-2/large-parquet/ --format parquet
       --iter-bundles --memory 3650722201
+      --min-total-worker-network-receive-gbps 50
 
 - name: "read_images_fixed_size"
   python: "3.10"
@@ -95,6 +96,7 @@
     script: >
       python read_and_consume_benchmark.py
       s3://anyscale-imagenet/ILSVRC/Data/CLS-LOC/ --format image --iter-bundles
+      --min-total-worker-network-receive-gbps 50
 
 - name: read_tfrecords
   python: "3.10"
@@ -118,7 +120,7 @@
     script: >
       python read_and_consume_benchmark.py
       s3://ray-benchmark-data-internal-us-west-2/imagenet/tfrecords --format tfrecords
-      --iter-bundles
+      --iter-bundles --min-total-worker-network-receive-gbps 50
 
 - name: "read_from_uris_fixed_size"
   python: "3.10"

--- a/release/release_data_tests.yaml
+++ b/release/release_data_tests.yaml
@@ -52,7 +52,7 @@
     script: >
       python read_and_consume_benchmark.py
       s3://ray-benchmark-data/tpch/parquet/sf1000/lineitem --format parquet
-      --iter-bundles
+      --iter-bundles --repeat-reads 3
       --min-total-worker-network-receive-gbps 0.001
 
 - name: "read_large_parquet_fixed_size"

--- a/release/release_data_tests.yaml
+++ b/release/release_data_tests.yaml
@@ -51,8 +51,8 @@
     timeout: 3600
     script: >
       python read_and_consume_benchmark.py
-      s3://ray-benchmark-data-internal-us-west-2/imagenet/parquet --format parquet
-      --iter-bundles --repeat-reads 5
+      s3://ray-benchmark-data/tpch/parquet/sf1000/lineitem --format parquet
+      --iter-bundles
       --min-total-worker-network-receive-gbps 0.001
 
 - name: "read_large_parquet_fixed_size"

--- a/release/release_data_tests.yaml
+++ b/release/release_data_tests.yaml
@@ -52,7 +52,8 @@
     script: >
       python read_and_consume_benchmark.py
       s3://ray-benchmark-data-internal-us-west-2/imagenet/parquet --format parquet
-      --iter-bundles --min-total-worker-network-receive-gbps 0.001
+      --iter-bundles --repeat-reads 5
+      --min-total-worker-network-receive-gbps 0.001
 
 - name: "read_large_parquet_fixed_size"
   python: "3.10"

--- a/release/release_data_tests.yaml
+++ b/release/release_data_tests.yaml
@@ -52,7 +52,7 @@
     script: >
       python read_and_consume_benchmark.py
       s3://ray-benchmark-data/tpch/parquet/sf1000/lineitem --format parquet
-      --iter-bundles --repeat-reads 3
+      --iter-bundles
       --min-total-worker-network-receive-gbps 0.001
 
 - name: "read_large_parquet_fixed_size"

--- a/release/release_data_tests.yaml
+++ b/release/release_data_tests.yaml
@@ -42,8 +42,8 @@
         - RAYTEST_FAIL_ON_WORKER_OOM=1
         - RAYTEST_FAIL_ON_DEAD_NODES=1
         - RAYTEST_MAX_OBJ_STORE_UTIL_PERCENT=100
-        # Footer read tuning.
-        - RAY_DATA_PARQUET_BIN_PACKING_BYTES=67108864
+        # Use a 256 MiB bin-packing target for the network diagnostic.
+        - RAY_DATA_PARQUET_BIN_PACKING_BYTES=268435456
     anyscale_sdk_2026: true
     cluster_compute: read_benchmark_compute.yaml
 


### PR DESCRIPTION
### Summary

- Add an optional worker network bandwidth check to the Dataset benchmark helper.
- Measure network receive bandwidth across the workers and exclude the head node.
- Use the SF10000 dataset with 256 MiB read units for `read_parquet_fixed_size`.
- Fail if the four workers receive less than 50 Gbps in total.
- Record the total, average, and per-worker bandwidth.


### Tests
 TPCH SF1000 / 64 MiB read units 92c0482 [release test result](https://buildkite.com/ray-project/release/builds/106940/canvas?sid=01a09854-8648-4402-8488-a32f528dd71e&tab=output)
<img width="1444" height="785" alt="Screenshot 2026-09-13 at 05 18 10" src="https://github.com/user-attachments/assets/fb7434a2-1cc0-4fe7-b4c8-8df5945dea1a" />



 TPCH SF10000 / 256 MiB read units 53aea93 [release test result](https://buildkite.com/ray-project/release/builds/106963/canvas?sid=01a09a2d-6d38-419d-bdcd-9504d37c4478&tab=output)
<img width="1444" height="788" alt="Screenshot 2026-09-13 at 04 48 45" src="https://github.com/user-attachments/assets/a690f62e-edb8-4492-9817-e2d199ff513f" />


---

Part of #65922  
Part of #65919  
Depends on #65924