### PR TITLE
[train] Fix single-file upload in _upload_to_fs_path

### DIFF
--- a/python/ray/train/_internal/storage.py
+++ b/python/ray/train/_internal/storage.py
@@ -30,6 +30,7 @@ except ImportError:
 import fnmatch
 import logging
 import os
+import posixpath
 import shutil
 from pathlib import Path
 from typing import TYPE_CHECKING, Callable, Dict, List, Optional, Tuple, Type, Union
@@ -213,17 +214,19 @@ def _upload_to_fs_path(
             Ex: ["*.png"] to exclude all .png images.
     """
 
+    if os.path.isfile(local_path):
+        # Upload a single file to `fs_path` (a file path), creating only its
+        # parent directory — mirroring `_download_from_fs_path`. `exclude` does
+        # not apply to a single file.
+        parent = posixpath.dirname(fs_path)
+        if parent:
+            _create_directory(fs=fs, fs_path=parent)
+        _pyarrow_fs_copy_files(local_path, fs_path, destination_filesystem=fs)
+        return
+
     if not exclude:
-        if os.path.isfile(local_path):
-            # Upload a single file to `fs_path` (a file path), creating only its
-            # parent directory — mirroring `_download_from_fs_path`.
-            parent = os.path.dirname(fs_path)
-            if parent:
-                _create_directory(fs=fs, fs_path=parent)
-            _pyarrow_fs_copy_files(local_path, fs_path, destination_filesystem=fs)
-        else:
-            _create_directory(fs=fs, fs_path=fs_path)
-            _pyarrow_fs_copy_files(local_path, fs_path, destination_filesystem=fs)
+        _create_directory(fs=fs, fs_path=fs_path)
+        _pyarrow_fs_copy_files(local_path, fs_path, destination_filesystem=fs)
         return
 
     _upload_to_uri_with_exclude_fsspec(

--- a/python/ray/train/_internal/storage.py
+++ b/python/ray/train/_internal/storage.py
@@ -214,10 +214,16 @@ def _upload_to_fs_path(
     """
 
     if not exclude:
-        # TODO(justinvyu): uploading a single file doesn't work
-        # (since we always create a directory at fs_path)
-        _create_directory(fs=fs, fs_path=fs_path)
-        _pyarrow_fs_copy_files(local_path, fs_path, destination_filesystem=fs)
+        if os.path.isfile(local_path):
+            # Upload a single file to `fs_path` (a file path), creating only its
+            # parent directory — mirroring `_download_from_fs_path`.
+            parent = os.path.dirname(fs_path)
+            if parent:
+                _create_directory(fs=fs, fs_path=parent)
+            _pyarrow_fs_copy_files(local_path, fs_path, destination_filesystem=fs)
+        else:
+            _create_directory(fs=fs, fs_path=fs_path)
+            _pyarrow_fs_copy_files(local_path, fs_path, destination_filesystem=fs)
         return
 
     _upload_to_uri_with_exclude_fsspec(

--- a/python/ray/train/tests/test_checkpoint.py
+++ b/python/ray/train/tests/test_checkpoint.py
@@ -226,6 +226,32 @@ def test_metadata(checkpoint: Checkpoint):
         checkpoint.set_metadata({"non_json_serializable": Test()})
 
 
+@pytest.mark.parametrize("fs_type", ["local", "custom_fs"])
+def test_upload_single_file(fs_type, tmp_path):
+    """Uploading a single file should place the file at ``fs_path`` (as a file,
+    not under a directory), mirroring ``_download_from_fs_path`` for files."""
+    local_file = tmp_path / "model.pt"
+    local_file.write_text("weights-data")
+
+    if fs_type == "local":
+        fs = pyarrow.fs.LocalFileSystem()
+        fs_path = str(tmp_path / "uploaded" / "model.pt")
+    else:
+        fs = _create_mock_custom_fs(tmp_path / "custom_fs")
+        fs_path = "model.pt"
+
+    _upload_to_fs_path(local_path=str(local_file), fs=fs, fs_path=fs_path)
+
+    file_info = fs.get_file_info(fs_path)
+    assert file_info.type == pyarrow.fs.FileType.File, (
+        f"Expected a file at {fs_path}, got {file_info.type}"
+    )
+
+    if fs_type == "local":
+        with open(fs_path) as f:
+            assert f.read() == "weights-data"
+
+
 if __name__ == "__main__":
     import sys
 

--- a/python/ray/train/tests/test_checkpoint.py
+++ b/python/ray/train/tests/test_checkpoint.py
@@ -243,9 +243,9 @@ def test_upload_single_file(fs_type, tmp_path):
     _upload_to_fs_path(local_path=str(local_file), fs=fs, fs_path=fs_path)
 
     file_info = fs.get_file_info(fs_path)
-    assert file_info.type == pyarrow.fs.FileType.File, (
-        f"Expected a file at {fs_path}, got {file_info.type}"
-    )
+    assert (
+        file_info.type == pyarrow.fs.FileType.File
+    ), f"Expected a file at {fs_path}, got {file_info.type}"
 
     if fs_type == "local":
         with open(fs_path) as f:

--- a/python/ray/train/v2/_internal/execution/storage.py
+++ b/python/ray/train/v2/_internal/execution/storage.py
@@ -24,6 +24,7 @@ except (ImportError, ModuleNotFoundError) as e:
 import fnmatch
 import logging
 import os
+import posixpath
 import shutil
 from pathlib import Path
 from typing import TYPE_CHECKING, Callable, List, Optional, Tuple, Type, Union
@@ -208,17 +209,19 @@ def _upload_to_fs_path(
             Ex: ["*.png"] to exclude all .png images.
     """
 
+    if os.path.isfile(local_path):
+        # Upload a single file to `fs_path` (a file path), creating only its
+        # parent directory — mirroring `_download_from_fs_path`. `exclude` does
+        # not apply to a single file.
+        parent = posixpath.dirname(fs_path)
+        if parent:
+            _create_directory(fs=fs, fs_path=parent)
+        _pyarrow_fs_copy_files(local_path, fs_path, destination_filesystem=fs)
+        return
+
     if not exclude:
-        if os.path.isfile(local_path):
-            # Upload a single file to `fs_path` (a file path), creating only its
-            # parent directory — mirroring `_download_from_fs_path`.
-            parent = os.path.dirname(fs_path)
-            if parent:
-                _create_directory(fs=fs, fs_path=parent)
-            _pyarrow_fs_copy_files(local_path, fs_path, destination_filesystem=fs)
-        else:
-            _create_directory(fs=fs, fs_path=fs_path)
-            _pyarrow_fs_copy_files(local_path, fs_path, destination_filesystem=fs)
+        _create_directory(fs=fs, fs_path=fs_path)
+        _pyarrow_fs_copy_files(local_path, fs_path, destination_filesystem=fs)
         return
 
     _upload_to_uri_with_exclude_fsspec(

--- a/python/ray/train/v2/_internal/execution/storage.py
+++ b/python/ray/train/v2/_internal/execution/storage.py
@@ -209,10 +209,16 @@ def _upload_to_fs_path(
     """
 
     if not exclude:
-        # TODO(justinvyu): uploading a single file doesn't work
-        # (since we always create a directory at fs_path)
-        _create_directory(fs=fs, fs_path=fs_path)
-        _pyarrow_fs_copy_files(local_path, fs_path, destination_filesystem=fs)
+        if os.path.isfile(local_path):
+            # Upload a single file to `fs_path` (a file path), creating only its
+            # parent directory — mirroring `_download_from_fs_path`.
+            parent = os.path.dirname(fs_path)
+            if parent:
+                _create_directory(fs=fs, fs_path=parent)
+            _pyarrow_fs_copy_files(local_path, fs_path, destination_filesystem=fs)
+        else:
+            _create_directory(fs=fs, fs_path=fs_path)
+            _pyarrow_fs_copy_files(local_path, fs_path, destination_filesystem=fs)
         return
 
     _upload_to_uri_with_exclude_fsspec(


### PR DESCRIPTION
## Summary

`_upload_to_fs_path` unconditionally called `_create_directory(fs_path)` before copying, so uploading a single file (where `local_path` is a file) raised `IsADirectoryError` from `pyarrow.fs.copy_files`. This mirrors `_download_from_fs_path`, which already handles the file case by creating only the parent directory.

## Changes

- In both `python/ray/train/_internal/storage.py` and `python/ray/train/v2/_internal/execution/storage.py`, detect the single-file case with `os.path.isfile(local_path)` and create only the parent directory before copying.
- Add `test_upload_single_file` (parametrized over local and custom filesystems) to `python/ray/train/tests/test_checkpoint.py`.

## Why this is not a duplicate

Searched open/closed issues and PRs for "single file checkpoint upload", "upload single file", and `_upload_to_fs_path` — no existing work covers this. The `TODO(justinvyu)` comment in the code was previously unaddressed.

## Test plan

- `python -m py_compile python/ray/train/_internal/storage.py python/ray/train/v2/_internal/execution/storage.py python/ray/train/tests/test_checkpoint.py` — passed.
- Reproduced the bug end-to-end against the installed Ray build: single-file upload raised `IsADirectoryError`.
- Verified the fixed logic in isolation: a single-file upload now lands at `fs_path` as `FileType.File` with the correct content, on both `LocalFileSystem` and a custom fsspec-backed filesystem.
- I could not run `pytest python/ray/train/tests/test_checkpoint.py` locally because this checkout does not have the compiled `ray._raylet` extension built; the full test run is left to CI.

_AI assistance was used in preparing this change._
