### PR TITLE
[core][sandbox] Bound the image cache via LRU eviction v2

### DIFF
--- a/doc/source/ray-core/sandboxes.md
+++ b/doc/source/ray-core/sandboxes.md
@@ -241,6 +241,12 @@ ray.get(sb.delete.remote())
 
 Sandboxes boot from OCI container images. The image manager pulls an image straight from the registry's HTTP API (anonymously, with no Docker daemon and no credentials), extracts its root filesystem into `/tmp/ray/sandbox/images` on the node, and caches it for reuse by subsequent sandboxes on that node using the same image. Sandboxes with write access to the filesystem get their own private writable overlay on top of the cached root filesystem.
 
+### Bound the image cache
+
+The cache defaults to half of the filesystem that holds it. Set `RAY_SANDBOX_IMAGE_CACHE_MAX_BYTES` on worker nodes to choose a limit in bytes, or set it to `0` to disable eviction. Before a pull, Ray evicts the least recently used images when the cache exceeds this limit. Images used by containers listed by `runsc list` are protected. Cleanup waits for a later pull if another pull or sandbox startup is in progress, and is skipped if container state cannot be read.
+
+This is a best-effort limit: a new pull or images in use can take the cache over the limit. Image sizes are measured once at extraction and saved for subsequent cleanup passes. Ray no longer creates an additional uncompressed tar archive of each image.
+
 ### Route Docker Hub pulls through a mirror
 
 Because image pulls are anonymous, every node pulling from Docker Hub consumes the anonymous pull-rate limit and downloads the image over the WAN. In a large cluster, concurrent pulls of multi-GB images can quickly hit the rate limit or saturate network bandwidth, causing image pulls to fail or become slow.

--- a/doc/source/ray-core/sandboxes.md
+++ b/doc/source/ray-core/sandboxes.md
@@ -245,7 +245,7 @@ Sandboxes boot from OCI container images. The image manager pulls an image strai
 
 The cache defaults to half of the filesystem that holds it. Set `RAY_SANDBOX_IMAGE_CACHE_MAX_BYTES` on worker nodes to choose a limit in bytes, or set it to `0` to disable eviction. Before a pull, Ray evicts the least recently used images when the cache exceeds this limit. Images used by containers listed by `runsc list` are protected. Cleanup waits for a later pull if another pull or sandbox startup is in progress, and is skipped if container state cannot be read.
 
-This is a best-effort limit: a new pull or images in use can take the cache over the limit. Image sizes are measured once at extraction and saved for subsequent cleanup passes. Ray no longer creates an additional uncompressed tar archive of each image.
+This is a best-effort limit: a new pull or images in use can take the cache over the limit.
 
 ### Route Docker Hub pulls through a mirror
 

--- a/doc/source/ray-core/sandboxes.md
+++ b/doc/source/ray-core/sandboxes.md
@@ -243,7 +243,7 @@ Sandboxes boot from OCI container images. The image manager pulls an image strai
 
 ### Bound the image cache
 
-The cache defaults to half of the filesystem that holds it. Set `RAY_SANDBOX_IMAGE_CACHE_MAX_BYTES` on worker nodes to choose a limit in bytes, or set it to `0` to disable eviction. Before a pull, Ray evicts the least recently used images when the cache exceeds this limit. Images used by containers listed by `runsc list` are protected. Cleanup waits for a later pull if another pull or sandbox startup is in progress, and is skipped if container state cannot be read.
+The cache defaults to half of the filesystem that holds it. Set `RAY_SANDBOX_IMAGE_CACHE_MAX_BYTES` on worker nodes to choose a limit in bytes, or set it to `0` to disable eviction. Before a pull, Ray evicts the least recently used images when the cache exceeds this limit. Images used by containers listed by `runsc list` are protected. Cleanup skips images whose pulls or sandbox startups are in progress, and is skipped if container state cannot be read. Only one cleanup pass runs at a time.
 
 This is a best-effort limit: a new pull or images in use can take the cache over the limit.
 

--- a/python/ray/experimental/sandbox/_internal/image_utils.py
+++ b/python/ray/experimental/sandbox/_internal/image_utils.py
@@ -13,7 +13,7 @@ import urllib.error
 import urllib.parse
 import urllib.request
 import uuid
-from contextlib import contextmanager
+from contextlib import ExitStack, contextmanager
 from typing import BinaryIO, Dict, Iterator, Optional, Tuple, Union
 
 from ray.experimental.sandbox.exceptions import SandboxCreationError
@@ -364,7 +364,7 @@ def extract_tar_layer(
             pass
 
 
-def _evict_unused_images(images_dir: str, keep: str) -> None:
+def _evict_unused_images(images_dir: str) -> None:
     """Trim the cache using saved sizes, while holding its exclusive lock."""
     max_bytes = shutil.disk_usage(images_dir).total // 2
     raw = os.environ.get("RAY_SANDBOX_IMAGE_CACHE_MAX_BYTES", "")
@@ -396,66 +396,90 @@ def _evict_unused_images(images_dir: str, keep: str) -> None:
     if total <= max_bytes:
         return
 
-    result = subprocess.run(
-        ["runsc", "--root", RUNSC_ROOT, "list", "--format=json"],
-        capture_output=True,
-        text=True,
-        check=True,
-        timeout=10,
-    )
-    # runsc emits null when there are no containers. Protect every listed
-    # container, including ones that have been created but not started yet.
-    containers = json.loads(result.stdout)
-    if containers is None:
-        containers = []
-    if not isinstance(containers, list):
-        raise ValueError("Expected a list of runsc containers")
-    in_use = set()
-    for container in containers:
-        bundle = container["bundle"]
-        with open(os.path.join(bundle, "config.json"), encoding="utf-8") as f:
-            rootfs = json.load(f)["root"]["path"]
-        in_use.add(os.path.realpath(os.path.join(bundle, rootfs)))
-
-    for _, name, path, size in sorted(entries):
-        if total <= max_bytes:
-            break
-        if name == keep:
-            continue
-        if os.path.realpath(os.path.join(path, "rootfs")) in in_use:
-            continue
-        try:
-            shutil.rmtree(path)
-        except OSError:
-            logger.warning(
-                "Failed to evict cached sandbox image %s", path, exc_info=True
+    with ExitStack() as locks:
+        candidates = []
+        for _, name, path, size in entries:
+            lock = locks.enter_context(
+                open(os.path.join(images_dir, f"{name}.startup.lock"), "a")
             )
-            continue
-        total -= size
-        logger.info("Evicted cached sandbox image %s (%d bytes)", name, size)
+            try:
+                fcntl.flock(lock, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            except BlockingIOError:
+                lock.close()
+                continue
+            # A pull may have completed since the scan. Refresh its saved
+            # size and recency while holding the startup lock.
+            marker = os.path.join(path, ".extracted")
+            with open(marker, encoding="utf-8") as f:
+                current_size = int(f.read())
+            total += current_size - size
+            candidates.append((os.path.getmtime(marker), name, path, current_size))
+
+        if not candidates or total <= max_bytes:
+            return
+
+        # Lock all candidates before taking one gVisor snapshot, and hold
+        # their locks through deletion so new startups cannot race it.
+        result = subprocess.run(
+            ["runsc", "--root", RUNSC_ROOT, "list", "--format=json"],
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=10,
+        )
+        # runsc emits null when there are no containers. Protect every listed
+        # container, including ones that have been created but not started yet.
+        containers = json.loads(result.stdout)
+        if containers is None:
+            containers = []
+        if not isinstance(containers, list):
+            raise ValueError("Expected a list of runsc containers")
+        in_use = set()
+        for container in containers:
+            bundle = container["bundle"]
+            with open(os.path.join(bundle, "config.json"), encoding="utf-8") as f:
+                rootfs = json.load(f)["root"]["path"]
+            in_use.add(os.path.realpath(os.path.join(bundle, rootfs)))
+
+        for _, name, path, size in sorted(candidates):
+            if total <= max_bytes:
+                break
+            if os.path.realpath(os.path.join(path, "rootfs")) in in_use:
+                continue
+            try:
+                shutil.rmtree(path)
+            except OSError:
+                logger.warning(
+                    "Failed to evict cached sandbox image %s", path, exc_info=True
+                )
+                continue
+            total -= size
+            logger.info("Evicted cached sandbox image %s (%d bytes)", name, size)
 
 
 @contextmanager
 def image_cache_context(images_dir: str, image: str) -> Iterator[None]:
-    """Try eviction, then protect pulls and container startup with a shared lock.
+    """Protect this image's pull and startup with a shared startup lock.
 
-    Concurrent pulls/startups may proceed together. Eviction only runs when
-    none are in progress; after startup, runsc list identifies images in use.
-    Closing the lock releases it even if startup fails or the process exits.
+    Eviction passes are serialized by .cache.lock and skip images whose
+    startup locks are held. After startup, runsc list identifies images in
+    use. Closing a lock releases it even if startup fails or the process exits.
     """
     os.makedirs(images_dir, mode=0o777, exist_ok=True)
-    with open(os.path.join(images_dir, ".cache.lock"), "a") as lock:
+    name = sanitize_image_name(image)
+    with open(os.path.join(images_dir, f"{name}.startup.lock"), "a") as startup_lock:
+        fcntl.flock(startup_lock, fcntl.LOCK_SH)
         try:
-            fcntl.flock(lock, fcntl.LOCK_EX | fcntl.LOCK_NB)
-        except BlockingIOError:
-            pass
-        else:
-            try:
-                _evict_unused_images(images_dir, sanitize_image_name(image))
-            except Exception:
-                # Best-effort eviction must not prevent sandbox creation.
-                logger.warning("Skipping sandbox image eviction", exc_info=True)
-        fcntl.flock(lock, fcntl.LOCK_SH)
+            with open(os.path.join(images_dir, ".cache.lock"), "a") as cache_lock:
+                try:
+                    fcntl.flock(cache_lock, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                except BlockingIOError:
+                    pass
+                else:
+                    _evict_unused_images(images_dir)
+        except Exception:
+            # Best-effort eviction must not prevent sandbox creation.
+            logger.warning("Skipping sandbox image eviction", exc_info=True)
         yield
 
 
@@ -641,14 +665,13 @@ def pull_and_extract_container_image(
                     ) from err
 
             size = _dir_size_bytes(tmp_extract_dir)
-            with open(
-                os.path.join(tmp_extract_dir, ".extracted"), "w", encoding="utf-8"
-            ) as f_mark:
-                f_mark.write(str(size))
-
             if os.path.exists(target_dir):
                 shutil.rmtree(target_dir, ignore_errors=True)
             os.replace(tmp_extract_dir, target_dir)
+            # Only publish the marker at the final path, whose startup lock
+            # we hold. Temporary directories must not become eviction candidates.
+            with open(marker_path, "w", encoding="utf-8") as f_mark:
+                f_mark.write(str(size))
 
             return target_dir
         finally:

--- a/python/ray/experimental/sandbox/_internal/image_utils.py
+++ b/python/ray/experimental/sandbox/_internal/image_utils.py
@@ -6,19 +6,23 @@ import os
 import platform
 import re
 import shutil
+import subprocess
 import tarfile
 import tempfile
 import urllib.error
 import urllib.parse
 import urllib.request
 import uuid
-from typing import BinaryIO, Dict, Optional, Tuple, Union
+from contextlib import contextmanager
+from typing import BinaryIO, Dict, Iterator, Optional, Tuple, Union
 
 from ray.experimental.sandbox.exceptions import SandboxCreationError
 
 logger = logging.getLogger(__name__)
 
 DEFAULT_IMAGES_DIR = "/tmp/ray/sandbox/images"
+# Must match the root used for every sandbox runsc invocation.
+RUNSC_ROOT = "/tmp/runsc"
 _USER_AGENT = "ray-sandbox/1.0 (python-urllib)"
 
 
@@ -360,6 +364,116 @@ def extract_tar_layer(
             pass
 
 
+def _evict_unused_images(images_dir: str, keep: str) -> None:
+    """Trim the cache using saved sizes, while holding its exclusive lock."""
+    max_bytes = shutil.disk_usage(images_dir).total // 2
+    raw = os.environ.get("RAY_SANDBOX_IMAGE_CACHE_MAX_BYTES", "")
+    if raw.strip():
+        try:
+            max_bytes = int(raw)
+        except ValueError:
+            logger.warning("Ignoring invalid RAY_SANDBOX_IMAGE_CACHE_MAX_BYTES=%r", raw)
+    if max_bytes <= 0:
+        return
+
+    entries = []
+    with os.scandir(images_dir) as cached:
+        for entry in cached:
+            if not entry.is_dir(follow_symlinks=False):
+                continue
+            try:
+                marker = os.path.join(entry.path, ".extracted")
+                with open(marker, encoding="utf-8") as f:
+                    size = int(f.read())
+                mtime = os.path.getmtime(marker)
+            except (OSError, ValueError):
+                # Skip images without a valid saved size.
+                continue
+            if size >= 0:
+                entries.append((mtime, entry.name, entry.path, size))
+
+    total = sum(size for _, _, _, size in entries)
+    if total <= max_bytes:
+        return
+
+    result = subprocess.run(
+        ["runsc", "--root", RUNSC_ROOT, "list", "--format=json"],
+        capture_output=True,
+        text=True,
+        check=True,
+        timeout=10,
+    )
+    # runsc emits null when there are no containers. Protect every listed
+    # container, including ones that have been created but not started yet.
+    containers = json.loads(result.stdout)
+    if containers is None:
+        containers = []
+    if not isinstance(containers, list):
+        raise ValueError("Expected a list of runsc containers")
+    in_use = set()
+    for container in containers:
+        bundle = container["bundle"]
+        with open(os.path.join(bundle, "config.json"), encoding="utf-8") as f:
+            rootfs = json.load(f)["root"]["path"]
+        in_use.add(os.path.realpath(os.path.join(bundle, rootfs)))
+
+    for _, name, path, size in sorted(entries):
+        if total <= max_bytes:
+            break
+        if name == keep:
+            continue
+        if os.path.realpath(os.path.join(path, "rootfs")) in in_use:
+            continue
+        try:
+            shutil.rmtree(path)
+        except OSError:
+            logger.warning(
+                "Failed to evict cached sandbox image %s", path, exc_info=True
+            )
+            continue
+        total -= size
+        logger.info("Evicted cached sandbox image %s (%d bytes)", name, size)
+
+
+@contextmanager
+def image_cache_context(images_dir: str, image: str) -> Iterator[None]:
+    """Try eviction, then protect pulls and container startup with a shared lock.
+
+    Concurrent pulls/startups may proceed together. Eviction only runs when
+    none are in progress; after startup, runsc list identifies images in use.
+    Closing the lock releases it even if startup fails or the process exits.
+    """
+    os.makedirs(images_dir, mode=0o777, exist_ok=True)
+    with open(os.path.join(images_dir, ".cache.lock"), "a") as lock:
+        try:
+            fcntl.flock(lock, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError:
+            pass
+        else:
+            try:
+                _evict_unused_images(images_dir, sanitize_image_name(image))
+            except (
+                OSError,
+                ValueError,
+                KeyError,
+                TypeError,
+                subprocess.SubprocessError,
+            ):
+                # If container state cannot be read, leave the cache intact.
+                logger.warning("Skipping sandbox image eviction", exc_info=True)
+        fcntl.flock(lock, fcntl.LOCK_SH)
+        yield
+
+
+def _dir_size_bytes(path: str) -> int:
+    """Measure extracted file sizes once, without following image symlinks."""
+    return sum(
+        os.lstat(os.path.join(directory, name)).st_size
+        for directory, _, files in os.walk(path)
+        for name in files
+    )
+
+
 def pull_and_extract_container_image(
     image: str,
     images_dir: str = DEFAULT_IMAGES_DIR,
@@ -386,15 +500,19 @@ def pull_and_extract_container_image(
     target_dir = os.path.join(images_dir, safe_name)
     lock_path = os.path.join(images_dir, f"{safe_name}.lock")
 
-    with open(lock_path, "w", encoding="utf-8") as f_lock:
+    with image_cache_context(images_dir, image), open(
+        lock_path, "w", encoding="utf-8"
+    ) as f_lock:
         try:
             fcntl.flock(f_lock, fcntl.LOCK_EX)
             marker_path = os.path.join(target_dir, ".extracted")
             if os.path.isdir(target_dir) and os.path.exists(marker_path):
                 if os.path.isfile(image):
                     if os.path.getmtime(marker_path) >= os.path.getmtime(image):
+                        os.utime(marker_path, None)
                         return target_dir
                 else:
+                    os.utime(marker_path, None)
                     return target_dir
 
             tmp_extract_dir = os.path.join(
@@ -405,8 +523,6 @@ def pull_and_extract_container_image(
             tmp_rootfs_dir = os.path.join(tmp_extract_dir, "rootfs")
             os.makedirs(tmp_rootfs_dir, mode=0o755, exist_ok=True)
 
-            tar_path = os.path.join(images_dir, f"{safe_name}.tar")
-
             if os.path.isfile(image):
                 try:
                     with open(image, "rb") as f:
@@ -415,15 +531,6 @@ def pull_and_extract_container_image(
                     shutil.rmtree(tmp_extract_dir, ignore_errors=True)
                     raise SandboxCreationError(
                         f"Failed to extract local image archive '{image}': {err}"
-                    ) from err
-            elif os.path.isfile(tar_path):
-                try:
-                    with open(tar_path, "rb") as f:
-                        extract_tar_layer(f, tmp_extract_dir)
-                except Exception as err:
-                    shutil.rmtree(tmp_extract_dir, ignore_errors=True)
-                    raise SandboxCreationError(
-                        f"Failed to extract cached image archive '{tar_path}': {err}"
                     ) from err
             else:
                 if (
@@ -531,26 +638,19 @@ def pull_and_extract_container_image(
                                 tmp_blob_file.seek(0)
                                 extract_tar_layer(tmp_blob_file, tmp_rootfs_dir)
 
-                    with tarfile.open(tar_path, "w") as tar:
-                        tar.add(tmp_extract_dir, arcname=".")
-
                 except Exception as err:
                     shutil.rmtree(tmp_extract_dir, ignore_errors=True)
-                    if os.path.exists(tar_path):
-                        try:
-                            os.remove(tar_path)
-                        except OSError:
-                            pass
                     if isinstance(err, SandboxCreationError):
                         raise
                     raise SandboxCreationError(
                         f"Failed to pull and extract container image '{image}': {err}"
                     ) from err
 
+            size = _dir_size_bytes(tmp_extract_dir)
             with open(
                 os.path.join(tmp_extract_dir, ".extracted"), "w", encoding="utf-8"
             ) as f_mark:
-                f_mark.write("ok")
+                f_mark.write(str(size))
 
             if os.path.exists(target_dir):
                 shutil.rmtree(target_dir, ignore_errors=True)

--- a/python/ray/experimental/sandbox/_internal/image_utils.py
+++ b/python/ray/experimental/sandbox/_internal/image_utils.py
@@ -452,14 +452,8 @@ def image_cache_context(images_dir: str, image: str) -> Iterator[None]:
         else:
             try:
                 _evict_unused_images(images_dir, sanitize_image_name(image))
-            except (
-                OSError,
-                ValueError,
-                KeyError,
-                TypeError,
-                subprocess.SubprocessError,
-            ):
-                # If container state cannot be read, leave the cache intact.
+            except Exception:
+                # Best-effort eviction must not prevent sandbox creation.
                 logger.warning("Skipping sandbox image eviction", exc_info=True)
         fcntl.flock(lock, fcntl.LOCK_SH)
         yield

--- a/python/ray/experimental/sandbox/backend/gvisor.py
+++ b/python/ray/experimental/sandbox/backend/gvisor.py
@@ -7,6 +7,7 @@ import time
 import uuid
 from typing import Callable, Dict, List, Optional, Union
 
+from ray.experimental.sandbox._internal.image_utils import RUNSC_ROOT
 from ray.experimental.sandbox.backend.base import (
     BaseSandboxBackend,
     ExecResult,
@@ -23,10 +24,6 @@ from ray.experimental.sandbox.exceptions import (
 from ray.experimental.sandbox.image_manager import BaseImageManager
 
 logger = logging.getLogger(__name__)
-
-# Directory where runsc keeps container state. Every runsc invocation for a
-# sandbox must agree on this, otherwise the container cannot be looked up.
-_RUNSC_ROOT = "/tmp/runsc"
 
 # Directory to store sandbox states, container images and overlay filesystem.
 _RAY_SANDBOX_DIR = "/tmp/ray/sandbox"
@@ -47,6 +44,10 @@ class GVisorSandboxBackend(BaseSandboxBackend):
                 "Please install gVisor (runsc) on the node."
             )
 
+        with self._image_manager.image_cache_context(config.image):
+            return self._create_sandbox(config)
+
+    def _create_sandbox(self, config: SandboxConfig) -> str:
         sandbox_uuid = uuid.uuid4().hex[:12]
         sandbox_id = f"ray-sandbox-{sandbox_uuid}"
         root_dir = os.path.join(_RAY_SANDBOX_DIR, sandbox_id)
@@ -354,7 +355,7 @@ class GVisorSandboxBackend(BaseSandboxBackend):
             or os.environ.get("RAY_SANDBOX_IGNORE_CGROUPS") == "1"
         ):
             args.append("--ignore-cgroups")
-        args.extend(["--root", _RUNSC_ROOT])
+        args.extend(["--root", RUNSC_ROOT])
         return args
 
     def _resolve_path(self, root_dir: str, relative_or_abs_path: str) -> str:

--- a/python/ray/experimental/sandbox/image_manager.py
+++ b/python/ray/experimental/sandbox/image_manager.py
@@ -5,10 +5,12 @@ import os
 import subprocess
 import tempfile
 from abc import ABC, abstractmethod
-from typing import Any, Callable, Dict, List, Optional, Union
+from contextlib import nullcontext
+from typing import Any, Callable, ContextManager, Dict, List, Optional, Union
 
 from ray.experimental.sandbox._internal.image_utils import (
     DEFAULT_IMAGES_DIR,
+    image_cache_context,
     pull_and_extract_container_image,
     sanitize_image_name,
 )
@@ -48,6 +50,10 @@ class BaseImageManager(ABC):
     (such as working directory and environment variables), and generating standard OCI
     runtime specifications (bundles) for sandbox execution backends.
     """
+
+    def image_cache_context(self, image: str) -> ContextManager[None]:
+        """Protect an image from eviction during sandbox creation, if needed."""
+        return nullcontext()
 
     @abstractmethod
     def pull_image(
@@ -217,6 +223,10 @@ class ImageManager(BaseImageManager):
 
     def __init__(self, images_dir: str = DEFAULT_IMAGES_DIR):
         self._images_dir = images_dir
+
+    def image_cache_context(self, image: str) -> ContextManager[None]:
+        """Protect the cache until the new sandbox is visible to runsc list."""
+        return image_cache_context(self._images_dir, image)
 
     @property
     def images_dir(self) -> str:

--- a/python/ray/experimental/sandbox/image_manager.py
+++ b/python/ray/experimental/sandbox/image_manager.py
@@ -225,7 +225,7 @@ class ImageManager(BaseImageManager):
         self._images_dir = images_dir
 
     def image_cache_context(self, image: str) -> ContextManager[None]:
-        """Protect the cache until the new sandbox is visible to runsc list."""
+        """Protect this image until the new sandbox is visible to runsc list."""
         return image_cache_context(self._images_dir, image)
 
     @property

--- a/python/ray/experimental/sandbox/tests/test_gvisor_backend.py
+++ b/python/ray/experimental/sandbox/tests/test_gvisor_backend.py
@@ -81,7 +81,6 @@ def test_gvisor_backend_container_image_support():
         assert os.path.exists(extracted_dir)
         assert os.path.isdir(extracted_dir)
         assert os.path.exists(os.path.join(extracted_dir, ".extracted"))
-        assert os.path.exists("/tmp/ray/sandbox/images/busybox_latest.tar")
 
         res = backend.exec_command(sandbox_id, "/bin/sh -c 'echo hello from busybox'")
         assert res.exit_code == 0

--- a/python/ray/experimental/sandbox/tests/test_image_cache.py
+++ b/python/ray/experimental/sandbox/tests/test_image_cache.py
@@ -1,0 +1,195 @@
+import io
+import json
+import os
+import subprocess
+import sys
+import tarfile
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ray.experimental.sandbox._internal import image_utils
+from ray.experimental.sandbox.backend.gvisor import GVisorSandboxBackend
+from ray.experimental.sandbox.config import SandboxConfig
+from ray.experimental.sandbox.image_manager import ImageManager
+
+
+def _cached_image(images_dir, name, size=100, mtime=1):
+    image_dir = images_dir / name
+    (image_dir / "rootfs").mkdir(parents=True)
+    (image_dir / "rootfs" / "data").write_bytes(b"x" * size)
+    marker = image_dir / ".extracted"
+    marker.write_text(str(size))
+    os.utime(marker, (mtime, mtime))
+    return image_dir
+
+
+def _local_tar(path, data=b"hello"):
+    with tarfile.open(path, "w") as archive:
+        member = tarfile.TarInfo("hello.txt")
+        member.size = len(data)
+        archive.addfile(member, io.BytesIO(data))
+
+
+@pytest.fixture
+def runsc_list(monkeypatch):
+    run = MagicMock(return_value=subprocess.CompletedProcess([], 0, "null"))
+    monkeypatch.setattr(image_utils.subprocess, "run", run)
+    monkeypatch.setenv("RAY_SANDBOX_IMAGE_CACHE_MAX_BYTES", "1")
+    return run
+
+
+@pytest.mark.parametrize("relative_root", [False, True])
+@pytest.mark.parametrize("status", ["created", "running", "stopped"])
+def test_eviction_uses_runsc_bundles(
+    tmp_path, monkeypatch, runsc_list, relative_root, status
+):
+    images_dir = tmp_path / "images"
+    old = _cached_image(images_dir, "old")
+    busy = _cached_image(images_dir, "busy", mtime=2)
+    kept = _cached_image(images_dir, "kept", mtime=3)
+    newer = _cached_image(images_dir, "newer", mtime=4)
+    newest = _cached_image(images_dir, "newest", mtime=5)
+    bundle = tmp_path / "bundle"
+    bundle.mkdir()
+    root = str(busy / "rootfs")
+    if relative_root:
+        (bundle / "rootfs").symlink_to(root, target_is_directory=True)
+        root = "rootfs"
+    (bundle / "config.json").write_text(json.dumps({"root": {"path": root}}))
+    runsc_list.return_value.stdout = json.dumps(
+        [{"id": "sandbox", "bundle": str(bundle), "status": status}]
+    )
+    monkeypatch.setenv("RAY_SANDBOX_IMAGE_CACHE_MAX_BYTES", "300")
+    with patch.object(
+        image_utils.os, "walk", side_effect=AssertionError("size rescan")
+    ):
+        with image_utils.image_cache_context(str(images_dir), "kept"):
+            pass
+    assert not old.exists()
+    assert busy.exists()
+    assert kept.exists()
+    assert not newer.exists()
+    assert newest.exists()
+    runsc_list.assert_called_once_with(
+        ["runsc", "--root", image_utils.RUNSC_ROOT, "list", "--format=json"],
+        capture_output=True,
+        text=True,
+        check=True,
+        timeout=10,
+    )
+
+
+@pytest.mark.parametrize(
+    "response",
+    [
+        FileNotFoundError("runsc"),
+        subprocess.CalledProcessError(1, "runsc"),
+        subprocess.TimeoutExpired("runsc", 10),
+        "invalid json",
+        "{}",
+        '[{"bundle": "/missing/bundle"}]',
+        '[{"status": "running"}]',
+    ],
+)
+def test_eviction_preserves_images_when_state_is_unavailable(
+    tmp_path, runsc_list, response
+):
+    image = _cached_image(tmp_path, "image")
+    if isinstance(response, Exception):
+        runsc_list.side_effect = response
+    else:
+        runsc_list.return_value.stdout = response
+    with image_utils.image_cache_context(str(tmp_path), "other"):
+        pass
+    assert image.exists()
+
+
+@pytest.mark.parametrize("raw", [None, "", "invalid", "0", "-1", "200"])
+def test_cache_limit(tmp_path, monkeypatch, runsc_list, raw):
+    old = _cached_image(tmp_path, "old")
+    new = _cached_image(tmp_path, "new", mtime=2)
+    if raw is None:
+        monkeypatch.delenv("RAY_SANDBOX_IMAGE_CACHE_MAX_BYTES")
+    else:
+        monkeypatch.setenv("RAY_SANDBOX_IMAGE_CACHE_MAX_BYTES", raw)
+    monkeypatch.setattr(
+        image_utils.shutil, "disk_usage", lambda _: MagicMock(total=200)
+    )
+    with image_utils.image_cache_context(str(tmp_path), "new"):
+        pass
+    assert new.exists()
+    assert old.exists() == (raw in ("0", "-1", "200"))
+    if old.exists():
+        runsc_list.assert_not_called()
+
+
+def test_cache_hit_reuses_size_and_refreshes_recency(tmp_path, runsc_list):
+    archive = tmp_path / "sample.tar"
+    _local_tar(archive)
+    os.utime(archive, (1, 1))
+    images_dir = tmp_path / "images"
+    manager = ImageManager(str(images_dir))
+    with patch.object(
+        image_utils, "_dir_size_bytes", wraps=image_utils._dir_size_bytes
+    ) as measure:
+        image_dir = manager.pull_image(str(archive))
+        marker = images_dir / "sample" / ".extracted"
+        assert marker.read_text() == "5"
+        os.utime(marker, (2, 2))
+        with patch.object(
+            image_utils.os, "walk", side_effect=AssertionError("size rescan")
+        ):
+            assert ImageManager(str(images_dir)).pull_image(str(archive)) == image_dir
+        assert marker.stat().st_mtime > 2
+        assert marker.read_text() == "5"
+        assert measure.call_count == 1
+
+        # Updating the local source archive still invalidates the cache.
+        _local_tar(archive, b"updated image")
+        os.utime(archive, (marker.stat().st_mtime + 1,) * 2)
+        manager.pull_image(str(archive))
+        assert marker.read_text() == "13"
+        assert measure.call_count == 2
+
+
+@pytest.mark.parametrize("fail_startup", [False, True])
+def test_startup_lock_protects_image_and_releases_on_exit(
+    tmp_path, monkeypatch, runsc_list, fail_startup
+):
+    archive = tmp_path / "sample.tar"
+    _local_tar(archive)
+    images_dir = tmp_path / "images"
+    manager = ImageManager(str(images_dir))
+    backend = GVisorSandboxBackend(manager)
+    monkeypatch.setattr(
+        "ray.experimental.sandbox.backend.gvisor.shutil.which", lambda _: "runsc"
+    )
+
+    def start(config):
+        manager.pull_image(config.image)
+        # A competing pull must not evict an image before runsc sees it.
+        with image_utils.image_cache_context(str(images_dir), "competing"):
+            assert manager.is_image_extracted(config.image)
+        runsc_list.assert_not_called()
+        if fail_startup:
+            raise RuntimeError("startup failed")
+        return "sandbox"
+
+    monkeypatch.setattr(backend, "_create_sandbox", start)
+    config = SandboxConfig(image=str(archive))
+    if fail_startup:
+        with pytest.raises(RuntimeError, match="startup failed"):
+            backend.create_sandbox(config)
+    else:
+        assert backend.create_sandbox(config) == "sandbox"
+
+    # Once the context exits, an unreferenced image can be reclaimed.
+    with image_utils.image_cache_context(str(images_dir), "other"):
+        pass
+    assert not manager.is_image_extracted(str(archive))
+    runsc_list.assert_called_once()
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-v", __file__]))

--- a/python/ray/experimental/sandbox/tests/test_image_cache.py
+++ b/python/ray/experimental/sandbox/tests/test_image_cache.py
@@ -1,3 +1,4 @@
+import fcntl
 import io
 import json
 import os
@@ -31,6 +32,15 @@ def _local_tar(path, data=b"hello"):
         archive.addfile(member, io.BytesIO(data))
 
 
+def _assert_lock_held(path, shared=False):
+    with open(path, "a") as lock:
+        if shared:
+            fcntl.flock(lock, fcntl.LOCK_SH | fcntl.LOCK_NB)
+        operation = fcntl.LOCK_EX if shared else fcntl.LOCK_SH
+        with pytest.raises(BlockingIOError):
+            fcntl.flock(lock, operation | fcntl.LOCK_NB)
+
+
 @pytest.fixture
 def runsc_list(monkeypatch):
     run = MagicMock(return_value=subprocess.CompletedProcess([], 0, "null"))
@@ -60,6 +70,22 @@ def test_eviction_uses_runsc_bundles(
     runsc_list.return_value.stdout = json.dumps(
         [{"id": "sandbox", "bundle": str(bundle), "status": status}]
     )
+
+    def list_containers(*args, **kwargs):
+        # The entire candidate set must be locked before reading gVisor
+        # state, including candidates that turn out to be in use.
+        for name in ("old", "busy", "newer", "newest"):
+            _assert_lock_held(images_dir / f"{name}.startup.lock")
+        return runsc_list.return_value
+
+    runsc_list.side_effect = list_containers
+    rmtree = image_utils.shutil.rmtree
+
+    def remove_image(path):
+        _assert_lock_held(f"{path}.startup.lock")
+        rmtree(path)
+
+    monkeypatch.setattr(image_utils.shutil, "rmtree", remove_image)
     monkeypatch.setenv("RAY_SANDBOX_IMAGE_CACHE_MAX_BYTES", "300")
     with patch.object(
         image_utils.os, "walk", side_effect=AssertionError("size rescan")
@@ -103,6 +129,10 @@ def test_eviction_preserves_images_when_state_is_unavailable(
     with image_utils.image_cache_context(str(tmp_path), "other"):
         pass
     assert image.exists()
+    # A failed pass must release both the eviction and candidate locks.
+    for name in (".cache.lock", "image.startup.lock"):
+        with open(tmp_path / name, "a") as lock:
+            fcntl.flock(lock, fcntl.LOCK_EX | fcntl.LOCK_NB)
 
 
 @pytest.mark.parametrize("raw", [None, "", "invalid", "0", "-1", "200"])
@@ -165,13 +195,23 @@ def test_startup_lock_protects_image_and_releases_on_exit(
     monkeypatch.setattr(
         "ray.experimental.sandbox.backend.gvisor.shutil.which", lambda _: "runsc"
     )
+    extract = image_utils.extract_tar_layer
+
+    def extract_image(*args):
+        _assert_lock_held(images_dir / "sample.startup.lock", shared=True)
+        extract(*args)
+
+    monkeypatch.setattr(image_utils, "extract_tar_layer", extract_image)
 
     def start(config):
         manager.pull_image(config.image)
-        # A competing pull must not evict an image before runsc sees it.
+        _assert_lock_held(images_dir / "sample.startup.lock", shared=True)
+        unused = _cached_image(images_dir, "unused")
+        # A competing pull can evict other images while this one starts.
         with image_utils.image_cache_context(str(images_dir), "competing"):
             assert manager.is_image_extracted(config.image)
-        runsc_list.assert_not_called()
+            assert not unused.exists()
+        runsc_list.assert_called_once()
         if fail_startup:
             raise RuntimeError("startup failed")
         return "sandbox"
@@ -185,10 +225,81 @@ def test_startup_lock_protects_image_and_releases_on_exit(
         assert backend.create_sandbox(config) == "sandbox"
 
     # Once the context exits, an unreferenced image can be reclaimed.
+    runsc_list.reset_mock()
     with image_utils.image_cache_context(str(images_dir), "other"):
         pass
     assert not manager.is_image_extracted(str(archive))
     runsc_list.assert_called_once()
+
+
+def test_eviction_serializes_passes_without_blocking_other_startups(
+    tmp_path, runsc_list
+):
+    image = _cached_image(tmp_path, "image")
+
+    def list_containers(*args, **kwargs):
+        _assert_lock_held(tmp_path / ".cache.lock")
+        _assert_lock_held(tmp_path / "image.startup.lock")
+        # Another image can start while this pass holds the cache lock.
+        # Its attempt at eviction must skip the already-running pass.
+        with image_utils.image_cache_context(str(tmp_path), "new"):
+            _assert_lock_held(tmp_path / "new.startup.lock", shared=True)
+            with image_utils.image_cache_context(str(tmp_path), "new"):
+                assert image.exists()
+        return runsc_list.return_value
+
+    runsc_list.side_effect = list_containers
+    with image_utils.image_cache_context(str(tmp_path), "other"):
+        pass
+    assert not image.exists()
+    runsc_list.assert_called_once()
+
+
+def test_eviction_during_image_publication(tmp_path, monkeypatch, runsc_list):
+    archive = tmp_path / "sample.tar"
+    _local_tar(archive)
+    images_dir = tmp_path / "images"
+    replace = os.replace
+
+    def publish_image(source, destination):
+        unused = _cached_image(images_dir, "unused")
+        with image_utils.image_cache_context(str(images_dir), "competing"):
+            assert not unused.exists()
+            assert os.path.isdir(source)
+        replace(source, destination)
+
+    monkeypatch.setattr(os, "replace", publish_image)
+    manager = ImageManager(str(images_dir))
+    manager.pull_image(str(archive))
+    assert manager.is_image_extracted(str(archive))
+    assert (images_dir / "sample" / ".extracted").read_text() == "5"
+    runsc_list.assert_called_once()
+
+
+@pytest.mark.parametrize("updated_size", [50, 100])
+def test_eviction_refreshes_metadata_after_locking(
+    tmp_path, monkeypatch, runsc_list, updated_size
+):
+    old = _cached_image(tmp_path, "old")
+    new = _cached_image(tmp_path, "new", mtime=2)
+    monkeypatch.setenv("RAY_SANDBOX_IMAGE_CACHE_MAX_BYTES", "150")
+    flock = fcntl.flock
+
+    def lock_image(lock, operation):
+        if lock.name == str(tmp_path / "old.startup.lock"):
+            # A pull completed between the scan and taking the startup lock.
+            marker = old / ".extracted"
+            marker.write_text(str(updated_size))
+            os.utime(marker, (3, 3))
+        flock(lock, operation)
+
+    monkeypatch.setattr(fcntl, "flock", lock_image)
+    with image_utils.image_cache_context(str(tmp_path), "other"):
+        pass
+    assert old.exists()
+    assert new.exists() == (updated_size == 50)
+    if updated_size == 50:
+        runsc_list.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/python/ray/experimental/sandbox/tests/test_image_utils.py
+++ b/python/ray/experimental/sandbox/tests/test_image_utils.py
@@ -217,7 +217,7 @@ def test_pull_and_extract_remote_image(tmp_path):
     assert os.path.exists(
         os.path.join(extracted_dir, "rootfs", "bin", "sh")
     ) or os.path.exists(os.path.join(extracted_dir, "rootfs", "bin", "busybox"))
-    assert os.path.exists(str(images_dir / "busybox_latest.tar"))
+    assert not os.path.exists(str(images_dir / "busybox_latest.tar"))
 
 
 def test_pull_and_extract_docker_io_prefixed_image(tmp_path):


### PR DESCRIPTION
## Description

This is an alternative proposal to achieve https://github.com/ray-project/ray/pull/65748

It tries to improve on the original PR in a number of ways:

1. Avoid re-computing the image size over and over, only do it once when the image is extracted
2. Make it easier to follow the logic of which images are in use, by using the ground truth runsc command
3. Allow eviction of unused images while other images are pulling or starting. Each pull/startup holds a shared `<image>.startup.lock`; eviction serializes on `.cache.lock`, acquires exclusive nonblocking candidate startup locks, then reads gVisor state once while retaining those locks through deletion.

## Related issues

Related to #65748; this alternative uses gVisor state instead of persistent usage markers and saves image sizes at extraction.

## Additional information

Image sizes and recency are refreshed from saved metadata after candidate locks are acquired. The extraction marker is written only after the image directory reaches its final path, preventing concurrent eviction of temporary extraction directories.

Validation: 61 selected unit tests passed; 8 tests were deselected. Tests ran in a virtual environment through a temporary harness that bypasses native Ray initialization and the Linux sandbox setup. The local native extension is out of sync with the checkout, so full gVisor integration was not run. The exclusions cover runsc/registry tests and an existing directory-permission failure also reproduced on unchanged code.

```sh
/private/tmp/ray-image-cache.f39odz/venv/bin/python /private/tmp/ray-image-cache.f39odz/run_unit_tests.py -q python/ray/experimental/sandbox/tests/test_image_cache.py python/ray/experimental/sandbox/tests/test_image_manager.py python/ray/experimental/sandbox/tests/test_image_utils.py -k 'not test_get_default_oci_spec and not test_image_manager_create_oci_spec and not test_image_manager_prepare_oci_bundle and not test_sandbox_runtime_image_manager_integration and not test_pull_and_extract_remote_image and not test_pull_and_extract_docker_io_prefixed_image and not test_pull_nonexistent_image and not test_extract_tar_layer_usr_merge'
/private/tmp/ray-image-cache.f39odz/venv/bin/python -m pre_commit run
```

All applicable pre-commit hooks passed. AI assistance was used for implementation and validation.
