### PR TITLE
[Data] Return an empty list from Dataset.unique() on an empty dataset

### DIFF
--- a/python/ray/data/dataset.py
+++ b/python/ray/data/dataset.py
@@ -3847,7 +3847,7 @@ class Dataset:
             A list with unique elements in the given column.
         """  # noqa: E501
         ret = self._aggregate_on(Unique, column, ignore_nulls=ignore_nulls)
-        return self._aggregate_result(ret)
+        return self._aggregate_result(ret) or []
 
     @AllToAllAPI
     @ConsumptionAPI

--- a/python/ray/data/tests/test_unique_e2e.py
+++ b/python/ray/data/tests/test_unique_e2e.py
@@ -20,6 +20,8 @@ def test_unique(ray_start_regular_shared_2_cpus, disable_fallback_to_object_exte
     )
     assert set(ds.unique("a")) == {1}
 
+    assert ds.limit(0).unique("a") == []
+
 
 @pytest.mark.parametrize("batch_format", ["pandas", "pyarrow"])
 def test_unique_with_nulls(


### PR DESCRIPTION
## Description

`Dataset.unique()` is documented to return a list, but it goes through the scalar aggregation path, which yields `None` when the dataset has no rows. `sorted(ds.unique("col"))` or `len(ds.unique("col"))` then fails on an empty dataset, for example after a `filter` that matched nothing.

Return `[]` in that case.

## Related issues

None.

## Additional information

Added an assertion to `test_unique` in `test_unique_e2e.py`. It fails on master (`assert None == []`) and passes with this change.