### PR TITLE
[Data] Reject a zero height or width in read_images

### DIFF
--- a/python/ray/data/_internal/datasource/image_datasource.py
+++ b/python/ray/data/_internal/datasource/image_datasource.py
@@ -52,7 +52,7 @@ class ImageDatasource(FileBasedDatasource):
                 f"but got {len(size)} integers instead."
             )
 
-        if size is not None and (size[0] < 0 or size[1] < 0):
+        if size is not None and (size[0] <= 0 or size[1] <= 0):
             raise ValueError(
                 f"Expected `size` to contain positive integers, but got {size} instead."
             )

--- a/python/ray/data/tests/datasource/test_image.py
+++ b/python/ray/data/tests/datasource/test_image.py
@@ -61,7 +61,9 @@ class TestReadImages:
             (64, 64, 3),
         ]
 
-    @pytest.mark.parametrize("size", [(-32, 32), (32, -32), (-32, -32)])
+    @pytest.mark.parametrize(
+        "size", [(-32, 32), (32, -32), (-32, -32), (0, 32), (32, 0), (0, 0)]
+    )
     def test_invalid_size(self, ray_start_regular_shared, size):
         with pytest.raises(ValueError):
             ray.data.read_images("example://image-datasets/simple", size=size)


### PR DESCRIPTION
## Description

The guard allowed `0` while its own message said "positive integers", so `read_images(size=(0, 224))` reached PIL and failed inside a read task:

```
# was: RayTaskError(ValueError) ... height and width must be > 0
# now: ValueError: Expected `size` to contain positive integers, but got (0, 224) instead.
```

`read_videos` already rejects `0` (`video_datasource.py`), and `test_video.py` asserts it.

## Related issues

None.

## Additional information

Added the three zero cases to the existing `test_invalid_size` parametrization. `test_image.py` 23 passed; reverting the guard fails those three. `pre-commit` clean. Bazel/C++ not run locally.

No open PR touches either file. AI assistance (Claude) was used; I reviewed every changed line and ran the tests above.
