### PR TITLE
[Data] Reject a non-positive bins in UniformKBinsDiscretizer

### DIFF
--- a/python/ray/data/preprocessors/discretizer.py
+++ b/python/ray/data/preprocessors/discretizer.py
@@ -64,6 +64,16 @@ class _AbstractKBinsDiscretizer(SerializablePreprocessorBase):
                 "in it."
             )
 
+    def _validate_bins_are_positive(self):
+        # A non-positive bin count has no meaning, and `pd.cut` does not refuse
+        # it: zero produces an all-null column, so the failure is silent.
+        counts = self.bins.values() if isinstance(self.bins, dict) else [self.bins]
+        for count in counts:
+            if count <= 0:
+                raise ValueError(
+                    f"bins must be a positive integer, but got {count} instead."
+                )
+
     def __repr__(self):
         return (
             f"{self.__class__.__name__}("
@@ -393,6 +403,7 @@ class UniformKBinsDiscretizer(_AbstractKBinsDiscretizer):
         super().__init__()
         self._columns = columns
         self._bins = bins
+        self._validate_bins_are_positive()
         self._right = right
         self._include_lowest = include_lowest
         self._duplicates = duplicates

--- a/python/ray/data/preprocessors/discretizer.py
+++ b/python/ray/data/preprocessors/discretizer.py
@@ -67,9 +67,12 @@ class _AbstractKBinsDiscretizer(SerializablePreprocessorBase):
     def _validate_bins_are_positive(self):
         # A non-positive bin count has no meaning, and `pd.cut` does not refuse
         # it: zero produces an all-null column, so the failure is silent.
+        # Only integers are checked here. `_fit` already rejects other types
+        # with a message naming `bins`, and comparing e.g. a list to 0 would
+        # replace that message with a bare operator TypeError.
         counts = self.bins.values() if isinstance(self.bins, dict) else [self.bins]
         for count in counts:
-            if count <= 0:
+            if isinstance(count, int) and count <= 0:
                 raise ValueError(
                     f"bins must be a positive integer, but got {count} instead."
                 )

--- a/python/ray/data/tests/preprocessors/test_discretizer.py
+++ b/python/ray/data/tests/preprocessors/test_discretizer.py
@@ -306,6 +306,14 @@ def test_uniform_kbins_discretizer_serialization():
     assert len(result) == 3
 
 
+@pytest.mark.parametrize("bins", (0, -3, {"A": 0}))
+def test_uniform_kbins_discretizer_rejects_non_positive_bins(bins):
+    # A non-positive bin count has no meaning; without this check `bins=0`
+    # produced an all-null column instead of an error.
+    with pytest.raises(ValueError, match="bins must be a positive integer"):
+        UniformKBinsDiscretizer(["A"], bins=bins)
+
+
 if __name__ == "__main__":
     import sys
 

--- a/python/ray/data/tests/preprocessors/test_discretizer.py
+++ b/python/ray/data/tests/preprocessors/test_discretizer.py
@@ -314,6 +314,16 @@ def test_uniform_kbins_discretizer_rejects_non_positive_bins(bins):
         UniformKBinsDiscretizer(["A"], bins=bins)
 
 
+@pytest.mark.parametrize("bins", ([1, 2], "abc", 3.5))
+def test_uniform_kbins_discretizer_defers_non_integer_bins_to_fit(bins):
+    # Non-integer `bins` keeps reaching the type check in `_fit`, which names
+    # the parameter, rather than tripping the positivity comparison.
+    discretizer = UniformKBinsDiscretizer(["A"], bins=bins)
+    ds = ray.data.from_pandas(pd.DataFrame({"A": [1.0, 2.0]}))
+    with pytest.raises(TypeError, match="`bins` must be an integer"):
+        discretizer.fit(ds)
+
+
 if __name__ == "__main__":
     import sys
 


### PR DESCRIPTION
## Description

`pd.cut` accepts a zero bin count, so `UniformKBinsDiscretizer(bins=0)` returned an all-null column instead of raising:

```
UniformKBinsDiscretizer(["A"], bins=0).fit_transform(ds).take(2)
# was: [{'A': None}, {'A': None}]
# now: ValueError: bins must be a positive integer, but got 0 instead.
```

Validated at construction, alongside the existing check for the dict form of `bins`. `CustomKBinsDiscretizer` is unaffected — its `bins` are edges, not counts.

## Related issues

None.

## Additional information

Covers `0`, negative, and the per-column dict form. `test_discretizer.py` 53 passed, `test_preprocessors.py` 31, `test_scaler.py` 28; reverting the check fails the new test. `pre-commit` clean. Bazel/C++ not run locally.

No open PR touches either file. AI assistance (Claude) was used; I reviewed every changed line and ran the tests above.
