### PR TITLE
[docs] Clarify resource dictionary keys

### DIFF
--- a/doc/source/ray-core/scheduling/placement-group.rst
+++ b/doc/source/ray-core/scheduling/placement-group.rst
@@ -41,12 +41,9 @@ Create a Placement Group (Reserve Resources)
 You can create a placement group using :func:`ray.util.placement_group`.
 Placement groups take in a list of bundles and a :ref:`placement strategy <pgroup-strategy>`.
 
-Bundles are specified by a list of dictionaries, e.g., ``[{"CPU": 1}, {"CPU": 1, "GPU": 1}]``).
-
-- ``CPU`` corresponds to ``num_cpus`` as used in :func:`ray.remote <ray.remote>`.
-- ``GPU`` corresponds to ``num_gpus`` as used in :func:`ray.remote <ray.remote>`.
-- ``memory`` corresponds to ``memory`` as used in :func:`ray.remote <ray.remote>`
-- Other resources corresponds to ``resources`` as used in :func:`ray.remote <ray.remote>` (E.g., ``ray.init(resources={"disk": 1})`` can have a bundle of ``{"disk": 1}``).
+Bundles are specified by a list of resource dictionaries, e.g., ``[{"CPU": 1}, {"CPU": 1, "GPU": 1}]``.
+For details on how resource dictionary keys correspond to task and actor options such as ``num_cpus``
+and ``num_gpus``, see :ref:`resource-dict-remote-options`.
 
 Placement group scheduling is asynchronous. The `ray.util.placement_group` returns immediately.
 

--- a/doc/source/ray-core/scheduling/resources.rst
+++ b/doc/source/ray-core/scheduling/resources.rst
@@ -154,6 +154,40 @@ If resources are specified explicitly, they are required both at schedule time a
 You can also explicitly specify a task's or actor's logical resource requirements (for example, one task may require a GPU) instead of using default ones via :func:`ray.remote() <ray.remote>`
 and :meth:`task.options() <ray.remote_function.RemoteFunction.options>`/:meth:`actor.options() <ray.actor.ActorClass.options>`.
 
+.. _resource-dict-remote-options:
+
+Resource dictionaries and ``ray.remote`` options
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Some Ray APIs describe resource requirements as a dictionary of resource names to quantities.
+For example, a :ref:`placement group bundle <ray-placement-group-doc-ref>` can be written as
+``{"CPU": 2, "GPU": 1, "memory": 1073741824, "custom_resource": 1}``.
+The pre-defined resource keys correspond to the task and actor resource options:
+
+- ``"CPU"`` corresponds to ``num_cpus``.
+- ``"GPU"`` corresponds to ``num_gpus``.
+- ``"memory"`` corresponds to ``memory`` and is measured in bytes.
+- Custom resource names correspond to entries in the ``resources`` argument.
+
+``object_store_memory`` configures the object store size and isn't a schedulable resource requirement.
+
+When you define a task or actor with :func:`ray.remote() <ray.remote>` or ``.options()``,
+use the dedicated keyword arguments for pre-defined resources and the ``resources`` dictionary for custom resources:
+
+.. code-block:: python
+
+    @ray.remote(
+        num_cpus=2,
+        num_gpus=1,
+        memory=1024 * 1024 * 1024,
+        resources={"custom_resource": 1},
+    )
+    def task():
+        ...
+
+For APIs that accept a resource dictionary directly, the equivalent resource shape is
+``{"CPU": 2, "GPU": 1, "memory": 1073741824, "custom_resource": 1}``.
+
 .. tab-set::
 
     .. tab-item:: Python


### PR DESCRIPTION
## Why are these changes needed?

Fixes #48709.

This adds a central Ray Core docs section explaining how resource dictionary keys map to `ray.remote` task and actor options, including CPU, GPU, memory, custom resources, and why `object_store_memory` is different. It also links placement group bundle documentation to the new explanation.

## Related issue number

Closes #48709

## Checks

- `git diff --check origin/master..HEAD -- doc/source/ray-core/scheduling/resources.rst doc/source/ray-core/scheduling/placement-group.rst`
- Manual check for one RST anchor, one cross-reference, trailing whitespace, and tab characters
- Attempted `DOC_LIB=ray-core sphinx-build -b html -d _build/doctrees source _build/html`, but the local environment is missing `sphinx_click`