### PR TITLE
[Serve] Populate multiplexed model ID on direct-ingress HTTP/gRPC paths

### DIFF
--- a/python/ray/serve/_private/http_util.py
+++ b/python/ray/serve/_private/http_util.py
@@ -52,6 +52,7 @@ from ray.serve._private.constants import (
     SERVE_HTTP_REQUEST_ID_HEADER,
     SERVE_HTTP_REQUEST_TIMEOUT_S_HEADER,
     SERVE_LOGGER_NAME,
+    SERVE_MULTIPLEXED_MODEL_ID,
     SERVE_SESSION_ID,
 )
 from ray.serve._private.constants_utils import warn_if_deprecated_env_var_set
@@ -909,6 +910,24 @@ def parse_session_id_header(headers: Dict[bytes, bytes]) -> str:
     """
     for key, value in headers.items():
         if _matches_session_id_header(key.decode("utf-8")):
+            return value.decode("utf-8")
+    return ""
+
+
+def _matches_multiplexed_model_id_header(header_key: str) -> bool:
+    """True if ``header_key`` refers to the multiplexed-model-id header.
+
+    Compares case-insensitively and treats ``-`` and ``_`` as equivalent so
+    intermediate proxies that rewrite the separator (nginx, AWS API Gateway,
+    ...) don't silently drop the multiplexed model ID.
+    """
+    return header_key.lower().replace("-", "_") == SERVE_MULTIPLEXED_MODEL_ID
+
+
+def parse_multiplexed_model_id_header(headers: Dict[bytes, bytes]) -> str:
+    """Return the multiplexed-model-id header value, or '' if absent."""
+    for key, value in headers.items():
+        if _matches_multiplexed_model_id_header(key.decode("utf-8")):
             return value.decode("utf-8")
     return ""
 

--- a/python/ray/serve/_private/replica.py
+++ b/python/ray/serve/_private/replica.py
@@ -134,6 +134,7 @@ from ray.serve._private.http_util import (
     configure_http_options_with_defaults,
     convert_object_to_asgi_messages,
     parse_disconnect_disabled_header,
+    parse_multiplexed_model_id_header,
     parse_request_timeout_header,
     parse_session_id_header,
     retry_after_headers,
@@ -2663,8 +2664,7 @@ class Replica:
             _request_protocol=RequestProtocol.GRPC,
             grpc_context=c,
             app_name=self._deployment_id.app_name,
-            # TODO(edoakes): populate this.
-            multiplexed_model_id="",
+            multiplexed_model_id=c.multiplexed_model_id() or "",
             route=self._deployment_id.app_name,
             tracing_context=self.get_grpc_tracing_context(c),
             is_streaming=is_streaming,
@@ -3157,8 +3157,7 @@ class Replica:
             call_method="__call__",
             route=self._determine_http_route(scope),
             app_name=self._deployment_id.app_name,
-            # TODO(edoakes): populate the multiplexed model ID.
-            multiplexed_model_id="",
+            multiplexed_model_id=parse_multiplexed_model_id_header(headers),
             session_id=session_id,
             is_streaming=True,
             _request_protocol=RequestProtocol.HTTP,

--- a/python/ray/serve/grpc_util.py
+++ b/python/ray/serve/grpc_util.py
@@ -180,6 +180,14 @@ class RayServegRPCContext:
         """
         return self._invocation_metadata_dict.get("tracestate")
 
+    def multiplexed_model_id(self) -> Optional[str]:
+        """Accesses the multiplexed model ID for the RPC.
+
+        Returns:
+          The multiplexed model ID from the request metadata, or None if not set.
+        """
+        return self._invocation_metadata_dict.get("multiplexed_model_id")
+
     def invocation_metadata(self) -> List[Tuple[str, str]]:
         """Accesses the metadata sent by the client.
 

--- a/python/ray/serve/tests/unit/test_grpc_util.py
+++ b/python/ray/serve/tests/unit/test_grpc_util.py
@@ -112,6 +112,21 @@ def test_ray_serve_grpc_context_serializable():
     assert deserialized_context.__dict__ == context.__dict__
 
 
+def test_ray_serve_grpc_context_multiplexed_model_id():
+    """The multiplexed model ID is read from the RPC invocation metadata."""
+    fake_context = FakeGrpcContext()
+    fake_context._invocation_metadata = [
+        ("application", "my_app"),
+        ("multiplexed_model_id", "m1"),
+    ]
+    context = RayServegRPCContext(fake_context)
+    assert context.multiplexed_model_id() == "m1"
+
+    # Absent metadata yields None.
+    empty_context = RayServegRPCContext(FakeGrpcContext())
+    assert empty_context.multiplexed_model_id() is None
+
+
 def test_add_grpc_address():
     """Test `add_grpc_address` adds the address to the gRPC server."""
     fake_grpc_server = FakeGrpcServer()

--- a/python/ray/serve/tests/unit/test_http_util.py
+++ b/python/ray/serve/tests/unit/test_http_util.py
@@ -18,6 +18,7 @@ from ray.serve._private.http_util import (
     configure_http_options_with_defaults,
     convert_object_to_asgi_messages,
     get_http_response_status,
+    parse_multiplexed_model_id_header,
     retry_after_headers,
     send_http_response_on_exception,
 )
@@ -429,6 +430,27 @@ class TestBackpressureHTTPResponse:
         exc = pickle.loads(pickle.dumps(BackPressureError(3, 2)))
         assert exc.status_code == 503
         assert exc.retry_after_s is None
+
+
+def test_parse_multiplexed_model_id_header():
+    """The multiplexed-model-id header is parsed with ``-``/``_`` tolerance."""
+    assert (
+        parse_multiplexed_model_id_header({b"serve_multiplexed_model_id": b"m1"})
+        == "m1"
+    )
+    # Proxies (nginx, AWS API Gateway) rewrite underscores to hyphens.
+    assert (
+        parse_multiplexed_model_id_header({b"serve-multiplexed-model-id": b"m2"})
+        == "m2"
+    )
+    # Header matching is case-insensitive.
+    assert (
+        parse_multiplexed_model_id_header({b"Serve_Multiplexed_Model_Id": b"m3"})
+        == "m3"
+    )
+    # Absent header returns the empty string.
+    assert parse_multiplexed_model_id_header({b"other": b"value"}) == ""
+    assert parse_multiplexed_model_id_header({}) == ""
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Why

Fixes #65976.

With `RAY_SERVE_ENABLE_HA_PROXY=1`, requests are routed straight to the replica
servers, bypassing the Python proxy that normally parses the
`serve_multiplexed_model_id` header. The direct-ingress paths hard-coded
`multiplexed_model_id=""` (the `TODO(edoakes)` stubs), so
`serve.get_multiplexed_model_id()` returned `""` and model multiplexing silently
stopped working.

## What changed

Parse the header on both direct-ingress paths so the ID is populated in
`RequestMetadata`:

- **HTTP**: new `parse_multiplexed_model_id_header()` helper in `http_util.py`,
  using the same `-`/`_` normalization the Python proxy applies, wired into the
  direct-ingress ASGI path in `replica.py`.
- **gRPC**: new `RayServegRPCContext.multiplexed_model_id()` accessor that reads
  the `multiplexed_model_id` invocation metadata (matching the existing gRPC
  proxy `setup_variables` behavior), wired into the direct-ingress gRPC path.

This does not touch HAProxy replica selection (routing by model ID on the
HAProxy side still needs a design decision, as noted in the issue). It makes the
requested model ID available inside the replica in HAProxy mode, which is the
first half of the fix.

## Not a duplicate

Confirmed via the issue timeline and `gh pr list` that no PR references #65976
and no open PR touches this code path.

## Tests

```
python -m pytest python/ray/serve/tests/unit/test_http_util.py \
                 python/ray/serve/tests/unit/test_grpc_util.py -q
# 32 passed in 0.07s
```

Added unit tests:

- `test_parse_multiplexed_model_id_header` (normal, hyphenated, mixed-case, and
  absent header).
- `test_ray_serve_grpc_context_multiplexed_model_id` (present and absent
  metadata).

## Note

AI assistance was used to draft this change; the submitter reviewed every line
and ran the tests above.
