### PR TITLE
[core] Force-inline RDT Python payloads regardless of size thresholds

### DIFF
--- a/doc/source/ray-core/direct-transport/direct-transport.rst
+++ b/doc/source/ray-core/direct-transport/direct-transport.rst
@@ -22,6 +22,12 @@ This feature augments the familiar Ray :class:`ObjectRef <ray.ObjectRef>` API by
 .. note::
    RDT is currently in **alpha** and doesn't support all Ray Core APIs yet. Future releases may introduce breaking API changes. See the :ref:`limitations <limitations>` section for more details.
 
+RDT keeps the serialized Python portion of an object in worker memory and sends it over gRPC,
+including when it exceeds the usual object or task inlining thresholds.
+This applies to RDT actor task returns and to objects created with ``ray.put(_tensor_transport=...)``.
+Tensors use the selected tensor transport. The Python portion is still subject to the gRPC message size limit,
+and is not eligible for object-store spilling.
+
 Getting started
 ===============
 

--- a/python/ray/_raylet.pxd
+++ b/python/ray/_raylet.pxd
@@ -158,7 +158,8 @@ cdef class CoreWorker:
             size_t data_size, shared_ptr[CBuffer] &metadata, const c_vector[CObjectID]
             &contained_id, const CAddress &caller_address,
             int64_t *task_output_inlined_bytes,
-            shared_ptr[CRayObject] *return_ptr)
+            shared_ptr[CRayObject] *return_ptr,
+            c_bool force_inline)
     cdef store_task_outputs(
             self,
             worker, outputs,

--- a/python/ray/_raylet.pyx
+++ b/python/ray/_raylet.pyx
@@ -3696,6 +3696,7 @@ cdef class CoreWorker:
             c_vector[CObjectID] contained_object_ids = ObjectRefsToVector(
                 serialized_object.contained_object_refs)
             size_t total_bytes = serialized_object.total_bytes
+            shared_ptr[CRayObject] inlined_object
 
         with nogil:
             check_status(CCoreWorkerProcess.GetCoreWorker()
@@ -3707,7 +3708,8 @@ cdef class CoreWorker:
                     &c_object_id,
                     &data,
                     inline_small_object,
-                    c_tensor_transport))
+                    c_tensor_transport,
+                    c_tensor_transport.has_value()))
 
         if (data.get() == NULL):
             # Object already exists
@@ -3721,10 +3723,18 @@ cdef class CoreWorker:
                 Buffer.make(data))
 
         with nogil:
+            if c_tensor_transport.has_value():
+                # Tensor data travels out of band. Keep the Python payload in
+                # worker memory even when it exceeds the ordinary inline limit.
+                inlined_object = make_shared[CRayObject](
+                    data, metadata,
+                    CCoreWorkerProcess.GetCoreWorker().GetObjectRefs(contained_object_ids),
+                    False, c_tensor_transport)
             check_status(
                 CCoreWorkerProcess.GetCoreWorker().SealOwned(
                             c_object_id,
-                            pin_object))
+                            pin_object,
+                            inlined_object))
 
         return c_object_id.Binary()
 
@@ -4680,7 +4690,8 @@ cdef class CoreWorker:
                            const c_vector[CObjectID] &contained_id,
                            const CAddress &caller_address,
                            int64_t *task_output_inlined_bytes,
-                           shared_ptr[CRayObject] *return_ptr):
+                           shared_ptr[CRayObject] *return_ptr,
+                           c_bool force_inline):
         """Store a task return value in plasma or as an inlined object."""
         with nogil:
             # For objects that can't be inlined, return_ptr will only be set if
@@ -4688,7 +4699,7 @@ cdef class CoreWorker:
             check_status(
                 CCoreWorkerProcess.GetCoreWorker().AllocateReturnObject(
                     return_id, data_size, metadata, contained_id, caller_address,
-                    task_output_inlined_bytes, return_ptr))
+                    task_output_inlined_bytes, return_ptr, force_inline))
 
         if return_ptr.get() != NULL:
             if return_ptr.get().HasData():
@@ -4843,7 +4854,8 @@ cdef class CoreWorker:
                     contained_id,
                     caller_address,
                     &task_output_inlined_bytes,
-                    return_ptr):
+                    return_ptr,
+                    c_tensor_transport.has_value()):
                 if (attempt > max_attempts):
                     raise RaySystemError(
                         "Failed to store task output with object id {} after {} attempts.".format(

--- a/python/ray/includes/common.pxd
+++ b/python/ray/includes/common.pxd
@@ -350,6 +350,10 @@ cdef extern from "ray/common/ray_object.h" nogil:
         CRayObject(const shared_ptr[CBuffer] &data,
                    const shared_ptr[CBuffer] &metadata,
                    const c_vector[CObjectReference] &nested_refs)
+        CRayObject(const shared_ptr[CBuffer] &data,
+                   const shared_ptr[CBuffer] &metadata,
+                   const c_vector[CObjectReference] &nested_refs,
+                   c_bool copy_data, optional[c_string] tensor_transport)
         c_bool HasData() const
         c_bool HasMetadata() const
         const size_t DataSize() const

--- a/python/ray/includes/libcoreworker.pxd
+++ b/python/ray/includes/libcoreworker.pxd
@@ -193,7 +193,8 @@ cdef extern from "ray/core_worker/core_worker.h" nogil:
             const c_vector[CObjectID] &contained_object_id,
             const CAddress &caller_address,
             int64_t *task_output_inlined_bytes,
-            shared_ptr[CRayObject] *return_object)
+            shared_ptr[CRayObject] *return_object,
+            c_bool force_inline)
         CRayStatus SealReturnObject(
             const CObjectID &return_id,
             const shared_ptr[CRayObject] &return_object,
@@ -291,7 +292,8 @@ cdef extern from "ray/core_worker/core_worker.h" nogil:
                     const c_vector[CObjectID] &contained_object_ids,
                     CObjectID *object_id, shared_ptr[CBuffer] *data,
                     c_bool inline_small_object,
-                    const optional[c_string] &tensor_transport)
+                    const optional[c_string] &tensor_transport,
+                    c_bool force_inline)
         CRayStatus CreateExisting(const shared_ptr[CBuffer] &metadata,
                                   const size_t data_size,
                                   const CObjectID &object_id,
@@ -316,7 +318,8 @@ cdef extern from "ray/core_worker/core_worker.h" nogil:
         CRayStatus ExperimentalRegisterMutableObjectReaderRemote(
                 const CObjectID &object_id,
                 const c_vector[CReaderRefInfo] &remote_reader_ref_info)
-        CRayStatus SealOwned(const CObjectID &object_id, c_bool pin_object)
+        CRayStatus SealOwned(const CObjectID &object_id, c_bool pin_object,
+                            const shared_ptr[CRayObject] &inlined_object)
         CRayStatus SealExisting(const CObjectID &object_id, c_bool pin_object,
                                 const CObjectID &generator_id,
                                 const unique_ptr[CAddress] &owner_address)

--- a/python/ray/tests/rdt/test_rdt_custom.py
+++ b/python/ray/tests/rdt/test_rdt_custom.py
@@ -8,6 +8,7 @@ import numpy
 import pytest
 
 import ray
+from ray._common.test_utils import wait_for_condition
 from ray.experimental import (
     CommunicatorMetadata,
     TensorTransportManager,
@@ -58,14 +59,17 @@ class SharedMemoryTransport(TensorTransportManager):
 
         serialized_rdt_object = pickle.dumps(rdt_object)
         size = len(serialized_rdt_object)
-        # Shm name can't be as long as the obj_id, so we truncate it.
-        name = obj_id[:20]
-        shm_obj = shm.SharedMemory(name=name, create=True, size=size)
+        # Driver-created object IDs share a prefix. Let the OS choose a
+        # short, unique name instead of truncating the object ID.
+        shm_obj = shm.SharedMemory(create=True, size=size)
         shm_obj.buf[:size] = serialized_rdt_object
         self.shared_memory_objects[obj_id] = shm_obj
 
         return ShmTransportMetadata(
-            tensor_meta=tensor_meta, tensor_device="cpu", shm_name=name, shm_size=size
+            tensor_meta=tensor_meta,
+            tensor_device="cpu",
+            shm_name=shm_obj.name,
+            shm_size=size,
         )
 
     def get_communicator_metadata(
@@ -116,11 +120,22 @@ class SharedMemoryTransport(TensorTransportManager):
         pass
 
 
-def test_register_and_use_custom_transport(ray_start_regular):
+@pytest.fixture(scope="module")
+def shared_memory_transport():
     register_tensor_transport(
         "shared_memory", ["cpu"], SharedMemoryTransport, numpy.ndarray
     )
 
+    # Classes defined in test files get pickled by ref. So we need to
+    # explicitly pickle the transport class in this module by value.
+    # Note that this doesn't happen if you define the transport class on the
+    # driver, something with pytest convinces cloudpickle to pickle by ref.
+    from ray import cloudpickle
+
+    cloudpickle.register_pickle_by_value(sys.modules[SharedMemoryTransport.__module__])
+
+
+def test_register_and_use_custom_transport(ray_start_regular, shared_memory_transport):
     @ray.remote
     class Actor:
         @ray.method(tensor_transport="shared_memory")
@@ -133,14 +148,6 @@ def test_register_and_use_custom_transport(ray_start_regular):
         def sum(self, data):
             return data.sum().item()
 
-    # Classes defined in test files get pickled by ref. So we need to
-    # explicitly pickle the transport class in this module by value.
-    # Note that this doesn't happen if you define the transport class on the
-    # driver, something with pytest convinces cloudpickle to pickle by ref.
-    from ray import cloudpickle
-
-    cloudpickle.register_pickle_by_value(sys.modules[SharedMemoryTransport.__module__])
-
     actors = [Actor.remote() for _ in range(2)]
     ref = actors[0].echo.remote(numpy.array([1, 2, 3]))
     result = actors[1].sum.remote(ref)
@@ -150,6 +157,135 @@ def test_register_and_use_custom_transport(ray_start_regular):
     ref = actors[0].non_rdt_echo.remote(numpy.array([1, 2, 3]))
     result = actors[1].sum.remote(ref)
     assert ray.get(result) == 6
+
+
+@pytest.mark.parametrize(
+    "ray_start_regular",
+    [
+        {
+            "include_dashboard": False,
+            "_system_config": {
+                "max_direct_call_object_size": 1024,
+                "task_rpc_inlined_bytes_limit": 1024 * 1024,
+            },
+        },
+        {
+            "include_dashboard": False,
+            "_system_config": {
+                "max_direct_call_object_size": 1024 * 1024,
+                "task_rpc_inlined_bytes_limit": 1024,
+            },
+        },
+    ],
+    indirect=True,
+    ids=["object-size-limit", "rpc-size-limit"],
+)
+@pytest.mark.parametrize("source", ["task-return", "put", "driver-put"])
+def test_large_rdt_payload_stays_in_memory(
+    ray_start_regular, shared_memory_transport, source
+):
+    # Independently exceed the per-object and per-RPC inlining limits. The
+    # tensor is small; it is the surrounding Python payload that is large.
+    payload = b"x" * (128 * 1024)
+
+    @ray.remote
+    class Actor:
+        def make_data(self):
+            return {
+                "tensor": numpy.array([1, 2, 3]),
+                "payload": payload,
+                "nested": ray.put("nested object"),
+            }
+
+        @ray.method(tensor_transport="shared_memory")
+        def produce(self):
+            return self.make_data()
+
+        def put(self):
+            return ray.put(self.make_data(), _tensor_transport="shared_memory")
+
+        def hold(self, refs):
+            self.ref = refs[0]
+
+        def read(self):
+            data = ray.get(self.ref)
+            assert numpy.array_equal(data["tensor"], [1, 2, 3])
+            assert data["payload"] == payload
+            assert ray.get(data["nested"]) == "nested object"
+            return ray._private.worker.global_worker.core_worker.object_exists(
+                self.ref, memory_store_only=True
+            )
+
+        def release(self):
+            del self.ref
+
+        def num_rdt_objects(self):
+            return (
+                ray._private.worker.global_worker.rdt_manager.rdt_store.get_num_objects()
+            )
+
+        def plain_produce(self):
+            return payload
+
+        def plain_put(self):
+            return ray.put(payload)
+
+    sender, borrower = Actor.remote(), Actor.remote()
+    # Plain actor methods and nested ObjectRefs do not trigger the usual
+    # submission-time registration of a custom transport on the actors.
+    manager = ray._private.worker.global_worker.rdt_manager
+    for actor in (sender, borrower):
+        manager.wait_until_custom_transports_registered(actor)
+    if source == "driver-put":
+        ref = ray.put(
+            {
+                "tensor": numpy.array([1, 2, 3]),
+                "payload": payload,
+                "nested": ray.put("nested object"),
+            },
+            _tensor_transport="shared_memory",
+        )
+    else:
+        ref = (
+            ray.get(sender.put.remote(), timeout=20)
+            if source == "put"
+            else sender.produce.remote()
+        )
+
+    def num_rdt_objects():
+        if source == "driver-put":
+            return manager.rdt_store.get_num_objects()
+        return ray.get(sender.num_rdt_objects.remote())
+
+    ready, _ = ray.wait([ref], timeout=20, fetch_local=False)
+    assert ready == [ref]
+    del ready
+    core_worker = ray._private.worker.global_worker.core_worker
+    assert core_worker.object_exists(ref, memory_store_only=True)
+    data = ray.get(ref, timeout=20)
+    assert numpy.array_equal(data["tensor"], [1, 2, 3])
+    assert data["payload"] == payload
+    assert ray.get(data["nested"]) == "nested object"
+    del data
+
+    # The borrower receives a nested RDT ObjectRef rather than an already
+    # resolved argument. It must keep both the tensor and nested object alive
+    # after the driver drops its Python reference.
+    ray.get(borrower.hold.remote([ref]))
+    del ref
+    assert ray.get(borrower.read.remote())
+    assert num_rdt_objects() == 1
+    ray.get(borrower.release.remote())
+    wait_for_condition(lambda: num_rdt_objects() == 0)
+
+    # Ordinary task returns and puts must still use Plasma above these limits.
+    plain_ref = (
+        ray.get(sender.plain_put.remote())
+        if source != "task-return"
+        else sender.plain_produce.remote()
+    )
+    assert ray.get(plain_ref) == payload
+    assert not core_worker.object_exists(plain_ref, memory_store_only=True)
 
 
 if __name__ == "__main__":

--- a/python/ray/tests/rdt/test_rdt_gloo.py
+++ b/python/ray/tests/rdt/test_rdt_gloo.py
@@ -84,16 +84,12 @@ class ErrorActor:
         time.sleep(100)
 
 
-@pytest.mark.parametrize("data_size_bytes", [100])
+@pytest.mark.parametrize("data_size_bytes", [100, 1024 * 1024])
 def test_gc_rdt_object(ray_start_regular, data_size_bytes):
     """
-    For small data, GPU objects are inlined, but the actual data lives
-    on the remote actor. Therefore, if we decrement the reference count
-    upon inlining, we may cause the tensors on the sender actor to be
-    freed before transferring to the receiver actor.
-
-    # TODO(kevin85421): Add a test for large CPU data that is not inlined
-    # after https://github.com/ray-project/ray/issues/54281 is fixed.
+    RDT objects are inlined even with a large Python payload, but tensors live
+    on the remote actor. Their references must survive inlining until the
+    receiver has finished transferring them.
     """
     world_size = 2
     actors = [GPUTestActor.remote() for _ in range(world_size)]
@@ -148,7 +144,7 @@ def test_gc_rdt_metadata(ray_start_regular):
     )
 
 
-@pytest.mark.parametrize("data_size_bytes", [100])
+@pytest.mark.parametrize("data_size_bytes", [100, 1024 * 1024])
 def test_gc_del_ref_before_recv_finish(ray_start_regular, data_size_bytes):
     """
     This test deletes the ObjectRef of the GPU object before calling

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -1230,7 +1230,11 @@ Status CoreWorker::CreateOwnedAndIncrementLocalRef(
     ObjectID *object_id,
     std::shared_ptr<Buffer> *data,
     bool inline_small_object,
-    const std::optional<std::string> &tensor_transport) {
+    const std::optional<std::string> &tensor_transport,
+    bool force_inline) {
+  if (force_inline && is_experimental_mutable_object) {
+    return Status::Invalid("Mutable objects cannot be force-inlined.");
+  }
   auto status = WaitForActorRegistered(contained_object_ids);
   if (!status.ok()) {
     return status;
@@ -1238,20 +1242,27 @@ Status CoreWorker::CreateOwnedAndIncrementLocalRef(
   *object_id = ObjectID::FromIndex(worker_context_->GetCurrentInternalTaskId(),
                                    worker_context_->GetNextPutIndex());
   SubscribeToNodeChanges();
-  reference_counter_->AddOwnedObject(*object_id,
-                                     contained_object_ids,
-                                     rpc_address_,
-                                     CurrentCallSite(),
-                                     data_size + metadata->Size(),
-                                     LineageReconstructionEligibility::INELIGIBLE_PUT,
-                                     /*add_local_ref=*/true,
-                                     NodeID::FromBinary(rpc_address_.node_id()),
-                                     /*tensor_transport=*/tensor_transport);
+  reference_counter_->AddOwnedObject(
+      *object_id,
+      contained_object_ids,
+      rpc_address_,
+      CurrentCallSite(),
+      data_size + metadata->Size(),
+      LineageReconstructionEligibility::INELIGIBLE_PUT,
+      /*add_local_ref=*/true,
+      force_inline ? std::nullopt
+                   : std::make_optional(NodeID::FromBinary(rpc_address_.node_id())),
+      /*tensor_transport=*/tensor_transport);
 
   // Register the callback to free the RDT object when it is out of scope.
   if (tensor_transport.has_value()) {
     reference_counter_->AddObjectOutOfScopeOrFreedCallback(*object_id,
                                                            free_actor_object_callback_);
+  }
+
+  if (force_inline) {
+    *data = std::make_shared<LocalMemoryBuffer>(data_size);
+    return Status::OK();
   }
 
   status = plasma_store_provider_->Create(metadata,
@@ -1313,7 +1324,17 @@ Status CoreWorker::ExperimentalChannelSetError(const ObjectID &object_id) {
   return experimental_mutable_object_provider_->SetError(object_id);
 }
 
-Status CoreWorker::SealOwned(const ObjectID &object_id, bool pin_object) {
+Status CoreWorker::SealOwned(const ObjectID &object_id,
+                             bool pin_object,
+                             const std::shared_ptr<RayObject> &inlined_object) {
+  if (inlined_object != nullptr) {
+    RAY_CHECK(!inlined_object->HasData() || !inlined_object->GetData()->IsPlasmaBuffer());
+    // Publish only after the caller has finished writing. No plasma copy exists
+    // to seal or pin; the reference counter keeps the worker-memory copy alive.
+    memory_store_->Put(
+        *inlined_object, object_id, reference_counter_->HasReference(object_id));
+    return Status::OK();
+  }
   auto status = SealExisting(object_id, pin_object, ObjectID::Nil());
   if (status.ok()) {
     return status;
@@ -2868,7 +2889,8 @@ Status CoreWorker::AllocateReturnObject(const ObjectID &object_id,
                                         const std::vector<ObjectID> &contained_object_ids,
                                         const rpc::Address &owner_address,
                                         int64_t *task_output_inlined_bytes,
-                                        std::shared_ptr<RayObject> *return_object) {
+                                        std::shared_ptr<RayObject> *return_object,
+                                        bool force_inline) {
   bool object_already_exists = false;
   std::shared_ptr<Buffer> data_buffer;
   if (data_size > 0) {
@@ -2896,7 +2918,7 @@ Status CoreWorker::AllocateReturnObject(const ObjectID &object_id,
                               RayObject(nullptr, metadata, {}).IsException();
 
     // Allocate a buffer for the return object.
-    if (inline_error ||
+    if (force_inline || inline_error ||
         (static_cast<int64_t>(data_size) < max_direct_call_object_size_ &&
          // ensure we don't exceed the limit if we allocate this object inline.
          (*task_output_inlined_bytes + static_cast<int64_t>(data_size) <=
@@ -3927,7 +3949,7 @@ void CoreWorker::HandleGetObjectStatus(rpc::GetObjectStatusRequest request,
 void CoreWorker::PopulateObjectStatus(const ObjectID &object_id,
                                       const std::shared_ptr<RayObject> &obj,
                                       rpc::GetObjectStatusReply *reply) {
-  // If obj is the concrete object value, it is small, so we
+  // If obj is the concrete object value, it is in worker memory, so we
   // send the object back to the caller in the GetObjectStatus
   // reply, bypassing a Plasma put and object transfer. If obj
   // is an indicator that the object is in Plasma, we set an

--- a/src/ray/core_worker/core_worker.h
+++ b/src/ray/core_worker/core_worker.h
@@ -616,6 +616,8 @@ class CoreWorker : public std::enable_shared_from_this<CoreWorker> {
   /// \param[in] inline_small_object Whether to inline create this object if it's
   /// small.
   /// \param[in] tensor_transport The tensor transport to use for the object.
+  /// \param[in] force_inline Allocate in worker memory regardless of size. Mutable
+  /// objects cannot be inlined. Pass the completed object to SealOwned().
   /// \return Status.
   Status CreateOwnedAndIncrementLocalRef(
       bool is_experimental_mutable_object,
@@ -625,7 +627,8 @@ class CoreWorker : public std::enable_shared_from_this<CoreWorker> {
       ObjectID *object_id,
       std::shared_ptr<Buffer> *data,
       bool inline_small_object = true,
-      const std::optional<std::string> &tensor_transport = std::nullopt);
+      const std::optional<std::string> &tensor_transport = std::nullopt,
+      bool force_inline = false);
 
   /// Create and return a buffer in the object store that can be directly written
   /// into, for an object ID that already exists. After writing to the buffer, the
@@ -655,8 +658,12 @@ class CoreWorker : public std::enable_shared_from_this<CoreWorker> {
   ///
   /// \param[in] object_id Object ID corresponding to the object.
   /// \param[in] pin_object Whether or not to pin the object at the local raylet.
+  /// \param[in] inlined_object Completed object allocated with force_inline, or
+  /// nullptr for an object allocated in plasma.
   /// \return Status.
-  Status SealOwned(const ObjectID &object_id, bool pin_object);
+  Status SealOwned(const ObjectID &object_id,
+                   bool pin_object,
+                   const std::shared_ptr<RayObject> &inlined_object = nullptr);
 
   /// Finalize placing an object into the object store. This should be called after
   /// a corresponding `CreateExisting()` call and then writing into the returned buffer.
@@ -1225,6 +1232,7 @@ class CoreWorker : public std::enable_shared_from_this<CoreWorker> {
   /// objects of a task. It is used to decide if the current object should be inlined. If
   /// the current object is inlined, the task_output_inlined_bytes will be updated.
   /// \param[out] return_object RayObject containing buffers to write results into.
+  /// \param[in] force_inline Bypass the per-object and per-task inline size limits.
   /// \return Status.
   Status AllocateReturnObject(const ObjectID &object_id,
                               const size_t &data_size,
@@ -1232,7 +1240,8 @@ class CoreWorker : public std::enable_shared_from_this<CoreWorker> {
                               const std::vector<ObjectID> &contained_object_id,
                               const rpc::Address &owner_address,
                               int64_t *task_output_inlined_bytes,
-                              std::shared_ptr<RayObject> *return_object);
+                              std::shared_ptr<RayObject> *return_object,
+                              bool force_inline = false);
 
   /// Seal a return object for an executing task. The caller should already have
   /// written into the data buffer.

--- a/src/ray/core_worker/tests/core_worker_test.cc
+++ b/src/ray/core_worker/tests/core_worker_test.cc
@@ -17,6 +17,7 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <future>
 #include <memory>
 #include <string>
@@ -366,6 +367,121 @@ TaskSpecification CreateStreamingGeneratorTaskSpec() {
   task.GetMutableMessage().set_streaming_generator(true);
   task.GetMutableMessage().set_generator_backpressure_num_objects(-1);
   return task;
+}
+
+TEST_F(CoreWorkerTest, ForceInlineReturnBypassesObjectAndTaskLimits) {
+  const size_t data_size = RayConfig::instance().max_direct_call_object_size() + 1;
+  const auto metadata = MakeRayObject("", "meta")->GetMetadata();
+  int64_t inlined_bytes = RayConfig::instance().task_rpc_inlined_bytes_limit();
+  const int64_t initial_inlined_bytes = inlined_bytes;
+
+  // Explicit inlining applies to each object even after the task's aggregate
+  // inline budget is exhausted. The buffer remains private until it is written.
+  for (int i = 0; i < 2; i++) {
+    std::shared_ptr<RayObject> return_object;
+    const auto object_id = ObjectID::FromRandom();
+    ASSERT_TRUE(core_worker_
+                    ->AllocateReturnObject(object_id,
+                                           data_size,
+                                           metadata,
+                                           {},
+                                           core_worker_->GetRpcAddress(),
+                                           &inlined_bytes,
+                                           &return_object,
+                                           /*force_inline=*/true)
+                    .ok());
+    ASSERT_NE(return_object, nullptr);
+    ASSERT_NE(return_object->GetData(), nullptr);
+    EXPECT_EQ(return_object->GetData()->Size(), data_size);
+    EXPECT_FALSE(return_object->GetData()->IsPlasmaBuffer());
+    EXPECT_EQ(return_object->GetMetadata(), metadata);
+    EXPECT_EQ(memory_store_->GetIfExists(object_id), nullptr);
+    EXPECT_EQ(inlined_bytes,
+              initial_inlined_bytes + (i + 1) * static_cast<int64_t>(data_size));
+  }
+}
+
+TEST_F(CoreWorkerTest, ForceInlinePutPublishesAfterSealAndReleasesNestedReference) {
+  const auto inner_id = ObjectID::FromRandom();
+  reference_counter_->AddOwnedObject(inner_id,
+                                     {},
+                                     core_worker_->GetRpcAddress(),
+                                     "",
+                                     1,
+                                     LineageReconstructionEligibility::INELIGIBLE_PUT,
+                                     /*add_local_ref=*/true);
+  const size_t data_size = RayConfig::instance().max_direct_call_object_size() + 1;
+  const auto metadata = MakeRayObject("", "meta")->GetMetadata();
+  ObjectID object_id;
+  std::shared_ptr<Buffer> data;
+  ASSERT_TRUE(core_worker_
+                  ->CreateOwnedAndIncrementLocalRef(
+                      /*is_experimental_mutable_object=*/false,
+                      metadata,
+                      data_size,
+                      {inner_id},
+                      &object_id,
+                      &data,
+                      /*inline_small_object=*/false,
+                      /*tensor_transport=*/std::nullopt,
+                      /*force_inline=*/true)
+                  .ok());
+  ASSERT_NE(data, nullptr);
+  EXPECT_FALSE(data->IsPlasmaBuffer());
+  EXPECT_EQ(data->Size(), data_size);
+  EXPECT_EQ(memory_store_->GetIfExists(object_id), nullptr);
+  ASSERT_TRUE(reference_counter_->HasReference(object_id));
+  auto locality = reference_counter_->GetLocalityData(object_id);
+  ASSERT_TRUE(locality.has_value());
+  EXPECT_TRUE(locality->nodes_containing_object.empty());
+
+  // Dropping the original inner reference must not free it while the new
+  // inlined object contains it, including during the write-before-seal window.
+  core_worker_->RemoveLocalReference(inner_id);
+  EXPECT_TRUE(reference_counter_->HasReference(inner_id));
+  const std::string expected(data_size, 'x');
+  std::copy(expected.begin(), expected.end(), data->Data());
+  auto object = std::make_shared<RayObject>(
+      data, metadata, core_worker_->GetObjectRefs({inner_id}));
+  ASSERT_TRUE(core_worker_->SealOwned(object_id, /*pin_object=*/true, object).ok());
+  const auto stored = memory_store_->GetIfExists(object_id);
+  ASSERT_NE(stored, nullptr);
+  EXPECT_FALSE(stored->IsInPlasmaError());
+  EXPECT_EQ(std::string(reinterpret_cast<const char *>(stored->GetData()->Data()),
+                        stored->GetData()->Size()),
+            expected);
+  ASSERT_EQ(stored->GetNestedRefs().size(), 1);
+  EXPECT_EQ(stored->GetNestedRefs()[0].object_id(), inner_id.Binary());
+  EXPECT_TRUE(
+      reference_counter_->GetLocalityData(object_id)->nodes_containing_object.empty());
+
+  // Ordinary ownership cleanup must release both the worker-memory value and
+  // the nested reference without a plasma pin or a separate cleanup callback.
+  core_worker_->RemoveLocalReference(object_id);
+  EXPECT_EQ(memory_store_->GetIfExists(object_id), nullptr);
+  EXPECT_FALSE(reference_counter_->HasReference(object_id));
+  EXPECT_FALSE(reference_counter_->HasReference(inner_id));
+}
+
+TEST_F(CoreWorkerTest, ForceInlineRejectsMutableObjectsBeforeAddingOwnership) {
+  const auto metadata = MakeRayObject("", "meta")->GetMetadata();
+  const auto initial_owned_objects = reference_counter_->NumObjectsOwnedByUs();
+  ObjectID object_id = ObjectID::Nil();
+  std::shared_ptr<Buffer> data;
+  const auto status = core_worker_->CreateOwnedAndIncrementLocalRef(
+      /*is_experimental_mutable_object=*/true,
+      metadata,
+      /*data_size=*/1,
+      {},
+      &object_id,
+      &data,
+      /*inline_small_object=*/false,
+      /*tensor_transport=*/std::nullopt,
+      /*force_inline=*/true);
+  EXPECT_TRUE(status.IsInvalid());
+  EXPECT_TRUE(object_id.IsNil());
+  EXPECT_EQ(data, nullptr);
+  EXPECT_EQ(reference_counter_->NumObjectsOwnedByUs(), initial_owned_objects);
 }
 
 TEST_F(CoreWorkerTest, PeekObjectRefStreamNReturnsExpectedRefs) {


### PR DESCRIPTION
## Description

RDT sends tensors through a separate transport, but its serialized Python payload currently falls back to Plasma when it exceeds the ordinary per-object or per-task RPC inlining thresholds. This adds a per-object force-inline option to CoreWorker and uses it for RDT actor task returns and `ray.put(_tensor_transport=...)`, so that Python data stays in worker memory and travels over gRPC independently of those thresholds.

Force-inlined puts are published only after serialization finishes. Ownership, nested ObjectRefs, transport metadata, and RDT cleanup remain intact without recording a Plasma pin. Ordinary puts and task returns retain their existing allocation behavior.

## Related issues

Fixes #65490.

This implements the maintainer-requested dynamic inlining capability. On 2026-09-08, the issue was open with no assignees or comments; searches for open PRs referencing #65490 or with inline/inlining in the title found no competing PR. Related RDT PRs were also checked for overlap. AI assistance was used for investigation, implementation, and validation.

## Additional information

Both the exact baseline `317c2888eade3c294c4fdb46eff9d9ec290b08f2` and the modified tree were built from source on a Linux CPU validation host, including `_raylet`, raylet, and GCS. No prebuilt Ray wheel was overlaid on the changed native code.

Validation:

- `python -m pytest -q python/ray/tests/rdt/test_rdt_custom.py::test_large_rdt_payload_stays_in_memory --timeout=120`: baseline 6 failed at the worker-memory assertion; modified 6 passed. Covers actor returns, actor puts, driver puts, both inlining limits, nested references, remote borrowers, GC, and ordinary-object Plasma behavior.
- `bazel test //src/ray/core_worker/tests:core_worker_test --nocache_test_results --test_output=errors --test_timeout=180` (fastbuild, 6 jobs): 39 passed, including three new allocation/ownership regressions.
- `python -m pytest -q python/ray/tests/rdt/test_rdt_custom.py python/ray/tests/rdt/test_rdt_gloo.py python/ray/tests/rdt/test_rdt_manager.py -k 'not large_rdt_payload_stays_in_memory' --timeout=180`: 52 passed, 1 skipped, 1 failed. The existing `test_free_rdt_object_handles_transport_failure` fails because caplog does not capture a log that appears on stderr. Running `python -m pytest -q python/ray/tests/rdt/test_rdt_manager.py --timeout=120` separately on both baseline and modified source yields the same 7 passed / 1 failed result. The skip is the existing lineage reconstruction test.
- After the final test-helper change to unique shared-memory names, the six focused cases and `test_register_and_use_custom_transport` were rerun successfully (6 passed and 1 passed).
- Black, Ruff, `cython-lint --no-pycodestyle`, full Cython transpilation, and `git diff --check` passed. Documentation lint reports the same two pre-existing trailing-whitespace findings as the baseline.

The Python payload remains subject to gRPC message-size limits and uses worker memory that cannot be spilled through the object store. This is documented. Validation used CPU/Gloo and a custom shared-memory transport; no GPU/NCCL/NIXL/RDMA or throughput improvement is claimed.
