### PR TITLE
Use posix_spawn for specific-server to fix gRPC fork race

### DIFF
--- a/python/ray/_private/services.py
+++ b/python/ray/_private/services.py
@@ -894,6 +894,7 @@ def start_ray_process(
     stdout_file: Optional[IO[AnyStr]] = None,
     stderr_file: Optional[IO[AnyStr]] = None,
     pipe_stdin: bool = False,
+    use_posix_spawn: bool = False,
 ):
     """Start one of the Ray processes.
 
@@ -908,6 +909,11 @@ def start_ray_process(
             (e.g., "raylet").
         fate_share: If true, the child will be killed if its parent (us) dies.
             True must only be passed after detection of this functionality.
+        use_posix_spawn: If true, skip preexec_fn so CPython can use
+            posix_spawn() instead of fork(). This avoids a race condition
+            where fork() in a multi-threaded gRPC process copies corrupted
+            poller state into the child (see #63202). Cannot be combined
+            with fate_share.
         env_updates: A dictionary of additional environment variables to
             run the command with (in addition to the caller's environment
             variables).
@@ -1037,6 +1043,15 @@ def start_ray_process(
         # version, and tmux 2.1)
         command = ["tmux", "new-session", "-d", f"{' '.join(command)}"]
 
+    if use_posix_spawn and fate_share:
+        raise ValueError(
+            "'use_posix_spawn' cannot be combined with 'fate_share' because "
+            "posix_spawn skips preexec_fn which is needed for fate-sharing."
+        )
+
+    # On non-Linux or Windows, posix_spawn offers no benefit.
+    use_posix_spawn = use_posix_spawn and sys.platform.startswith("linux")
+
     if fate_share:
         assert ray._private.utils.detect_fate_sharing_support(), (
             "kernel-level fate-sharing must only be specified if "
@@ -1068,6 +1083,16 @@ def start_ray_process(
                 f"got {total_chrs}"
             )
 
+    # When use_posix_spawn is set, we pass preexec_fn=None so that CPython
+    # can use posix_spawn() instead of fork(). This avoids a gRPC poller
+    # race condition in multi-threaded processes (see #63202).
+    if use_posix_spawn:
+        popen_preexec_fn = None
+    elif sys.platform != "win32":
+        popen_preexec_fn = preexec_fn
+    else:
+        popen_preexec_fn = None
+
     process = ConsolePopen(
         command,
         env=modified_env,
@@ -1075,7 +1100,7 @@ def start_ray_process(
         stdout=stdout_file,
         stderr=stderr_file,
         stdin=subprocess.PIPE if pipe_stdin else None,
-        preexec_fn=preexec_fn if sys.platform != "win32" else None,
+        preexec_fn=popen_preexec_fn,
         creationflags=CREATE_SUSPENDED if win32_fate_sharing else 0,
     )
 
@@ -2491,13 +2516,21 @@ def start_ray_client_server(
     if node_id:
         command.append(f"--node-id={node_id}")
 
+    # The proxier is a multi-threaded gRPC server. Spawning specific-server
+    # children via fork() races with gRPC's poller threads, causing ~7%
+    # crash rate (see #63202). Skip preexec_fn for specific-server so
+    # CPython can use posix_spawn() instead of fork(). The proxier already
+    # monitors and cleans up specific-server processes, so kernel-level
+    # fate-sharing is not required.
+    is_specific_server = server_type == "specific-server"
     process_info = start_ray_process(
         command,
         ray_constants.PROCESS_TYPE_RAY_CLIENT_SERVER,
         stdout_file=stdout_file,
         stderr_file=stderr_file,
-        fate_share=fate_share,
+        fate_share=False if is_specific_server else fate_share,
         env_updates=env_updates,
+        use_posix_spawn=is_specific_server,
     )
     return process_info
 

--- a/python/ray/tests/test_posix_spawn_specific_server.py
+++ b/python/ray/tests/test_posix_spawn_specific_server.py
@@ -1,0 +1,144 @@
+"""Tests for the posix_spawn fix for specific-server spawning (#63202).
+
+The proxier is a multi-threaded gRPC server. Spawning specific-server
+children via fork() races with gRPC's poller threads. This fix skips
+preexec_fn for specific-server so CPython uses posix_spawn() instead.
+"""
+
+import subprocess
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def test_use_posix_spawn_and_fate_share_raises():
+    """use_posix_spawn=True + fate_share=True must raise ValueError."""
+    from ray._private.services import start_ray_process
+
+    with pytest.raises(ValueError, match="cannot be combined"):
+        start_ray_process(
+            command=[sys.executable, "-c", "pass"],
+            process_type="test",
+            fate_share=True,
+            use_posix_spawn=True,
+        )
+
+
+@pytest.mark.skipif(
+    sys.platform != "linux", reason="posix_spawn optimization is Linux-only"
+)
+def test_posix_spawn_skips_preexec_fn():
+    """When use_posix_spawn=True, preexec_fn must be None."""
+    from ray._private.services import ConsolePopen
+
+    with patch.object(
+        ConsolePopen, "__init__", return_value=None
+    ) as mock_init:
+        mock_init.return_value = None
+        try:
+            from ray._private.services import start_ray_process
+
+            start_ray_process(
+                command=[sys.executable, "-c", "pass"],
+                process_type="test",
+                fate_share=False,
+                use_posix_spawn=True,
+                stdout_file=subprocess.DEVNULL,
+                stderr_file=subprocess.DEVNULL,
+            )
+        except (OSError, TypeError, AttributeError):
+            # ConsolePopen mock doesn't create a real process — that's fine,
+            # we only need to inspect how it was called.
+            pass
+
+        mock_init.assert_called_once()
+        _, kwargs = mock_init.call_args
+        assert kwargs.get("preexec_fn") is None, (
+            "preexec_fn must be None when use_posix_spawn=True"
+        )
+
+
+@pytest.mark.skipif(
+    sys.platform != "linux", reason="posix_spawn optimization is Linux-only"
+)
+def test_normal_spawn_uses_preexec_fn():
+    """Without use_posix_spawn, preexec_fn must be set (on Linux)."""
+    from ray._private.services import ConsolePopen
+
+    with patch.object(
+        ConsolePopen, "__init__", return_value=None
+    ) as mock_init:
+        mock_init.return_value = None
+        try:
+            from ray._private.services import start_ray_process
+
+            start_ray_process(
+                command=[sys.executable, "-c", "pass"],
+                process_type="test",
+                fate_share=False,
+                use_posix_spawn=False,
+                stdout_file=subprocess.DEVNULL,
+                stderr_file=subprocess.DEVNULL,
+            )
+        except (OSError, TypeError, AttributeError):
+            pass
+
+        mock_init.assert_called_once()
+        _, kwargs = mock_init.call_args
+        assert kwargs.get("preexec_fn") is not None, (
+            "preexec_fn must be set when use_posix_spawn=False on Linux"
+        )
+
+
+def test_client_server_specific_server_disables_fate_share():
+    """start_ray_client_server must pass fate_share=False for specific-server."""
+    with patch("ray._private.services.start_ray_process") as mock_start:
+        mock_start.return_value = MagicMock()
+        from ray._private.services import start_ray_client_server
+
+        start_ray_client_server(
+            address="127.0.0.1:6379",
+            ray_client_server_ip="127.0.0.1",
+            ray_client_server_port=10001,
+            server_type="specific-server",
+            fate_share=True,
+        )
+
+        mock_start.assert_called_once()
+        _, kwargs = mock_start.call_args
+        assert kwargs["fate_share"] is False, (
+            "fate_share must be False for specific-server"
+        )
+        assert kwargs["use_posix_spawn"] is True, (
+            "use_posix_spawn must be True for specific-server"
+        )
+
+
+def test_client_server_proxy_keeps_fate_share():
+    """start_ray_client_server must preserve fate_share for proxy server."""
+    with patch("ray._private.services.start_ray_process") as mock_start:
+        mock_start.return_value = MagicMock()
+        from ray._private.services import start_ray_client_server
+
+        start_ray_client_server(
+            address="127.0.0.1:6379",
+            ray_client_server_ip="127.0.0.1",
+            ray_client_server_port=10001,
+            server_type="proxy",
+            fate_share=True,
+            runtime_env_agent_address="127.0.0.1:8000",
+        )
+
+        mock_start.assert_called_once()
+        _, kwargs = mock_start.call_args
+        assert kwargs["fate_share"] is True, (
+            "fate_share must be preserved for proxy server"
+        )
+        assert kwargs["use_posix_spawn"] is False, (
+            "use_posix_spawn must be False for proxy server"
+        )
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Why are these changes needed?

Fixes #63202.

The Ray Client proxier is a multi-threaded gRPC server. When it spawns `specific-server` child processes, Python's `subprocess.Popen` with `preexec_fn` forces the `fork()` code path. In a multi-threaded process, `fork()` copies gRPC's internal poller thread state into the child, causing a race condition that crashes ~7% of spawns with:

```
Check failed: next_worker->state == KICKED
```

This PR skips `preexec_fn` for `specific-server` spawns so CPython can use `posix_spawn()` instead of `fork()`. `posix_spawn` creates a fresh process without cloning thread state, eliminating the race entirely.

### What this changes

- Adds `use_posix_spawn` parameter to `start_ray_process()` — when `True`, sets `preexec_fn=None` so CPython takes the `posix_spawn()` path
- In `start_ray_client_server()`, passes `use_posix_spawn=True` and `fate_share=False` when `server_type == "specific-server"`
- Adds validation: `use_posix_spawn=True` + `fate_share=True` raises `ValueError` (incompatible — `preexec_fn` is needed for fate-sharing)
- `use_posix_spawn` only activates on Linux (no-op on other platforms)

### Why this is safe

- The proxier already monitors and cleans up `specific-server` processes, so kernel-level fate-sharing is not required
- `specific-server` runs behind the proxier's gRPC channel and does not receive terminal SIGINT in normal operation, so the SIGINT mask from `preexec_fn` is not needed
- On Python < 3.12 where `POSIX_SPAWN_CLOSEFROM` is unavailable, CPython may fall back to `fork()` — but this is no worse than the current behavior

Credit to @leviska for the original production-validated approach shared in #63202.

## Related issue number

Fixes #63202

## Checks

- [x] I've signed the [CLA](http://ray.io/cla)
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've added any new APIs to the API Reference.
- [x] I've made sure the tests are passing. Run the tests locally:
  - `pytest python/ray/tests/test_posix_spawn_specific_server.py -v`