### PR TITLE
Enable gRPC fork support in driver process

### DIFF
--- a/python/ray/_private/worker.py
+++ b/python/ray/_private/worker.py
@@ -1676,6 +1676,15 @@ def init(
             "is not the main thread."
         )
 
+    # Enable gRPC fork support in the driver process before any gRPC
+    # channel is created. Without this, fork() after gRPC initialization
+    # deadlocks because the child inherits locked mutexes from gRPC's
+    # background threads. Ray already sets these for worker processes
+    # (in worker_pool.cc) but not for the driver. See #59661.
+    if sys.platform != "win32":
+        os.environ.setdefault("GRPC_ENABLE_FORK_SUPPORT", "1")
+        os.environ.setdefault("GRPC_POLL_STRATEGY", "poll")
+
     # If available, use RAY_ADDRESS to override if the address was left
     # unspecified, or set to "auto" in the call to init
     address_env_var = os.environ.get(ray_constants.RAY_ADDRESS_ENVIRONMENT_VARIABLE)

--- a/python/ray/tests/test_basic_4.py
+++ b/python/ray/tests/test_basic_4.py
@@ -1,5 +1,6 @@
 # coding: utf-8
 import logging
+import math
 import os
 import subprocess
 import sys
@@ -141,6 +142,28 @@ def test_fork_support(shutdown_only):
         return ray.get(pool_factorial.remote())
 
     assert ray.get(g.remote()) == 5914
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="fork is not relevant on Windows.",
+)
+def test_driver_fork_after_init(shutdown_only):
+    """Test that fork() in the driver process works after ray.init().
+
+    ray.init() initializes gRPC, which spawns background threads. Without
+    GRPC_ENABLE_FORK_SUPPORT and GRPC_POLL_STRATEGY=poll set before gRPC
+    init, fork() in the driver deadlocks because the child inherits locked
+    mutexes from gRPC threads that don't exist in the child. See #59661.
+    """
+    ray.init()
+
+    import multiprocessing
+
+    ctx = multiprocessing.get_context("fork")
+    with ctx.Pool(1) as pool:
+        result = pool.apply(math.factorial, (6,))
+    assert result == 720
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
## Why are these changes needed?

Fixes #59661.

`ray.init()` initializes gRPC in the driver process, which spawns background threads. If user code (e.g. TensorFlow's `tf.data`, Python's `multiprocessing`) later calls `fork()`, the child inherits locked mutexes from gRPC threads that no longer exist in the child — causing a deadlock.

Ray already sets `GRPC_ENABLE_FORK_SUPPORT=1` and `GRPC_POLL_STRATEGY=poll` for **worker** processes (in `worker_pool.cc`, gated by `support_fork`), but never for the **driver** process itself. This means any `fork()` in user code running in the driver after `ray.init()` is unsafe.

### What this changes

Sets `GRPC_ENABLE_FORK_SUPPORT=1` and `GRPC_POLL_STRATEGY=poll` in `init()` (in `worker.py`) before any gRPC channel is created. Uses `os.environ.setdefault()` so explicit user overrides are respected. Gated on `sys.platform != "win32"` since fork is not relevant on Windows.

### Why this is safe

- `GRPC_POLL_STRATEGY=poll` is slightly less efficient than `epoll`/`kqueue`, but driver gRPC traffic is light (GCS client, dashboard) so the impact is negligible
- `setdefault` ensures we never override a user's explicit choice
- This matches what Ray already does for worker processes — just extends it to the driver

## Related issue number

Fixes #59661

## Checks

- [x] I've signed the [CLA](http://ray.io/cla)
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
- [x] I've added any new APIs to the API Reference.
- [x] I've made sure the tests are passing. Run the tests locally:
  - `pytest python/ray/tests/test_basic_4.py::test_driver_fork_after_init -v`