### PR TITLE
[Serve] Distinguish ActorUnavailableError from actor death in health checks

### DIFF
--- a/python/ray/serve/_private/constants.py
+++ b/python/ray/serve/_private/constants.py
@@ -321,6 +321,16 @@ PROXY_DRAIN_CHECK_PERIOD_S = 5
 #: being marked unhealthy.
 REPLICA_HEALTH_CHECK_UNHEALTHY_THRESHOLD = 3
 
+#: Consecutive failed health checks allowed before marking an actor unhealthy
+#: when the latest failure is ``ActorUnavailableError``. Applies to replicas and
+#: deployment-scoped actors. Application failures share this counter; a successful
+#: check resets it. Defaults to 3 to tolerate transient unavailability. Set it to
+#: 1 for immediate replacement. Higher values can delay replacement when actor
+#: death information is unavailable.
+REPLICA_ACTOR_UNAVAILABLE_UNHEALTHY_THRESHOLD = get_env_int_positive(
+    "RAY_SERVE_REPLICA_ACTOR_UNAVAILABLE_UNHEALTHY_THRESHOLD", 3
+)
+
 # Watchdog that detects a wedged user code event loop when user code runs in a
 # separate thread (RAY_SERVE_RUN_USER_CODE_IN_SEPARATE_THREAD=1) and no user-defined
 # check_health is present. The main loop periodically schedules asyncio.sleep(0) on

--- a/python/ray/serve/_private/deployment_state.py
+++ b/python/ray/serve/_private/deployment_state.py
@@ -30,6 +30,7 @@ from ray import ObjectRef, cloudpickle
 from ray._common import ray_constants
 from ray.actor import ActorHandle
 from ray.exceptions import (
+    ActorUnavailableError,
     RayActorError,
     RayError,
     RayTaskError,
@@ -81,6 +82,7 @@ from ray.serve._private.constants import (
     RAY_SERVE_SHUTDOWN_TIER_TIMEOUT_S,
     RAY_SERVE_STATUS_GAUGE_REPORT_INTERVAL_S,
     RAY_SERVE_USE_PACK_SCHEDULING_STRATEGY,
+    REPLICA_ACTOR_UNAVAILABLE_UNHEALTHY_THRESHOLD,
     REPLICA_HEALTH_CHECK_UNHEALTHY_THRESHOLD,
     REPLICA_STARTUP_SHUTDOWN_LATENCY_BUCKETS_MS,
     REQUEST_LATENCY_BUCKETS_MS,
@@ -313,6 +315,8 @@ class DeploymentActorWrapper:
             try:
                 ray.get(self._health_check_ref)
                 return ReplicaHealthCheckResponse.SUCCEEDED
+            except ActorUnavailableError:
+                return ReplicaHealthCheckResponse.ACTOR_UNAVAILABLE
             except RayActorError:
                 return ReplicaHealthCheckResponse.ACTOR_CRASHED
             except RayError as e:
@@ -377,6 +381,26 @@ class DeploymentActorWrapper:
                     "marking unhealthy."
                 )
                 self._healthy = False
+        elif response is ReplicaHealthCheckResponse.ACTOR_UNAVAILABLE:
+            self._consecutive_health_check_failures += 1
+            if (
+                self._consecutive_health_check_failures
+                >= REPLICA_ACTOR_UNAVAILABLE_UNHEALTHY_THRESHOLD
+            ):
+                logger.warning(
+                    f"Deployment actor '{self._config.name}' ({self._deployment_id}) "
+                    "is temporarily unavailable after "
+                    f"{self._consecutive_health_check_failures} consecutive failed "
+                    "health checks, marking it unhealthy."
+                )
+                self._healthy = False
+            else:
+                logger.warning(
+                    f"Deployment actor '{self._config.name}' ({self._deployment_id}) "
+                    "is temporarily unavailable "
+                    f"({self._consecutive_health_check_failures}/"
+                    f"{REPLICA_ACTOR_UNAVAILABLE_UNHEALTHY_THRESHOLD}); will retry."
+                )
         elif response is ReplicaHealthCheckResponse.ACTOR_CRASHED:
             logger.warning(
                 f"Deployment actor '{self._config.name}' ({self._deployment_id}) "
@@ -549,6 +573,7 @@ class ReplicaHealthCheckResponse(Enum):
     SUCCEEDED = 2
     APP_FAILURE = 3
     ACTOR_CRASHED = 4
+    ACTOR_UNAVAILABLE = 5
 
 
 @dataclass
@@ -1641,6 +1666,8 @@ class ActorReplicaWrapper:
             - APP_FAILURE if the active health check failed (or didn't return
               before the timeout).
             - ACTOR_CRASHED if the underlying actor crashed.
+            - ACTOR_UNAVAILABLE if the underlying actor is temporarily unavailable
+              and may recover (e.g. a transient network partition).
         """
         # Reset the last health check status for this check cycle.
         # We do this because _check_active_health_check is being called in a loop,
@@ -1663,6 +1690,10 @@ class ActorReplicaWrapper:
                 self._last_health_check_failed = False
                 # Health check succeeded without exception.
                 response = ReplicaHealthCheckResponse.SUCCEEDED
+            except ActorUnavailableError:
+                # Communication failed without confirmed actor death at the caller.
+                response = ReplicaHealthCheckResponse.ACTOR_UNAVAILABLE
+                self._last_health_check_failed = True
             except RayActorError:
                 # Health check failed due to actor crashing.
                 response = ReplicaHealthCheckResponse.ACTOR_CRASHED
@@ -1789,6 +1820,24 @@ class ActorReplicaWrapper:
                     "times in a row, marking it unhealthy."
                 )
                 self._healthy = False
+        elif response is ReplicaHealthCheckResponse.ACTOR_UNAVAILABLE:
+            self._consecutive_health_check_failures += 1
+            if (
+                self._consecutive_health_check_failures
+                >= REPLICA_ACTOR_UNAVAILABLE_UNHEALTHY_THRESHOLD
+            ):
+                logger.warning(
+                    f"Actor for {self._replica_id} is temporarily unavailable after "
+                    f"{self._consecutive_health_check_failures} consecutive failed "
+                    "health checks, marking it unhealthy."
+                )
+                self._healthy = False
+            else:
+                logger.warning(
+                    f"Actor for {self._replica_id} is temporarily unavailable "
+                    f"({self._consecutive_health_check_failures}/"
+                    f"{REPLICA_ACTOR_UNAVAILABLE_UNHEALTHY_THRESHOLD}); will retry."
+                )
         elif response is ReplicaHealthCheckResponse.ACTOR_CRASHED:
             # Actor crashed, mark the replica unhealthy immediately.
             logger.warning(

--- a/python/ray/serve/tests/unit/test_deployment_state.py
+++ b/python/ray/serve/tests/unit/test_deployment_state.py
@@ -9,6 +9,7 @@ import pytest
 import ray.serve._private.deployment_state as ds_mod
 from ray._common.ray_constants import DEFAULT_MAX_CONCURRENCY_ASYNC
 from ray._raylet import NodeID
+from ray.exceptions import ActorDiedError, ActorUnavailableError, RayError
 from ray.serve._private.application_state import ApplicationState
 from ray.serve._private.autoscaling_state import AutoscalingStateManager
 from ray.serve._private.common import (
@@ -920,6 +921,123 @@ class TestDeploymentActorWrapper:
                 code_version="v1",
             )
             wrapper.kill()  # should not raise
+
+    def _make_wrapper(self) -> DeploymentActorWrapper:
+        config = DeploymentActorConfig(name="counter", actor_class="builtins:object")
+        # A truthy handle satisfies `_should_start_new_deployment_actor_health_
+        # check()`; being a MagicMock means `check_health()` kicking off a new
+        # (mocked) health check never issues a real remote call. `__ray_ready__`
+        # must be set explicitly since MagicMock doesn't auto-mock dunder names.
+        mock_handle = MagicMock()
+        mock_handle.__ray_ready__ = MagicMock(
+            remote=MagicMock(return_value=MagicMock())
+        )
+        wrapper = DeploymentActorWrapper(
+            deployment_id=TEST_DEPLOYMENT_ID,
+            config=config,
+            code_version="v1",
+            recovered_handle=mock_handle,
+        )
+        return wrapper
+
+    def test_check_health_actor_unavailable_default_threshold(self):
+        """The default tolerates two unavailable failures and rejects the third."""
+        wrapper = self._make_wrapper()
+        with (
+            patch(
+                "ray.serve._private.deployment_state.check_obj_ref_ready_nowait",
+                return_value=True,
+            ),
+            patch(
+                "ray.serve._private.deployment_state.ray.get",
+                side_effect=ActorUnavailableError("net", None),
+            ),
+        ):
+            for failures in range(1, 4):
+                wrapper._health_check_ref = object()
+                assert wrapper.check_health() is (failures < 3)
+                assert wrapper._consecutive_health_check_failures == failures
+
+    def test_check_health_actor_unavailable_tolerates_threshold(self):
+        """With a threshold of 3, ActorUnavailableError should be tolerated for
+        that many consecutive failures before the deployment actor is marked
+        unhealthy, and a SUCCEEDED response in between should reset the
+        counter."""
+        wrapper = self._make_wrapper()
+        with patch(
+            "ray.serve._private.deployment_state.REPLICA_ACTOR_UNAVAILABLE_UNHEALTHY_THRESHOLD",
+            3,
+        ):
+            with (
+                patch(
+                    "ray.serve._private.deployment_state.check_obj_ref_ready_nowait",
+                    return_value=True,
+                ),
+                patch(
+                    "ray.serve._private.deployment_state.ray.get",
+                    side_effect=ActorUnavailableError("net", None),
+                ),
+            ):
+                wrapper._health_check_ref = object()
+                assert wrapper.check_health() is True
+                assert wrapper._consecutive_health_check_failures == 1
+
+                wrapper._health_check_ref = object()
+                assert wrapper.check_health() is True
+                assert wrapper._consecutive_health_check_failures == 2
+
+            # A successful health check in between resets the counter.
+            with (
+                patch(
+                    "ray.serve._private.deployment_state.check_obj_ref_ready_nowait",
+                    return_value=True,
+                ),
+                patch("ray.serve._private.deployment_state.ray.get"),
+            ):
+                wrapper._health_check_ref = object()
+                assert wrapper.check_health() is True
+                assert wrapper._consecutive_health_check_failures == 0
+
+            with (
+                patch(
+                    "ray.serve._private.deployment_state.check_obj_ref_ready_nowait",
+                    return_value=True,
+                ),
+                patch(
+                    "ray.serve._private.deployment_state.ray.get",
+                    side_effect=ActorUnavailableError("net", None),
+                ),
+            ):
+                # Failures 1, 2, then 3 crosses the threshold.
+                wrapper._health_check_ref = object()
+                assert wrapper.check_health() is True
+                wrapper._health_check_ref = object()
+                assert wrapper.check_health() is True
+                wrapper._health_check_ref = object()
+                assert wrapper.check_health() is False
+                assert wrapper._consecutive_health_check_failures == 3
+
+    def test_check_health_actor_died_marks_unhealthy_immediately(self):
+        """ActorDiedError (a plain actor crash) should mark the deployment actor
+        unhealthy immediately, regardless of the ActorUnavailableError
+        threshold."""
+        wrapper = self._make_wrapper()
+        with patch(
+            "ray.serve._private.deployment_state.REPLICA_ACTOR_UNAVAILABLE_UNHEALTHY_THRESHOLD",
+            3,
+        ):
+            with (
+                patch(
+                    "ray.serve._private.deployment_state.check_obj_ref_ready_nowait",
+                    return_value=True,
+                ),
+                patch(
+                    "ray.serve._private.deployment_state.ray.get",
+                    side_effect=ActorDiedError(),
+                ),
+            ):
+                wrapper._health_check_ref = object()
+                assert wrapper.check_health() is False
 
 
 def check_counts(
@@ -4330,6 +4448,156 @@ class TestActorReplicaWrapper:
             and replica_scheduling_request.actor_options["max_concurrency"]
             == max_ongoing_requests
         )
+
+    def _make_actor_replica(self) -> ActorReplicaWrapper:
+        actor_replica = ActorReplicaWrapper(
+            version=deployment_version("1"),
+            replica_id=ReplicaID(
+                "abc123",
+                deployment_id=DeploymentID(name="test_deployment", app_name="test_app"),
+            ),
+        )
+        # `_should_start_new_health_check()` requires a real actor handle;
+        # a MagicMock lets `check_health()` kick off (mocked) new health
+        # checks without making any real remote calls.
+        actor_replica._actor_handle = MagicMock()
+        return actor_replica
+
+    def test_check_health_actor_unavailable_default_threshold(self):
+        """The default tolerates two unavailable failures and rejects the third."""
+        actor_replica = self._make_actor_replica()
+        with (
+            patch(
+                "ray.serve._private.deployment_state.check_obj_ref_ready_nowait",
+                return_value=True,
+            ),
+            patch(
+                "ray.serve._private.deployment_state.ray.get",
+                side_effect=ActorUnavailableError("net", None),
+            ),
+        ):
+            for failures in range(1, 4):
+                actor_replica._health_check_ref = object()
+                assert actor_replica.check_health() is (failures < 3)
+                assert actor_replica._consecutive_health_check_failures == failures
+
+    def test_check_health_actor_unavailable_tolerates_threshold(self):
+        """With a threshold of 3, ActorUnavailableError should be tolerated for
+        that many consecutive failures before the replica is marked unhealthy, and
+        a SUCCEEDED response in between should reset the counter."""
+        actor_replica = self._make_actor_replica()
+        with patch(
+            "ray.serve._private.deployment_state.REPLICA_ACTOR_UNAVAILABLE_UNHEALTHY_THRESHOLD",
+            3,
+        ):
+            with (
+                patch(
+                    "ray.serve._private.deployment_state.check_obj_ref_ready_nowait",
+                    return_value=True,
+                ),
+                patch(
+                    "ray.serve._private.deployment_state.ray.get",
+                    side_effect=ActorUnavailableError("net", None),
+                ),
+            ):
+                actor_replica._health_check_ref = object()
+                assert actor_replica.check_health() is True
+                assert actor_replica._consecutive_health_check_failures == 1
+
+                actor_replica._health_check_ref = object()
+                assert actor_replica.check_health() is True
+                assert actor_replica._consecutive_health_check_failures == 2
+
+            # A successful health check in between resets the counter.
+            with (
+                patch(
+                    "ray.serve._private.deployment_state.check_obj_ref_ready_nowait",
+                    return_value=True,
+                ),
+                patch("ray.serve._private.deployment_state.ray.get"),
+            ):
+                actor_replica._health_check_ref = object()
+                assert actor_replica.check_health() is True
+                assert actor_replica._consecutive_health_check_failures == 0
+
+            with (
+                patch(
+                    "ray.serve._private.deployment_state.check_obj_ref_ready_nowait",
+                    return_value=True,
+                ),
+                patch(
+                    "ray.serve._private.deployment_state.ray.get",
+                    side_effect=ActorUnavailableError("net", None),
+                ),
+            ):
+                # Failures 1, 2, then 3 crosses the threshold.
+                actor_replica._health_check_ref = object()
+                assert actor_replica.check_health() is True
+                actor_replica._health_check_ref = object()
+                assert actor_replica.check_health() is True
+                actor_replica._health_check_ref = object()
+                assert actor_replica.check_health() is False
+                assert actor_replica._consecutive_health_check_failures == 3
+
+    def test_check_health_actor_died_marks_unhealthy_immediately(self):
+        """ActorDiedError (a plain actor crash) should mark the replica unhealthy
+        immediately, regardless of the ActorUnavailableError threshold."""
+        actor_replica = self._make_actor_replica()
+        with patch(
+            "ray.serve._private.deployment_state.REPLICA_ACTOR_UNAVAILABLE_UNHEALTHY_THRESHOLD",
+            3,
+        ):
+            with (
+                patch(
+                    "ray.serve._private.deployment_state.check_obj_ref_ready_nowait",
+                    return_value=True,
+                ),
+                patch(
+                    "ray.serve._private.deployment_state.ray.get",
+                    side_effect=ActorDiedError(),
+                ),
+            ):
+                actor_replica._health_check_ref = object()
+                assert actor_replica.check_health() is False
+
+
+@pytest.mark.parametrize("deployment_actor", [False, True])
+@pytest.mark.parametrize(
+    "failures, expected_health",
+    [
+        (
+            ["app", "unavailable", "unavailable", "unavailable"],
+            [True, True, True, False],
+        ),
+        (["unavailable", "unavailable", "app"], [True, True, False]),
+        (["app", "unavailable", "success", "unavailable"], [True, True, True, True]),
+        (["unavailable", "died"], [True, False]),
+    ],
+)
+def test_health_check_mixed_failures(
+    deployment_actor, failures, expected_health, monkeypatch
+):
+    """Mixed failures share a counter and use the latest failure's threshold."""
+    if deployment_actor:
+        wrapper = TestDeploymentActorWrapper()._make_wrapper()
+    else:
+        wrapper = TestActorReplicaWrapper()._make_actor_replica()
+    monkeypatch.setattr(ds_mod, "REPLICA_ACTOR_UNAVAILABLE_UNHEALTHY_THRESHOLD", 4)
+    monkeypatch.setattr(ds_mod, "REPLICA_HEALTH_CHECK_UNHEALTHY_THRESHOLD", 3)
+    monkeypatch.setattr(ds_mod, "DEPLOYMENT_ACTOR_HEALTH_CHECK_UNHEALTHY_THRESHOLD", 3)
+    monkeypatch.setattr(ds_mod, "check_obj_ref_ready_nowait", lambda ref: True)
+    errors = {
+        "app": RayError("application health check failed"),
+        "unavailable": ActorUnavailableError("network disruption", None),
+        "died": ActorDiedError(),
+        "success": None,
+    }
+    for failure, healthy in zip(failures, expected_health):
+        wrapper._health_check_ref = object()
+        with patch.object(ds_mod.ray, "get", side_effect=errors[failure]):
+            assert wrapper.check_health() is healthy
+        if failure == "success":
+            assert wrapper._consecutive_health_check_failures == 0
 
 
 def test_get_active_node_ids(mock_deployment_state_manager):

--- a/python/ray/serve/tests/unit/test_deployment_state.py
+++ b/python/ray/serve/tests/unit/test_deployment_state.py
@@ -922,7 +922,8 @@ class TestDeploymentActorWrapper:
             )
             wrapper.kill()  # should not raise
 
-    def _make_wrapper(self) -> DeploymentActorWrapper:
+    @staticmethod
+    def _make_wrapper() -> DeploymentActorWrapper:
         config = DeploymentActorConfig(name="counter", actor_class="builtins:object")
         # MagicMock does not automatically create __ray_ready__.
         mock_handle = MagicMock()
@@ -1015,22 +1016,22 @@ class TestDeploymentActorWrapper:
         unhealthy immediately, regardless of the ActorUnavailableError
         threshold."""
         wrapper = self._make_wrapper()
-        with patch(
-            "ray.serve._private.deployment_state.REPLICA_ACTOR_UNAVAILABLE_UNHEALTHY_THRESHOLD",
-            3,
+        with (
+            patch(
+                "ray.serve._private.deployment_state.REPLICA_ACTOR_UNAVAILABLE_UNHEALTHY_THRESHOLD",
+                3,
+            ),
+            patch(
+                "ray.serve._private.deployment_state.check_obj_ref_ready_nowait",
+                return_value=True,
+            ),
+            patch(
+                "ray.serve._private.deployment_state.ray.get",
+                side_effect=ActorDiedError(),
+            ),
         ):
-            with (
-                patch(
-                    "ray.serve._private.deployment_state.check_obj_ref_ready_nowait",
-                    return_value=True,
-                ),
-                patch(
-                    "ray.serve._private.deployment_state.ray.get",
-                    side_effect=ActorDiedError(),
-                ),
-            ):
-                wrapper._health_check_ref = object()
-                assert wrapper.check_health() is False
+            wrapper._health_check_ref = object()
+            assert wrapper.check_health() is False
 
 
 def check_counts(
@@ -4442,7 +4443,8 @@ class TestActorReplicaWrapper:
             == max_ongoing_requests
         )
 
-    def _make_actor_replica(self) -> ActorReplicaWrapper:
+    @staticmethod
+    def _make_actor_replica() -> ActorReplicaWrapper:
         actor_replica = ActorReplicaWrapper(
             version=deployment_version("1"),
             replica_id=ReplicaID(
@@ -4531,22 +4533,22 @@ class TestActorReplicaWrapper:
         """ActorDiedError (a plain actor crash) should mark the replica unhealthy
         immediately, regardless of the ActorUnavailableError threshold."""
         actor_replica = self._make_actor_replica()
-        with patch(
-            "ray.serve._private.deployment_state.REPLICA_ACTOR_UNAVAILABLE_UNHEALTHY_THRESHOLD",
-            3,
+        with (
+            patch(
+                "ray.serve._private.deployment_state.REPLICA_ACTOR_UNAVAILABLE_UNHEALTHY_THRESHOLD",
+                3,
+            ),
+            patch(
+                "ray.serve._private.deployment_state.check_obj_ref_ready_nowait",
+                return_value=True,
+            ),
+            patch(
+                "ray.serve._private.deployment_state.ray.get",
+                side_effect=ActorDiedError(),
+            ),
         ):
-            with (
-                patch(
-                    "ray.serve._private.deployment_state.check_obj_ref_ready_nowait",
-                    return_value=True,
-                ),
-                patch(
-                    "ray.serve._private.deployment_state.ray.get",
-                    side_effect=ActorDiedError(),
-                ),
-            ):
-                actor_replica._health_check_ref = object()
-                assert actor_replica.check_health() is False
+            actor_replica._health_check_ref = object()
+            assert actor_replica.check_health() is False
 
 
 @pytest.mark.parametrize("deployment_actor", [False, True])
@@ -4569,9 +4571,9 @@ def test_health_check_failure_thresholds(
 ):
     """Failures share a counter and use the latest failure's threshold."""
     if deployment_actor:
-        wrapper = TestDeploymentActorWrapper()._make_wrapper()
+        wrapper = TestDeploymentActorWrapper._make_wrapper()
     else:
-        wrapper = TestActorReplicaWrapper()._make_actor_replica()
+        wrapper = TestActorReplicaWrapper._make_actor_replica()
     monkeypatch.setattr(
         ds_mod, "REPLICA_ACTOR_UNAVAILABLE_UNHEALTHY_THRESHOLD", threshold
     )

--- a/python/ray/serve/tests/unit/test_deployment_state.py
+++ b/python/ray/serve/tests/unit/test_deployment_state.py
@@ -924,10 +924,7 @@ class TestDeploymentActorWrapper:
 
     def _make_wrapper(self) -> DeploymentActorWrapper:
         config = DeploymentActorConfig(name="counter", actor_class="builtins:object")
-        # A truthy handle satisfies `_should_start_new_deployment_actor_health_
-        # check()`; being a MagicMock means `check_health()` kicking off a new
-        # (mocked) health check never issues a real remote call. `__ray_ready__`
-        # must be set explicitly since MagicMock doesn't auto-mock dunder names.
+        # MagicMock does not automatically create __ray_ready__.
         mock_handle = MagicMock()
         mock_handle.__ray_ready__ = MagicMock(
             remote=MagicMock(return_value=MagicMock())
@@ -959,10 +956,7 @@ class TestDeploymentActorWrapper:
                 assert wrapper._consecutive_health_check_failures == failures
 
     def test_check_health_actor_unavailable_tolerates_threshold(self):
-        """With a threshold of 3, ActorUnavailableError should be tolerated for
-        that many consecutive failures before the deployment actor is marked
-        unhealthy, and a SUCCEEDED response in between should reset the
-        counter."""
+        """A successful check resets the counter before the threshold is reached."""
         wrapper = self._make_wrapper()
         with patch(
             "ray.serve._private.deployment_state.REPLICA_ACTOR_UNAVAILABLE_UNHEALTHY_THRESHOLD",
@@ -1008,7 +1002,6 @@ class TestDeploymentActorWrapper:
                     side_effect=ActorUnavailableError("net", None),
                 ),
             ):
-                # Failures 1, 2, then 3 crosses the threshold.
                 wrapper._health_check_ref = object()
                 assert wrapper.check_health() is True
                 wrapper._health_check_ref = object()
@@ -4457,9 +4450,7 @@ class TestActorReplicaWrapper:
                 deployment_id=DeploymentID(name="test_deployment", app_name="test_app"),
             ),
         )
-        # `_should_start_new_health_check()` requires a real actor handle;
-        # a MagicMock lets `check_health()` kick off (mocked) new health
-        # checks without making any real remote calls.
+        # Mock remote health-check calls.
         actor_replica._actor_handle = MagicMock()
         return actor_replica
 
@@ -4482,9 +4473,7 @@ class TestActorReplicaWrapper:
                 assert actor_replica._consecutive_health_check_failures == failures
 
     def test_check_health_actor_unavailable_tolerates_threshold(self):
-        """With a threshold of 3, ActorUnavailableError should be tolerated for
-        that many consecutive failures before the replica is marked unhealthy, and
-        a SUCCEEDED response in between should reset the counter."""
+        """A successful check resets the counter before the threshold is reached."""
         actor_replica = self._make_actor_replica()
         with patch(
             "ray.serve._private.deployment_state.REPLICA_ACTOR_UNAVAILABLE_UNHEALTHY_THRESHOLD",
@@ -4530,7 +4519,6 @@ class TestActorReplicaWrapper:
                     side_effect=ActorUnavailableError("net", None),
                 ),
             ):
-                # Failures 1, 2, then 3 crosses the threshold.
                 actor_replica._health_check_ref = object()
                 assert actor_replica.check_health() is True
                 actor_replica._health_check_ref = object()
@@ -4563,26 +4551,30 @@ class TestActorReplicaWrapper:
 
 @pytest.mark.parametrize("deployment_actor", [False, True])
 @pytest.mark.parametrize(
-    "failures, expected_health",
+    "threshold, failures, expected_health",
     [
+        (1, ["unavailable"], [False]),
         (
+            4,
             ["app", "unavailable", "unavailable", "unavailable"],
             [True, True, True, False],
         ),
-        (["unavailable", "unavailable", "app"], [True, True, False]),
-        (["app", "unavailable", "success", "unavailable"], [True, True, True, True]),
-        (["unavailable", "died"], [True, False]),
+        (4, ["unavailable", "unavailable", "app"], [True, True, False]),
+        (4, ["app", "unavailable", "success", "unavailable"], [True, True, True, True]),
+        (4, ["unavailable", "died"], [True, False]),
     ],
 )
-def test_health_check_mixed_failures(
-    deployment_actor, failures, expected_health, monkeypatch
+def test_health_check_failure_thresholds(
+    deployment_actor, threshold, failures, expected_health, monkeypatch
 ):
-    """Mixed failures share a counter and use the latest failure's threshold."""
+    """Failures share a counter and use the latest failure's threshold."""
     if deployment_actor:
         wrapper = TestDeploymentActorWrapper()._make_wrapper()
     else:
         wrapper = TestActorReplicaWrapper()._make_actor_replica()
-    monkeypatch.setattr(ds_mod, "REPLICA_ACTOR_UNAVAILABLE_UNHEALTHY_THRESHOLD", 4)
+    monkeypatch.setattr(
+        ds_mod, "REPLICA_ACTOR_UNAVAILABLE_UNHEALTHY_THRESHOLD", threshold
+    )
     monkeypatch.setattr(ds_mod, "REPLICA_HEALTH_CHECK_UNHEALTHY_THRESHOLD", 3)
     monkeypatch.setattr(ds_mod, "DEPLOYMENT_ACTOR_HEALTH_CHECK_UNHEALTHY_THRESHOLD", 3)
     monkeypatch.setattr(ds_mod, "check_obj_ref_ready_nowait", lambda ref: True)


### PR DESCRIPTION
## Description

This PR distinguishes temporary actor unavailability from actor death in Serve health checks and adds a configurable failure threshold before replacement.

Previously, health checks caught `ActorUnavailableError` in the except `RayActorError` handler and immediately marked the replica unhealthy. This means a temporary network issue can cause a live replica to be replaced, even when its node is still ALIVE. Increasing `health_check_timeout_s` does not help here because the health-check ObjectRef is already ready, and resolving it raises an exception.

Ray Core already distinguishes unavailable actors from dead actors, and the DeploymentHandle routing path handles `ActorUnavailableError` separately. To keep health checks consistent with that distinction, this PR adds an `ACTOR_UNAVAILABLE` response and uses a configurable failure threshold for it.

The default threshold is 3, so transient unavailability is tolerated by default. Set the threshold to 1 to retain the previous immediate-replacement behavior. `ActorDiedError` still marks the actor unhealthy immediately. The same handling is applied to both replica and deployment-scoped actor health checks.

## Related issues

Closes: https://github.com/ray-project/ray/issues/65985

## Additional information

### Implementation details

Health-check results are handled as follows:

| Result | Before | After |
|---|---|---|
| `ActorUnavailableError` | Classified as `ACTOR_CRASHED`; immediate replacement | Classified as `ACTOR_UNAVAILABLE`; uses the configurable threshold, default 3 |
| `ActorDiedError` | Immediately unhealthy | Same as before |
| Application failure | Existing consecutive-failure threshold | Same as before |
| Successful health check | Reset the failure counter | Same as before |

The new setting is `RAY_SERVE_REPLICA_ACTOR_UNAVAILABLE_UNHEALTHY_THRESHOLD`. Set this environment variable in the Serve controller actor's environment before the controller starts.

Both application failures and `ActorUnavailableError` increment the existing consecutive health-check failure counter, which resets after a successful check. This ensures that alternating failure types still count toward replacement. The most recent failure type determines which threshold applies. I’m open to using separate counters if independent tracking is preferred.

A higher threshold allows more time for communication to recover before the actor is replaced. It can also delay replacement if the actor has actually died but the caller has not received that information yet.

### Changed behavior (observed)

I compared the original and patched versions in a local two-node Ray 2.56.0 cluster, with a 10-second health-check period and a 300-second timeout.

| Network fault | Original | Patched, threshold 5 |
|---|---|---|
| Replica RPC traffic rejected for 20 seconds (using iptables REJECT to trigger RPC errors without waiting for a timeout) | Live replica replaced; the original actor’s recorded death cause was `RAY_KILL` | Same actor ID and PID; an in-memory marker initialized at replica startup was preserved." |
| About 22 seconds of head/worker TCP disruption, including GCS and ray_syncer | Live replica replaced while the node remained ALIVE | Replica preserved; health check succeeded after connectivity returned |

In the broader partition test, both versions logged the syncer disconnection and the RPC failure. With the patch, the controller logged:

```text
Actor for Replica(id='u85zuux9', deployment='Probe', app='health-repro') is temporarily unavailable (1/5); will retry.
Replica(id='u85zuux9', deployment='Probe', app='health-repro') passed the health check after 1 consecutive failures.
```

I also killed the replica process with SIGKILL while using the patch and threshold 5. Serve still replaced it at the next failed health check without waiting for five failures.

### Tests

```bash
python -m pytest --import-mode=importlib -q \
  --pyargs ray.serve.tests.unit.test_deployment_state
# 268 passed in 6.18s
```

Added unit tests for both replica and deployment-scoped actor health checks:

- Temporary unavailability is tolerated until the default threshold of 3 is reached.
- The configured failure threshold is respected, and a successful health check resets the counter.
- `ActorDiedError` immediately marks the actor unhealthy.
- Application failures and `ActorUnavailableError` share the failure counter, with the threshold determined by the most recent failure type.

### Duplicate check and AI assistance

I searched PRs for `ActorUnavailableError` and serve health check, and both open and closed issues for `ActorUnavailableError`. I found no existing fix for this controller health-check behavior.

AI assistance was used for investigation, implementation, local validation, and drafting this description.