### PR TITLE
[cherry-pick][2.59.0][serve] Reserve per-replica memory in controller benchmark to stop OOM kills at the 8K checkpoint (#65847)

### DIFF
--- a/python/ray/serve/_private/benchmarks/common.py
+++ b/python/ray/serve/_private/benchmarks/common.py
@@ -387,11 +387,16 @@ _CONTROLLER_AUTOSCALING_CONFIG = {
 }
 
 _CONTROLLER_WAITER_TIMEOUT_S = 2400
-# Halve the reservation as the target doubles past 4096 so peak cluster CPU stays
-# flat (~1638 CPU, ~205 nodes); these replicas are idle waiters, so a lighter
-# reservation changes packing density only, not per-replica work.
+# Halve the CPU reservation as the target doubles past 4096; these replicas are
+# idle waiters, so the lighter reservation only packs them more densely. Node
+# count above the threshold is governed by the per-node replica cap below.
 _CONTROLLER_REPLICA_NUM_CPUS = 0.4
 _CONTROLLER_DENSE_PACK_ABOVE = 4096
+# Dense packing is memory-bound, not CPU-bound: each replica process has ~600MB
+# RSS however small its CPU reservation, and 40/node OOMs a 32GB worker (#65847).
+# 34/node keeps nodes at ~85% of the memory-monitor kill threshold (~241 nodes
+# at 8192). At or below the threshold the cap is inert: CPU packs 20/node.
+_CONTROLLER_DENSE_PACK_MAX_REPLICAS_PER_NODE = 34
 
 
 def _controller_replica_num_cpus(target_replicas: int) -> float:
@@ -430,6 +435,7 @@ class ControllerBenchHelloWorld:
     max_ongoing_requests=2,
     graceful_shutdown_timeout_s=1,
     ray_actor_options={"num_cpus": _CONTROLLER_REPLICA_NUM_CPUS},
+    max_replicas_per_node=_CONTROLLER_DENSE_PACK_MAX_REPLICAS_PER_NODE,
 )
 class ControllerBenchMetricsGenerator:
     """Autoscaling deployment that generates handle metrics to stress the controller."""
@@ -701,7 +707,7 @@ async def run_controller_benchmark(
                 ray_actor_options={
                     **(ControllerBenchMetricsGenerator.ray_actor_options or {}),
                     "num_cpus": _controller_replica_num_cpus(target_replicas),
-                }
+                },
             ).bind(hello_world)
             handle = serve.run(app, name="default", route_prefix=None)
 

--- a/release/serve_tests/compute_tpl_8_cpu_autoscaling.yaml
+++ b/release/serve_tests/compute_tpl_8_cpu_autoscaling.yaml
@@ -20,8 +20,10 @@ worker_nodes:
       # smaller min workers will make the head node cpu usage very high, and crash the head node.
       # issue: https://github.com/ray-project/ray/issues/18908
       min_nodes: 5
-      # 4096 max replicas
-      max_nodes: 220
+      # Sized for the 8192-replica controller-benchmark checkpoint: the per-node
+      # replica cap (serve/_private/benchmarks/common.py) gives ~241 nodes, plus
+      # slack. A cap, not a target; the autoscaler launches what placement needs.
+      max_nodes: 280
       market_type: ON_DEMAND
       # New SDK's `resources` is a full override, so include `CPU: 8`
       # explicitly alongside the custom `proxy` resource.


### PR DESCRIPTION
Cherry-pick of #65847 (master commit 8b6eb72340edcbdad130b790d61806bda1b7394a) onto releases/2.59.0.

Fixes the serve_controller_benchmark failure on the 2.59.0 release-test runs (deployment went UNHEALTHY / replica health-check failure from OOM kills at the 8K-replica checkpoint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)