### PR TITLE
[cherry-pick][2.59.0][Serve] Import jinja2 lazily and declare it in the serve extra (#65542)

### DIFF
--- a/python/deplocks/base_deps/ray_base_deps_tpu_py3.10.lock
+++ b/python/deplocks/base_deps/ray_base_deps_tpu_py3.10.lock
@@ -1142,10 +1142,12 @@ jaxlib==0.5.1 \
     #   chex
     #   jax
     #   optax
-jinja2==3.1.6 ; sys_platform != 'win32' \
+jinja2==3.1.6 \
     --hash=sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d \
     --hash=sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67
-    # via memray
+    # via
+    #   memray
+    #   ray
 jmespath==1.1.0 \
     --hash=sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d \
     --hash=sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64

--- a/python/deplocks/base_deps/ray_base_deps_tpu_py3.11.lock
+++ b/python/deplocks/base_deps/ray_base_deps_tpu_py3.11.lock
@@ -1126,10 +1126,12 @@ jaxlib==0.10.0 \
     # via
     #   jax
     #   optax
-jinja2==3.1.6 ; sys_platform != 'win32' \
+jinja2==3.1.6 \
     --hash=sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d \
     --hash=sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67
-    # via memray
+    # via
+    #   memray
+    #   ray
 jmespath==1.1.0 \
     --hash=sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d \
     --hash=sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64

--- a/python/deplocks/base_deps/ray_base_deps_tpu_py3.12.lock
+++ b/python/deplocks/base_deps/ray_base_deps_tpu_py3.12.lock
@@ -1126,10 +1126,12 @@ jaxlib==0.10.0 \
     # via
     #   jax
     #   optax
-jinja2==3.1.6 ; sys_platform != 'win32' \
+jinja2==3.1.6 \
     --hash=sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d \
     --hash=sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67
-    # via memray
+    # via
+    #   memray
+    #   ray
 jmespath==1.1.0 \
     --hash=sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d \
     --hash=sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64

--- a/python/deplocks/base_deps/ray_base_deps_tpu_py3.13.lock
+++ b/python/deplocks/base_deps/ray_base_deps_tpu_py3.13.lock
@@ -1126,10 +1126,12 @@ jaxlib==0.10.0 \
     # via
     #   jax
     #   optax
-jinja2==3.1.6 ; sys_platform != 'win32' \
+jinja2==3.1.6 \
     --hash=sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d \
     --hash=sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67
-    # via memray
+    # via
+    #   memray
+    #   ray
 jmespath==1.1.0 \
     --hash=sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d \
     --hash=sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64

--- a/python/deplocks/base_deps/ray_base_deps_tpu_py3.14.lock
+++ b/python/deplocks/base_deps/ray_base_deps_tpu_py3.14.lock
@@ -1140,10 +1140,12 @@ jaxlib==0.10.0 \
     # via
     #   jax
     #   optax
-jinja2==3.1.6 ; sys_platform != 'win32' \
+jinja2==3.1.6 \
     --hash=sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d \
     --hash=sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67
-    # via memray
+    # via
+    #   memray
+    #   ray
 jmespath==1.1.0 \
     --hash=sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d \
     --hash=sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64

--- a/python/deplocks/base_extra_testdeps/ray-base_extra_testdeps_py3.10.lock
+++ b/python/deplocks/base_extra_testdeps/ray-base_extra_testdeps_py3.10.lock
@@ -2197,6 +2197,7 @@ jinja2==3.1.6 \
     #   jupyterlab-server
     #   memray
     #   nbconvert
+    #   ray
 jmespath==1.1.0 \
     --hash=sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d \
     --hash=sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64

--- a/python/deplocks/base_extra_testdeps/ray-base_extra_testdeps_py3.11.lock
+++ b/python/deplocks/base_extra_testdeps/ray-base_extra_testdeps_py3.11.lock
@@ -1524,6 +1524,7 @@ jinja2==3.1.6 \
     #   jupyterlab-server
     #   memray
     #   nbconvert
+    #   ray
 jmespath==1.1.0 \
     --hash=sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d \
     --hash=sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64

--- a/python/deplocks/base_extra_testdeps/ray-base_extra_testdeps_py3.12.lock
+++ b/python/deplocks/base_extra_testdeps/ray-base_extra_testdeps_py3.12.lock
@@ -1524,6 +1524,7 @@ jinja2==3.1.6 \
     #   jupyterlab-server
     #   memray
     #   nbconvert
+    #   ray
 jmespath==1.1.0 \
     --hash=sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d \
     --hash=sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64

--- a/python/deplocks/base_extra_testdeps/ray-base_extra_testdeps_py3.13.lock
+++ b/python/deplocks/base_extra_testdeps/ray-base_extra_testdeps_py3.13.lock
@@ -1532,6 +1532,7 @@ jinja2==3.1.6 \
     #   jupyterlab-server
     #   memray
     #   nbconvert
+    #   ray
 jmespath==1.1.0 \
     --hash=sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d \
     --hash=sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64

--- a/python/deplocks/base_extra_testdeps/ray-base_extra_testdeps_py3.14.lock
+++ b/python/deplocks/base_extra_testdeps/ray-base_extra_testdeps_py3.14.lock
@@ -1499,6 +1499,7 @@ jinja2==3.1.6 \
     #   jupyterlab-server
     #   memray
     #   nbconvert
+    #   ray
 jmespath==1.1.0 \
     --hash=sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d \
     --hash=sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64

--- a/python/deplocks/base_extra_testdeps/ray-gpu-base_extra_testdeps_py3.10.lock
+++ b/python/deplocks/base_extra_testdeps/ray-gpu-base_extra_testdeps_py3.10.lock
@@ -2165,6 +2165,7 @@ jinja2==3.1.6 \
     #   jupyterlab-server
     #   memray
     #   nbconvert
+    #   ray
 jmespath==1.1.0 \
     --hash=sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d \
     --hash=sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64

--- a/python/deplocks/base_extra_testdeps/ray-llm-base_extra_testdeps_py3.11.lock
+++ b/python/deplocks/base_extra_testdeps/ray-llm-base_extra_testdeps_py3.11.lock
@@ -1686,6 +1686,7 @@ jinja2==3.1.6 \
     #   jupyterlab-server
     #   memray
     #   nbconvert
+    #   ray
 jmespath==1.1.0 \
     --hash=sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d \
     --hash=sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64

--- a/python/deplocks/base_extra_testdeps/ray-llm-base_extra_testdeps_py3.12.lock
+++ b/python/deplocks/base_extra_testdeps/ray-llm-base_extra_testdeps_py3.12.lock
@@ -1686,6 +1686,7 @@ jinja2==3.1.6 \
     #   jupyterlab-server
     #   memray
     #   nbconvert
+    #   ray
 jmespath==1.1.0 \
     --hash=sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d \
     --hash=sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64

--- a/python/deplocks/base_extra_testdeps/ray-ml-base_extra_testdeps_py3.10.lock
+++ b/python/deplocks/base_extra_testdeps/ray-ml-base_extra_testdeps_py3.10.lock
@@ -2501,6 +2501,7 @@ jinja2==3.1.6 \
     #   jupyterlab-server
     #   memray
     #   nbconvert
+    #   ray
     #   torch
 jmespath==1.1.0 \
     --hash=sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d \

--- a/python/deplocks/base_slim/ray_base_slim_py3.10.lock
+++ b/python/deplocks/base_slim/ray_base_slim_py3.10.lock
@@ -1307,6 +1307,7 @@ jinja2==3.1.6 \
     #   jupyterlab-server
     #   memray
     #   nbconvert
+    #   ray
 jmespath==1.1.0 \
     --hash=sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d \
     --hash=sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64

--- a/python/deplocks/base_slim/ray_base_slim_py3.11.lock
+++ b/python/deplocks/base_slim/ray_base_slim_py3.11.lock
@@ -1295,6 +1295,7 @@ jinja2==3.1.6 \
     #   jupyterlab-server
     #   memray
     #   nbconvert
+    #   ray
 jmespath==1.1.0 \
     --hash=sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d \
     --hash=sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64

--- a/python/deplocks/base_slim/ray_base_slim_py3.12.lock
+++ b/python/deplocks/base_slim/ray_base_slim_py3.12.lock
@@ -1295,6 +1295,7 @@ jinja2==3.1.6 \
     #   jupyterlab-server
     #   memray
     #   nbconvert
+    #   ray
 jmespath==1.1.0 \
     --hash=sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d \
     --hash=sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64

--- a/python/deplocks/base_slim/ray_base_slim_py3.13.lock
+++ b/python/deplocks/base_slim/ray_base_slim_py3.13.lock
@@ -1295,6 +1295,7 @@ jinja2==3.1.6 \
     #   jupyterlab-server
     #   memray
     #   nbconvert
+    #   ray
 jmespath==1.1.0 \
     --hash=sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d \
     --hash=sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64

--- a/python/deplocks/base_slim/ray_base_slim_py3.14.lock
+++ b/python/deplocks/base_slim/ray_base_slim_py3.14.lock
@@ -1252,6 +1252,7 @@ jinja2==3.1.6 \
     #   jupyterlab-server
     #   memray
     #   nbconvert
+    #   ray
 jmespath==1.1.0 \
     --hash=sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d \
     --hash=sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64

--- a/python/deplocks/ci/core-build-ci_depset_py3.10.lock
+++ b/python/deplocks/ci/core-build-ci_depset_py3.10.lock
@@ -2140,6 +2140,7 @@ jinja2==3.1.6 \
     #   gradio
     #   memray
     #   moto
+    #   ray
     #   torch
     #   torch-geometric
 jmespath==1.1.0 \

--- a/python/deplocks/ci/core-build-ci_depset_py3.12.lock
+++ b/python/deplocks/ci/core-build-ci_depset_py3.12.lock
@@ -2093,6 +2093,7 @@ jinja2==3.1.6 \
     #   gradio
     #   memray
     #   moto
+    #   ray
     #   torch
     #   torch-geometric
 jmespath==1.1.0 \

--- a/python/deplocks/ci/core-gpu-cu130-build-ci_depset_py3.10.lock
+++ b/python/deplocks/ci/core-gpu-cu130-build-ci_depset_py3.10.lock
@@ -2110,6 +2110,7 @@ jinja2==3.1.6 \
     #   gradio
     #   memray
     #   moto
+    #   ray
     #   torch
     #   torch-geometric
 jmespath==1.1.0 \

--- a/python/deplocks/ci/core-gpu-cu130-build-ci_depset_py3.12.lock
+++ b/python/deplocks/ci/core-gpu-cu130-build-ci_depset_py3.12.lock
@@ -2174,6 +2174,7 @@ jinja2==3.1.6 \
     #   gradio
     #   memray
     #   moto
+    #   ray
     #   torch
     #   torch-geometric
 jmespath==1.1.0 \

--- a/python/deplocks/ci/core-gpubuild-ci_depset_py3.10.lock
+++ b/python/deplocks/ci/core-gpubuild-ci_depset_py3.10.lock
@@ -2110,6 +2110,7 @@ jinja2==3.1.6 \
     #   gradio
     #   memray
     #   moto
+    #   ray
     #   torch
     #   torch-geometric
 jmespath==1.1.0 \

--- a/python/deplocks/ci/core-gpubuild-ci_depset_py3.12.lock
+++ b/python/deplocks/ci/core-gpubuild-ci_depset_py3.12.lock
@@ -2174,6 +2174,7 @@ jinja2==3.1.6 \
     #   gradio
     #   memray
     #   moto
+    #   ray
     #   torch
     #   torch-geometric
 jmespath==1.1.0 \

--- a/python/deplocks/ci/data-base-ci_depset_py3.10.lock
+++ b/python/deplocks/ci/data-base-ci_depset_py3.10.lock
@@ -2061,6 +2061,7 @@ jinja2==3.1.6 \
     #   distributed
     #   flask
     #   memray
+    #   ray
     #   torch
     #   torch-geometric
 jmespath==1.1.0 \

--- a/python/deplocks/ci/data-base-ci_depset_py3.11.lock
+++ b/python/deplocks/ci/data-base-ci_depset_py3.11.lock
@@ -2067,6 +2067,7 @@ jinja2==3.1.6 \
     #   distributed
     #   flask
     #   memray
+    #   ray
     #   torch
     #   torch-geometric
 jmespath==1.1.0 \

--- a/python/deplocks/ci/data-base-ci_depset_py3.12.lock
+++ b/python/deplocks/ci/data-base-ci_depset_py3.12.lock
@@ -2192,6 +2192,7 @@ jinja2==3.1.6 \
     #   distributed
     #   flask
     #   memray
+    #   ray
     #   torch
     #   torch-geometric
 jmespath==1.1.0 \

--- a/python/deplocks/ci/docgpu_depset_py3.10.lock
+++ b/python/deplocks/ci/docgpu_depset_py3.10.lock
@@ -2808,6 +2808,7 @@ jinja2==3.1.6 \
     #   memray
     #   moto
     #   nbconvert
+    #   ray
     #   torch
     #   torch-geometric
 jmespath==1.1.0 \

--- a/python/deplocks/ci/docgpu_depset_py3.12.lock
+++ b/python/deplocks/ci/docgpu_depset_py3.12.lock
@@ -2698,6 +2698,7 @@ jinja2==3.1.6 \
     #   memray
     #   moto
     #   nbconvert
+    #   ray
     #   torch
     #   torch-geometric
 jmespath==1.1.0 \

--- a/python/deplocks/ci/macos_depset_py3.10.lock
+++ b/python/deplocks/ci/macos_depset_py3.10.lock
@@ -1769,6 +1769,7 @@ jinja2==3.1.6 \
     #   gradio
     #   memray
     #   moto
+    #   ray
     #   torch
 jmespath==1.1.0 \
     --hash=sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d \

--- a/python/deplocks/ci/ml-build-ci_depset_py3.10.lock
+++ b/python/deplocks/ci/ml-build-ci_depset_py3.10.lock
@@ -1982,6 +1982,7 @@ jinja2==3.1.6 \
     #   jupyterlab-server
     #   memray
     #   nbconvert
+    #   ray
     #   torch
     #   torch-geometric
 jmespath==1.1.0 \

--- a/python/deplocks/ci/ml-build-ci_depset_py3.12.lock
+++ b/python/deplocks/ci/ml-build-ci_depset_py3.12.lock
@@ -1781,6 +1781,7 @@ jinja2==3.1.6 \
     #   jupyterlab-server
     #   memray
     #   nbconvert
+    #   ray
     #   torch
     #   torch-geometric
 jmespath==1.1.0 \

--- a/python/deplocks/ci/ml-gpubuild-ci_depset_py3.10.lock
+++ b/python/deplocks/ci/ml-gpubuild-ci_depset_py3.10.lock
@@ -1964,6 +1964,7 @@ jinja2==3.1.6 \
     #   jupyterlab-server
     #   memray
     #   nbconvert
+    #   ray
     #   torch
     #   torch-geometric
 jmespath==1.1.0 \

--- a/python/deplocks/ci/ml-gpubuild-ci_depset_py3.12.lock
+++ b/python/deplocks/ci/ml-gpubuild-ci_depset_py3.12.lock
@@ -1862,6 +1862,7 @@ jinja2==3.1.6 \
     #   jupyterlab-server
     #   memray
     #   nbconvert
+    #   ray
     #   torch
     #   torch-geometric
 jmespath==1.1.0 \

--- a/python/deplocks/ci/ml-lightning1gpubuild-ci_depset_py3.10.lock
+++ b/python/deplocks/ci/ml-lightning1gpubuild-ci_depset_py3.10.lock
@@ -1963,6 +1963,7 @@ jinja2==3.1.6 \
     #   jupyterlab-server
     #   memray
     #   nbconvert
+    #   ray
     #   torch
     #   torch-geometric
 jmespath==1.1.0 \

--- a/python/deplocks/ci/ml-torchft-ci_depset_py3.10.lock
+++ b/python/deplocks/ci/ml-torchft-ci_depset_py3.10.lock
@@ -1983,6 +1983,7 @@ jinja2==3.1.6 \
     #   jupyterlab-server
     #   memray
     #   nbconvert
+    #   ray
     #   torch
     #   torch-geometric
 jmespath==1.1.0 \

--- a/python/deplocks/ci/relaxed_data-ci_depset_py3.10.lock
+++ b/python/deplocks/ci/relaxed_data-ci_depset_py3.10.lock
@@ -2044,6 +2044,7 @@ jinja2==3.1.6 \
 #   distributed
 #   flask
 #   memray
+#   ray
 #   torch
 #   torch-geometric
 jmespath==1.1.0 \

--- a/python/deplocks/ci/relaxed_data-ci_depset_py3.12.lock
+++ b/python/deplocks/ci/relaxed_data-ci_depset_py3.12.lock
@@ -2175,6 +2175,7 @@ jinja2==3.1.6 \
 #   distributed
 #   flask
 #   memray
+#   ray
 #   torch
 #   torch-geometric
 jmespath==1.1.0 \

--- a/python/deplocks/ci/relaxed_windows-tests-ci_depset_py3.10.lock
+++ b/python/deplocks/ci/relaxed_windows-tests-ci_depset_py3.10.lock
@@ -1824,6 +1824,7 @@ jinja2==3.1.6 \
 # via
 #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
 #   -r python/requirements/test-requirements.txt
+#   -r python/requirements.txt
 #   flask
 #   moto
 #   torch

--- a/python/deplocks/ci/rllib-build-ci_depset_py3.10.lock
+++ b/python/deplocks/ci/rllib-build-ci_depset_py3.10.lock
@@ -1623,6 +1623,7 @@ jinja2==3.1.6 \
     #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
     #   flask
     #   memray
+    #   ray
     #   torch
     #   torch-geometric
 jmespath==1.1.0 \

--- a/python/deplocks/ci/rllib-build-ci_depset_py3.12.lock
+++ b/python/deplocks/ci/rllib-build-ci_depset_py3.12.lock
@@ -1567,6 +1567,7 @@ jinja2==3.1.6 \
     #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
     #   flask
     #   memray
+    #   ray
     #   torch
     #   torch-geometric
 jmespath==1.1.0 \

--- a/python/deplocks/ci/rllib-gpubuild-ci_depset_py3.10.lock
+++ b/python/deplocks/ci/rllib-gpubuild-ci_depset_py3.10.lock
@@ -1605,6 +1605,7 @@ jinja2==3.1.6 \
     #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
     #   flask
     #   memray
+    #   ray
     #   torch
     #   torch-geometric
 jmespath==1.1.0 \

--- a/python/deplocks/ci/rllib-gpubuild-ci_depset_py3.12.lock
+++ b/python/deplocks/ci/rllib-gpubuild-ci_depset_py3.12.lock
@@ -1648,6 +1648,7 @@ jinja2==3.1.6 \
     #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
     #   flask
     #   memray
+    #   ray
     #   torch
     #   torch-geometric
 jmespath==1.1.0 \

--- a/python/deplocks/ci/serve_base_depset_py3.10.lock
+++ b/python/deplocks/ci/serve_base_depset_py3.10.lock
@@ -1318,6 +1318,7 @@ jinja2==3.1.6 \
     #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
     #   gradio
     #   memray
+    #   ray
     #   torch
 jmespath==1.1.0 \
     --hash=sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d \

--- a/python/deplocks/ci/serve_base_depset_py3.12.lock
+++ b/python/deplocks/ci/serve_base_depset_py3.12.lock
@@ -1304,6 +1304,7 @@ jinja2==3.1.6 \
     #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
     #   gradio
     #   memray
+    #   ray
     #   torch
 jmespath==1.1.0 \
     --hash=sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d \

--- a/python/deplocks/ci/serve_ci_depset_py3.10.lock
+++ b/python/deplocks/ci/serve_ci_depset_py3.10.lock
@@ -1317,6 +1317,7 @@ jinja2==3.1.6 \
 #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
 #   gradio
 #   memray
+#   ray
 #   torch
 jmespath==1.1.0 \
     --hash=sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d \

--- a/python/deplocks/ci/serve_ci_depset_py3.12.lock
+++ b/python/deplocks/ci/serve_ci_depset_py3.12.lock
@@ -1303,6 +1303,7 @@ jinja2==3.1.6 \
 #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
 #   gradio
 #   memray
+#   ray
 #   torch
 jmespath==1.1.0 \
     --hash=sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d \

--- a/python/deplocks/ci/windows-tests-ci_depset_py3.10.lock
+++ b/python/deplocks/ci/windows-tests-ci_depset_py3.10.lock
@@ -1825,6 +1825,7 @@ jinja2==3.1.6 \
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
     #   -r python/requirements/test-requirements.txt
+    #   -r python/requirements.txt
     #   flask
     #   moto
     #   torch

--- a/python/deplocks/docs/doctest_depset_py3.10.lock
+++ b/python/deplocks/docs/doctest_depset_py3.10.lock
@@ -2826,6 +2826,7 @@ jinja2==3.1.6 \
     #   memray
     #   moto
     #   nbconvert
+    #   ray
     #   torch
     #   torch-geometric
 jmespath==1.1.0 \

--- a/python/deplocks/llm/ray_py312_cpu.lock
+++ b/python/deplocks/llm/ray_py312_cpu.lock
@@ -891,11 +891,12 @@ importlib-metadata==6.11.0 \
     # via
     #   -c python/deplocks/llm/ray_test_py312_cpu.lock
     #   opentelemetry-api
-jinja2==3.1.6 ; sys_platform != 'win32' \
+jinja2==3.1.6 \
     --hash=sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d \
     --hash=sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67
     # via
     #   -c python/deplocks/llm/ray_test_py312_cpu.lock
+    #   -r python/requirements.txt
     #   memray
 jsonschema==4.24.1 \
     --hash=sha256:6b916866aa0b61437785f1277aa2cbd63512e8d4b47151072ef13292049b4627 \
@@ -990,7 +991,7 @@ markdown-it-py==2.2.0 \
     #   mdit-py-plugins
     #   rich
     #   textual
-markupsafe==3.0.3 ; sys_platform != 'win32' \
+markupsafe==3.0.3 \
     --hash=sha256:d6dd0be5b5b189d31db7cda48b91d7e0a9795f31430b7f271219ab30f1d3ac9d
     # via
     #   -c python/deplocks/llm/ray_test_py312_cpu.lock

--- a/python/deplocks/llm/ray_py312_cu130.lock
+++ b/python/deplocks/llm/ray_py312_cu130.lock
@@ -891,11 +891,12 @@ importlib-metadata==6.11.0 \
     # via
     #   -c python/deplocks/llm/ray_test_py312_cu130.lock
     #   opentelemetry-api
-jinja2==3.1.6 ; sys_platform != 'win32' \
+jinja2==3.1.6 \
     --hash=sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d \
     --hash=sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67
     # via
     #   -c python/deplocks/llm/ray_test_py312_cu130.lock
+    #   -r python/requirements.txt
     #   memray
 jsonschema==4.24.1 \
     --hash=sha256:6b916866aa0b61437785f1277aa2cbd63512e8d4b47151072ef13292049b4627 \
@@ -990,7 +991,7 @@ markdown-it-py==2.2.0 \
     #   mdit-py-plugins
     #   rich
     #   textual
-markupsafe==3.0.3 ; sys_platform != 'win32' \
+markupsafe==3.0.3 \
     --hash=sha256:d6dd0be5b5b189d31db7cda48b91d7e0a9795f31430b7f271219ab30f1d3ac9d
     # via
     #   -c python/deplocks/llm/ray_test_py312_cu130.lock

--- a/python/deplocks/llm/ray_test_py312_cpu.lock
+++ b/python/deplocks/llm/ray_test_py312_cpu.lock
@@ -1334,6 +1334,7 @@ jinja2==3.1.6 \
     --hash=sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
+    #   -r python/requirements.txt
     #   jupyter-server
     #   jupyterlab
     #   jupyterlab-server

--- a/python/deplocks/llm/ray_test_py312_cu130.lock
+++ b/python/deplocks/llm/ray_test_py312_cu130.lock
@@ -1334,6 +1334,7 @@ jinja2==3.1.6 \
     --hash=sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
+    #   -r python/requirements.txt
     #   jupyter-server
     #   jupyterlab
     #   jupyterlab-server

--- a/python/deplocks/llm/rayllm_py312_cpu.lock
+++ b/python/deplocks/llm/rayllm_py312_cpu.lock
@@ -1734,6 +1734,7 @@ jinja2==3.1.6 \
     --hash=sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67
     # via
     #   -c python/deplocks/llm/rayllm_test_py312_cpu.lock
+    #   -r python/requirements.txt
     #   fastapi
     #   humming-kernels
     #   memray

--- a/python/deplocks/llm/rayllm_py312_cu130.lock
+++ b/python/deplocks/llm/rayllm_py312_cu130.lock
@@ -1740,6 +1740,7 @@ jinja2==3.1.6 \
     --hash=sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67
     # via
     #   -c python/deplocks/llm/rayllm_test_py312_cu130.lock
+    #   -r python/requirements.txt
     #   fastapi
     #   humming-kernels
     #   memray

--- a/python/deplocks/llm/rayllm_subset_py312_cu130.lock
+++ b/python/deplocks/llm/rayllm_subset_py312_cu130.lock
@@ -891,10 +891,11 @@ importlib-metadata==6.11.0 \
     # via
     #   -c python/deplocks/llm/rayllm_py312_cu130.lock
     #   opentelemetry-api
-jinja2==3.1.6 ; sys_platform != 'win32' \
+jinja2==3.1.6 \
     --hash=sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67
     # via
     #   -c python/deplocks/llm/rayllm_py312_cu130.lock
+    #   -r python/requirements.txt
     #   memray
 jsonschema==4.24.1 \
     --hash=sha256:6b916866aa0b61437785f1277aa2cbd63512e8d4b47151072ef13292049b4627 \
@@ -989,7 +990,7 @@ markdown-it-py==2.2.0 \
     #   mdit-py-plugins
     #   rich
     #   textual
-markupsafe==3.0.3 ; sys_platform != 'win32' \
+markupsafe==3.0.3 \
     --hash=sha256:d6dd0be5b5b189d31db7cda48b91d7e0a9795f31430b7f271219ab30f1d3ac9d
     # via
     #   -c python/deplocks/llm/rayllm_py312_cu130.lock

--- a/python/deplocks/llm/rayllm_test_py312_cpu.lock
+++ b/python/deplocks/llm/rayllm_test_py312_cpu.lock
@@ -2117,6 +2117,7 @@ jinja2==3.1.6 \
     --hash=sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67
     # via
     #   -c python/deplocks/llm/ray_test_py312_cpu.lock
+    #   -r python/requirements.txt
     #   fastapi
     #   humming-kernels
     #   jupyter-server

--- a/python/deplocks/llm/rayllm_test_py312_cu130.lock
+++ b/python/deplocks/llm/rayllm_test_py312_cu130.lock
@@ -2121,6 +2121,7 @@ jinja2==3.1.6 \
     --hash=sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67
     # via
     #   -c python/deplocks/llm/ray_test_py312_cu130.lock
+    #   -r python/requirements.txt
     #   fastapi
     #   humming-kernels
     #   jupyter-server

--- a/python/deplocks/ray-torch/ray-torch-cu128_base_py3.14.lock
+++ b/python/deplocks/ray-torch/ray-torch-cu128_base_py3.14.lock
@@ -1810,6 +1810,7 @@ jinja2==3.1.6 \
     #   jupyterlab-server
     #   memray
     #   nbconvert
+    #   ray
     #   torch
 jiter==0.15.0 \
     --hash=sha256:01a8222cf05ab1128e239421156c207949808acaaea2bdfd33130ae666786e86 \

--- a/python/deplocks/ray_img/ray_img_cu130_py310.lock
+++ b/python/deplocks/ray_img/ray_img_cu130_py310.lock
@@ -922,12 +922,13 @@ importlib-metadata==6.11.0 \
 # via
 #   -c /tmp/ray-deps/requirements_compiled_py3.10.txt
 #   opentelemetry-api
-jinja2==3.1.6; sys_platform != "win32" \
+jinja2==3.1.6 \
     --hash=sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d \
     --hash=sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67
 # via
 #   -c /tmp/ray-deps/requirements_compiled_py3.10.txt
 #   memray
+#   ray
 jsonschema==4.24.1 \
     --hash=sha256:6b916866aa0b61437785f1277aa2cbd63512e8d4b47151072ef13292049b4627 \
     --hash=sha256:fe45a130cc7f67cd0d67640b4e7e3e2e666919462ae355eda238296eafeb4b5d
@@ -1021,7 +1022,7 @@ markdown-it-py==2.2.0; sys_platform != "win32" \
 #   mdit-py-plugins
 #   rich
 #   textual
-markupsafe==3.0.3; sys_platform != "win32" \
+markupsafe==3.0.3 \
     --hash=sha256:0303439a41979d9e74d18ff5e2dd8c43ed6c6001fd40e5bf2e43f7bd9bbc523f \
     --hash=sha256:068f375c472b3e7acbe2d5318dea141359e6900156b5b2ba06a30b169086b91a \
     --hash=sha256:0bf2a864d67e76e5c9a34dc26ec616a66b9888e25e7b9460e1c76d3293bd9dbf \

--- a/python/deplocks/ray_img/ray_img_cu130_py311.lock
+++ b/python/deplocks/ray_img/ray_img_cu130_py311.lock
@@ -910,12 +910,13 @@ importlib-metadata==6.11.0 \
 # via
 #   -c /tmp/ray-deps/requirements_compiled_py3.11.txt
 #   opentelemetry-api
-jinja2==3.1.6; sys_platform != "win32" \
+jinja2==3.1.6 \
     --hash=sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d \
     --hash=sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67
 # via
 #   -c /tmp/ray-deps/requirements_compiled_py3.11.txt
 #   memray
+#   ray
 jsonschema==4.24.1 \
     --hash=sha256:6b916866aa0b61437785f1277aa2cbd63512e8d4b47151072ef13292049b4627 \
     --hash=sha256:fe45a130cc7f67cd0d67640b4e7e3e2e666919462ae355eda238296eafeb4b5d
@@ -1009,7 +1010,7 @@ markdown-it-py==2.2.0; sys_platform != "win32" \
 #   mdit-py-plugins
 #   rich
 #   textual
-markupsafe==3.0.3; sys_platform != "win32" \
+markupsafe==3.0.3 \
     --hash=sha256:0303439a41979d9e74d18ff5e2dd8c43ed6c6001fd40e5bf2e43f7bd9bbc523f \
     --hash=sha256:068f375c472b3e7acbe2d5318dea141359e6900156b5b2ba06a30b169086b91a \
     --hash=sha256:0bf2a864d67e76e5c9a34dc26ec616a66b9888e25e7b9460e1c76d3293bd9dbf \

--- a/python/deplocks/ray_img/ray_img_cu130_py312.lock
+++ b/python/deplocks/ray_img/ray_img_cu130_py312.lock
@@ -910,12 +910,13 @@ importlib-metadata==6.11.0 \
 # via
 #   -c /tmp/ray-deps/requirements_compiled_py3.12.txt
 #   opentelemetry-api
-jinja2==3.1.6; sys_platform != "win32" \
+jinja2==3.1.6 \
     --hash=sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d \
     --hash=sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67
 # via
 #   -c /tmp/ray-deps/requirements_compiled_py3.12.txt
 #   memray
+#   ray
 jsonschema==4.24.1 \
     --hash=sha256:6b916866aa0b61437785f1277aa2cbd63512e8d4b47151072ef13292049b4627 \
     --hash=sha256:fe45a130cc7f67cd0d67640b4e7e3e2e666919462ae355eda238296eafeb4b5d
@@ -1009,7 +1010,7 @@ markdown-it-py==2.2.0; sys_platform != "win32" \
 #   mdit-py-plugins
 #   rich
 #   textual
-markupsafe==3.0.3; sys_platform != "win32" \
+markupsafe==3.0.3 \
     --hash=sha256:0303439a41979d9e74d18ff5e2dd8c43ed6c6001fd40e5bf2e43f7bd9bbc523f \
     --hash=sha256:068f375c472b3e7acbe2d5318dea141359e6900156b5b2ba06a30b169086b91a \
     --hash=sha256:0bf2a864d67e76e5c9a34dc26ec616a66b9888e25e7b9460e1c76d3293bd9dbf \

--- a/python/deplocks/ray_img/ray_img_cu130_py313.lock
+++ b/python/deplocks/ray_img/ray_img_cu130_py313.lock
@@ -910,12 +910,13 @@ importlib-metadata==6.11.0 \
 # via
 #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
 #   opentelemetry-api
-jinja2==3.1.6; sys_platform != "win32" \
+jinja2==3.1.6 \
     --hash=sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d \
     --hash=sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67
 # via
 #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
 #   memray
+#   ray
 jsonschema==4.24.1 \
     --hash=sha256:6b916866aa0b61437785f1277aa2cbd63512e8d4b47151072ef13292049b4627 \
     --hash=sha256:fe45a130cc7f67cd0d67640b4e7e3e2e666919462ae355eda238296eafeb4b5d
@@ -1009,7 +1010,7 @@ markdown-it-py==2.2.0; sys_platform != "win32" \
 #   mdit-py-plugins
 #   rich
 #   textual
-markupsafe==3.0.3; sys_platform != "win32" \
+markupsafe==3.0.3 \
     --hash=sha256:0303439a41979d9e74d18ff5e2dd8c43ed6c6001fd40e5bf2e43f7bd9bbc523f \
     --hash=sha256:068f375c472b3e7acbe2d5318dea141359e6900156b5b2ba06a30b169086b91a \
     --hash=sha256:0bf2a864d67e76e5c9a34dc26ec616a66b9888e25e7b9460e1c76d3293bd9dbf \

--- a/python/deplocks/ray_img/ray_img_cu130_py314.lock
+++ b/python/deplocks/ray_img/ray_img_cu130_py314.lock
@@ -867,12 +867,13 @@ importlib-metadata==6.11.0 \
 # via
 #   -c /tmp/ray-deps/requirements_compiled_py3.14.txt
 #   opentelemetry-api
-jinja2==3.1.6; sys_platform != "win32" \
+jinja2==3.1.6 \
     --hash=sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d \
     --hash=sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67
 # via
 #   -c /tmp/ray-deps/requirements_compiled_py3.14.txt
 #   memray
+#   ray
 jsonschema==4.24.1 \
     --hash=sha256:6b916866aa0b61437785f1277aa2cbd63512e8d4b47151072ef13292049b4627 \
     --hash=sha256:fe45a130cc7f67cd0d67640b4e7e3e2e666919462ae355eda238296eafeb4b5d
@@ -966,7 +967,7 @@ markdown-it-py==2.2.0; sys_platform != "win32" \
 #   mdit-py-plugins
 #   rich
 #   textual
-markupsafe==3.0.3; sys_platform != "win32" \
+markupsafe==3.0.3 \
     --hash=sha256:0303439a41979d9e74d18ff5e2dd8c43ed6c6001fd40e5bf2e43f7bd9bbc523f \
     --hash=sha256:068f375c472b3e7acbe2d5318dea141359e6900156b5b2ba06a30b169086b91a \
     --hash=sha256:0bf2a864d67e76e5c9a34dc26ec616a66b9888e25e7b9460e1c76d3293bd9dbf \

--- a/python/deplocks/ray_img/ray_img_py310.lock
+++ b/python/deplocks/ray_img/ray_img_py310.lock
@@ -938,12 +938,13 @@ importlib-metadata==6.11.0 \
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.10.txt
     #   opentelemetry-api
-jinja2==3.1.6 ; sys_platform != 'win32' \
+jinja2==3.1.6 \
     --hash=sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d \
     --hash=sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.10.txt
     #   memray
+    #   ray
 jsonschema==4.24.1 \
     --hash=sha256:6b916866aa0b61437785f1277aa2cbd63512e8d4b47151072ef13292049b4627 \
     --hash=sha256:fe45a130cc7f67cd0d67640b4e7e3e2e666919462ae355eda238296eafeb4b5d
@@ -1037,7 +1038,7 @@ markdown-it-py==2.2.0 ; sys_platform != 'win32' \
     #   mdit-py-plugins
     #   rich
     #   textual
-markupsafe==3.0.3 ; sys_platform != 'win32' \
+markupsafe==3.0.3 \
     --hash=sha256:0303439a41979d9e74d18ff5e2dd8c43ed6c6001fd40e5bf2e43f7bd9bbc523f \
     --hash=sha256:068f375c472b3e7acbe2d5318dea141359e6900156b5b2ba06a30b169086b91a \
     --hash=sha256:0bf2a864d67e76e5c9a34dc26ec616a66b9888e25e7b9460e1c76d3293bd9dbf \

--- a/python/deplocks/ray_img/ray_img_py311.lock
+++ b/python/deplocks/ray_img/ray_img_py311.lock
@@ -926,12 +926,13 @@ importlib-metadata==6.11.0 \
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.11.txt
     #   opentelemetry-api
-jinja2==3.1.6 ; sys_platform != 'win32' \
+jinja2==3.1.6 \
     --hash=sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d \
     --hash=sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.11.txt
     #   memray
+    #   ray
 jsonschema==4.24.1 \
     --hash=sha256:6b916866aa0b61437785f1277aa2cbd63512e8d4b47151072ef13292049b4627 \
     --hash=sha256:fe45a130cc7f67cd0d67640b4e7e3e2e666919462ae355eda238296eafeb4b5d
@@ -1025,7 +1026,7 @@ markdown-it-py==2.2.0 ; sys_platform != 'win32' \
     #   mdit-py-plugins
     #   rich
     #   textual
-markupsafe==3.0.3 ; sys_platform != 'win32' \
+markupsafe==3.0.3 \
     --hash=sha256:0303439a41979d9e74d18ff5e2dd8c43ed6c6001fd40e5bf2e43f7bd9bbc523f \
     --hash=sha256:068f375c472b3e7acbe2d5318dea141359e6900156b5b2ba06a30b169086b91a \
     --hash=sha256:0bf2a864d67e76e5c9a34dc26ec616a66b9888e25e7b9460e1c76d3293bd9dbf \

--- a/python/deplocks/ray_img/ray_img_py312.lock
+++ b/python/deplocks/ray_img/ray_img_py312.lock
@@ -926,12 +926,13 @@ importlib-metadata==6.11.0 \
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.12.txt
     #   opentelemetry-api
-jinja2==3.1.6 ; sys_platform != 'win32' \
+jinja2==3.1.6 \
     --hash=sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d \
     --hash=sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.12.txt
     #   memray
+    #   ray
 jsonschema==4.24.1 \
     --hash=sha256:6b916866aa0b61437785f1277aa2cbd63512e8d4b47151072ef13292049b4627 \
     --hash=sha256:fe45a130cc7f67cd0d67640b4e7e3e2e666919462ae355eda238296eafeb4b5d
@@ -1025,7 +1026,7 @@ markdown-it-py==2.2.0 ; sys_platform != 'win32' \
     #   mdit-py-plugins
     #   rich
     #   textual
-markupsafe==3.0.3 ; sys_platform != 'win32' \
+markupsafe==3.0.3 \
     --hash=sha256:0303439a41979d9e74d18ff5e2dd8c43ed6c6001fd40e5bf2e43f7bd9bbc523f \
     --hash=sha256:068f375c472b3e7acbe2d5318dea141359e6900156b5b2ba06a30b169086b91a \
     --hash=sha256:0bf2a864d67e76e5c9a34dc26ec616a66b9888e25e7b9460e1c76d3293bd9dbf \

--- a/python/deplocks/ray_img/ray_img_py313.lock
+++ b/python/deplocks/ray_img/ray_img_py313.lock
@@ -926,12 +926,13 @@ importlib-metadata==6.11.0 \
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
     #   opentelemetry-api
-jinja2==3.1.6 ; sys_platform != 'win32' \
+jinja2==3.1.6 \
     --hash=sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d \
     --hash=sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.13.txt
     #   memray
+    #   ray
 jsonschema==4.24.1 \
     --hash=sha256:6b916866aa0b61437785f1277aa2cbd63512e8d4b47151072ef13292049b4627 \
     --hash=sha256:fe45a130cc7f67cd0d67640b4e7e3e2e666919462ae355eda238296eafeb4b5d
@@ -1025,7 +1026,7 @@ markdown-it-py==2.2.0 ; sys_platform != 'win32' \
     #   mdit-py-plugins
     #   rich
     #   textual
-markupsafe==3.0.3 ; sys_platform != 'win32' \
+markupsafe==3.0.3 \
     --hash=sha256:0303439a41979d9e74d18ff5e2dd8c43ed6c6001fd40e5bf2e43f7bd9bbc523f \
     --hash=sha256:068f375c472b3e7acbe2d5318dea141359e6900156b5b2ba06a30b169086b91a \
     --hash=sha256:0bf2a864d67e76e5c9a34dc26ec616a66b9888e25e7b9460e1c76d3293bd9dbf \

--- a/python/deplocks/ray_img/ray_img_py314.lock
+++ b/python/deplocks/ray_img/ray_img_py314.lock
@@ -883,12 +883,13 @@ importlib-metadata==6.11.0 \
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.14.txt
     #   opentelemetry-api
-jinja2==3.1.6 ; sys_platform != 'win32' \
+jinja2==3.1.6 \
     --hash=sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d \
     --hash=sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67
     # via
     #   -c /tmp/ray-deps/requirements_compiled_py3.14.txt
     #   memray
+    #   ray
 jsonschema==4.24.1 \
     --hash=sha256:6b916866aa0b61437785f1277aa2cbd63512e8d4b47151072ef13292049b4627 \
     --hash=sha256:fe45a130cc7f67cd0d67640b4e7e3e2e666919462ae355eda238296eafeb4b5d
@@ -982,7 +983,7 @@ markdown-it-py==2.2.0 ; sys_platform != 'win32' \
     #   mdit-py-plugins
     #   rich
     #   textual
-markupsafe==3.0.3 ; sys_platform != 'win32' \
+markupsafe==3.0.3 \
     --hash=sha256:0303439a41979d9e74d18ff5e2dd8c43ed6c6001fd40e5bf2e43f7bd9bbc523f \
     --hash=sha256:068f375c472b3e7acbe2d5318dea141359e6900156b5b2ba06a30b169086b91a \
     --hash=sha256:0bf2a864d67e76e5c9a34dc26ec616a66b9888e25e7b9460e1c76d3293bd9dbf \

--- a/python/deplocks/tests/data/datatfds_py3.12.lock
+++ b/python/deplocks/tests/data/datatfds_py3.12.lock
@@ -995,10 +995,12 @@ izulu==0.50.0 \
     --hash=sha256:4e9ae2508844e7c5f62c468a8b9e2deba2f60325ef63f01e65b39fd9a6b3fab4 \
     --hash=sha256:cc8e252d5e8560c70b95380295008eeb0786f7b745a405a40d3556ab3252d5f5
     # via taskiq
-jinja2==3.1.6 ; sys_platform != 'win32' \
+jinja2==3.1.6 \
     --hash=sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d \
     --hash=sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67
-    # via memray
+    # via
+    #   memray
+    #   ray
 jsonschema==4.25.1 \
     --hash=sha256:3fba0169e345c7175110351d456342c364814cfcf3b964ba4587f22915230a63 \
     --hash=sha256:e4a9655ce0da0c0b67a085847e00a3a51449e1157f4f75e9fb5aa545e122eb85

--- a/python/ray/serve/_private/haproxy.py
+++ b/python/ray/serve/_private/haproxy.py
@@ -16,8 +16,6 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Set, Tuple
 
-from jinja2 import Environment
-
 import ray
 from ray._common.network_utils import get_localhost_ip
 from ray._common.utils import get_or_create_event_loop
@@ -1294,6 +1292,10 @@ class HAProxyApi(ProxyApi):
     def _generate_config_file_internal(self) -> None:
         """Internal config generation without locking (for use within locked sections)."""
         try:
+            # Imported lazily so that a plain `import ray.serve` doesn't require
+            # jinja2; it's only needed when HAProxy mode is actually used.
+            from jinja2 import Environment
+
             env = Environment()
             # Escapes names before they are rendered into set-var-fmt values.
             env.filters["haproxy_fmt"] = _haproxy_fmt_literal

--- a/python/ray/serve/tests/unit/test_haproxy_process_manager.py
+++ b/python/ray/serve/tests/unit/test_haproxy_process_manager.py
@@ -7,7 +7,9 @@ stop, which keeps serving its stale config indefinitely.
 """
 import asyncio
 import os
+import subprocess
 import sys
+import textwrap
 from typing import Optional
 
 import pytest
@@ -158,6 +160,30 @@ class TestCountHaproxyProcesses:
     def test_returns_zero_when_no_match(self, api):
         api.config_file_path = "/tmp/not-in-any-cmdline/haproxy.cfg"
         assert api.count_haproxy_processes() == 0
+
+
+def test_import_serve_does_not_require_jinja2():
+    """A plain `import ray.serve` must not require jinja2 (issue #65507).
+
+    jinja2 is only needed when HAProxy mode actually renders its config, so
+    haproxy.py must import it lazily; a module-scope import breaks
+    `import ray.serve` on installs that don't have jinja2.
+    """
+    code = textwrap.dedent(
+        """
+        import importlib.abc, sys
+
+        class BlockJinja(importlib.abc.MetaPathFinder):
+            def find_spec(self, fullname, path=None, target=None):
+                if fullname == "jinja2" or fullname.startswith("jinja2."):
+                    raise ModuleNotFoundError("No module named 'jinja2'")
+
+        sys.meta_path.insert(0, BlockJinja())
+        import ray.serve
+        import ray.serve._private.controller
+        """
+    )
+    subprocess.check_call([sys.executable, "-c", code])
 
 
 if __name__ == "__main__":

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -59,4 +59,5 @@ pyOpenSSL
 celery
 taskiq
 mmh3
+jinja2
 ray-haproxy>=2.8.25,<2.9.0; sys_platform == 'linux'

--- a/python/requirements_compiled.txt
+++ b/python/requirements_compiled.txt
@@ -896,6 +896,7 @@ jedi==0.19.2
     # via ipython
 jinja2==3.1.6
     # via
+    #   -r python/requirements.txt
     #   -r python/requirements/test-requirements.txt
     #   aim
     #   ax-platform

--- a/python/setup.py
+++ b/python/setup.py
@@ -284,6 +284,8 @@ if setup_spec.type == SetupType.RAY:
             "fastapi >= 0.133.0",  # >= 0.133.0 required for starlette >= 1.0.
             "watchfiles",
             "mmh3",
+            # Used by the HAProxy ingress controller to render its config.
+            "jinja2",
             "ray-haproxy>=2.8.25,<2.9.0; sys_platform == 'linux'",
         ],
         "tune": [

--- a/release/ray_release/byod/audio_transcription_py3.10.lock
+++ b/release/ray_release/byod/audio_transcription_py3.10.lock
@@ -1995,6 +1995,7 @@ jinja2==3.1.6 \
     #   nbclassic
     #   nbconvert
     #   notebook
+    #   ray
     #   torch
 jmespath==1.0.1 \
     --hash=sha256:02e2e4cc71b5bcab88332eebf907519190dd9e6e82107fa7f83b1003a6252980 \

--- a/release/ray_release/byod/document_embedding_py3.10.lock
+++ b/release/ray_release/byod/document_embedding_py3.10.lock
@@ -2008,6 +2008,7 @@ jinja2==3.1.6 \
     #   nbclassic
     #   nbconvert
     #   notebook
+    #   ray
     #   torch
 jmespath==1.0.1 \
     --hash=sha256:02e2e4cc71b5bcab88332eebf907519190dd9e6e82107fa7f83b1003a6252980 \

--- a/release/ray_release/byod/image_classification_py3.10.lock
+++ b/release/ray_release/byod/image_classification_py3.10.lock
@@ -1974,6 +1974,7 @@ jinja2==3.1.6 \
     #   nbclassic
     #   nbconvert
     #   notebook
+    #   ray
     #   torch
 jmespath==1.0.1 \
     --hash=sha256:02e2e4cc71b5bcab88332eebf907519190dd9e6e82107fa7f83b1003a6252980 \

--- a/release/ray_release/byod/large_image_embedding_py3.10.lock
+++ b/release/ray_release/byod/large_image_embedding_py3.10.lock
@@ -1994,6 +1994,7 @@ jinja2==3.1.6 \
     #   nbclassic
     #   nbconvert
     #   notebook
+    #   ray
     #   torch
 jmespath==1.0.1 \
     --hash=sha256:02e2e4cc71b5bcab88332eebf907519190dd9e6e82107fa7f83b1003a6252980 \

--- a/release/ray_release/byod/llm_batch/llm_batch_single_node_benchmark_py312_cu130.lock
+++ b/release/ray_release/byod/llm_batch/llm_batch_single_node_benchmark_py312_cu130.lock
@@ -833,9 +833,11 @@ izulu==0.50.0 \
     --hash=sha256:4e9ae2508844e7c5f62c468a8b9e2deba2f60325ef63f01e65b39fd9a6b3fab4 \
     --hash=sha256:cc8e252d5e8560c70b95380295008eeb0786f7b745a405a40d3556ab3252d5f5
     # via taskiq
-jinja2==3.1.6 ; sys_platform != 'win32' \
+jinja2==3.1.6 \
     --hash=sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67
-    # via memray
+    # via
+    #   -r python/requirements.txt
+    #   memray
 jsonschema==4.26.0 \
     --hash=sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326 \
     --hash=sha256:d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce
@@ -918,7 +920,7 @@ markdown-it-py==4.0.0 \
     #   mdit-py-plugins
     #   rich
     #   textual
-markupsafe==3.0.2 ; sys_platform != 'win32' \
+markupsafe==3.0.2 \
     --hash=sha256:e17c96c14e19278594aa4841ec148115f9c7615a47382ecb6b82bd8fea3ab0c8
     # via jinja2
 mdit-py-plugins==0.5.0 ; sys_platform != 'win32' \

--- a/release/ray_release/byod/ml_torchft_py3.13.lock
+++ b/release/ray_release/byod/ml_torchft_py3.13.lock
@@ -2370,6 +2370,7 @@ jinja2==3.1.6 \
     #   jupyterlab-server
     #   memray
     #   nbconvert
+    #   ray
     #   torch
 jmespath==1.1.0 \
     --hash=sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d \

--- a/release/ray_release/byod/video_object_detection_py3.10.lock
+++ b/release/ray_release/byod/video_object_detection_py3.10.lock
@@ -2156,6 +2156,7 @@ jinja2==3.1.6 \
     #   nbclassic
     #   nbconvert
     #   notebook
+    #   ray
     #   torch
 jmespath==1.0.1 \
     --hash=sha256:02e2e4cc71b5bcab88332eebf907519190dd9e6e82107fa7f83b1003a6252980 \


### PR DESCRIPTION
Cherry-pick of #65542 (master commit e11fe03ba0cb8830c7bb8703422ea15f9f824d49) onto releases/2.59.0.

One conflict resolved: the original commit also updated `python/deplocks/ray-torch/ray-torch-cu128_base_py3.11.lock`, which does not exist on this branch (only the py3.14 ray-torch lock is present on releases/2.59.0) — dropped that file from the pick; all other 82 lock/requirements updates applied cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)