### PR TITLE
[Data] Keep the filter when a predicate names a synthesized column

### DIFF
--- a/python/ray/data/_internal/datasource/parquet_datasource.py
+++ b/python/ray/data/_internal/datasource/parquet_datasource.py
@@ -200,10 +200,12 @@ class _SplitPredicateResult:
             pushdown), or None if none could be extracted.
         partition_predicate: Conjuncts referencing only partition columns
             (for partition pruning), or None if none could be extracted.
-        residual_predicate: Conjuncts that mix partition and data columns
-            and can't be split safely (e.g. an ``OR`` straddling both
-            kinds). The caller must keep these as a ``Filter`` above the
-            read; dropping them would over-include rows.
+        residual_predicate: Conjuncts that can't be pushed either way --
+            those naming a synthesized column (which exists only after the
+            read), and those mixing partition and data columns
+            unsplittably (e.g. an ``OR`` straddling both kinds). The caller
+            must keep these as a ``Filter`` above the read; dropping them
+            would over-include rows.
     """
 
     data_predicate: Optional[Expr]
@@ -214,6 +216,7 @@ class _SplitPredicateResult:
 def _split_predicate_by_columns(
     predicate: Expr,
     partition_columns: set,
+    synthesized_columns: Optional[set] = None,
 ) -> _SplitPredicateResult:
     """Split a predicate into data, partition, and residual parts.
 
@@ -224,14 +227,22 @@ def _split_predicate_by_columns(
       evaluate it at scan time.
     - References only partition columns → partition bucket; the partition
       parser can evaluate it from file paths.
+    - References a synthesized column → residual bucket; the column does
+      not exist in the file, so neither pushdown path can bind it.
     - References both kinds (i.e. a non-``AND`` whose column set spans
       both) → residual bucket; semantics-preserving splitting is
       impossible (e.g. ``data > 5 OR partition == "US"``), so the caller
       must keep these as a ``Filter`` above the read.
 
+    Splitting the ``AND`` chain is what keeps an unpushable conjunct from
+    costing the others their pushdown: ``data > 5 AND path == "f"`` still
+    prunes row groups on ``data > 5``.
+
     Args:
         predicate: The predicate expression to analyze.
         partition_columns: Set of partition column names.
+        synthesized_columns: Names produced after the read (e.g. ``path``,
+            ``row_hash``), which no pushdown path can evaluate.
 
     Returns:
         :class:`_SplitPredicateResult` with the three buckets. Combining
@@ -275,19 +286,29 @@ def _split_predicate_by_columns(
         >>> result.residual_predicate is not None
         True
     """
+    synthesized_columns = synthesized_columns or set()
     referenced_cols = set(get_column_references(predicate))
-    data_cols = referenced_cols - partition_columns
+    data_cols = referenced_cols - partition_columns - synthesized_columns
     partition_cols_in_predicate = referenced_cols & partition_columns
+    synthesized_in_predicate = referenced_cols & synthesized_columns
 
-    if not partition_cols_in_predicate:
+    if synthesized_in_predicate:
+        if not data_cols and not partition_cols_in_predicate:
+            # Nothing here is pushable.
+            return _SplitPredicateResult(
+                data_predicate=None,
+                partition_predicate=None,
+                residual_predicate=predicate,
+            )
+        # Mixed with pushable columns -- fall through to the ``AND`` split.
+    elif not partition_cols_in_predicate:
         # Pure data predicate (or no column refs).
         return _SplitPredicateResult(
             data_predicate=predicate,
             partition_predicate=None,
             residual_predicate=None,
         )
-
-    if not data_cols:
+    elif not data_cols:
         # Pure partition predicate.
         return _SplitPredicateResult(
             data_predicate=None,
@@ -297,8 +318,12 @@ def _split_predicate_by_columns(
 
     # Mixed predicate - keep splitting if it's an AND chain.
     if isinstance(predicate, BinaryExpr) and predicate.op == Operation.AND:
-        left_result = _split_predicate_by_columns(predicate.left, partition_columns)
-        right_result = _split_predicate_by_columns(predicate.right, partition_columns)
+        left_result = _split_predicate_by_columns(
+            predicate.left, partition_columns, synthesized_columns
+        )
+        right_result = _split_predicate_by_columns(
+            predicate.right, partition_columns, synthesized_columns
+        )
 
         def combine_predicates(
             left: Optional[Expr], right: Optional[Expr]

--- a/python/ray/data/_internal/datasource_v2/scanners/arrow_file_scanner.py
+++ b/python/ray/data/_internal/datasource_v2/scanners/arrow_file_scanner.py
@@ -53,6 +53,15 @@ class ArrowFileScanner(
     ignore_prefixes: Optional[List[str]] = None
 
     @property
+    def synthesized_columns(self) -> Set[str]:
+        """Columns produced after the read, which PyArrow cannot bind.
+
+        A predicate naming one of these must stay as a ``Filter`` above the
+        read: the column does not exist in the file PyArrow scans.
+        """
+        return set()
+
+    @property
     def partition_columns(self) -> Set[str]:
         """Return the set of partition column names, or empty if unpartitioned."""
         if self.partitioning is None:

--- a/python/ray/data/_internal/datasource_v2/scanners/parquet_scanner.py
+++ b/python/ray/data/_internal/datasource_v2/scanners/parquet_scanner.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Set
 
 import pyarrow as pa
 
@@ -38,6 +38,15 @@ class ParquetScanner(ArrowFileScanner):
     # ``pre_buffer``, ``dictionary_columns``). Carries the deprecated
     # ``dataset_kwargs`` payload from ``read_parquet`` to the worker.
     parquet_format_kwargs: Dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def synthesized_columns(self) -> Set[str]:
+        names = set()
+        if self.include_paths:
+            names.add(INCLUDE_PATHS_COLUMN_NAME)
+        if self.include_row_hash:
+            names.add(ROW_HASH_COLUMN_NAME)
+        return names
 
     def read_schema(self) -> pa.Schema:
         """Return schema after column pruning and tensor check.

--- a/python/ray/data/_internal/logical/operators/read_operator.py
+++ b/python/ray/data/_internal/logical/operators/read_operator.py
@@ -384,22 +384,27 @@ class ReadFiles(
 
         assert isinstance(self.scanner, SupportsFilterPushdown)
 
+        # Columns the reader manufactures after the scan (``path``,
+        # ``row_hash``). They are in ``scanner.schema``, so a user can filter
+        # on them, but pyarrow cannot bind them against the file.
+        synthesized: Set[str] = getattr(self.scanner, "synthesized_columns", set())
         partition_cols: Set[str] = (
             self.scanner.partition_columns
             if isinstance(self.scanner, SupportsPartitionPruning)
             else set()
         )
 
-        if not partition_cols:
+        if not partition_cols and not synthesized:
             new_scanner, _residual = self.scanner.push_filters(predicate_expr)
             return replace(self, scanner=new_scanner)
 
-        split = _split_predicate_by_columns(predicate_expr, partition_cols)
+        split = _split_predicate_by_columns(predicate_expr, partition_cols, synthesized)
 
         if split.data_predicate is None and split.partition_predicate is None:
-            # Entire predicate is residual (e.g. a single mixed-column
-            # ``OR``); nothing safe to push. Returning ``self`` tells
-            # ``PredicatePushdown`` to keep the ``Filter`` above us.
+            # Entire predicate is residual (a single mixed-column ``OR``, or a
+            # predicate naming only synthesized columns); nothing safe to push.
+            # Returning ``self`` tells ``PredicatePushdown`` to keep the
+            # ``Filter`` above us.
             return self
 
         new_scanner = self.scanner
@@ -416,7 +421,8 @@ class ReadFiles(
         # Residual conjuncts can't be pushed through either ``push_filters``
         # (pyarrow only binds data columns) or ``prune_partitions`` (path
         # parser only binds partition columns), so re-emit them as a
-        # ``Filter`` above the new ``ReadFiles``. Without this, we'd keep
+        # ``Filter`` above the new ``ReadFiles`` -- which is also where a
+        # synthesized column has come into existence. Without this, we'd keep
         # the splittable parts and silently drop the residual — letting
         # rows through that the original predicate would have rejected.
         return Filter(

--- a/python/ray/data/tests/test_predicate_pushdown.py
+++ b/python/ray/data/tests/test_predicate_pushdown.py
@@ -16,10 +16,14 @@ from ray.data._internal.logical.operators import (
     Filter,
     Limit,
     Project,
+    ReadFiles,
     Repartition,
     Sort,
 )
 from ray.data._internal.logical.optimizers import LogicalOptimizer
+from ray.data._internal.planner.plan_expression.expression_visitors import (
+    get_column_references,
+)
 from ray.data._internal.util import rows_same
 from ray.data.datasource.partitioning import Partitioning
 from ray.data.datasource.path_util import _unwrap_protocol
@@ -1167,6 +1171,41 @@ class TestPushIntoBranchesBehavior:
         )
         expected = expected_single.union(expected_single)
         assert rows_same(ds.to_pandas(), expected.to_pandas())
+
+
+def test_filter_on_include_paths_column(ray_start_regular_shared, tmp_path):
+    """``path`` is synthesized after the read, so its filter can't be pushed."""
+    pq.write_table(pa.table({"x": [1, 2]}), tmp_path / "a.parquet")
+    pq.write_table(pa.table({"x": [3, 4]}), tmp_path / "b.parquet")
+    target = str(tmp_path / "a.parquet")
+
+    ds = ray.data.read_parquet(str(tmp_path), include_paths=True).filter(
+        expr=col("path") == target
+    )
+
+    assert ds.take_all() == [{"x": 1, "path": target}, {"x": 2, "path": target}]
+
+
+def test_filter_mixing_synthesized_and_data_column(ray_start_regular_shared, tmp_path):
+    """Only the ``path`` conjunct stays above the read; ``x`` still pushes down."""
+    pq.write_table(pa.table({"x": [1, 2]}), tmp_path / "a.parquet")
+    pq.write_table(pa.table({"x": [3, 4]}), tmp_path / "b.parquet")
+    target = str(tmp_path / "a.parquet")
+
+    ds = ray.data.read_parquet(str(tmp_path), include_paths=True).filter(
+        expr=(col("x") > 1) & (col("path") == target)
+    )
+
+    assert ds.take_all() == [{"x": 2, "path": target}]
+
+    # The residual ``Filter`` is only the synthesized conjunct -- ``x > 1``
+    # reached the scanner, so row-group pruning survives.
+    optimized_plan = LogicalOptimizer().optimize(ds._logical_plan)
+    filters = get_operators_of_type(optimized_plan, Filter)
+    assert len(filters) == 1
+    assert get_column_references(filters[0].predicate_expr) == ["path"]
+    reads = get_operators_of_type(optimized_plan, ReadFiles)
+    assert get_column_references(reads[0].scanner.predicate) == ["x"]
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Why

`include_paths=True` / `include_row_hash=True` add columns after the read, so they
are in the dataset schema but in no Parquet file. `ReadFiles.apply_predicate` pushes
any predicate at the scanner regardless, and `PredicatePushdown` then deletes the
`Filter` that would have evaluated it. PyArrow cannot bind the column, so the read
raises:

```python
ds = ray.data.read_parquet(root, include_paths=True)
ds.filter(expr=col("path") == one_file).take_all()
# ArrowInvalid: No match for FieldRef.Name(path) in x: int64
```

The same filter written as a UDF works, so the expression API is strictly worse here
than the callable one.

## What changes

A scanner now reports which columns it manufactures after the scan:
`ParquetScanner.synthesized_columns` is `{"path"}` under `include_paths=True`,
`{"row_hash"}` under `include_row_hash=True`.

`apply_predicate` uses that to send each conjunct to the one place that can evaluate
it:

| conjunct references | goes to | why |
|---|---|---|
| data columns (`x > 1`) | the PyArrow scanner | in the file; prunes row groups |
| partition columns (`year == "2020"`) | `prune_manifest` | in the path; prunes whole files |
| synthesized columns (`path == ...`) | a `Filter` above the read | does not exist until after the read |

Splitting rather than giving up on the whole predicate is what keeps this cheap. On
`(col("x") > 1) & (col("path") == target)`:

| | residual `Filter` holds | scanner predicate |
|---|---|---|
| master | *(Filter deleted)* | `x`, `path` -> `ArrowInvalid` |
| this PR | `path` | `x` |

`x > 1` still reaches the scanner and keeps its row-group pruning; only `path`
stays above.

When nothing in the predicate is pushable — `col("path") == target` on its own —
`apply_predicate` returns the read operator it was given, unmodified. That is the
existing way an operator declines a pushdown: `PredicatePushdown` compares the
returned operator to the one it passed in, sees they are the same object, and leaves
the `Filter` where it was.

Not included: pruning files by `path` at the manifest level. `path` is known per file
at listing time, so an exact-match predicate could drop files before opening them.
That is a new capability rather than a bug fix, and it needs the same limit wiring as
partition pruning (listing must not stop early when the reader will discard files), so
it belongs in its own PR.

## Test

`test_filter_on_include_paths_column` and `test_filter_mixing_synthesized_and_data_column`
in `python/ray/data/tests/test_predicate_pushdown.py`. The first fails on master with
the `ArrowInvalid` above; the second pins the split, so it also fails against an
all-or-nothing version of this fix.

```
pytest python/ray/data/tests/test_predicate_pushdown.py \
       python/ray/data/tests/unit/test_parquet_predicate_split.py
85 passed
```

Not a duplicate: `gh pr list --search "predicate pushdown"` / `"include_paths"` shows
no open PR touching `apply_predicate` or synthesized-column handling.

AI assistance was used to write this change.
