### PR TITLE
[Data] Raise instead of keeping every file when a partition filter can't be evaluated

### DIFF
--- a/python/ray/data/datasource/partitioning.py
+++ b/python/ray/data/datasource/partitioning.py
@@ -361,9 +361,13 @@ class PathPartitionParser:
                 return bool(result.as_py())
 
             return bool(result)
-        except Exception:
+        except KeyError:
+            # Only a missing partition column is a genuine "can't tell" -- keep
+            # the file. Narrow, so a type mismatch (ArrowNotImplementedError,
+            # e.g. a string partition value compared to an int) propagates
+            # instead of silently keeping every file.
             logger.debug(
-                "Failed to evaluate predicate on partition for path %s, "
+                "Path %s has no value for a partition column in the predicate, "
                 "conservatively including file.",
                 path,
                 exc_info=True,

--- a/python/ray/data/tests/test_partitioning.py
+++ b/python/ray/data/tests/test_partitioning.py
@@ -22,7 +22,8 @@ from ray.data.datasource.partitioning import (
     PartitionStyle,
     PathPartitionFilter,
 )
-from ray.data.expressions import col
+from ray.data.datatype import DataType
+from ray.data.expressions import col, udf
 from ray.data.tests.conftest import *  # noqa
 from ray.tests.conftest import *  # noqa
 
@@ -1008,6 +1009,51 @@ def test_evaluate_predicate_on_partition_type_mismatch():
     assert parser.evaluate_predicate_on_partition(
         "year=2020/data.parquet", col("month") == "01"
     )
+
+
+@udf(DataType(int))
+def _year_as_int(year):
+    return pa.compute.cast(year, pa.int64())
+
+
+@pytest.mark.parametrize(
+    "predicate,expected",
+    [
+        # Correctly typed comparison -- the common case, both outcomes.
+        (col("year") == "2020", True),
+        (col("year") == "2019", False),
+        (col("year") != "2019", True),
+        (col("year") > "2019", True),
+        # Compound predicates over partition columns.
+        ((col("year") == "2020") & (col("month") == "01"), True),
+        ((col("year") == "2020") & (col("month") == "02"), False),
+        ((col("year") == "2019") | (col("month") == "01"), True),
+        # Non-comparison kernels.
+        (col("year").is_null(), False),
+        (col("year").is_in(["2019", "2020"]), True),
+        (col("year").is_in(["2018", "2019"]), False),
+        # A UDF over a partition column runs on the parsed value, so it can
+        # do the cast the user should have written -- and must keep working.
+        (_year_as_int(col("year")) == 2020, True),
+        # A column the path does not partition on is unknowable from the path
+        # alone, so the file is conservatively kept. This is the one case the
+        # narrowed ``except KeyError`` still swallows.
+        (col("day") == "15", True),
+        ((col("year") == "2020") & (col("day") == "15"), True),
+    ],
+)
+def test_evaluate_predicate_on_partition_unaffected_cases(predicate, expected):
+    """Everything that evaluated correctly before the narrowing still does.
+
+    ``evaluate_predicate_on_partition`` used to swallow every exception and
+    return ``True``. Narrowing that to ``KeyError`` only changes behaviour for
+    predicates that *raised*; these all returned a real answer already, and
+    must return the same one.
+    """
+    parser = PathPartitionParser(Partitioning(PartitionStyle.HIVE))
+    path = "year=2020/month=01/data.parquet"
+
+    assert parser.evaluate_predicate_on_partition(path, predicate) is expected
 
 
 if __name__ == "__main__":

--- a/python/ray/data/tests/test_partitioning.py
+++ b/python/ray/data/tests/test_partitioning.py
@@ -993,6 +993,23 @@ def test_evaluate_predicate_on_unpartitioned_file():
     assert result is False
 
 
+def test_evaluate_predicate_on_partition_type_mismatch():
+    """A type mismatch must raise, not conservatively keep every file."""
+    parser = PathPartitionParser(Partitioning(PartitionStyle.HIVE))
+
+    # `year` parses as a string, so comparing it to an int has no Arrow kernel.
+    # Swallowing that returned True for every file, silently voiding the filter.
+    with pytest.raises(pa.lib.ArrowNotImplementedError):
+        parser.evaluate_predicate_on_partition(
+            "year=2020/data.parquet", col("year") == 2020
+        )
+
+    # A path carrying no value for the predicate's column is still kept.
+    assert parser.evaluate_predicate_on_partition(
+        "year=2020/data.parquet", col("month") == "01"
+    )
+
+
 if __name__ == "__main__":
     import sys
 


### PR DESCRIPTION
## Why

`PathPartitionParser.evaluate_predicate_on_partition` catches every exception
and answers `True` -- "keep this file". A predicate Arrow can't evaluate is
therefore answered `True` for every file, so the filter silently disappears
and the query returns the whole table:

```python
# hive-partitioned by year; partition values parse as strings
ds.filter(expr=col("year") == 2020).count()   # -> every row, no error
```

The identical mismatch on a data column already raises
`ArrowNotImplementedError`. One user error, two opposite behaviours, decided
only by whether the value is in the file or in the directory name.

Narrowing the handler to `KeyError` keeps the one case that legitimately
can't be decided -- a path carrying no value for a partition column the
predicate names, as in a mixed-depth layout -- and lets the type mismatch
propagate exactly as it does for data columns.

## Why `KeyError` and not something wider

The swallowed errors are not one kind. Probing the failure modes against a
string partition value: `==` and `>` against an int raise
`ArrowNotImplementedError`, `is_in` raises `ArrowTypeError`, arithmetic raises
`TypeError`, and an unknown column raises `KeyError`.

Three of those four are the same user error -- a type mismatch -- wearing
three exception types, so an allowlist of "errors to raise" would be leaky by
construction. The benign case is exactly one type. Narrowing to it is the only
cut that separates them cleanly.

Adding `except Exception: return True` underneath would restore the old
behaviour in full, so it is not a safety net; it is a revert.

## What doesn't change

Narrowing only changes behaviour for predicates that previously *raised*.
Everything that already returned a real answer must return the same one, so
that is asserted directly in
`test_evaluate_predicate_on_partition_unaffected_cases`: correctly typed
`==` / `!=` / `>`, compound `&` and `|` over partition columns, `is_null`,
`is_in`, and a UDF over a partition column -- plus the missing-column case,
which is the one thing the narrowed handler still swallows.

All 13 of those pass unchanged against master's `except Exception`. Only the
type-mismatch test flips. That A/B is what makes the narrowing defensible.

## Test

```
pytest python/ray/data/tests/test_partitioning.py
```

On this branch: 32 failed, 51 passed. On unmodified master: 32 failed, 37
passed. The same 32 failures either way -- they are pre-existing S3 failures in
my environment -- so the delta is exactly the 14 added tests, and nothing
regressed.

`test_evaluate_predicate_on_partition_type_mismatch` fails on master with
`DID NOT RAISE ArrowNotImplementedError` and passes here.

AI assistance was used to write this change.
