### PR TITLE
[core] Fix test_zero_capacity_deletion_semantics error when testing locally

### DIFF
--- a/python/ray/tests/test_advanced_2.py
+++ b/python/ray/tests/test_advanced_2.py
@@ -700,10 +700,9 @@ def test_zero_capacity_deletion_semantics(shutdown_only):
     ray.init(num_cpus=2, num_gpus=1, resources={"test_resource": 1})
 
     def delete_miscellaneous_item(resources):
-        del resources["memory"]
-        del resources["object_store_memory"]
+        keep = {"CPU", "GPU", "test_resource"}
         for key in list(resources.keys()):
-            if key.startswith("node:"):
+            if key not in keep:
                 del resources[key]
 
     def test():


### PR DESCRIPTION
## Description

`test_zero_capacity_deletion_semantics` was failing when testing locally because Ray automatically registers the testing hardware as a resource. The original test used a blacklist, which explicitly removed `memory`, `object_store_memory`, and `node:*` keys, but had no knowledge of hardware-specific resources (like `accelerator_type:*`). After stripping the known keys, `resources` still contained `{'accelerator_type:M4': 1.0}`, causing the retry loop to exhaust its attempts and raise:

```
RuntimeError: ('Resources were available even after 5 retries.', {'accelerator_type:M4': 1.0})
```

### What changed

Replaced the blacklist with a whitelist. Instead of enumerating keys to remove, the helper now keeps only the three resources the test actually cares about (`CPU`, `GPU`, `test_resource`) and drops everything else. This makes the test robust against any current or future auto-detected resource types Ray may register.

## Verfication
After the code change, the test passed locally