### PR TITLE
[cherry-pick][2.59.0][llm] Fix s3:// model_source dropped for streaming load formats (#65753)

### DIFF
--- a/python/ray/llm/_internal/serve/engines/vllm/vllm_engine.py
+++ b/python/ray/llm/_internal/serve/engines/vllm/vllm_engine.py
@@ -181,24 +181,39 @@ def _normalize_vllm_engine_kwargs(engine_kwargs: Dict[str, Any]) -> Dict[str, An
     return normalized_kwargs
 
 
+def _resolve_hf_model_id_from_mirror(engine_config: "VLLMEngineConfig") -> None:
+    """Resolve hf_model_id to a local path or, for streaming load formats
+    that skip local download, the mirror's URI."""
+    if not engine_config.mirror_config:
+        return
+
+    from ray.llm._internal.common.utils.download_utils import (
+        STREAMING_LOAD_FORMATS,
+        get_model_location_on_disk,
+    )
+
+    local_path = get_model_location_on_disk(engine_config.actual_hf_model_id)
+    if local_path and local_path != engine_config.actual_hf_model_id:
+        engine_config.hf_model_id = local_path
+        logger.info(f"Resolved model from mirror to local path: {local_path}")
+    elif (
+        engine_config.engine_kwargs.get("load_format") in STREAMING_LOAD_FORMATS
+        and engine_config.mirror_config.bucket_uri
+    ):
+        engine_config.hf_model_id = engine_config.mirror_config.bucket_uri
+        logger.info(
+            f"Streaming load format; using mirror URI: "
+            f"{engine_config.mirror_config.bucket_uri}"
+        )
+
+
 def _get_vllm_engine_config(
     llm_config: LLMConfig,
     *,
     device_type: Optional[str] = None,
 ) -> Tuple["AsyncEngineArgs", "VllmConfig"]:
     engine_config = llm_config.get_engine_config()
-
-    # Resolve to local cache path if model was downloaded from S3/GCS mirror
-    # Only do this if mirror_config was specified (intentional S3/GCS download)
-    if engine_config.mirror_config:
-        from ray.llm._internal.common.utils.download_utils import (
-            get_model_location_on_disk,
-        )
-
-        local_path = get_model_location_on_disk(engine_config.actual_hf_model_id)
-        if local_path and local_path != engine_config.actual_hf_model_id:
-            engine_config.hf_model_id = local_path
-            logger.info(f"Resolved model from mirror to local path: {local_path}")
+    _resolve_hf_model_id_from_mirror(engine_config)
 
     from vllm.usage.usage_lib import UsageContext
 

--- a/python/ray/llm/tests/serve/cpu/configs/test_models.py
+++ b/python/ray/llm/tests/serve/cpu/configs/test_models.py
@@ -201,6 +201,105 @@ class TestModelConfig:
         assert engine_config.mirror_config is not None
         assert engine_config.mirror_config.bucket_uri == bucket_uri
 
+    def test_streaming_load_format_falls_back_to_mirror_uri(self):
+        """Streaming load formats skip local download, so hf_model_id
+        falls back to mirror_config.bucket_uri instead of the alias."""
+        from ray.llm._internal.serve.engines.vllm.vllm_engine import (
+            _resolve_hf_model_id_from_mirror,
+        )
+
+        bucket_uri = "s3://my-bucket/my-model"
+        llm_config = LLMConfig(
+            model_loading_config=ModelLoadingConfig(
+                model_id="qwen-0.5b",
+                model_source=bucket_uri,
+            ),
+            engine_kwargs=dict(load_format="runai_streamer"),
+        )
+        engine_config = llm_config.get_engine_config()
+        assert engine_config.hf_model_id == "qwen-0.5b"
+
+        with patch(
+            "ray.llm._internal.common.utils.download_utils.get_model_location_on_disk",
+            side_effect=lambda model_id: model_id,
+        ):
+            _resolve_hf_model_id_from_mirror(engine_config)
+
+        assert engine_config.hf_model_id == bucket_uri
+
+    def test_streaming_load_format_prefers_local_path_if_already_downloaded(self):
+        """If a local path IS resolved, it should still win over the mirror
+        URI fallback."""
+        from ray.llm._internal.serve.engines.vllm.vllm_engine import (
+            _resolve_hf_model_id_from_mirror,
+        )
+
+        local_path = "/tmp/fake/local/model/path"
+        llm_config = LLMConfig(
+            model_loading_config=ModelLoadingConfig(
+                model_id="qwen-0.5b",
+                model_source="s3://my-bucket/my-model",
+            ),
+            engine_kwargs=dict(load_format="runai_streamer"),
+        )
+        engine_config = llm_config.get_engine_config()
+
+        with patch(
+            "ray.llm._internal.common.utils.download_utils.get_model_location_on_disk",
+            return_value=local_path,
+        ):
+            _resolve_hf_model_id_from_mirror(engine_config)
+
+        assert engine_config.hf_model_id == local_path
+
+    def test_non_streaming_load_format_unaffected_by_mirror_fallback(self):
+        """Without a streaming load_format, if nothing was downloaded yet,
+        hf_model_id stays as the alias -- the new fallback must not kick in
+        outside the streaming-format case."""
+        from ray.llm._internal.serve.engines.vllm.vllm_engine import (
+            _resolve_hf_model_id_from_mirror,
+        )
+
+        llm_config = LLMConfig(
+            model_loading_config=ModelLoadingConfig(
+                model_id="qwen-0.5b",
+                model_source="s3://my-bucket/my-model",
+            ),
+        )
+        engine_config = llm_config.get_engine_config()
+
+        with patch(
+            "ray.llm._internal.common.utils.download_utils.get_model_location_on_disk",
+            side_effect=lambda model_id: model_id,
+        ):
+            _resolve_hf_model_id_from_mirror(engine_config)
+
+        assert engine_config.hf_model_id == "qwen-0.5b"
+
+    def test_streaming_load_format_with_empty_bucket_uri_keeps_alias(self):
+        """An empty/falsy bucket_uri must not overwrite hf_model_id."""
+        from ray.llm._internal.serve.engines.vllm.vllm_engine import (
+            _resolve_hf_model_id_from_mirror,
+        )
+
+        llm_config = LLMConfig(
+            model_loading_config=ModelLoadingConfig(
+                model_id="qwen-0.5b",
+                model_source="s3://my-bucket/my-model",
+            ),
+            engine_kwargs=dict(load_format="runai_streamer"),
+        )
+        engine_config = llm_config.get_engine_config()
+        engine_config.mirror_config.bucket_uri = ""
+
+        with patch(
+            "ray.llm._internal.common.utils.download_utils.get_model_location_on_disk",
+            side_effect=lambda model_id: model_id,
+        ):
+            _resolve_hf_model_id_from_mirror(engine_config)
+
+        assert engine_config.hf_model_id == "qwen-0.5b"
+
     def test_hf_model_source_used_as_hf_model_id(self):
         """A plain HuggingFace model_source is used directly as hf_model_id."""
         llm_config = LLMConfig(


### PR DESCRIPTION
Cherry-pick of #65753 (master commit 8dcc669153d8afa2458d1a6190cadb25e1802e40) onto releases/2.59.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)