### PR TITLE
[serve] Deflake test_proxy_response_generator by waiting for the request to execute

### DIFF
--- a/python/ray/serve/tests/test_proxy_response_generator.py
+++ b/python/ray/serve/tests/test_proxy_response_generator.py
@@ -5,6 +5,7 @@ import pytest
 
 from ray import serve
 from ray._common.test_utils import SignalActor, async_wait_for_condition
+from ray.actor import ActorHandle
 from ray.serve._private.proxy_response_generator import ProxyResponseGenerator
 
 
@@ -16,6 +17,15 @@ def disconnect_task_and_event() -> Tuple[asyncio.Event, asyncio.Task]:
         return await event.wait()
 
     return event, asyncio.ensure_future(wait_for_event())
+
+
+async def wait_for_one_waiter(signal_actor: ActorHandle):
+    """Block until the in-flight request is parked in `signal_actor.wait`."""
+
+    async def one_waiter():
+        return await signal_actor.cur_num_waiters.remote() == 1
+
+    await async_wait_for_condition(one_waiter)
 
 
 @pytest.mark.asyncio
@@ -82,10 +92,7 @@ class TestUnary:
         )
         h.remote()
 
-        async def one_waiter():
-            return await signal_actor.cur_num_waiters.remote() == 1
-
-        await async_wait_for_condition(one_waiter)
+        await wait_for_one_waiter(signal_actor)
 
         gen = ProxyResponseGenerator(h.remote(), timeout_s=0.1)
 
@@ -109,7 +116,10 @@ class TestUnary:
             stream=False,
         )
 
-        gen = ProxyResponseGenerator(h.remote(), timeout_s=0.1)
+        # Only start the timeout clock once the request is executing on the replica.
+        response = h.remote()
+        await wait_for_one_waiter(signal_actor)
+        gen = ProxyResponseGenerator(response, timeout_s=0.1)
 
         with pytest.raises(TimeoutError):
             await gen.__anext__()
@@ -133,10 +143,7 @@ class TestUnary:
         )
         h.remote()
 
-        async def one_waiter():
-            return await signal_actor.cur_num_waiters.remote() == 1
-
-        await async_wait_for_condition(one_waiter)
+        await wait_for_one_waiter(signal_actor)
 
         gen = ProxyResponseGenerator(h.remote(), disconnected_task=disconnect_task)
 
@@ -171,6 +178,7 @@ class TestUnary:
         )
 
         gen = ProxyResponseGenerator(h.remote(), disconnected_task=disconnect_task)
+        await wait_for_one_waiter(signal_actor)
 
         async def get_next():
             return await gen.__anext__()
@@ -257,10 +265,7 @@ class TestStreaming:
         )
         h.remote()
 
-        async def one_waiter():
-            return await signal_actor.cur_num_waiters.remote() == 1
-
-        await async_wait_for_condition(one_waiter)
+        await wait_for_one_waiter(signal_actor)
 
         gen = ProxyResponseGenerator(h.remote(), timeout_s=0.1)
 
@@ -285,7 +290,10 @@ class TestStreaming:
             stream=True,
         )
 
-        gen = ProxyResponseGenerator(h.remote(), timeout_s=0.1)
+        # Only start the timeout clock once the request is executing on the replica.
+        response = h.remote()
+        await wait_for_one_waiter(signal_actor)
+        gen = ProxyResponseGenerator(response, timeout_s=0.1)
         assert (await gen.__anext__()) == "hi"
         with pytest.raises(TimeoutError):
             await gen.__anext__()
@@ -310,10 +318,7 @@ class TestStreaming:
         )
         h.remote()
 
-        async def one_waiter():
-            return await signal_actor.cur_num_waiters.remote() == 1
-
-        await async_wait_for_condition(one_waiter)
+        await wait_for_one_waiter(signal_actor)
 
         gen = ProxyResponseGenerator(h.remote(), disconnected_task=disconnect_task)
 
@@ -350,6 +355,7 @@ class TestStreaming:
 
         gen = ProxyResponseGenerator(h.remote(), disconnected_task=disconnect_task)
         assert (await gen.__anext__()) == "hi"
+        await wait_for_one_waiter(signal_actor)
 
         async def get_next():
             return await gen.__anext__()
@@ -387,6 +393,7 @@ class TestStreaming:
             disconnected_task=disconnect_task,
         )
         assert (await gen.__anext__()) == "hi"
+        await wait_for_one_waiter(signal_actor)
 
         gen.stop_checking_for_disconnect()
 


### PR DESCRIPTION
linux://python/ray/serve/tests:test_proxy_response_generator` has flaked 6 times since 2026-09-02 (5 on the py3.12 shard, 1 on the same-event-loop shard), always green on retry.

The `*_while_executing` tests (and `test_stop_checking_for_disconnect`) assert `signal_actor.cur_num_waiters == 1` after a 0.1s timeout/disconnect to prove the request was executing on the replica, but nothing waits for that state: it is inferred from the 0.1s deadline. The streaming timeout test additionally needs its first chunk within 100ms of a cold `h.remote()`, because `timeout_s` counts from construction. On a loaded runner the cancel races the cold first request. Reproduced on a 4-core box with 3 CPU stressors: 3/6 runs failed on py3.11 and 1/6 on py3.12, as `TestUnary::test_disconnect_while_executing` (`assert 0 == 1`) and `TestStreaming::test_timeout_while_executing` (`TimeoutError` on the `"hi"` assert). In-process timestamps put the request in `signal_actor.wait` 23-28ms after `h.remote()` idle and 30-81ms under load, against a cancel at ~101ms.

Fix: hoist the wait the `*_while_assigning` tests already use into a module helper (`wait_for_one_waiter`) and, in the executing tests, wait for the request to be parked in `signal_actor.wait` before constructing the generator or opening the 0.1s disconnect window. The deadline can now only fire while the request is executing; no timeouts were widened and runtime is unchanged.

Validation under the same load: fixed file 8/8 (py3.11) and 5/5 (py3.12) green, 2/2 idle. With `cancel()` made a no-op, exactly the 8 timeout/disconnect tests fail on `assert gen.cancelled()`, so they still guard cancellation.
