### PR TITLE
[cherry-pick][2.59.0][Data] External shuffle planner + Join & Aggregations + shuffle_compression rename (#65499, #65897, #65590)

### DIFF
--- a/python/ray/data/BUILD.bazel
+++ b/python/ray/data/BUILD.bazel
@@ -804,6 +804,20 @@ py_test(
 )
 
 py_test(
+    name = "test_hash_shuffle_external_repartition",
+    size = "medium",
+    srcs = ["tests/test_hash_shuffle_external_repartition.py"],
+    tags = [
+        "exclusive",
+        "team:data",
+    ],
+    deps = [
+        ":conftest",
+        "//:ray_lib",
+    ],
+)
+
+py_test(
     name = "test_hudi",
     size = "small",
     srcs = ["tests/datasource/test_hudi.py"],

--- a/python/ray/data/_internal/execution/operators/shuffle_operators/external_shuffle_map_operator.py
+++ b/python/ray/data/_internal/execution/operators/shuffle_operators/external_shuffle_map_operator.py
@@ -72,7 +72,6 @@ class ExternalHashShuffleMapOp(
     """External-shuffle map operator. See module docstring."""
 
     _DEFAULT_SHUFFLE_MAP_TASK_NUM_CPUS = 1.0
-    _DEFAULT_PRE_MAP_MERGE_THRESHOLD = 1024 * 1024 * 1024  # 1 GB
 
     def __init__(
         self,
@@ -81,7 +80,6 @@ class ExternalHashShuffleMapOp(
         *,
         num_partitions: int,
         partition_fn: PartitionFn,
-        pre_map_merge_threshold: int = _DEFAULT_PRE_MAP_MERGE_THRESHOLD,
         map_runtime_env: Optional[Dict[str, Any]] = None,
         map_cpus: float = _DEFAULT_SHUFFLE_MAP_TASK_NUM_CPUS,
         name: str = "ExternalHashShuffleMap",
@@ -100,7 +98,9 @@ class ExternalHashShuffleMapOp(
         self._map_runtime_env: Optional[Dict[str, Any]] = map_runtime_env
 
         # -- Pre-map merge ---------------------------------------------------
-        self._pre_map_merge_threshold: int = pre_map_merge_threshold
+        # Buffered blocks are coalesced per node into a single map task once
+        # this size is reached; <= 0 disables batching (one task per bundle).
+        self._input_batch_bytes: int = data_context.shuffle_input_batch_bytes
         self._merge_buffer_refs_by_node: Dict[str, List[ObjectRef]] = defaultdict(list)
         self._merge_buffer_bytes_by_node: Dict[str, int] = defaultdict(int)
         self._merge_buffer_bundles_by_node: Dict[str, List[RefBundle]] = defaultdict(
@@ -173,7 +173,7 @@ class ExternalHashShuffleMapOp(
     def _add_input_inner(self, refs: RefBundle, input_index: int) -> None:
         assert input_index == 0
 
-        if self._pre_map_merge_threshold > 0:
+        if self._input_batch_bytes > 0:
             preferred_locs = refs.get_preferred_object_locations()
             node_id = (
                 max(preferred_locs, key=lambda n: preferred_locs[n])
@@ -187,10 +187,7 @@ class ExternalHashShuffleMapOp(
                 )
             self._merge_buffer_bundles_by_node[node_id].append(refs)
 
-            if (
-                self._merge_buffer_bytes_by_node[node_id]
-                >= self._pre_map_merge_threshold
-            ):
+            if self._merge_buffer_bytes_by_node[node_id] >= self._input_batch_bytes:
                 self._flush_merge_buffer(node_id)
         else:
             self._submit_shuffle_map_task(

--- a/python/ray/data/_internal/execution/operators/shuffle_operators/external_shuffle_map_operator.py
+++ b/python/ray/data/_internal/execution/operators/shuffle_operators/external_shuffle_map_operator.py
@@ -1,12 +1,3 @@
-"""ExternalHashShuffleMapOp — map phase of the external-shuffle variant.
-
-Drives one ``_external_shuffle_map_task`` per input group and, once all mappers finish,
-emits N ``RefBundle`` wrappers to the output queue — one per partition_id,
-each carrying the SAME shared Ray object (the list of handle refs)
-and a distinct ``__partition__<pid>`` sentinel. Wire protocol and task
-body live in ``external_shuffle_runtime.py`` / ``external_shuffle_tasks.py``.
-"""
-
 import functools
 import logging
 import os
@@ -36,6 +27,7 @@ from ray.data._internal.execution.operators.base_physical_operator import (
     InternalQueueOperatorMixin,
 )
 from ray.data._internal.execution.operators.shuffle_operators.external_shuffle_tasks import (  # noqa: E501
+    BlockTransformer,
     PartitionFn,
     _external_shuffle_map_task,
 )
@@ -80,6 +72,7 @@ class ExternalHashShuffleMapOp(
         *,
         num_partitions: int,
         partition_fn: PartitionFn,
+        block_transformer: Optional[BlockTransformer] = None,
         map_runtime_env: Optional[Dict[str, Any]] = None,
         map_cpus: float = _DEFAULT_SHUFFLE_MAP_TASK_NUM_CPUS,
         name: str = "ExternalHashShuffleMap",
@@ -92,6 +85,7 @@ class ExternalHashShuffleMapOp(
 
         self._num_partitions: int = num_partitions
         self._partition_fn: PartitionFn = partition_fn
+        self._block_transformer: Optional[BlockTransformer] = block_transformer
 
         # -- Map task config -------------------------------------------------
         self._shuffle_map_task_num_cpus: float = map_cpus
@@ -253,6 +247,7 @@ class ExternalHashShuffleMapOp(
             map_id=cur_task_idx,
             shuffle_id=self._shuffle_id,
             compression=compression,
+            block_transformer=self._block_transformer,
         )
 
         task = MetadataOpTask(

--- a/python/ray/data/_internal/execution/operators/shuffle_operators/external_shuffle_map_operator.py
+++ b/python/ray/data/_internal/execution/operators/shuffle_operators/external_shuffle_map_operator.py
@@ -233,11 +233,11 @@ class ExternalHashShuffleMapOp(
         if self._map_runtime_env is not None:
             ray_options["runtime_env"] = self._map_runtime_env
 
-        # Pass the raw hash_shuffle_compression through (same as the object-store
+        # Pass the raw shuffle_compression through (same as the object-store
         # ShuffleMapOp). Normalization — casing and the "none" sentinel — lives
         # in _codec_for, which both the map (encode) and reduce (decode) sides
         # go through, so they can't disagree on the codec.
-        compression: Optional[str] = self.data_context.hash_shuffle_compression
+        compression: Optional[str] = self.data_context.shuffle_compression
 
         handle_ref = _external_shuffle_map_task.options(**ray_options).remote(
             *block_refs,

--- a/python/ray/data/_internal/execution/operators/shuffle_operators/external_shuffle_reduce_operator.py
+++ b/python/ray/data/_internal/execution/operators/shuffle_operators/external_shuffle_reduce_operator.py
@@ -87,6 +87,7 @@ class ExternalHashShuffleReduceOp(PhysicalOperator, SubProgressBarMixin):
         reduce_fn: ReduceFn,
         disallow_block_splitting: bool = False,
         reduce_ray_remote_args: Optional[Dict[str, Any]] = None,
+        peak_memory_multiplier: float = SHUFFLE_PEAK_MEMORY_MULTIPLIER,
         name: str = "ExternalHashShuffleReduce",
         fused_output_map_transformer: Optional["MapTransformer"] = None,
         fused_output_map_task_kwargs: Optional[Dict[str, Any]] = None,
@@ -101,6 +102,7 @@ class ExternalHashShuffleReduceOp(PhysicalOperator, SubProgressBarMixin):
         self._num_partitions: int = num_partitions
         self._reduce_fn: ReduceFn = reduce_fn
         self._disallow_block_splitting: bool = disallow_block_splitting
+        self._peak_memory_multiplier: float = peak_memory_multiplier
 
         # -- Reduce task config & tracking -----------------------------------
         self._reduce_ray_remote_args: Dict[str, Any] = dict(
@@ -188,7 +190,7 @@ class ExternalHashShuffleReduceOp(PhysicalOperator, SubProgressBarMixin):
     ) -> None:
         """Submit one reduce task for this partition wrapper."""
         reduce_options = self._reduce_task_remote_args(
-            int(estimated_bytes * SHUFFLE_PEAK_MEMORY_MULTIPLIER)
+            int(estimated_bytes * self._peak_memory_multiplier)
             if estimated_bytes > 0
             else 0
         )
@@ -389,7 +391,7 @@ class ExternalHashShuffleReduceOp(PhysicalOperator, SubProgressBarMixin):
         sizes = [b for b in partition_bytes.values() if b > 0]
         if sizes:
             avg_bytes = sum(sizes) / len(sizes)
-            memory = int(avg_bytes * SHUFFLE_PEAK_MEMORY_MULTIPLIER)
+            memory = int(avg_bytes * self._peak_memory_multiplier)
         return ExecutionResources.from_resource_dict(
             self._reduce_task_remote_args(memory)
         )

--- a/python/ray/data/_internal/execution/operators/shuffle_operators/external_shuffle_reduce_operator.py
+++ b/python/ray/data/_internal/execution/operators/shuffle_operators/external_shuffle_reduce_operator.py
@@ -1,22 +1,8 @@
-"""ExternalHashShuffleReduceOp — reduce phase of the external-shuffle variant.
-
-One partition wrapper in (via ``_add_input_inner``), one reduce task
-out. The executor's normal backpressure + resource manager gate
-dispatch.
-
-Each wrapper carries a single ObjectRef — the shared handle-list
-Ray object built by the map op — plus a ``__partition__<pid>``
-sentinel in its metadata. The reduce task resolves that ref (a list of
-per-mapper handle refs), materializes the individual handle dicts, and
-fetches its partition's shards over Arrow Flight from each source node's
-``ShuffleFileServer``.
-"""
-
 import functools
 import logging
 import typing
 from collections import deque
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 
 import pyarrow as pa
 
@@ -55,7 +41,6 @@ from ray.data._internal.execution.operators.shuffle_operators.shuffle_tasks impo
 from ray.data._internal.execution.operators.sub_progress import SubProgressBarMixin
 from ray.data.block import BlockAccessor, BlockStats, TaskExecWorkerStats, to_stats
 from ray.data.context import DataContext
-from ray.types import ObjectRef
 
 if typing.TYPE_CHECKING:
     from ray.data._internal.execution.operators.map_transformer import (
@@ -69,18 +54,23 @@ logger = logging.getLogger(__name__)
 class ExternalHashShuffleReduceOp(PhysicalOperator, SubProgressBarMixin):
     """External-shuffle reduce operator.
 
-    Structurally mirrors ``ShuffleReduceOp``: one wrapper bundle in via
-    ``_add_input_inner``, one reduce task out. The wrapper carries
-    ``shared_handles_ref`` + partition_id sentinel; ``_external_shuffle_reduce_task``
-    uses those to fetch its partition's bytes over Arrow Flight from each
-    mapper's ``ShuffleFileServer``.
+    Structurally mirrors ``ShuffleReduceOp``: one wrapper bundle per partition
+    per input in via ``_add_input_inner``, one reduce task out. Each wrapper
+    carries ``shared_handles_ref`` + partition_id sentinel;
+    ``_external_shuffle_reduce_task`` uses those to fetch its partition's bytes
+    over Arrow Flight from each mapper's ``ShuffleFileServer``.
+
+    Supports one or more co-partitioned upstream ``ExternalHashShuffleMapOp``s.
+    With multiple inputs (e.g. join) every input must be partitioned into the
+    same ``num_partitions``; this op pairs up the per-partition wrappers across
+    all inputs and the reducer receives one table list per input.
     """
 
     _DEFAULT_SHUFFLE_REDUCE_TASK_NUM_CPUS = 1.0
 
     def __init__(
         self,
-        input_op: ExternalHashShuffleMapOp,
+        input_op: Union[ExternalHashShuffleMapOp, List[ExternalHashShuffleMapOp]],
         data_context: DataContext,
         *,
         num_partitions: int,
@@ -89,19 +79,31 @@ class ExternalHashShuffleReduceOp(PhysicalOperator, SubProgressBarMixin):
         reduce_ray_remote_args: Optional[Dict[str, Any]] = None,
         peak_memory_multiplier: float = SHUFFLE_PEAK_MEMORY_MULTIPLIER,
         name: str = "ExternalHashShuffleReduce",
+        should_emit_empty_partitions: bool = True,
         fused_output_map_transformer: Optional["MapTransformer"] = None,
         fused_output_map_task_kwargs: Optional[Dict[str, Any]] = None,
         fused_output_map_target_max_block_size_override: Optional[int] = None,
     ):
+        input_ops: List[PhysicalOperator] = (
+            [input_op]
+            if isinstance(input_op, ExternalHashShuffleMapOp)
+            else list(input_op)
+        )
+        assert input_ops, (
+            "ExternalHashShuffleReduceOp requires at least one upstream "
+            "ExternalHashShuffleMapOp"
+        )
         super().__init__(
             name=name,
-            input_dependencies=[input_op],
+            input_dependencies=input_ops,
             data_context=data_context,
         )
 
+        self._num_inputs: int = len(input_ops)
         self._num_partitions: int = num_partitions
         self._reduce_fn: ReduceFn = reduce_fn
         self._disallow_block_splitting: bool = disallow_block_splitting
+        self._emit_empty_partitions: bool = should_emit_empty_partitions
         self._peak_memory_multiplier: float = peak_memory_multiplier
 
         # -- Reduce task config & tracking -----------------------------------
@@ -110,6 +112,11 @@ class ExternalHashShuffleReduceOp(PhysicalOperator, SubProgressBarMixin):
         )
         self._shuffle_reduce_tasks: Dict[int, DataOpTask] = {}
         self._num_reduce_tasks_submitted: int = 0
+
+        # -- Per-partition pairing across inputs -----------------------------
+        # partition_id -> input_index -> that input's wrapper bundle. A reduce
+        # task is submitted once all inputs delivered their wrapper.
+        self._pending_inputs: Dict[int, Dict[int, RefBundle]] = {}
 
         # -- Fused downstream map --------------------------------------------
         self._fused_output_map_transformer = fused_output_map_transformer
@@ -148,47 +155,61 @@ class ExternalHashShuffleReduceOp(PhysicalOperator, SubProgressBarMixin):
         return remote_args
 
     def _add_input_inner(self, refs: RefBundle, input_index: int) -> None:
-        """Dispatch one reduce task per partition wrapper. Backpressure is
-        executor-driven — no accumulation, no dispatch loop."""
-        assert input_index == 0
+        assert 0 <= input_index < self._num_inputs
         if not refs.block_refs:
             refs.destroy_if_owned()
             return
 
         partition_id = extract_partition_id(refs)
-        estimated_bytes = sum((m.size_bytes or 0) for m in refs.metadata)
         estimated_rows = sum((m.num_rows or 0) for m in refs.metadata)
 
-        # Empty-partition fast path: wrappers for partitions that no
-        # mapper wrote rows to have ``num_rows==0`` (the map op sums
-        # per-partition decoded row counts across mappers into wrapper
-        # metadata). Do not gate on ``size_bytes``: a ``null``-typed
-        # table can have rows with ``tbl.nbytes == 0``. Skipped when a
-        # downstream map is fused in — the map still needs to run even
-        # on empty partitions (e.g. Write).
         schema = refs.schema
         if (
-            self._fused_output_map_transformer is None
+            self._num_inputs == 1
+            and self._fused_output_map_transformer is None
             and isinstance(schema, pa.Schema)
             and estimated_rows == 0
         ):
-            self._emit_empty_partition(refs, schema)
+            if self._emit_empty_partitions:
+                self._emit_empty_partition(refs, schema)
+            else:
+                refs.destroy_if_owned()
             return
 
-        # Wrapper carries a single ObjectRef pointing at the map op's
-        # shared handle list; passing that one ref through Ray dispatch
-        # keeps arg bookkeeping O(1) per reducer instead of O(#mappers).
-        handles_ref = refs.block_refs[0]
+        pending = self._pending_inputs.setdefault(partition_id, {})
+        assert input_index not in pending, (
+            f"input {input_index} already delivered a wrapper for partition "
+            f"{partition_id}; each ExternalHashShuffleMapOp must emit at most "
+            f"one wrapper per partition"
+        )
+        pending[input_index] = refs
+        if len(pending) == self._num_inputs:
+            del self._pending_inputs[partition_id]
+            self._submit_reduce_task(
+                partition_id, [pending[i] for i in range(self._num_inputs)]
+            )
 
-        self._submit_reduce_task(partition_id, handles_ref, estimated_bytes)
+    def all_inputs_done(self) -> None:
+        super().all_inputs_done()
+        for partition_id in list(self._pending_inputs.keys()):
+            pending = self._pending_inputs.pop(partition_id)
+            bundles = [pending.get(i) for i in range(self._num_inputs)]
+            self._submit_reduce_task(partition_id, bundles)
 
     def _submit_reduce_task(
         self,
         partition_id: int,
-        handles_ref: ObjectRef,
-        estimated_bytes: int,
+        bundles: List[Optional[RefBundle]],
     ) -> None:
-        """Submit one reduce task for this partition wrapper."""
+        handles_refs: List[Any] = []
+        estimated_bytes = 0
+        for bundle in bundles:
+            if bundle is not None and bundle.block_refs:
+                handles_refs.append(bundle.block_refs[0])
+                estimated_bytes += sum((m.size_bytes or 0) for m in bundle.metadata)
+            else:
+                handles_refs.append([])
+
         reduce_options = self._reduce_task_remote_args(
             int(estimated_bytes * self._peak_memory_multiplier)
             if estimated_bytes > 0
@@ -213,15 +234,16 @@ class ExternalHashShuffleReduceOp(PhysicalOperator, SubProgressBarMixin):
             map_task_context.kwargs.update(self._fused_output_map_task_kwargs)
 
         block_gen = _external_shuffle_reduce_task.options(**reduce_options).remote(
-            handles_ref,  # pyrefly: ignore[bad-argument-type]
-            partition_id,
-            self._reduce_fn,
-            self._max_bytes_per_fetch,
-            self._fetch_threads,
-            target_max_block_size,
-            self._fused_output_map_transformer,
-            map_task_context,
-            self.data_context,
+            *handles_refs,  # pyrefly: ignore[bad-argument-type]
+            partition_id=partition_id,
+            reduce_fn=self._reduce_fn,
+            max_bytes_per_fetch=self._max_bytes_per_fetch,
+            fetch_threads=self._fetch_threads,
+            target_max_block_size=target_max_block_size,
+            map_transformer=self._fused_output_map_transformer,
+            map_task_context=map_task_context,
+            data_context=self.data_context,
+            emit_empty_partition=self._emit_empty_partitions,
         )
 
         data_task = DataOpTask(
@@ -233,7 +255,7 @@ class ExternalHashShuffleReduceOp(PhysicalOperator, SubProgressBarMixin):
                 self._handle_reduce_output_ready, partition_id
             ),
             task_done_callback=functools.partial(
-                self._handle_reduce_done, partition_id
+                self._handle_reduce_done, partition_id, bundles
             ),
             task_resource_bundle=ExecutionResources.from_resource_dict(reduce_options),
             operator_name=self.name,
@@ -327,11 +349,14 @@ class ExternalHashShuffleReduceOp(PhysicalOperator, SubProgressBarMixin):
     def _handle_reduce_done(
         self,
         partition_id: int,
+        input_bundles: List[Optional[RefBundle]],
         exc: Optional[Exception],
         task_exec_stats: Optional[TaskExecWorkerStats],
         task_exec_driver_stats: Optional[TaskExecDriverStats],
     ) -> None:
-        """Callback when a reduce task finishes (with or without exception)."""
+        for input_bundle in input_bundles:
+            if input_bundle is not None:
+                input_bundle.destroy_if_owned()
         if partition_id not in self._shuffle_reduce_tasks:
             return
         self._shuffle_reduce_tasks.pop(partition_id)
@@ -347,7 +372,7 @@ class ExternalHashShuffleReduceOp(PhysicalOperator, SubProgressBarMixin):
             )
 
     def has_execution_finished(self) -> bool:
-        if self._shuffle_reduce_tasks or self._output_queue:
+        if self._shuffle_reduce_tasks or self._output_queue or self._pending_inputs:
             return False
         return super().has_execution_finished()
 
@@ -355,6 +380,7 @@ class ExternalHashShuffleReduceOp(PhysicalOperator, SubProgressBarMixin):
         return (
             not self._shuffle_reduce_tasks
             and not self._output_queue
+            and not self._pending_inputs
             and super().has_completed()
         )
 
@@ -362,13 +388,20 @@ class ExternalHashShuffleReduceOp(PhysicalOperator, SubProgressBarMixin):
         super()._do_shutdown(force)
         self._shuffle_reduce_tasks.clear()
         self._output_queue.clear()
-        # ShuffleFileServer actors + handle refs are owned upstream; nothing to
-        # clean up here.
+        for pending in self._pending_inputs.values():
+            for bundle in pending.values():
+                bundle.destroy_if_owned()
+        self._pending_inputs.clear()
 
     def get_stats(self) -> Dict[str, List[BlockStats]]:
         return {self._name: self._output_blocks_stats}
 
     def num_output_rows_total(self) -> Optional[int]:
+        # Multi-input reduces (e.g. join) can grow or shrink the row count, so
+        # it is unknown until the reducers run; a single-input reduce preserves
+        # it.
+        if self._num_inputs > 1:
+            return None
         upstream = self.input_dependencies[0]
         assert isinstance(upstream, ExternalHashShuffleMapOp)
         return upstream.num_output_rows_total()
@@ -383,15 +416,13 @@ class ExternalHashShuffleReduceOp(PhysicalOperator, SubProgressBarMixin):
         return usage
 
     def incremental_resource_usage(self) -> ExecutionResources:
-        """Per-task resource ask for the framework's budget allocator."""
-        upstream = self.input_dependencies[0]
-        assert isinstance(upstream, ExternalHashShuffleMapOp)
-        partition_bytes = upstream.get_partition_bytes()
         memory = 0
-        sizes = [b for b in partition_bytes.values() if b > 0]
-        if sizes:
-            avg_bytes = sum(sizes) / len(sizes)
-            memory = int(avg_bytes * self._peak_memory_multiplier)
+        for upstream in self.input_dependencies:
+            assert isinstance(upstream, ExternalHashShuffleMapOp)
+            sizes = [b for b in upstream.get_partition_bytes().values() if b > 0]
+            if sizes:
+                avg_bytes = sum(sizes) / len(sizes)
+                memory += int(avg_bytes * self._peak_memory_multiplier)
         return ExecutionResources.from_resource_dict(
             self._reduce_task_remote_args(memory)
         )

--- a/python/ray/data/_internal/execution/operators/shuffle_operators/external_shuffle_runtime.py
+++ b/python/ray/data/_internal/execution/operators/shuffle_operators/external_shuffle_runtime.py
@@ -53,7 +53,7 @@ _ENDPOINT_POLL_WARN_EVERY = 15  # ~30s at the interval above
 _DEFAULT_HANDLE_BATCH_BYTES = 64 * MiB
 
 # pyarrow-supported shard codecs (``"none"``/``None`` = uncompressed). Rides
-# ``data_context.hash_shuffle_compression``.
+# ``data_context.shuffle_compression``.
 Compression = Optional[
     Literal[
         "none", "gzip", "bz2", "brotli", "lz4", "lz4_frame", "lz4_raw", "zstd", "snappy"
@@ -271,7 +271,7 @@ class _PartitionWriter:
     ):
         self._out_file = out_file
         self._map_id = map_id
-        # Codec from data_context.hash_shuffle_compression (same field the reduce reads).
+        # Codec from data_context.shuffle_compression (same field the reduce reads).
         self._compression = compression
         self._staging: Dict[int, List[pa.Table]] = {}
         self._index: Dict[int, List[Tuple[int, int]]] = {}

--- a/python/ray/data/_internal/execution/operators/shuffle_operators/external_shuffle_tasks.py
+++ b/python/ray/data/_internal/execution/operators/shuffle_operators/external_shuffle_tasks.py
@@ -356,10 +356,10 @@ def _external_shuffle_reduce_task(
                 [] for _ in range(num_inputs)
             ]
             output_buffer: Optional[BlockOutputBuffer] = None
-            # Codec from data_context.hash_shuffle_compression (same field the map used).
+            # Codec from data_context.shuffle_compression (same field the map used).
             _compression = (
                 data_context if data_context is not None else DataContext.get_current()
-            ).hash_shuffle_compression
+            ).shuffle_compression
 
             def _flush(tables_by_input: List[List[pa.Table]]):
                 """Call reduce_fn on ``tables_by_input`` and yield reshaped raw blocks.

--- a/python/ray/data/_internal/execution/operators/shuffle_operators/external_shuffle_tasks.py
+++ b/python/ray/data/_internal/execution/operators/shuffle_operators/external_shuffle_tasks.py
@@ -1,19 +1,3 @@
-"""External-shuffle task bodies (map + reduce).
-
-- each MAP task writes ONE file (all its partitions, Arrow IPC) and returns ONE
-  small handle (path + per-partition offset index + ``shuffle_id`` /
-  ``node_id``). Driver tracks O(N) handles; bulk data stays on local disk and
-  never enters Ray's object store.
-- a per-node ``ShuffleFileServer`` Ray actor runs its OWN Arrow Flight server
-  that ``pread``s requested byte-ranges and streams them back. The REDUCE task
-  is a client of that server.
-  Cross-node this is the real out-of-band transport; single-node it is a
-  loopback Flight connection (still the real code path, not a direct ``open``).
-
-Uses the standard ``PartitionFn`` / ``ReduceFn`` contracts, so group-by /
-sort / aggregate / join factories compose unchanged.
-"""
-
 import os
 import pickle
 import random
@@ -55,9 +39,10 @@ from ray.data._internal.execution.operators.shuffle_operators.external_shuffle_r
     _read_ipc,
 )
 
-# PartitionFn/ReduceFn contracts are shared with the object-store variant.
-# External shuffle is single-input (for now), so ReduceFn's outer list always has length 1.
+# PartitionFn/ReduceFn/BlockTransformer contracts are shared with the
+# object-store variant.
 from ray.data._internal.execution.operators.shuffle_operators.shuffle_tasks import (  # noqa: E402,E501
+    BlockTransformer,
     PartitionFn,
     ReduceFn,
 )
@@ -65,11 +50,13 @@ from ray.data._internal.output_buffer import (
     BlockOutputBuffer,
     OutputBlockSizeOption,
 )
+from ray.data._internal.table_block import TableBlockAccessor
 from ray.data.block import (
     Block,
     BlockAccessor,
     BlockExecStats,
     BlockMetadataWithSchema,
+    BlockType,
     TaskExecWorkerStats,
 )
 from ray.data.context import DataContext
@@ -89,6 +76,7 @@ def _external_shuffle_map_task(
     map_id: int,
     shuffle_id: str,
     compression: Optional[str] = None,
+    block_transformer: Optional[BlockTransformer] = None,
 ) -> ShuffleHandle:
     """Map stage: partition input blocks, write them to a single file under
     ``out_dir``, and return a ``ShuffleHandle`` (on-disk path +
@@ -109,10 +97,25 @@ def _external_shuffle_map_task(
         map_id: This map task's index.
         shuffle_id: Unique per-shuffle id; part of the file server's actor name.
         compression: Arrow IPC codec name (e.g. "lz4", "zstd") or None.
+        block_transformer: Optional transform applied to the concatenation of
+            all input blocks before partitioning (e.g. map-side partial
+            aggregation). May change the block schema.
 
     Returns:
         ShuffleHandle describing the on-disk shards for reducers to fetch.
     """
+    if block_transformer is not None:
+        arrow_inputs = [
+            TableBlockAccessor.try_convert_block_type(block, block_type=BlockType.ARROW)
+            for block in blocks
+            if BlockAccessor.for_block(block).num_rows() > 0
+        ] or [
+            TableBlockAccessor.try_convert_block_type(
+                blocks[0], block_type=BlockType.ARROW
+            )
+        ]
+        combined_input = transform_pyarrow.concat(arrow_inputs, promote_types=True)
+        blocks = (block_transformer(combined_input),)
     node_id = ray.get_runtime_context().get_node_id()
     # Ensure the file-server actor exists (get_if_exists=True → reuse across
     # mappers on the same node). We don't need to keep the handle: reducers
@@ -137,20 +140,20 @@ def _external_shuffle_map_task(
     try:
         with open(tmp_path, "wb") as out_file:
             writer = _PartitionWriter(out_file, map_id, compression)
-            for blk in blocks:
+            for block in blocks:
                 # Accept any Ray Data Block (Arrow / pandas / ...) at the
                 # boundary and normalize to ``pa.Table`` here. Downstream
                 # (partition_fn, IPC serialize) is Arrow-only. No-op when
                 # already Arrow.
-                if not isinstance(blk, pa.Table):
-                    blk = BlockAccessor.for_block(blk).to_arrow()
+                if not isinstance(block, pa.Table):
+                    block = BlockAccessor.for_block(block).to_arrow()
                 if output_schema is None:
                     # First-seen schema; reducer uses it to type empty
                     # partitions (ShuffleHandle["schema"]).
-                    output_schema = getattr(blk, "schema", None)
-                if blk.num_rows == 0:
+                    output_schema = getattr(block, "schema", None)
+                if block.num_rows == 0:
                     continue
-                for partition_id, shard in partition_fn(blk).items():
+                for partition_id, shard in partition_fn(block).items():
                     writer.add_shard(partition_id, shard)
             writer.flush_all()
 
@@ -168,7 +171,7 @@ def _external_shuffle_map_task(
             else:
                 expected_size = 0
             assert final_size_on_close == expected_size, (
-                f"_external_shuffle_map_task: file size mismatch — wrote "
+                f"_external_shuffle_map_task: file size mismatch, wrote "
                 f"{final_size_on_close} bytes, index implies {expected_size}"
             )
 
@@ -207,9 +210,9 @@ def _external_shuffle_map_task(
     }
 
 
-@ray.remote
+@ray.remote  # pyrefly: ignore[no-matching-overload]
 def _external_shuffle_reduce_task(
-    handles: List[ShuffleHandle],
+    *handles_by_input: List[ShuffleHandle],
     partition_id: int,
     reduce_fn: ReduceFn,
     max_bytes_per_fetch: int,
@@ -218,6 +221,7 @@ def _external_shuffle_reduce_task(
     map_transformer: Optional[Any],
     map_task_context: Optional["TaskContext"],
     data_context: Optional["DataContext"],
+    emit_empty_partition: bool = True,
 ) -> Generator[Union[Block, bytes], None, None]:
     """Reduce stage: fetch this partition's shards from every mapper over Arrow
     Flight, run ``reduce_fn`` on the accumulated tables, and yield ``(block,
@@ -231,7 +235,10 @@ def _external_shuffle_reduce_task(
     its future completes.
 
     Args:
-        handles: One ``ShuffleHandle`` per mapper (single upstream input).
+        *handles_by_input: One handle list per upstream input (one for
+            repartition/sort/aggregate, two for join), each holding one
+            ``ShuffleHandle`` per mapper. ``tables_by_input`` passed to
+            ``reduce_fn`` is aligned with this order.
         partition_id: Partition this reducer owns.
         reduce_fn: User-supplied reduce callable.
         max_bytes_per_fetch: Per-FETCH-frame payload cap.
@@ -241,13 +248,35 @@ def _external_shuffle_reduce_task(
             output stream (or None).
         map_task_context: TaskContext for the fused map, or None.
         data_context: DataContext to install for the fused map, or None.
+        emit_empty_partition: If True (default), a single-input partition with
+            no shards yields one schema-typed empty block. Aggregations pass
+            False (the mappers' pre-finalize schema would conflict with
+            finalized partitions). Multi-input reduces always run reduce_fn.
     """
     start_time_s = time.perf_counter()
 
-    # Pull per-partition source refs + an output schema for the empty-partition
-    # fallback path (so the N-block contract still emits a typed 0-row block
-    # when no mapper produced any data for this partition_id).
-    sources, output_schema = _handles_to_sources(handles, partition_id)
+    num_inputs = len(handles_by_input)
+    sources_by_input: List[List[Any]] = []
+    schemas_by_input: List[Optional[pa.Schema]] = []
+    for handles in handles_by_input:
+        sources, schema = _handles_to_sources(handles, partition_id)
+        sources_by_input.append(sources)
+        schemas_by_input.append(schema)
+    output_schema: Optional[pa.Schema] = next(
+        (s for s in schemas_by_input if s is not None), None
+    )
+
+    def _with_typed_empty_inputs(
+        tables_by_input: List[List[pa.Table]],
+    ) -> List[List[pa.Table]]:
+        if num_inputs == 1:
+            return tables_by_input
+        out: List[List[pa.Table]] = []
+        for tables, schema in zip(tables_by_input, schemas_by_input):
+            if not tables and schema is not None:
+                tables = [schema.empty_table()]
+            out.append(tables)
+        return out
 
     def _yield_with_stats(block: Block):
         """Yield ``block`` then its pickled metadata. The two-yield protocol
@@ -283,44 +312,57 @@ def _external_shuffle_reduce_task(
             for out_block in map_transformer.apply_transform(blocks, map_task_context):
                 yield from _yield_with_stats(out_block)
 
-    # No shards for this partition. Yield a typed empty table so the
-    # N-block contract holds when the operator fast path was skipped
-    # (fused map, or wrapper schema missing). Do not call reduce_fn on
-    # ``[[]]``: concat/sort reduces yield nothing for empty input.
-    if not sources:
+    if not any(sources_by_input):
+        if num_inputs == 1:
 
-        def _empty_blocks():
-            assert output_schema is not None
-            yield output_schema.empty_table()
+            def _no_input_blocks():
+                if not emit_empty_partition:
+                    return
+                assert output_schema is not None
+                yield output_schema.empty_table()
 
-        yield from _emit_blocks(_empty_blocks())
+        else:
+
+            def _no_input_blocks():
+                yield from reduce_fn(
+                    partition_id,
+                    _with_typed_empty_inputs([[] for _ in range(num_inputs)]),
+                )
+
+        yield from _emit_blocks(_no_input_blocks())
     else:
-        # Shared per-shuffle staging dir; partition_id lives on the file.
-        shuffle_id = sources[0].shuffle_id
+        shuffle_id = next(s for srcs in sources_by_input for s in srcs).shuffle_id
         staging_dir = os.path.join(
             tempfile.gettempdir(), f"ray_shuffle_external_{shuffle_id}_reduce"
         )
         os.makedirs(staging_dir, exist_ok=True)
         prefetch_file = os.path.join(staging_dir, f"reduce_p{partition_id}.bin")
 
-        groups = _group_by_server(sources)
+        groups_by_input = [_group_by_server(srcs) for srcs in sources_by_input]
+        flat_groups = [group for groups in groups_by_input for group in groups]
+        group_input_idx = [
+            input_idx
+            for input_idx, groups in enumerate(groups_by_input)
+            for _ in groups
+        ]
 
         try:
             # Fetch each source region in parallel, pwrite at pre-assigned offsets
             # into this partition's staging file (disjoint → lock-free). Buffered
             # pwrite lands in page cache so the decode-side ``pread``s hit cache.
-            total_size, base_offsets, node_sizes = _compute_prefetch_layout(groups)
+            total_size, base_offsets, node_sizes = _compute_prefetch_layout(flat_groups)
 
-            # Accumulator for the final reduce.
-            accum_tables: List[pa.Table] = []
+            accum_tables_by_input: List[List[pa.Table]] = [
+                [] for _ in range(num_inputs)
+            ]
             output_buffer: Optional[BlockOutputBuffer] = None
             # Codec from data_context.hash_shuffle_compression (same field the map used).
             _compression = (
                 data_context if data_context is not None else DataContext.get_current()
             ).hash_shuffle_compression
 
-            def _flush(tables: List[pa.Table]):
-                """Call reduce_fn on ``tables`` and yield reshaped raw blocks.
+            def _flush(tables_by_input: List[List[pa.Table]]):
+                """Call reduce_fn on ``tables_by_input`` and yield reshaped raw blocks.
 
                 Fused map / stats are applied downstream of ``_reduce_output_blocks``.
                 """
@@ -331,9 +373,8 @@ def _external_shuffle_reduce_task(
                             target_max_block_size=target_max_block_size,
                         )
                     )
-                # Wrap in a 1-element list — external is single-input, but
-                # reduce_fn's signature is ``(partition_id, tables_by_input)``.
-                for block in reduce_fn(partition_id, [tables]):
+                tables_by_input = _with_typed_empty_inputs(tables_by_input)
+                for block in reduce_fn(partition_id, tables_by_input):
                     if output_buffer is None:
                         # target_max_block_size=None: emit blocks as-is.
                         yield block
@@ -364,32 +405,25 @@ def _external_shuffle_reduce_task(
                                 ) from e
                             raise
 
-                    n_threads = min(len(groups), max(1, fetch_threads))
-                    work = list(zip(base_offsets, node_sizes, groups))
+                    n_threads = min(len(flat_groups), max(1, fetch_threads))
+                    work = list(
+                        zip(base_offsets, node_sizes, flat_groups, group_input_idx)
+                    )
                     # Randomize submission order per reducer (seeded by partition_id →
                     # deterministic/retry-stable) so concurrent fan-in spreads evenly
                     # across file servers. Disjoint offsets make reordering safe.
                     if work:
                         random.Random(partition_id).shuffle(work)
 
-                    def _decode_region(base: int, size: int):
+                    def _decode_region(base: int, size: int, accum: List[pa.Table]):
                         """Decode one staging-file region's IPC frames into ``accum_tables``."""
                         pos = base
                         end = base + size
-                        region_tables: List[pa.Table] = []
                         while pos < end:
                             length = struct.unpack(">Q", os.pread(fd, 8, pos))[0]
                             ipc_buf = os.pread(fd, length, pos + 8)
                             pos += 8 + length
-                            region_tables.append(_read_ipc(ipc_buf, _compression))
-                        if len(region_tables) == 1:
-                            accum_tables.append(region_tables[0])
-                        elif region_tables:
-                            accum_tables.append(
-                                transform_pyarrow.combine_chunks(
-                                    pa.concat_tables(region_tables)
-                                )
-                            )
+                            accum.append(_read_ipc(ipc_buf, _compression))
 
                     with ThreadPoolExecutor(max_workers=n_threads) as ex:
                         futs = {
@@ -400,18 +434,20 @@ def _external_shuffle_reduce_task(
                                 group.node_id,
                                 group.members,
                                 max_bytes_per_fetch,
-                            ): (base, size)
-                            for base, size, group in work
+                            ): (base, size, input_idx)
+                            for base, size, group, input_idx in work
                         }
                         for fut in as_completed(futs):
                             fut.result()
-                            base, size = futs[fut]
+                            base, size, input_idx = futs[fut]
                             if size > 0:
-                                _decode_region(base, size)
+                                _decode_region(
+                                    base, size, accum_tables_by_input[input_idx]
+                                )
 
                     # Drain the accumulator tail.
-                    if accum_tables:
-                        yield from _flush(accum_tables)
+                    if any(accum_tables_by_input):
+                        yield from _flush(accum_tables_by_input)
                     if output_buffer is not None:
                         output_buffer.finalize()
                         yield from output_buffer.iter_ready_blocks()

--- a/python/ray/data/_internal/execution/operators/shuffle_operators/shuffle_map_operator.py
+++ b/python/ray/data/_internal/execution/operators/shuffle_operators/shuffle_map_operator.py
@@ -238,7 +238,7 @@ class ShuffleMapOp(InternalQueueOperatorMixin, PhysicalOperator, SubProgressBarM
             *block_refs,
             partition_fn=self._partition_fn,
             num_partitions=self._num_partitions,
-            compression=self.data_context.hash_shuffle_compression,
+            compression=self.data_context.shuffle_compression,
             block_transformer=self._block_transformer,
         )
         metadata_ref = map_refs[0]

--- a/python/ray/data/_internal/execution/resource_manager.py
+++ b/python/ray/data/_internal/execution/resource_manager.py
@@ -23,6 +23,9 @@ from ray.data._internal.execution.operators.hash_shuffle import (
     HashShufflingOperatorBase,
 )
 from ray.data._internal.execution.operators.input_data_buffer import InputDataBuffer
+from ray.data._internal.execution.operators.shuffle_operators.external_shuffle_map_operator import (  # noqa: E501
+    ExternalHashShuffleMapOp,
+)
 from ray.data._internal.execution.operators.shuffle_operators.shuffle_map_operator import (  # noqa: E501
     ShuffleMapOp,
 )
@@ -57,6 +60,7 @@ _BLOCKING_MATERIALIZING_OPERATORS = (
     HashShufflingOperatorBase,
     AllToAllOperator,
     ShuffleMapOp,
+    ExternalHashShuffleMapOp,
     # TODO remove after zip made fully streaming
     ZipOperator,
 )

--- a/python/ray/data/_internal/logical/rules/operator_fusion.py
+++ b/python/ray/data/_internal/logical/rules/operator_fusion.py
@@ -391,15 +391,15 @@ class FuseOperators(Rule):
         self._op_map.pop(down_op)
 
         if isinstance(up_op, ExternalHashShuffleReduceOp):
-            # External is single-input by design (no Join support).
             fused_op = ExternalHashShuffleReduceOp(
-                up_op.input_dependencies[0],
+                up_op.input_dependencies,
                 up_op.data_context,
                 num_partitions=up_op._num_partitions,
                 reduce_fn=up_op._reduce_fn,
                 disallow_block_splitting=up_op._disallow_block_splitting,
                 reduce_ray_remote_args=up_op._reduce_ray_remote_args,
                 peak_memory_multiplier=up_op._peak_memory_multiplier,
+                should_emit_empty_partitions=up_op._emit_empty_partitions,
                 name=name,
                 fused_output_map_transformer=down_op.get_map_transformer(),
                 fused_output_map_task_kwargs=down_op.get_map_task_kwargs(),

--- a/python/ray/data/_internal/logical/rules/operator_fusion.py
+++ b/python/ray/data/_internal/logical/rules/operator_fusion.py
@@ -24,6 +24,9 @@ from ray.data._internal.execution.operators.base_physical_operator import (
 )
 from ray.data._internal.execution.operators.limit_operator import LimitOperator
 from ray.data._internal.execution.operators.map_operator import MapOperator
+from ray.data._internal.execution.operators.shuffle_operators.external_shuffle_reduce_operator import (  # noqa: E501
+    ExternalHashShuffleReduceOp,
+)
 from ray.data._internal.execution.operators.shuffle_operators.shuffle_reduce_operator import (
     ShuffleReduceOp,
 )
@@ -74,9 +77,9 @@ class FuseOperators(Rule):
         # we fuse together MapOperator -> AllToAllOperator pairs.
         fused_dag = self._fuse_all_to_all_operators_in_dag(fused_dag)
 
-        # Fuse a downstream task-pool map into the V2 hash-shuffle reduce phase.
-        # Runs after map fusion so a downstream map chain is already collapsed
-        # into one TaskPoolMapOperator.
+        # Fuse a downstream task-pool map into the hash-shuffle reduce.
+        # Runs after map fusion so any downstream map chain is already
+        # collapsed into a single TaskPoolMapOperator.
         fused_dag = self._fuse_map_into_shuffle_reduce_in_dag(fused_dag)
 
         # Update output dependencies after fusion.
@@ -101,10 +104,9 @@ class FuseOperators(Rule):
     def _fuse_map_into_shuffle_reduce_in_dag(
         self, dag: PhysicalOperator, has_downstream_limit: bool = False
     ) -> PhysicalOperator:
-        """Starting at the given operator, traverses up the DAG and fuses a
-        task-pool map sitting directly downstream of a V2 hash-shuffle reduce
-        into the reduce (a ``ShuffleReduceOp -> TaskPoolMapOperator`` pair).
-
+        """Starting at the given operator, traverses up the DAG of operators
+        and fuses compatible ShuffleReduceOp -> TaskPoolMapOperator pairs
+        (object-store and external variants share the same fusion policy).
         Returns the current (root) operator after completing upstream fusions.
         """
         if self._can_fuse_map_into_shuffle_reduce(dag, has_downstream_limit):
@@ -122,7 +124,7 @@ class FuseOperators(Rule):
     def _can_fuse_map_into_shuffle_reduce(
         self, dag: PhysicalOperator, has_downstream_limit: bool
     ) -> bool:
-        """Whether ``dag`` is a task-pool map that can be fused into the V2
+        """Whether ``dag`` is a task-pool map that can be fused into the
         hash-shuffle reduce immediately upstream of it.
         """
         # `dag` must be a fusable task-pool map.
@@ -154,9 +156,12 @@ class FuseOperators(Rule):
         ):
             return False
 
-        # The sole upstream must be a reduce that hasn't already fused with a map.
+        # The sole upstream must be a hash-shuffle reduce (object-store or external)
+        # that hasn't already fused with a map.
         upstream_ops = dag.input_dependencies
-        if len(upstream_ops) != 1 or not isinstance(upstream_ops[0], ShuffleReduceOp):
+        if len(upstream_ops) != 1 or not isinstance(
+            upstream_ops[0], (ShuffleReduceOp, ExternalHashShuffleReduceOp)
+        ):
             return False
         reduce_op = upstream_ops[0]
         if reduce_op._fused_output_map_transformer is not None:
@@ -376,29 +381,49 @@ class FuseOperators(Rule):
         return True
 
     def _get_fused_map_into_shuffle_reduce_operator(
-        self, down_op: TaskPoolMapOperator, up_op: ShuffleReduceOp
-    ) -> ShuffleReduceOp:
+        self,
+        down_op: TaskPoolMapOperator,
+        up_op: Union[ShuffleReduceOp, ExternalHashShuffleReduceOp],
+    ) -> Union[ShuffleReduceOp, ExternalHashShuffleReduceOp]:
         name = up_op.name + "->" + down_op.name
 
         up_logical_op = self._op_map.pop(up_op)
         self._op_map.pop(down_op)
 
-        fused_op = ShuffleReduceOp(
-            up_op.input_dependencies,
-            up_op.data_context,
-            num_partitions=up_op._num_partitions,
-            reduce_fn=up_op._reduce_fn,
-            disallow_block_splitting=up_op._disallow_block_splitting,
-            reduce_ray_remote_args=up_op._reduce_ray_remote_args,
-            peak_memory_multiplier=up_op._peak_memory_multiplier,
-            should_emit_empty_partitions=up_op._emit_empty_partitions,
-            name=name,
-            fused_output_map_transformer=down_op.get_map_transformer(),
-            fused_output_map_task_kwargs=down_op.get_map_task_kwargs(),
-            fused_output_map_target_max_block_size_override=(
-                down_op.target_max_block_size_override
-            ),
-        )
+        if isinstance(up_op, ExternalHashShuffleReduceOp):
+            # External is single-input by design (no Join support).
+            fused_op = ExternalHashShuffleReduceOp(
+                up_op.input_dependencies[0],
+                up_op.data_context,
+                num_partitions=up_op._num_partitions,
+                reduce_fn=up_op._reduce_fn,
+                disallow_block_splitting=up_op._disallow_block_splitting,
+                reduce_ray_remote_args=up_op._reduce_ray_remote_args,
+                peak_memory_multiplier=up_op._peak_memory_multiplier,
+                name=name,
+                fused_output_map_transformer=down_op.get_map_transformer(),
+                fused_output_map_task_kwargs=down_op.get_map_task_kwargs(),
+                fused_output_map_target_max_block_size_override=(
+                    down_op.target_max_block_size_override
+                ),
+            )
+        else:  # object-store ShuffleReduceOp (may be multi-input for Join)
+            fused_op = ShuffleReduceOp(
+                up_op.input_dependencies,
+                up_op.data_context,
+                num_partitions=up_op._num_partitions,
+                reduce_fn=up_op._reduce_fn,
+                disallow_block_splitting=up_op._disallow_block_splitting,
+                reduce_ray_remote_args=up_op._reduce_ray_remote_args,
+                peak_memory_multiplier=up_op._peak_memory_multiplier,
+                should_emit_empty_partitions=up_op._emit_empty_partitions,
+                name=name,
+                fused_output_map_transformer=down_op.get_map_transformer(),
+                fused_output_map_task_kwargs=down_op.get_map_task_kwargs(),
+                fused_output_map_target_max_block_size_override=(
+                    down_op.target_max_block_size_override
+                ),
+            )
         fused_op.set_logical_operators(
             *up_op._logical_operators, *down_op._logical_operators
         )

--- a/python/ray/data/_internal/planner/plan_all_to_all_op.py
+++ b/python/ray/data/_internal/planner/plan_all_to_all_op.py
@@ -15,6 +15,12 @@ from ray.data._internal.execution.operators.hash_shuffle_v2 import (
     _make_hash_partition_fn,
     _sort_reduce,
 )
+from ray.data._internal.execution.operators.shuffle_operators.external_shuffle_map_operator import (  # noqa: E501
+    ExternalHashShuffleMapOp,
+)
+from ray.data._internal.execution.operators.shuffle_operators.external_shuffle_reduce_operator import (  # noqa: E501
+    ExternalHashShuffleReduceOp,
+)
 from ray.data._internal.execution.operators.shuffle_operators.shuffle_map_operator import (  # noqa: E501
     ShuffleMapOp,
 )
@@ -78,10 +84,11 @@ def _plan_hash_shuffle_repartition_v2(
     logical_op: Repartition,
     input_physical_op: PhysicalOperator,
 ) -> PhysicalOperator:
-    """Build the two-op (ShuffleMapOp → ShuffleReduceOp) DAG for V2 hash shuffle.
+    """Build the two-op Map → Reduce DAG for SHUFFLE_V2 hash-shuffle repartition.
 
-    Returns the reduce op; the executor crawls upstream via its
-    input_dependencies to find the map op.
+    Picks the external (file-transport) or object-store op pair based on
+    ``data_context.use_external_hash_shuffle``. Returns the reduce op; the
+    executor crawls upstream via its input_dependencies to find the map op.
     """
     from ray.data._internal.planner.exchange.sort_task_spec import SortKey
 
@@ -100,29 +107,41 @@ def _plan_hash_shuffle_repartition_v2(
         else SHUFFLE_PEAK_MEMORY_MULTIPLIER
     )
 
-    map_op = ShuffleMapOp(
+    if data_context.use_external_hash_shuffle:
+        map_cls, reduce_cls, prefix = (
+            ExternalHashShuffleMapOp,
+            ExternalHashShuffleReduceOp,
+            "ExternalHashShuffle",
+        )
+    else:
+        map_cls, reduce_cls, prefix = (
+            ShuffleMapOp,
+            ShuffleReduceOp,
+            "HashShuffle",
+        )
+
+    map_op = map_cls(
         input_physical_op,
         data_context,
         num_partitions=target_num_partitions,
         partition_fn=partition_fn,
         map_runtime_env=_SHUFFLE_MAP_RUNTIME_ENV,
         name=(
-            f"HashShuffleMap(keys={tuple(key_list)}, "
+            f"{prefix}Map(keys={tuple(key_list)}, "
             f"partitions={target_num_partitions})"
         ),
     )
-    reduce_op = ShuffleReduceOp(
-        map_op,
-        data_context,
+    reduce_kwargs = dict(
         num_partitions=target_num_partitions,
         reduce_fn=reduce_fn,
         disallow_block_splitting=True,
         peak_memory_multiplier=peak_memory_multiplier,
         name=(
-            f"HashShuffleReduce(keys={tuple(key_list)}, "
+            f"{prefix}Reduce(keys={tuple(key_list)}, "
             f"partitions={target_num_partitions})"
         ),
     )
+    reduce_op = reduce_cls(map_op, data_context, **reduce_kwargs)
     return reduce_op
 
 

--- a/python/ray/data/_internal/planner/plan_all_to_all_op.py
+++ b/python/ray/data/_internal/planner/plan_all_to_all_op.py
@@ -1,5 +1,5 @@
 import logging
-from typing import List
+from typing import List, Tuple, Type
 
 from ray.data._internal.execution.interfaces import PhysicalOperator
 from ray.data._internal.execution.operators.base_physical_operator import (
@@ -56,6 +56,20 @@ logger = logging.getLogger(__name__)
 _SORT_REDUCE_PEAK_MEMORY_MULTIPLIER = 3
 
 
+def _select_shuffle_v2_op_classes(
+    data_context: DataContext,
+) -> Tuple[Type[PhysicalOperator], Type[PhysicalOperator], str]:
+    """Pick the SHUFFLE_V2 map/reduce op family: external (file-transport) or
+    object-store, per ``data_context.use_external_hash_shuffle``.
+
+    Returns ``(map_cls, reduce_cls, name_prefix)`` where ``name_prefix`` is
+    ``"External"`` or ``""``, to be prepended to the op display names.
+    """
+    if data_context.use_external_hash_shuffle:
+        return ExternalHashShuffleMapOp, ExternalHashShuffleReduceOp, "External"
+    return ShuffleMapOp, ShuffleReduceOp, ""
+
+
 def _plan_gpu_shuffle_repartition(
     data_context: DataContext,
     logical_op: Repartition,
@@ -107,18 +121,7 @@ def _plan_hash_shuffle_repartition_v2(
         else SHUFFLE_PEAK_MEMORY_MULTIPLIER
     )
 
-    if data_context.use_external_hash_shuffle:
-        map_cls, reduce_cls, prefix = (
-            ExternalHashShuffleMapOp,
-            ExternalHashShuffleReduceOp,
-            "ExternalHashShuffle",
-        )
-    else:
-        map_cls, reduce_cls, prefix = (
-            ShuffleMapOp,
-            ShuffleReduceOp,
-            "HashShuffle",
-        )
+    map_cls, reduce_cls, prefix = _select_shuffle_v2_op_classes(data_context)
 
     map_op = map_cls(
         input_physical_op,
@@ -127,21 +130,22 @@ def _plan_hash_shuffle_repartition_v2(
         partition_fn=partition_fn,
         map_runtime_env=_SHUFFLE_MAP_RUNTIME_ENV,
         name=(
-            f"{prefix}Map(keys={tuple(key_list)}, "
+            f"{prefix}HashShuffleMap(keys={tuple(key_list)}, "
             f"partitions={target_num_partitions})"
         ),
     )
-    reduce_kwargs = dict(
+    reduce_op = reduce_cls(
+        map_op,
+        data_context,
         num_partitions=target_num_partitions,
         reduce_fn=reduce_fn,
         disallow_block_splitting=True,
         peak_memory_multiplier=peak_memory_multiplier,
         name=(
-            f"{prefix}Reduce(keys={tuple(key_list)}, "
+            f"{prefix}HashShuffleReduce(keys={tuple(key_list)}, "
             f"partitions={target_num_partitions})"
         ),
     )
-    reduce_op = reduce_cls(map_op, data_context, **reduce_kwargs)
     return reduce_op
 
 
@@ -190,7 +194,9 @@ def _plan_hash_shuffle_aggregate_v2(
     block_transformer = _make_aggregating_transformer(key_columns, aggs)
     reduce_fn = _make_aggregating_reduce_fn(key_columns, aggs)
 
-    map_op = ShuffleMapOp(
+    map_cls, reduce_cls, prefix = _select_shuffle_v2_op_classes(data_context)
+
+    map_op = map_cls(
         input_physical_op,
         data_context,
         num_partitions=num_partitions,
@@ -198,11 +204,11 @@ def _plan_hash_shuffle_aggregate_v2(
         block_transformer=block_transformer,
         map_runtime_env=_SHUFFLE_MAP_RUNTIME_ENV,
         name=(
-            f"HashAggregateMap(key_columns={key_columns}, "
+            f"{prefix}HashAggregateMap(key_columns={key_columns}, "
             f"num_partitions={num_partitions})"
         ),
     )
-    reduce_op = ShuffleReduceOp(
+    reduce_op = reduce_cls(
         map_op,
         data_context,
         num_partitions=num_partitions,
@@ -212,7 +218,7 @@ def _plan_hash_shuffle_aggregate_v2(
         # conflict with finalized non-empty partitions.
         should_emit_empty_partitions=False,
         name=(
-            f"HashAggregateReduce(key_columns={key_columns}, "
+            f"{prefix}HashAggregateReduce(key_columns={key_columns}, "
             f"num_partitions={num_partitions})"
         ),
     )

--- a/python/ray/data/_internal/planner/planner.py
+++ b/python/ray/data/_internal/planner/planner.py
@@ -24,12 +24,6 @@ from ray.data._internal.execution.operators.join import (
 from ray.data._internal.execution.operators.limit_operator import LimitOperator
 from ray.data._internal.execution.operators.mix_operator import MixOperator
 from ray.data._internal.execution.operators.output_splitter import OutputSplitter
-from ray.data._internal.execution.operators.shuffle_operators.shuffle_map_operator import (
-    ShuffleMapOp,
-)
-from ray.data._internal.execution.operators.shuffle_operators.shuffle_reduce_operator import (
-    ShuffleReduceOp,
-)
 from ray.data._internal.execution.operators.union_operator import UnionOperator
 from ray.data._internal.execution.operators.zip_operator import ZipOperator
 from ray.data._internal.logical.interfaces import (
@@ -64,7 +58,10 @@ from ray.data._internal.planner.checkpoint import (
     plan_read_op_with_checkpoint_filter,
     plan_write_op_with_checkpoint_writer,
 )
-from ray.data._internal.planner.plan_all_to_all_op import plan_all_to_all_op
+from ray.data._internal.planner.plan_all_to_all_op import (
+    _select_shuffle_v2_op_classes,
+    plan_all_to_all_op,
+)
 from ray.data._internal.planner.plan_download_op import plan_download_op
 from ray.data._internal.planner.plan_list_files_op import plan_list_files_op
 from ray.data._internal.planner.plan_read_files_op import plan_read_files_op
@@ -142,6 +139,9 @@ def plan_count_op(logical_op, physical_children, data_context):
     )
 
 
+_EXTERNAL_JOIN_REDUCE_PEAK_MEMORY_MULTIPLIER = 3
+
+
 def _plan_join_shuffle_v2(
     logical_op: Join,
     physical_children: List[PhysicalOperator],
@@ -152,21 +152,29 @@ def _plan_join_shuffle_v2(
     num_partitions = logical_op.num_partitions
     join_type = JoinType(logical_op.join_type)
 
-    left_map = ShuffleMapOp(
+    map_cls, reduce_cls, prefix = _select_shuffle_v2_op_classes(data_context)
+
+    left_map = map_cls(
         physical_children[0],
         data_context,
         num_partitions=num_partitions,
         partition_fn=_make_hash_partition_fn(left_keys, num_partitions),
         map_runtime_env=_SHUFFLE_MAP_RUNTIME_ENV,
-        name=f"JoinShuffleMapLeft(keys={tuple(left_keys)}, parts={num_partitions})",
+        name=(
+            f"{prefix}JoinShuffleMapLeft(keys={tuple(left_keys)}, "
+            f"parts={num_partitions})"
+        ),
     )
-    right_map = ShuffleMapOp(
+    right_map = map_cls(
         physical_children[1],
         data_context,
         num_partitions=num_partitions,
         partition_fn=_make_hash_partition_fn(right_keys, num_partitions),
         map_runtime_env=_SHUFFLE_MAP_RUNTIME_ENV,
-        name=f"JoinShuffleMapRight(keys={tuple(right_keys)}, parts={num_partitions})",
+        name=(
+            f"{prefix}JoinShuffleMapRight(keys={tuple(right_keys)}, "
+            f"parts={num_partitions})"
+        ),
     )
 
     reduce_fn = _make_join_reduce_fn(
@@ -178,14 +186,20 @@ def _plan_join_shuffle_v2(
         left_schema=logical_op.input_dependencies[0].infer_schema(),
         right_schema=logical_op.input_dependencies[1].infer_schema(),
     )
-    return ShuffleReduceOp(
+    reduce_kwargs = {}
+    if data_context.use_external_hash_shuffle:
+        reduce_kwargs[
+            "peak_memory_multiplier"
+        ] = _EXTERNAL_JOIN_REDUCE_PEAK_MEMORY_MULTIPLIER
+    return reduce_cls(
         [left_map, right_map],
         data_context,
         num_partitions=num_partitions,
         reduce_fn=reduce_fn,
         disallow_block_splitting=False,
         reduce_ray_remote_args=logical_op.aggregator_ray_remote_args,
-        name=f"JoinShuffleReduce(num_partitions={num_partitions})",
+        name=f"{prefix}JoinShuffleReduce(num_partitions={num_partitions})",
+        **reduce_kwargs,
     )
 
 

--- a/python/ray/data/context.py
+++ b/python/ray/data/context.py
@@ -145,6 +145,8 @@ DEFAULT_SHUFFLE_INPUT_BATCH_BYTES = env_integer(
     "RAY_DATA_SHUFFLE_INPUT_BATCH_BYTES", 1024 * 1024 * 1024
 )
 
+DEFAULT_ENABLE_EXTERNAL_SHUFFLE = env_bool("RAY_DATA_ENABLE_EXTERNAL_SHUFFLE", False)
+
 DEFAULT_SCHEDULING_STRATEGY = "SPREAD"
 
 # This default enables locality-based scheduling in Ray for tasks where arg data
@@ -767,15 +769,22 @@ class DataContext:
             its input shards. A non-positive value (``<= 0``) disables the
             timeout, fetching each batch in a single blocking call.
         shuffle_input_batch_bytes: Target batch size in bytes for coalescing
-            shuffle input blocks before partitioning. Currently only applies
-            to the ``SHUFFLE_V2`` shuffle strategy; other shuffle
-            strategies ignore it. Input blocks are buffered per node and
+            shuffle input blocks before partitioning. Applies to the
+            ``SHUFFLE_V2`` shuffle strategy (including external hash shuffle).
+            Other shuffle strategies ignore it. Input blocks are buffered per
+            node and
             processed as a batch once this size is reached; remaining
             buffered blocks are flushed when input is exhausted. Lower values
             increase shuffle parallelism (useful for CPU-intensive shuffles)
             at the cost of more, smaller intermediate shard objects. Set to
             ``0`` to disable batching, processing each input bundle
             individually. Defaults to 1GiB.
+        use_external_hash_shuffle: Whether keyed ``repartition()`` under the
+            ``SHUFFLE_V2`` strategy uses the external (on-disk, file-transport)
+            shuffle instead of the object store. Other operations (aggregate,
+            join) currently ignore this flag. Defaults to the
+            ``RAY_DATA_ENABLE_EXTERNAL_SHUFFLE`` environment variable
+            (``False`` when unset).
         max_hash_shuffle_aggregators: Maximum number of aggregating actors that can be
             provisioned for hash-shuffle aggregations.
         min_hash_shuffle_aggregator_wait_time_in_s: Minimum time to wait for hash
@@ -912,6 +921,10 @@ class DataContext:
     join_operator_actor_num_cpus_override: float = None
     hash_shuffle_operator_actor_num_cpus_override: float = None
     hash_aggregate_operator_actor_num_cpus_override: float = None
+
+    # Whether to use the on-disk (file-transport) path for hash-shuffle
+    # repartition. When False, use the object-store path.
+    use_external_hash_shuffle: bool = DEFAULT_ENABLE_EXTERNAL_SHUFFLE
 
     ################################################################
     # GPU Shuffle configuration

--- a/python/ray/data/context.py
+++ b/python/ray/data/context.py
@@ -129,9 +129,19 @@ DEFAULT_MAX_HASH_SHUFFLE_AGGREGATORS = env_integer(
     "RAY_DATA_MAX_HASH_SHUFFLE_AGGREGATORS", 128
 )
 
-DEFAULT_HASH_SHUFFLE_COMPRESSION = os.environ.get(
-    "RAY_DATA_HASH_SHUFFLE_COMPRESSION", "zstd"
-)
+
+def _deduce_default_shuffle_compression() -> str:
+    legacy_codec = os.environ.get("RAY_DATA_HASH_SHUFFLE_COMPRESSION")
+    if legacy_codec is not None:
+        logger.warning(
+            "RAY_DATA_HASH_SHUFFLE_COMPRESSION is deprecated, please use "
+            "RAY_DATA_SHUFFLE_COMPRESSION instead"
+        )
+
+    return os.environ.get("RAY_DATA_SHUFFLE_COMPRESSION", legacy_codec or "zstd")
+
+
+DEFAULT_SHUFFLE_COMPRESSION = _deduce_default_shuffle_compression()
 
 DEFAULT_HASH_SHUFFLE_REDUCE_BATCH_SIZE = env_integer(
     "RAY_DATA_HASH_SHUFFLE_REDUCE_BATCH_SIZE", 16
@@ -760,8 +770,9 @@ class DataContext:
             See :class:`DeltaConfig` for details.
         default_hash_shuffle_parallelism: Default parallelism level for hash-based
             shuffle operations if the number of partitions is unspecifed.
-        hash_shuffle_compression: Codec used to compress hash-shuffle
-            intermediate shards: "none", "lz4", or "zstd" (default "zstd").
+        shuffle_compression: Codec used to compress shuffle intermediate
+            shards: "none", "lz4", or "zstd" (default "zstd"). Deprecated
+            alias: ``hash_shuffle_compression``.
         hash_shuffle_reduce_batch_size: Number of shard object references each
             hash-shuffle reduce task dereferences per ``ray.get()`` call.
         hash_shuffle_reduce_get_timeout_s: Timeout in seconds, for the
@@ -876,8 +887,8 @@ class DataContext:
     # provided explicitly)
     default_hash_shuffle_parallelism: int = DEFAULT_MIN_PARALLELISM
 
-    # Codec for hash-shuffle intermediate shards ("none", "lz4", or "zstd").
-    hash_shuffle_compression: str = DEFAULT_HASH_SHUFFLE_COMPRESSION
+    # Codec for shuffle intermediate shards ("none", "lz4", or "zstd").
+    shuffle_compression: str = DEFAULT_SHUFFLE_COMPRESSION
 
     # Shard refs each reduce task dereferences per ray.get() call.
     hash_shuffle_reduce_batch_size: int = DEFAULT_HASH_SHUFFLE_REDUCE_BATCH_SIZE
@@ -1278,6 +1289,32 @@ class DataContext:
         # NOTE: Coercing to the enum resolves deprecated aliases (like
         #       `hash_shuffle_v2`) to their current strategy
         self._shuffle_strategy = ShuffleStrategy(value)
+
+    # Deprecated alias of `shuffle_compression`
+    @property
+    def hash_shuffle_compression(self) -> str:
+        self._warn_hash_shuffle_compression_deprecated(stacklevel=3)
+
+        return self.shuffle_compression
+
+    @hash_shuffle_compression.setter
+    def hash_shuffle_compression(self, value: str) -> None:
+        # NOTE: One frame deeper than the getter -- assignment routes through
+        #       `DataContext.__setattr__`
+        self._warn_hash_shuffle_compression_deprecated(stacklevel=4)
+
+        self.shuffle_compression = value
+
+    @staticmethod
+    def _warn_hash_shuffle_compression_deprecated(*, stacklevel: int) -> None:
+        # NOTE: `stacklevel` has to resolve to the caller, otherwise Python's
+        #       default filters drop the warning as library-internal
+        warnings.warn(
+            "`hash_shuffle_compression` is deprecated, please configure "
+            "`shuffle_compression` instead.",
+            DeprecationWarning,
+            stacklevel=stacklevel,
+        )
 
     @property
     def execution_callback_classes(self) -> List[Type["ExecutionCallback"]]:

--- a/python/ray/data/context.py
+++ b/python/ray/data/context.py
@@ -779,12 +779,11 @@ class DataContext:
             at the cost of more, smaller intermediate shard objects. Set to
             ``0`` to disable batching, processing each input bundle
             individually. Defaults to 1GiB.
-        use_external_hash_shuffle: Whether keyed ``repartition()`` under the
-            ``SHUFFLE_V2`` strategy uses the external (on-disk, file-transport)
-            shuffle instead of the object store. Other operations (aggregate,
-            join) currently ignore this flag. Defaults to the
-            ``RAY_DATA_ENABLE_EXTERNAL_SHUFFLE`` environment variable
-            (``False`` when unset).
+        use_external_hash_shuffle: Whether keyed ``repartition()``,
+            aggregations, and joins under the ``SHUFFLE_V2`` strategy use the
+            external (on-disk, file-transport) shuffle instead of the object
+            store. Defaults to the ``RAY_DATA_ENABLE_EXTERNAL_SHUFFLE``
+            environment variable (``False`` when unset).
         max_hash_shuffle_aggregators: Maximum number of aggregating actors that can be
             provisioned for hash-shuffle aggregations.
         min_hash_shuffle_aggregator_wait_time_in_s: Minimum time to wait for hash
@@ -922,8 +921,9 @@ class DataContext:
     hash_shuffle_operator_actor_num_cpus_override: float = None
     hash_aggregate_operator_actor_num_cpus_override: float = None
 
-    # Whether to use the on-disk (file-transport) path for hash-shuffle
-    # repartition. When False, use the object-store path.
+    # Whether to use the on-disk (file-transport) path for SHUFFLE_V2
+    # hash-shuffle operations (keyed repartition, aggregations, joins).
+    # When False, use the object-store path.
     use_external_hash_shuffle: bool = DEFAULT_ENABLE_EXTERNAL_SHUFFLE
 
     ################################################################

--- a/python/ray/data/tests/conftest.py
+++ b/python/ray/data/tests/conftest.py
@@ -318,24 +318,43 @@ def disable_fallback_to_object_extension(request, restore_data_context):
     )
 
 
-@pytest.fixture(
-    params=[
-        s
-        for s in ShuffleStrategy
-        if s != ShuffleStrategy.GPU_SHUFFLE
-        or os.environ.get("RAY_PYTEST_USE_GPU") == "1"
-    ]
-)
+# (shuffle_strategy, use_external_hash_shuffle) params. The fixture yields the
+# strategy, so ``shuffle_v2_external`` presents as SHUFFLE_V2 to tests.
+_SHUFFLE_METHOD_PARAMS = [
+    pytest.param(
+        (ShuffleStrategy.SORT_SHUFFLE_PULL_BASED, False), id="sort_shuffle_pull_based"
+    ),
+    pytest.param(
+        (ShuffleStrategy.SORT_SHUFFLE_PUSH_BASED, False), id="sort_shuffle_push_based"
+    ),
+    pytest.param((ShuffleStrategy.HASH_SHUFFLE, False), id="hash_shuffle"),
+    pytest.param((ShuffleStrategy.SHUFFLE_V2, False), id="shuffle_v2"),
+    pytest.param((ShuffleStrategy.SHUFFLE_V2, True), id="shuffle_v2_external"),
+]
+if os.environ.get("RAY_PYTEST_USE_GPU") == "1":
+    _SHUFFLE_METHOD_PARAMS.append(
+        pytest.param((ShuffleStrategy.GPU_SHUFFLE, False), id="gpu_shuffle")
+    )
+
+
+@pytest.fixture(params=_SHUFFLE_METHOD_PARAMS)
 def configure_shuffle_method(request):
-    shuffle_strategy = request.param
+    shuffle_strategy, use_external_hash_shuffle = request.param
 
     ctx = ray.data.context.DataContext.get_current()
 
     original_shuffle_strategy = ctx.shuffle_strategy
     original_default_hash_shuffle_parallelism = ctx.default_hash_shuffle_parallelism
     original_gpu_shuffle_num_actors = ctx.gpu_shuffle_num_actors
+    original_use_external_hash_shuffle = ctx.use_external_hash_shuffle
+    original_shuffle_input_batch_bytes = ctx.shuffle_input_batch_bytes
 
     ctx.shuffle_strategy = shuffle_strategy
+    ctx.use_external_hash_shuffle = use_external_hash_shuffle
+    if shuffle_strategy == ShuffleStrategy.SHUFFLE_V2:
+        # One map task per input bundle, so reducers see multiple shards per
+        # partition (the default batching folds small test data into one mapper).
+        ctx.shuffle_input_batch_bytes = 0
 
     # NOTE: We override default parallelism for hash-based shuffling to
     #       avoid excessive partitioning of the data (to achieve desired
@@ -350,11 +369,13 @@ def configure_shuffle_method(request):
     if shuffle_strategy == ShuffleStrategy.GPU_SHUFFLE:
         ctx.gpu_shuffle_num_actors = 1
 
-    yield request.param
+    yield shuffle_strategy
 
     ctx.shuffle_strategy = original_shuffle_strategy
     ctx.default_hash_shuffle_parallelism = original_default_hash_shuffle_parallelism
     ctx.gpu_shuffle_num_actors = original_gpu_shuffle_num_actors
+    ctx.use_external_hash_shuffle = original_use_external_hash_shuffle
+    ctx.shuffle_input_batch_bytes = original_shuffle_input_batch_bytes
 
 
 @pytest.fixture(params=[True, False])

--- a/python/ray/data/tests/test_context.py
+++ b/python/ray/data/tests/test_context.py
@@ -1,7 +1,7 @@
 import pytest
 
 import ray
-from ray.data.context import ShuffleStrategy
+from ray.data.context import ShuffleStrategy, _deduce_default_shuffle_compression
 from ray.util.annotations import RayDeprecationWarning
 
 
@@ -65,6 +65,31 @@ def test_hash_shuffle_v2_strategy_alias():
 
     with pytest.raises(ValueError):
         ShuffleStrategy("not_a_shuffle_strategy")
+
+
+def test_hash_shuffle_compression_alias(monkeypatch):
+    """`hash_shuffle_compression` remains a deprecated alias of
+    `shuffle_compression`."""
+
+    ctx = ray.data.DataContext()
+
+    with pytest.warns(DeprecationWarning, match="hash_shuffle_compression") as record:
+        ctx.hash_shuffle_compression = "lz4"
+    assert ctx.shuffle_compression == "lz4"
+    # Warning has to be blamed on the caller, otherwise Python's default
+    # filters drop it (`pytest.warns` alone passes at any `stacklevel`)
+    assert record[0].filename == __file__
+
+    ctx.shuffle_compression = "zstd"
+    with pytest.warns(DeprecationWarning, match="hash_shuffle_compression") as record:
+        assert ctx.hash_shuffle_compression == "zstd"
+    assert record[0].filename == __file__
+
+    # Deprecated env var is still honored, but the current one wins
+    monkeypatch.setenv("RAY_DATA_HASH_SHUFFLE_COMPRESSION", "lz4")
+    assert _deduce_default_shuffle_compression() == "lz4"
+    monkeypatch.setenv("RAY_DATA_SHUFFLE_COMPRESSION", "none")
+    assert _deduce_default_shuffle_compression() == "none"
 
 
 if __name__ == "__main__":

--- a/python/ray/data/tests/test_hash_shuffle_external_repartition.py
+++ b/python/ray/data/tests/test_hash_shuffle_external_repartition.py
@@ -1,0 +1,268 @@
+"""``ds.repartition()`` through the external (file-transport) hash-shuffle
+variant. External-only tests (flag-off default, chained ops, on-disk
+cleanup) follow the shared correctness block.
+"""
+
+import gc
+import glob
+import os
+import tempfile
+import time
+from typing import cast
+
+import pyarrow as pa
+import pytest
+
+import ray
+from ray.data.context import DataContext, ShuffleStrategy
+from ray.data.tests.conftest import *  # noqa: F401, F403
+from ray.data.tests.test_hash_shuffle_v2 import (
+    _assert_keys_colocated,
+    _keys_per_block,
+)
+from ray.tests.conftest import *  # noqa: F401, F403
+
+
+@pytest.fixture(autouse=True)
+def _assert_no_leftover_shuffle_dirs():
+    """After every test, assert no ``$TMPDIR/ray_shuffle_external_*`` dir
+    leaked. The map op's ``_teardown_shuffle`` fires ``_cleanup_shuffle_dir``
+    tasks eagerly and waits up to 5s, so by the time pytest teardown runs
+    all external shuffle output should be gone.
+    """
+    pattern = os.path.join(tempfile.gettempdir(), "ray_shuffle_external_*")
+    pre_existing = set(glob.glob(pattern))
+    yield
+    gc.collect()
+    deadline = time.monotonic() + 5.0
+    while time.monotonic() < deadline:
+        leftover = set(glob.glob(pattern)) - pre_existing
+        if not leftover:
+            return
+        time.sleep(0.1)
+    raise AssertionError(f"leftover shuffle dirs after test: {leftover}")
+
+
+# --- Correctness -------------------------------------------------------------
+
+
+def test_external_map_op_is_blocking_materializing():
+    """The resource manager must classify the external map op like the
+    object-store ``ShuffleMapOp``: as a blocking, materializing operator.
+
+    Otherwise the reduce op stays eligible for resource allocation during the
+    map phase (shrinking the map's budget), and the map op loses the
+    object-store backpressure exemption granted to materializing ops.
+    """
+    from ray.data._internal.execution.operators.shuffle_operators.external_shuffle_map_operator import (  # noqa: E501
+        ExternalHashShuffleMapOp,
+    )
+    from ray.data._internal.execution.resource_manager import (
+        _BLOCKING_MATERIALIZING_OPERATORS,
+    )
+
+    assert issubclass(ExternalHashShuffleMapOp, _BLOCKING_MATERIALIZING_OPERATORS)
+
+
+def test_external_sort_reduce_uses_higher_multiplier(
+    ray_start_regular_shared_2_cpus,
+    restore_data_context,
+    disable_fallback_to_object_extension,
+):
+    """Sorted external reduces request 3x, matching object-store ShuffleReduceOp."""
+    from ray.data._internal.execution.operators.shuffle_operators.external_shuffle_reduce_operator import (  # noqa: E501
+        ExternalHashShuffleReduceOp,
+    )
+    from ray.data._internal.execution.operators.shuffle_operators.shuffle_tasks import (
+        SHUFFLE_PEAK_MEMORY_MULTIPLIER,
+    )
+    from ray.data._internal.logical.optimizers import get_execution_plan
+
+    ctx = DataContext.get_current()
+    ctx.shuffle_strategy = ShuffleStrategy.SHUFFLE_V2
+    ctx.use_external_hash_shuffle = True
+
+    sorted_dag = get_execution_plan(
+        ray.data.range(10).repartition(2, keys=["id"], sort=True)._logical_plan
+    )[0].dag
+    # isinstance doubles as the flag-on routing check and narrows the type.
+    assert isinstance(sorted_dag, ExternalHashShuffleReduceOp)
+    assert sorted_dag._peak_memory_multiplier == 3
+
+    plain_dag = get_execution_plan(
+        ray.data.range(10).repartition(2, keys=["id"])._logical_plan
+    )[0].dag
+    assert isinstance(plain_dag, ExternalHashShuffleReduceOp)
+    assert plain_dag._peak_memory_multiplier == SHUFFLE_PEAK_MEMORY_MULTIPLIER
+
+
+@pytest.mark.parametrize("num_partitions", [1, 8])
+def test_external_repartition_keys_preserves_rows(
+    ray_start_regular_shared_2_cpus,
+    restore_data_context,
+    disable_fallback_to_object_extension,
+    num_partitions,
+):
+    """No rows are lost or duplicated; key totals are preserved; all-non-empty
+    partitions (1000 distinct keys) => exactly num_partitions output blocks."""
+    ctx = DataContext.get_current()
+    ctx.shuffle_strategy = ShuffleStrategy.SHUFFLE_V2
+    ctx.use_external_hash_shuffle = True
+
+    ds = ray.data.range(1000, override_num_blocks=10)
+    out = ds.repartition(num_partitions, keys=["id"]).materialize()
+    assert out.count() == 1000
+    assert out.sum("id") == sum(range(1000))
+    assert out.num_blocks() == num_partitions
+
+
+def test_external_same_key_lands_in_same_block(
+    ray_start_regular_shared_2_cpus,
+    restore_data_context,
+    disable_fallback_to_object_extension,
+):
+    """All rows sharing a key should end up in one block."""
+    ctx = DataContext.get_current()
+    ctx.shuffle_strategy = ShuffleStrategy.SHUFFLE_V2
+    ctx.use_external_hash_shuffle = True
+
+    ds = ray.data.range(500, override_num_blocks=10).map(
+        lambda row: {"k": row["id"] % 25, "v": row["id"]}
+    )
+    out = ds.repartition(5, keys=["k"])
+
+    _assert_keys_colocated(_keys_per_block(out, ["k"]))
+    assert out.count() == 500
+
+
+def test_external_more_partitions_than_keys_emits_empty_blocks(
+    ray_start_regular_shared_2_cpus,
+    restore_data_context,
+    disable_fallback_to_object_extension,
+):
+    """Requesting more partitions than there are distinct keys emits the extra
+    partitions as empty (0-row) blocks that still carry the dataset schema."""
+    ctx = DataContext.get_current()
+    ctx.shuffle_strategy = ShuffleStrategy.SHUFFLE_V2
+    ctx.use_external_hash_shuffle = True
+
+    # 3 distinct keys into 50 partitions => at most 3 non-empty, >=47 empty.
+    ds = ray.data.range(600, override_num_blocks=10).map(
+        lambda row: {"k": row["id"] % 3, "v": row["id"]}
+    )
+    out = ds.repartition(50, keys=["k"]).materialize()
+
+    assert out.count() == 600
+    assert out.num_blocks() == 50
+
+    rows_per_block = []
+    schemas = []
+    for ref_bundle in out.iter_internal_ref_bundles():
+        for block_ref in ref_bundle.block_refs:
+            block = cast(pa.Table, ray.get(block_ref))
+            rows_per_block.append(block.num_rows)
+            schemas.append(block.schema)
+
+    assert rows_per_block.count(0) >= 47
+    assert all(schema.equals(schemas[0]) for schema in schemas)
+
+    _assert_keys_colocated(_keys_per_block(out, ["k"]))
+
+
+def test_external_repartition_empty_dataset(
+    ray_start_regular_shared_2_cpus,
+    restore_data_context,
+    disable_fallback_to_object_extension,
+):
+    """Empty dataset should still output N blocks"""
+    ctx = DataContext.get_current()
+    ctx.shuffle_strategy = ShuffleStrategy.SHUFFLE_V2
+    ctx.use_external_hash_shuffle = True
+
+    ds = ray.data.range(100, override_num_blocks=4).filter(lambda row: False)
+    out = ds.repartition(4, keys=["id"]).materialize()
+    assert out.count() == 0
+    assert out.num_blocks() == 4
+    rows_per_block = [
+        cast(pa.Table, ray.get(block_ref)).num_rows
+        for ref_bundle in out.iter_internal_ref_bundles()
+        for block_ref in ref_bundle.block_refs
+    ]
+    assert rows_per_block == [0, 0, 0, 0]
+
+
+def test_external_repartition_preserves_null_typed_rows(
+    ray_start_regular_shared_2_cpus,
+    restore_data_context,
+    disable_fallback_to_object_extension,
+):
+    """A null-typed column has rows with ``tbl.nbytes == 0``. Empty-gating
+    by bytes would drop the partition; gating by ``num_rows`` must keep them.
+    """
+    ctx = DataContext.get_current()
+    ctx.shuffle_strategy = ShuffleStrategy.SHUFFLE_V2
+    ctx.use_external_hash_shuffle = True
+
+    table = pa.table({"k": pa.nulls(10)})
+    assert table.num_rows == 10
+    assert table.nbytes == 0
+
+    out = ray.data.from_arrow(table).repartition(4, keys=["k"]).materialize()
+    assert out.count() == 10
+    assert out.num_blocks() == 4
+
+
+def test_external_repartition_with_sort_produces_sorted_partitions(
+    ray_start_regular_shared_2_cpus,
+    restore_data_context,
+    disable_fallback_to_object_extension,
+):
+    """Check that rows are sorted in every partition."""
+    ctx = DataContext.get_current()
+    ctx.shuffle_strategy = ShuffleStrategy.SHUFFLE_V2
+    ctx.use_external_hash_shuffle = True
+
+    ds = ray.data.range(200, override_num_blocks=4)
+    out = ds.repartition(4, keys=["id"], sort=True)
+
+    for ref_bundle in out.iter_internal_ref_bundles():
+        for block_ref in ref_bundle.block_refs:
+            ids = cast(pa.Table, ray.get(block_ref))["id"].to_pylist()
+            assert ids == sorted(ids)
+
+
+def test_external_flag_off_keeps_object_store_path(
+    ray_start_regular_shared_2_cpus,
+    restore_data_context,
+    disable_fallback_to_object_extension,
+):
+    """With flag=False the planner must NOT dispatch to the external variant.
+
+    Row count alone can't distinguish the two paths, and the on-disk shuffle
+    dir gets cleaned up eagerly by ``_do_shutdown`` so a post-hoc filesystem
+    check races with cleanup. Patch ``ExternalHashShuffleMapOp.__init__`` to
+    raise so any construction of the external op fails the test immediately.
+    """
+    from unittest import mock
+
+    from ray.data._internal.execution.operators.shuffle_operators.external_shuffle_map_operator import (  # noqa: E501
+        ExternalHashShuffleMapOp,
+    )
+
+    ctx = DataContext.get_current()
+    ctx.shuffle_strategy = ShuffleStrategy.SHUFFLE_V2
+    ctx.use_external_hash_shuffle = False
+
+    with mock.patch.object(
+        ExternalHashShuffleMapOp,
+        "__init__",
+        side_effect=AssertionError("external op was constructed with flag=False"),
+    ):
+        ds = ray.data.range(200).repartition(4, keys=["id"])
+        assert ds.count() == 200
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main(["-v", __file__]))

--- a/python/ray/data/tests/test_hash_shuffle_external_smoke.py
+++ b/python/ray/data/tests/test_hash_shuffle_external_smoke.py
@@ -5,18 +5,31 @@ Wires the operators directly — bypassing the Ray Data planner — to verify
 the simplest end-to-end story: feed N input blocks, hash-partition into K
 partitions, reduce each with ``_concat_reduce``, then check row count and
 partition count. Catches wiring bugs (RefBundle shape, sentinel metadata,
-callback ordering, ShuffleFileServer lifecycle) that the planner-driven
-tests in ``test_hash_shuffle_external_repartition.py`` don't isolate.
+callback ordering, ShuffleFileServer lifecycle, empty-partition gating)
+that the planner-driven tests in
+``test_hash_shuffle_external_repartition.py`` don't isolate.
 """
 
+from typing import List, Optional, Sequence, cast
+
+import pyarrow as pa
 import pytest
 
 import ray
 from ray.data._internal.execution.block_ref_counter import BlockRefCounter
-from ray.data._internal.execution.interfaces import ExecutionOptions
+from ray.data._internal.execution.interfaces import (
+    BlockEntry,
+    ExecutionOptions,
+    RefBundle,
+)
 from ray.data._internal.execution.operators.hash_shuffle_v2 import (
     _concat_reduce,
     _make_hash_partition_fn,
+)
+from ray.data._internal.execution.operators.input_data_buffer import InputDataBuffer
+from ray.data._internal.execution.operators.map_transformer import (
+    BlockMapTransformFn,
+    MapTransformer,
 )
 from ray.data._internal.execution.operators.shuffle_operators.external_shuffle_map_operator import (  # noqa: E501
     ExternalHashShuffleMapOp,
@@ -26,6 +39,7 @@ from ray.data._internal.execution.operators.shuffle_operators.external_shuffle_r
 )
 from ray.data._internal.execution.util import make_ref_bundles
 from ray.data._internal.stats import Timer
+from ray.data.block import BlockAccessor
 from ray.data.context import DataContext
 from ray.data.tests.util import run_op_tasks_sync
 
@@ -45,84 +59,253 @@ def _total_rows(bundles) -> int:
     return sum(b.num_rows() or 0 for b in bundles)
 
 
-# --- tests -------------------------------------------------------------------
+def _arrow_ref_bundles(tables: Sequence[pa.Table]) -> List[RefBundle]:
+    """One RefBundle per Arrow table (preserves null-typed columns)."""
+    bundles = []
+    for table in tables:
+        bundles.append(
+            RefBundle(
+                (
+                    BlockEntry(
+                        # pyrefly: ignore[bad-argument-type]
+                        ray.put(table),
+                        BlockAccessor.for_block(table).get_metadata(),
+                    ),
+                ),
+                owns_blocks=True,
+                schema=table.schema,
+            )
+        )
+    return bundles
 
 
-@pytest.fixture(scope="module")
-def ray_init_shutdown():
-    if not ray.is_initialized():
-        ray.init(num_cpus=4, include_dashboard=False, ignore_reinit_error=True)
-    yield
-    # Leave Ray up; multiple tests in this file reuse it.
+def _drive_external_shuffle(
+    input_bundles: List[RefBundle],
+    *,
+    key_columns: List[str],
+    num_partitions: int,
+    fused_output_map_transformer: Optional[MapTransformer] = None,
+):
+    """Wire map→reduce, drive to completion, return (map_out, reduce_out, reduce_op).
 
-
-@pytest.mark.parametrize("num_blocks,rows,num_parts", [(4, 250, 4), (8, 100, 3)])
-def test_external_repartition_smoke(ray_init_shutdown, num_blocks, rows, num_parts):
-    """End-to-end: map → reduce, verify total row count preserved."""
+    Caller must shut down ``reduce_op`` (and its upstream map / InputDataBuffer)
+    via the returned reduce op's input chain, or use the try/finally in tests.
+    Returns ``(map_output, reduce_output, reduce_op, map_op, upstream)``.
+    """
     ctx = DataContext.get_current()
-    input_bundles = make_ref_bundles(
-        [list(range(i * rows, (i + 1) * rows)) for i in range(num_blocks)]
-    )
-    expected_total_rows = num_blocks * rows
-
-    # Feed bundles into a stub upstream — no real planner-driven input dep.
-    from ray.data._internal.execution.operators.input_data_buffer import (
-        InputDataBuffer,
-    )
-
     upstream = InputDataBuffer(ctx, input_bundles)
-    # PhysicalOperator.start() requires a BlockRefCounter (executor-wide
-    # in the real path; a fresh instance is fine for the hand-driven test).
     block_ref_counter = BlockRefCounter()
     upstream.start(ExecutionOptions(), block_ref_counter)
 
     map_op = ExternalHashShuffleMapOp(
         upstream,
         ctx,
-        num_partitions=num_parts,
-        partition_fn=_make_hash_partition_fn(["id"], num_parts),
+        num_partitions=num_partitions,
+        partition_fn=_make_hash_partition_fn(key_columns, num_partitions),
         name="ExternalHashShuffleMap-smoke",
     )
     reduce_op = ExternalHashShuffleReduceOp(
         map_op,
         ctx,
-        num_partitions=num_parts,
+        num_partitions=num_partitions,
         reduce_fn=_concat_reduce,
-        # default target_max_block_size = None ⇒ partition = block
         name="ExternalHashShuffleReduce-smoke",
+        fused_output_map_transformer=fused_output_map_transformer,
     )
 
     map_op.start(ExecutionOptions(), block_ref_counter)
     reduce_op.start(ExecutionOptions(), block_ref_counter)
 
-    try:
-        # Drive map by piping every upstream bundle in.
-        while upstream.has_next():
-            map_op.add_input(upstream.get_next(), input_index=0)
-        map_op.all_inputs_done()
+    while upstream.has_next():
+        map_op.add_input(upstream.get_next(), input_index=0)
+    map_op.all_inputs_done()
 
-        # Drain map → feed reduce. The map op emits one partition wrapper
-        # bundle per partition_id (not per mapper).
-        map_output = _run_and_collect(map_op)
-        assert len(map_output) == num_parts, (
-            f"expected {num_parts} partition wrappers from map, "
-            f"got {len(map_output)}"
-        )
+    map_output = _run_and_collect(map_op)
+    assert len(map_output) == num_partitions, (
+        f"expected {num_partitions} partition wrappers from map, "
+        f"got {len(map_output)}"
+    )
+    return map_output, reduce_op, map_op, upstream
+
+
+def _shutdown_ops(*ops) -> None:
+    for op in ops:
+        op.shutdown(Timer(), force=True)
+
+
+# --- tests -------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("num_blocks,rows,num_parts", [(4, 250, 4), (8, 100, 3)])
+def test_external_repartition_smoke(
+    ray_start_regular_shared_2_cpus, num_blocks, rows, num_parts
+):
+    """End-to-end: map → reduce, verify total row count preserved."""
+    input_bundles = make_ref_bundles(
+        [list(range(i * rows, (i + 1) * rows)) for i in range(num_blocks)]
+    )
+    expected_total_rows = num_blocks * rows
+
+    map_output, reduce_op, map_op, upstream = _drive_external_shuffle(
+        input_bundles, key_columns=["id"], num_partitions=num_parts
+    )
+    try:
         for bundle in map_output:
             reduce_op.add_input(bundle, input_index=0)
         reduce_op.all_inputs_done()
 
-        # Drain reduce + check invariants.
         reduce_output = _run_and_collect(reduce_op)
         got_rows = _total_rows(reduce_output)
-        assert got_rows == expected_total_rows, (
-            f"row count mismatch: got {got_rows}, expected " f"{expected_total_rows}"
-        )
-        assert len({id(bundle) for bundle in reduce_output}) >= 1
+        assert (
+            got_rows == expected_total_rows
+        ), f"row count mismatch: got {got_rows}, expected {expected_total_rows}"
     finally:
-        reduce_op.shutdown(Timer(), force=True)
-        map_op.shutdown(Timer(), force=True)
-        upstream.shutdown(Timer(), force=True)
+        _shutdown_ops(reduce_op, map_op, upstream)
+
+
+def test_empty_partition_fast_path(ray_start_regular_shared_2_cpus):
+    """Few distinct keys into many partitions: empty wrappers skip remote reduce.
+
+    Mirrors v2 ``test_more_partitions_than_keys_emits_empty_blocks`` at the
+    operator layer: map still emits N wrappers; empty ones
+    (``num_rows==0``) take the reduce empty fast path (no remote task);
+    outputs keep schema and total row count.
+    """
+    # 3 keys → 20 partitions ⇒ many empty wrappers.
+    num_parts = 20
+    rows = [{"k": i % 3, "v": i} for i in range(60)]
+    table = pa.Table.from_pylist(rows)
+    map_output, reduce_op, map_op, upstream = _drive_external_shuffle(
+        _arrow_ref_bundles([table]),
+        key_columns=["k"],
+        num_partitions=num_parts,
+    )
+    try:
+        empty_wrappers = [b for b in map_output if (b.num_rows() or 0) == 0]
+        non_empty_wrappers = [b for b in map_output if (b.num_rows() or 0) > 0]
+        assert len(empty_wrappers) >= 17
+        assert len(non_empty_wrappers) <= 3
+
+        for bundle in map_output:
+            reduce_op.add_input(bundle, input_index=0)
+
+        # Empty fast path queues output immediately; only non-empty need tasks.
+        assert len(reduce_op.get_active_tasks()) == len(non_empty_wrappers)
+        assert reduce_op.has_next()
+
+        reduce_op.all_inputs_done()
+        reduce_output = _run_and_collect(reduce_op)
+
+        assert _total_rows(reduce_output) == 60
+        assert len(reduce_output) == num_parts
+
+        schemas = [b.schema for b in reduce_output if b.schema is not None]
+        assert schemas
+        assert all(s.equals(schemas[0]) for s in schemas)
+
+        empty_out = [b for b in reduce_output if (b.num_rows() or 0) == 0]
+        assert len(empty_out) == len(empty_wrappers)
+        for bundle in empty_out:
+            block = cast(pa.Table, ray.get(bundle.block_refs[0]))
+            assert block.num_rows == 0
+            assert block.schema.equals(schemas[0])
+    finally:
+        _shutdown_ops(reduce_op, map_op, upstream)
+
+
+def test_null_typed_not_gated_as_empty(ray_start_regular_shared_2_cpus):
+    """Null-typed rows have ``tbl.nbytes == 0`` but must not take empty fast path.
+
+    Gating on ``size_bytes`` would drop them; gating on ``num_rows`` keeps them.
+    """
+    table = pa.table({"k": pa.nulls(10)})
+    assert table.num_rows == 10
+    assert table.nbytes == 0
+
+    num_parts = 4
+    map_output, reduce_op, map_op, upstream = _drive_external_shuffle(
+        _arrow_ref_bundles([table]),
+        key_columns=["k"],
+        num_partitions=num_parts,
+    )
+    try:
+        # All-null keys land in one partition; that wrapper has rows, nbytes may
+        # still be 0 on metadata.
+        non_empty = [b for b in map_output if (b.num_rows() or 0) > 0]
+        assert len(non_empty) == 1
+        assert non_empty[0].num_rows() == 10
+        # The bug was gating on bytes: the wrapper for a null-typed table can
+        # report size_bytes==0 even though it has rows (not asserted — the
+        # metadata representation may legitimately change).
+
+        for bundle in map_output:
+            reduce_op.add_input(bundle, input_index=0)
+
+        # Non-empty (by rows) must submit a remote reduce task, not fast-path.
+        assert len(reduce_op.get_active_tasks()) == 1
+
+        reduce_op.all_inputs_done()
+        reduce_output = _run_and_collect(reduce_op)
+        assert _total_rows(reduce_output) == 10
+        assert len(reduce_output) == num_parts
+    finally:
+        _shutdown_ops(reduce_op, map_op, upstream)
+
+
+def test_fused_map_on_empty_partitions(ray_start_regular_shared_2_cpus):
+    """With a fused downstream map, empty partitions must not take the fast path.
+
+    The operator empty fast path is skipped so the fused map still runs (e.g.
+    Write). Reduce then hits the ``not sources`` fallback and yields
+    ``schema.empty_table()`` into the fused transform.
+    """
+
+    def _mark(blocks, ctx):
+        # Marker column proves the fused map ran on every reduce stream,
+        # including empty partitions (remote task; no driver-side side effects).
+        for block in blocks:
+            n = block.num_rows
+            yield block.append_column(
+                "fused",
+                pa.array([True] * n, type=pa.bool_()),
+            )
+
+    fused = MapTransformer([BlockMapTransformFn(_mark)])
+
+    num_parts = 12
+    rows = [{"k": i % 2, "v": i} for i in range(20)]
+    table = pa.Table.from_pylist(rows)
+    map_output, reduce_op, map_op, upstream = _drive_external_shuffle(
+        _arrow_ref_bundles([table]),
+        key_columns=["k"],
+        num_partitions=num_parts,
+        fused_output_map_transformer=fused,
+    )
+    try:
+        empty_wrappers = [b for b in map_output if (b.num_rows() or 0) == 0]
+        assert len(empty_wrappers) >= 10
+
+        for bundle in map_output:
+            reduce_op.add_input(bundle, input_index=0)
+
+        # Fusion forces every partition — including empty — onto a remote task.
+        assert len(reduce_op.get_active_tasks()) == num_parts
+        assert not reduce_op.has_next()
+
+        reduce_op.all_inputs_done()
+        reduce_output = _run_and_collect(reduce_op)
+
+        assert _total_rows(reduce_output) == 20
+        assert len(reduce_output) == num_parts
+        empty_out = 0
+        for bundle in reduce_output:
+            block = cast(pa.Table, ray.get(bundle.block_refs[0]))
+            assert "fused" in block.column_names
+            if block.num_rows == 0:
+                empty_out += 1
+        assert empty_out == len(empty_wrappers)
+    finally:
+        _shutdown_ops(reduce_op, map_op, upstream)
 
 
 if __name__ == "__main__":

--- a/python/ray/data/tests/test_hash_shuffle_v2.py
+++ b/python/ray/data/tests/test_hash_shuffle_v2.py
@@ -6,6 +6,9 @@ import pytest
 import ray
 from ray.data._internal.execution.interfaces import ExecutionOptions, RefBundle
 from ray.data._internal.execution.operators.input_data_buffer import InputDataBuffer
+from ray.data._internal.execution.operators.shuffle_operators.external_shuffle_map_operator import (  # noqa: E501
+    ExternalHashShuffleMapOp,
+)
 from ray.data._internal.execution.operators.shuffle_operators.shuffle_map_operator import (  # noqa: E501
     ShuffleMapOp,
     make_partition_sentinel,
@@ -254,17 +257,20 @@ def test_get_shard_batch_warns_then_raises_on_stall(
     ray.cancel(ref, force=True)
 
 
+@pytest.mark.parametrize("map_op_cls", [ShuffleMapOp, ExternalHashShuffleMapOp])
 @pytest.mark.parametrize("batch_bytes,expected_num_tasks", [(0, 2), (10**9, 1)])
 def test_shuffle_input_batch_bytes_controls_map_task_batching(
     ray_start_regular_shared_2_cpus,
     restore_data_context,
+    map_op_cls,
     batch_bytes,
     expected_num_tasks,
 ):
     """batch_bytes=0 submits one map task per input bundle; a large value
-    buffers all input into a single map task, flushed when input ends."""
+    buffers all input into a single map task, flushed when input ends.
+    Both map-op variants share the same batching policy."""
     restore_data_context.shuffle_input_batch_bytes = batch_bytes
-    op = ShuffleMapOp(
+    op = map_op_cls(
         InputDataBuffer(restore_data_context, []),
         restore_data_context,
         num_partitions=2,

--- a/python/ray/data/tests/test_join.py
+++ b/python/ray/data/tests/test_join.py
@@ -17,13 +17,25 @@ from ray.tests.conftest import *  # noqa
 
 @pytest.fixture(
     autouse=True,
-    params=[ShuffleStrategy.HASH_SHUFFLE, ShuffleStrategy.SHUFFLE_V2],
-    ids=["shufflev1", "shufflev2"],
+    params=[
+        (ShuffleStrategy.HASH_SHUFFLE, False),
+        (ShuffleStrategy.SHUFFLE_V2, False),
+        (ShuffleStrategy.SHUFFLE_V2, True),
+    ],
+    ids=["shufflev1", "shufflev2", "shufflev2external"],
 )
 def hash_shuffle_version(request, restore_data_context):
-    """Run every join test on both v1 (old actor-based) & v2 shuffle."""
-    DataContext.get_current().shuffle_strategy = request.param
-    return request.param
+    """Run every join test on v1 (old actor-based), v2 (object-store), and v2
+    external (on-disk, file-transport) shuffle."""
+    strategy, use_external = request.param
+    ctx = DataContext.get_current()
+    ctx.shuffle_strategy = strategy
+    ctx.use_external_hash_shuffle = use_external
+    if strategy == ShuffleStrategy.SHUFFLE_V2:
+        # One map task per input bundle, so reducers see multiple shards per
+        # partition (the default batching folds small test data into one mapper).
+        ctx.shuffle_input_batch_bytes = 0
+    return strategy
 
 
 @pytest.mark.parametrize(

--- a/python/ray/data/tests/test_operator_fusion.py
+++ b/python/ray/data/tests/test_operator_fusion.py
@@ -574,8 +574,9 @@ def test_fuse_map_into_shuffle_reduce(
     assert sorted(extract_values("id", ds.take_all())) == list(range(100))
 
 
+@pytest.mark.parametrize("use_external", [False, True])
 def test_fused_shuffle_reduce_preserves_operator_config(
-    ray_start_regular_shared_2_cpus, restore_data_context
+    ray_start_regular_shared_2_cpus, restore_data_context, use_external
 ):
     """Fusing a map into ShuffleReduceOp must carry over operator-level config.
 
@@ -585,6 +586,7 @@ def test_fused_shuffle_reduce_preserves_operator_config(
     """
     ctx = DataContext.get_current()
     ctx.shuffle_strategy = ShuffleStrategy.SHUFFLE_V2
+    ctx.use_external_hash_shuffle = use_external
 
     ds = (
         ray.data.range(100)
@@ -593,9 +595,8 @@ def test_fused_shuffle_reduce_preserves_operator_config(
     )
     dag = get_execution_plan(ds._logical_plan)[0].dag
 
-    assert dag.name == (
-        "HashShuffleReduce(keys=('id',), partitions=4)->MapBatches(<lambda>)"
-    )
+    prefix = "ExternalHashShuffleReduce" if use_external else "HashShuffleReduce"
+    assert dag.name == (f"{prefix}(keys=('id',), partitions=4)->MapBatches(<lambda>)")
     assert dag._fused_output_map_transformer is not None
     assert dag._peak_memory_multiplier == 3
 

--- a/release/release_data_tests.yaml
+++ b/release/release_data_tests.yaml
@@ -340,6 +340,62 @@
       python groupby_benchmark.py --sf 100 --map-groups --group-by {{columns}}
       --shuffle-strategy {{shuffle_strategy}}
 
+# External (on-disk, file-transport) hash shuffle. map_groups is keyed
+# repartition under the hood, which is the one code path that honors
+# RAY_DATA_ENABLE_EXTERNAL_SHUFFLE, so these mirror the shuffle_v2
+# map_groups variants above with the flag on. Separate entries (rather
+# than a matrix axis on the blocks above) keep the existing tests'
+# perf-history names intact.
+- name: "map_groups_fixed_size_{{shuffle_strategy}}_external_{{columns}}"
+  python: "3.10"
+  matrix:
+    setup:
+      shuffle_strategy: [shuffle_v2]
+      columns:
+        - "column02 column14"  # 7M groups
+
+  cluster:
+    anyscale_sdk_2026: true
+    byod:
+      runtime_env:
+        - RAY_DATA_DEBUG_RESOURCE_MANAGER=1
+        - RAYTEST_FAIL_ON_WORKER_OOM=1
+        - RAYTEST_FAIL_ON_DEAD_NODES=1
+        - RAY_max_direct_call_object_size=8192
+        - RAY_DATA_ENABLE_EXTERNAL_SHUFFLE=1
+    cluster_compute: fixed_size_all_to_all_compute.yaml
+
+  run:
+    timeout: 7200
+    script: >
+      python groupby_benchmark.py --sf 1000 --map-groups --group-by {{columns}}
+      --shuffle-strategy {{shuffle_strategy}} --num-partitions 500
+
+- name: "map_groups_fixed_size_{{shuffle_strategy}}_external_{{columns}}"
+  python: "3.10"
+  matrix:
+    setup:
+      shuffle_strategy: [shuffle_v2]
+      columns:
+        - "column08 column13 column14"   # 84 groups
+
+  cluster:
+    anyscale_sdk_2026: true
+    byod:
+      runtime_env:
+        - RAY_DATA_DEBUG_RESOURCE_MANAGER=1
+        - RAYTEST_FAIL_ON_WORKER_OOM=1
+        - RAYTEST_FAIL_ON_DEAD_NODES=1
+        - RAY_max_direct_call_object_size=8192
+        - RAY_DATA_ENABLE_EXTERNAL_SHUFFLE=1
+    cluster_compute: fixed_size_all_to_all_compute.yaml
+
+  run:
+    timeout: 3600
+    script: >
+      python groupby_benchmark.py --sf 100 --map-groups --group-by {{columns}}
+      --shuffle-strategy {{shuffle_strategy}}
+
 ###############
 # Join tests
 ###############

--- a/release/release_data_tests.yaml
+++ b/release/release_data_tests.yaml
@@ -267,6 +267,44 @@
       python groupby_benchmark.py --sf 1000 --aggregate --group-by {{columns}}
       --shuffle-strategy {{shuffle_strategy}} --num-partitions 500
 
+# Aggregations through the external (on-disk, file-transport) hash shuffle:
+# the SF1000 shuffle_v2 variants above with RAY_DATA_ENABLE_EXTERNAL_SHUFFLE=1.
+- name: "aggregate_groups_fixed_size_{{shuffle_strategy}}_external_{{columns}}"
+  python: "3.10"
+  matrix:
+    setup:
+      shuffle_strategy: []
+      columns: []
+      bin_packing_bytes: []
+    adjustments:
+      - with:
+          shuffle_strategy: shuffle_v2
+          columns: "column08 column13 column14"   # 84 groups
+          bin_packing_bytes: 536870912
+      - with:
+          shuffle_strategy: shuffle_v2
+          columns: "column02 column14"  # 7M groups
+          bin_packing_bytes: 67108864
+
+  cluster:
+    anyscale_sdk_2026: true
+    byod:
+      runtime_env:
+        - RAY_DATA_DEBUG_RESOURCE_MANAGER=1
+        - RAYTEST_FAIL_ON_WORKER_OOM=1
+        - RAYTEST_FAIL_ON_DEAD_NODES=1
+        - RAY_max_direct_call_object_size=8192
+        - RAY_DATA_ENABLE_EXTERNAL_SHUFFLE=1
+        # Footer read tuning.
+        - RAY_DATA_PARQUET_BIN_PACKING_BYTES={{bin_packing_bytes}}
+    cluster_compute: fixed_size_all_to_all_compute.yaml
+
+  run:
+    timeout: 7200
+    script: >
+      python groupby_benchmark.py --sf 1000 --aggregate --group-by {{columns}}
+      --shuffle-strategy {{shuffle_strategy}} --num-partitions 500
+
 - name: "map_groups_fixed_size_{{shuffle_strategy}}_{{columns}}"
   python: "3.10"
   matrix:
@@ -340,12 +378,10 @@
       python groupby_benchmark.py --sf 100 --map-groups --group-by {{columns}}
       --shuffle-strategy {{shuffle_strategy}}
 
-# External (on-disk, file-transport) hash shuffle. map_groups is keyed
-# repartition under the hood, which is the one code path that honors
-# RAY_DATA_ENABLE_EXTERNAL_SHUFFLE, so these mirror the shuffle_v2
-# map_groups variants above with the flag on. Separate entries (rather
-# than a matrix axis on the blocks above) keep the existing tests'
-# perf-history names intact.
+# map_groups (keyed repartition under the hood) through the external
+# hash shuffle: the shuffle_v2 map_groups variants above with the flag on.
+# Separate entries (rather than a matrix axis on the blocks above) keep the
+# existing tests' perf-history names intact.
 - name: "map_groups_fixed_size_{{shuffle_strategy}}_external_{{columns}}"
   python: "3.10"
   matrix:
@@ -456,6 +492,38 @@
         - RAYTEST_FAIL_ON_WORKER_OOM=1
         - RAYTEST_FAIL_ON_DEAD_NODES=1
         - RAY_DATA_DEFAULT_SHUFFLE_STRATEGY=shuffle_v2
+        - RAY_max_direct_call_object_size=8192
+    cluster_compute: fixed_size_all_to_all_compute.yaml
+
+  matrix:
+    setup:
+      dataset: [sf1000]
+      join_type: [inner, left_outer, right_outer, full_outer]
+
+  run:
+    timeout: 10800
+    script: >
+      python join_benchmark.py
+      --left_dataset s3://ray-benchmark-data/tpch/parquet/{{dataset}}/lineitem
+      --right_dataset s3://ray-benchmark-data/tpch/parquet/{{dataset}}/orders
+      --left_join_keys column00
+      --right_join_keys column0
+      --join_type {{join_type}}
+      --num_partitions 1000
+
+# Joins through the external (on-disk, file-transport) hash shuffle:
+# the shuffle_v2 variants above with RAY_DATA_ENABLE_EXTERNAL_SHUFFLE=1.
+- name: "joins_{{dataset}}_{{join_type}}_shuffle_v2_external"
+  python: "3.10"
+  cluster:
+    anyscale_sdk_2026: true
+    byod:
+      runtime_env:
+        - RAY_DATA_DEBUG_RESOURCE_MANAGER=1
+        - RAYTEST_FAIL_ON_WORKER_OOM=1
+        - RAYTEST_FAIL_ON_DEAD_NODES=1
+        - RAY_DATA_DEFAULT_SHUFFLE_STRATEGY=shuffle_v2
+        - RAY_DATA_ENABLE_EXTERNAL_SHUFFLE=1
         - RAY_max_direct_call_object_size=8192
     cluster_compute: fixed_size_all_to_all_compute.yaml
 


### PR DESCRIPTION
Cherry-picks of #65499 (6560c19c7eabb541b626d12d193d5bae6cd369f0), #65897 (eece02ee54fbfd9fc8f0520f0ab35bdc211fdc9c), and #65590 (3d03569ae690d81aa0ef8b549447e8b19b459fb8) onto releases/2.59.0, in master merge order.

Combined into one PR because they are interdependent: #65897 alone conflicts in 6 files without #65499, and the #65590 rename must apply on top of both — picked standalone it would leave stale `hash_shuffle_compression` references in the external-shuffle files those PRs add. With all three stacked, remaining old-name references exactly match master (back-compat alias in context.py + its test only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)