### PR TITLE
[Data] Preserve nested TorchInference outputs on device-to-host transfer

### DIFF
--- a/python/ray/data/_internal/utils/torch_inference.py
+++ b/python/ray/data/_internal/utils/torch_inference.py
@@ -250,7 +250,9 @@ def make_torch_inference_callable(user_cls: Type[TorchInference]) -> "CallableCl
             )
             validate_processed_batch(out, self._ti_device, user_cls)
 
-            cpu_out = move_tensors_to_device(out, _CPU_DEVICE, non_blocking=False)
+            cpu_out = move_tensors_to_device(
+                out, _CPU_DEVICE, non_blocking=False, concat=False
+            )
 
             return self._ti_user.finalize(input_batch, cpu_out, output_other)
 

--- a/python/ray/data/tests/test_torch_inference.py
+++ b/python/ray/data/tests/test_torch_inference.py
@@ -485,6 +485,62 @@ def test_e2e_cuda_default_collate_and_finalize(shutdown_only):
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_e2e_cuda_ragged_output(shutdown_only):
+    # `process_on_device` may return `Dict[str, List[Tensor]]` with
+    # independently shaped tensors (e.g. detection masks): the managed D2H
+    # moves each tensor individually and preserves the structure instead of
+    # concatenating.
+    ray.init(num_cpus=2, num_gpus=1)
+
+    class RaggedPredictor(TorchInference):
+        def collate(self, input_batch):
+            return {"data": torch.from_numpy(input_batch["data"])}
+
+        def process_on_device(self, input_batch, collated_tensors, collated_other):
+            x = collated_tensors["data"]
+            # One differently shaped "mask" per row: row with global id `g`
+            # gets a (g % 3 + 1, g % 5 + 1) tensor filled with its row value.
+            return {
+                "masks": [
+                    torch.full(
+                        (int(g) % 3 + 1, int(g) % 5 + 1),
+                        float(row[0]),
+                        device=x.device,
+                    )
+                    for g, row in zip(input_batch["id"], x)
+                ]
+            }
+
+        def finalize(self, input_batch, output_tensors, output_other):
+            masks = output_tensors["masks"]
+            # Structure preserved: still a list of CPU tensors, ragged shapes
+            # intact.
+            assert isinstance(masks, list)
+            assert all(mask.device.type == "cpu" for mask in masks)
+            return {
+                "id": input_batch["id"],
+                "mask_rows": np.asarray([mask.shape[0] for mask in masks]),
+                "mask_val": np.asarray([float(mask[0, 0]) for mask in masks]),
+            }
+
+    ds = _make_gpu_source().map_batches(
+        RaggedPredictor,
+        batch_size=GPU_BATCH_SIZE,
+        batch_format="numpy",
+        compute=ray.data.ActorPoolStrategy(size=1),
+        num_gpus=1,
+    )
+
+    rows = sorted(ds.take_all(), key=lambda row: row["id"])
+    ids = np.asarray([row["id"] for row in rows], dtype=np.int64)
+    mask_rows = np.asarray([row["mask_rows"] for row in rows])
+    mask_vals = np.asarray([row["mask_val"] for row in rows])
+    assert np.array_equal(ids, np.arange(GPU_NUM_ROWS, dtype=np.int64))
+    assert np.array_equal(mask_rows, ids % 3 + 1)
+    assert np.array_equal(mask_vals, (1.0 + ids).astype(np.float32))
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
 def test_collate_output_must_be_cpu(shutdown_only):
     ray.init(num_cpus=2, num_gpus=1)
 

--- a/python/ray/data/tests/test_torch_tensor_utils.py
+++ b/python/ray/data/tests/test_torch_tensor_utils.py
@@ -145,6 +145,30 @@ def test_move_tensors_to_device():
     assert torch.equal(out["b"], torch.ones(2))
 
 
+def test_move_tensors_to_device_no_concat():
+    """With concat=False, nested sequences are moved tensor-by-tensor and the
+    structure is preserved — independently shaped tensors are allowed."""
+    device = torch.device("cpu")
+
+    # Dict[str, List[torch.Tensor]] with ragged shapes (would raise with
+    # concat=True). NOTE: mapping values must be homogeneous (all sequences);
+    # wrap flat tensors in single-element lists.
+    batch = {"masks": [torch.ones(2, 3), torch.ones(4, 5)], "flat": [torch.ones(1)]}
+    out = move_tensors_to_device(batch, device, concat=False)
+    assert isinstance(out["masks"], list)
+    assert torch.equal(out["masks"][0], torch.ones(2, 3))
+    assert torch.equal(out["masks"][1], torch.ones(4, 5))
+    assert isinstance(out["flat"], list)
+    assert torch.equal(out["flat"][0], torch.ones(1))
+
+    # Nested sequences keep their container types.
+    batch = [(torch.ones(1), torch.ones(2)), [torch.ones(3)]]
+    out = move_tensors_to_device(batch, device, concat=False)
+    assert isinstance(out[0], tuple) and isinstance(out[1], list)
+    assert torch.equal(out[0][1], torch.ones(2))
+    assert torch.equal(out[1][0], torch.ones(3))
+
+
 def test_move_invalid_batch_type():
     """Test that move_tensors_to_device raises an error for invalid batch types."""
     device = torch.device("cpu")

--- a/python/ray/data/util/torch_inference.py
+++ b/python/ray/data/util/torch_inference.py
@@ -193,7 +193,9 @@ class TorchInference:
             The resulting Torch tensors, optionally with side data:
 
             - ``tensors``: the tensors must be on the device; Ray Data moves
-              them back to the CPU before calling :meth:`finalize`.
+              them back to the CPU before calling :meth:`finalize`. Unlike
+              the input transfer, the output transfer preserves nested
+              sequences as-is.
             - ``(tensors, other)``: additionally hand ``other`` — any
               non-tensor side value, passed through untouched — to
               :meth:`finalize` as ``output_other``. When only ``tensors`` is

--- a/python/ray/data/util/torch_utils.py
+++ b/python/ray/data/util/torch_utils.py
@@ -468,11 +468,12 @@ def move_tensors_to_device(
     batch: TensorBatchType,
     device: Optional[Union[str, "torch.device"]] = None,
     non_blocking: bool = DEFAULT_TENSOR_NON_BLOCKING_TRANSFER,
+    concat: bool = True,
 ) -> TensorBatchReturnType:
     """Move tensors to the specified device.
 
-    Concatenate nested lists/tuples of tensors along the first (batch) dimension.
-    For example, for the input
+    By default, concatenate nested lists/tuples of tensors along the first
+    (batch) dimension. For example, for the input
     ((feature_0_chunk_0,), (feature_1_chunk_0, feature_1_chunk_1))
     the output will be (feature_0_chunk_0, feature_1_chunk_0+1)
     where each feature is concatenated along the batch dimension.
@@ -488,6 +489,11 @@ def move_tensors_to_device(
         device: The device to move tensors to. If None, tensors are not moved.
         non_blocking: If True, perform device transfer without forcing a
             synchronization.
+        concat: If True (the default), nested sequences of tensors are
+            concatenated along the first (batch) dimension during the
+            transfer, which requires each sequence's tensors to share dtype
+            and trailing shape. If False, every tensor is moved individually
+            and the input structure is preserved.
 
     Returns:
         The input tensors moved to the specified device
@@ -500,12 +506,24 @@ def move_tensors_to_device(
     elif _is_tensor_sequence(batch):
         return type(batch)([t.to(device, non_blocking=non_blocking) for t in batch])
     elif _is_nested_tensor_sequence(batch):
+        if not concat:
+            return type(batch)(
+                [
+                    move_tensors_to_device(t, device, non_blocking, concat=False)
+                    for t in batch
+                ]
+            )
         return type(batch)(
             [concat_tensors_to_device(t, device, non_blocking) for t in batch]
         )
     elif _is_tensor_mapping(batch):
         return {k: t.to(device, non_blocking=non_blocking) for k, t in batch.items()}
     elif _is_tensor_sequence_mapping(batch):
+        if not concat:
+            return {
+                k: move_tensors_to_device(v, device, non_blocking, concat=False)
+                for k, v in batch.items()
+            }
         return {
             k: concat_tensors_to_device(v, device, non_blocking)
             for k, v in batch.items()


### PR DESCRIPTION
## Summary
`TorchInference.process_on_device` can return nested tensors with independent shapes (for example per-row detection masks). The managed device-to-host transfer previously concatenated nested sequences along the batch dimension, which either failed or collapsed that structure before `finalize`.

`move_tensors_to_device` now takes `concat` (default `True`, so host-to-device / collate behavior is unchanged). The output transfer passes `concat=False` so nested sequences are moved tensor-by-tensor and preserved as-is.

## Test plan
- [x] `.venv/bin/python -m pytest python/ray/data/tests/test_torch_tensor_utils.py::test_move_tensors_to_device python/ray/data/tests/test_torch_tensor_utils.py::test_move_tensors_to_device_no_concat` (2 passed)
- [ ] `python/ray/data/tests/test_torch_inference.py::test_e2e_cuda_ragged_output` (skipped locally, no CUDA)


Made with [Cursor](https://cursor.com)