### PR TITLE
[serve.llm] Skip batcher jitter test on ARM

### DIFF
--- a/python/ray/llm/tests/serve/cpu/deployments/utils/test_batcher.py
+++ b/python/ray/llm/tests/serve/cpu/deployments/utils/test_batcher.py
@@ -1,4 +1,5 @@
 import asyncio
+import platform
 import sys
 import time
 from typing import List, Optional
@@ -196,6 +197,10 @@ class TestBatching:
 
         # Inner task is checked automatically with pytest.raises
 
+    @pytest.mark.skipif(
+        platform.machine().lower() in ("aarch64", "arm64"),
+        reason="Batcher jitter comparison is unreliable on ARM CI workers.",
+    )
     @pytest.mark.asyncio
     async def test_stable_streaming(self):
         """Test that the batcher does not add jitter to the stream when interval_ms is 0"""


### PR DESCRIPTION
## Why are these changes needed?

`test_stable_streaming` checks that disabling batching does not add jitter by comparing the mean and standard deviation of inter-chunk gaps through `Batcher` with a direct generator.

Shared ARM CI workers introduce enough unrelated scheduling variance to make the standard-deviation assertion flaky. In 21 recent postmerge runs per architecture, ARM64 failed the first attempt twice while x86 failed zero times. Both ARM failures passed on Bazel's second attempt.

This keeps the original jitter checks on other architectures and skips only this test on ARM64, matching the handling of the companion `test_stable_streaming_tpot` test in #65625.

No open PR references #65998 or addresses this batcher jitter test. #65625 changed only the companion LLM server test.

## Related issue number

Closes #65998.

## Checks

- [x] I've signed off every commit (using the `-s` flag).
- [x] I've run the repository formatting and lint hooks.
- [x] No documentation changes are needed.
- [x] Tests are passing.
- Testing Strategy
  - [x] Unit tests
  - [ ] Release tests
  - [ ] This PR is not tested :(

### Tests run

- `/home/ubuntu/work/ray/.venv/bin/python -m pytest python/ray/llm/tests/serve/cpu/deployments/utils/test_batcher.py -q -p no:randomly`: 13 passed.
- `pre-commit run --files python/ray/llm/tests/serve/cpu/deployments/utils/test_batcher.py`: passed.

AI assistance was used for this change.
