### PR TITLE
[data] Track autoscaling coordinator reservations per node

### DIFF
--- a/python/ray/data/_internal/cluster_autoscaler/base_autoscaling_coordinator.py
+++ b/python/ray/data/_internal/cluster_autoscaler/base_autoscaling_coordinator.py
@@ -2,12 +2,25 @@ import abc
 from enum import Enum
 from typing import Dict, List, Optional
 
+from ray.data._internal.execution.interfaces.common import NodeIdStr
+
 ResourceType = str
 ResourceDict = Dict[ResourceType, float]
 RequesterId = str
 LabelKey = str
 LabelValue = str
 LabelSelector = Dict[LabelKey, LabelValue]
+ReservedResources = Dict[NodeIdStr, ResourceDict]
+NodeResources = Dict[NodeIdStr, ResourceDict]
+
+# Standard resource types Ray Data requests leftovers for when
+# ``request_remaining`` is non-empty.
+STANDARD_RESOURCE_TYPES: List[ResourceType] = [
+    "CPU",
+    "GPU",
+    "memory",
+    "object_store_memory",
+]
 
 
 class ResourceRequestPriority(Enum):
@@ -18,15 +31,30 @@ class ResourceRequestPriority(Enum):
     HIGH = 10
 
 
+class ResourceRequestStrategy(str, Enum):
+    """How a requester's bundles are spread over nodes when reserving.
+    TODO(jhsu): See if we can punt the autoscaling coordinator into the
+    core execution layer."""
+
+    PACK = "PACK"
+    SPREAD = "SPREAD"
+    STRICT_PACK = "STRICT_PACK"
+    STRICT_SPREAD = "STRICT_SPREAD"
+
+    def is_spread_like(self) -> bool:
+        return self in (self.SPREAD, self.STRICT_SPREAD)
+
+
 class AutoscalingCoordinator(abc.ABC):
     @abc.abstractmethod
     def request_resources(
         self,
         resources: List[ResourceDict],
         expire_after_s: float,
-        request_remaining: bool = False,
+        request_remaining: Optional[List[ResourceType]] = None,
         priority: ResourceRequestPriority = ResourceRequestPriority.MEDIUM,
         label_selectors: Optional[List[LabelSelector]] = None,
+        strategy: ResourceRequestStrategy = ResourceRequestStrategy.PACK,
     ) -> None:
         """Request cluster resources.
 
@@ -39,12 +67,15 @@ class AutoscalingCoordinator(abc.ABC):
             expire_after_s: Time in seconds after which this request will expire.
                 The requester is responsible for periodically sending new requests
                 to avoid the request being purged.
-            request_remaining: If true, after reserving requested resources to each
-                requester, remaining resources will also be reserved to this requester.
+            request_remaining: Resource types for which leftover cluster capacity
+                should also be reserved after satisfying ``resources``. ``None``
+                or an empty list means no leftovers.
             priority: The priority of the request. Higher value means higher priority.
             label_selectors: Optional per-bundle label selectors, one per entry in
                 ``resources``. Forwarded to the autoscaler as
                 ``bundle_label_selectors``.
+            strategy: How to distribute this requester's bundles over nodes when
+                reserving. Cannot be changed on an ongoing request.
         """
         ...
 
@@ -54,7 +85,7 @@ class AutoscalingCoordinator(abc.ABC):
         ...
 
     @abc.abstractmethod
-    def get_reserved_resources(self) -> List[ResourceDict]:
+    def get_reserved_resources(self) -> NodeResources:
         """Get the reserved resources for the requester.
 
         Returns:

--- a/python/ray/data/_internal/cluster_autoscaler/default_autoscaling_coordinator.py
+++ b/python/ray/data/_internal/cluster_autoscaler/default_autoscaling_coordinator.py
@@ -4,7 +4,7 @@ import logging
 import threading
 import time
 from dataclasses import dataclass
-from typing import Callable, Dict, List, Optional
+from typing import Callable, Dict, FrozenSet, List, Optional, Set
 
 import ray
 import ray.exceptions
@@ -13,11 +13,16 @@ from .base_autoscaling_coordinator import (
     LabelKey,
     LabelSelector,
     LabelValue,
+    NodeResources,
     RequesterId,
+    ReservedResources,
     ResourceDict,
     ResourceRequestPriority,
+    ResourceRequestStrategy,
+    ResourceType,
 )
 from ray._common.utils import env_bool
+from ray.data._internal.execution.interfaces.common import NodeIdStr
 from ray.data._internal.execution.util import memory_string
 from ray.util.scheduling_strategies import NodeAffinitySchedulingStrategy
 
@@ -84,7 +89,7 @@ def _format_resource_bundle_for_log(bundle: ResourceDict) -> str:
     return "{" + ", ".join(resources) + "}"
 
 
-def _format_resources_for_log(resources: List[ResourceDict]) -> str:
+def _format_resource_bundles_for_log(resources: List[ResourceDict]) -> str:
     """Format and aggregate resource bundles for logging.
 
     Bundles that format to the same string (after dropping custom/zero-valued
@@ -97,7 +102,7 @@ def _format_resources_for_log(resources: List[ResourceDict]) -> str:
         A human-readable string, e.g. ``"[2 x {CPU: 1}, 1 x {GPU: 1}]"``.
 
     Example:
-        >>> _format_resources_for_log([{"CPU": 1}, {"CPU": 1}, {"GPU": 1}])
+        >>> _format_resource_bundles_for_log([{"CPU": 1}, {"CPU": 1}, {"GPU": 1}])
         '[2 x {CPU: 1}, 1 x {GPU: 1}]'
     """
     bundle_counts: Dict[str, int] = {}
@@ -114,6 +119,37 @@ def _format_resources_for_log(resources: List[ResourceDict]) -> str:
     )
 
 
+def _format_node_resources_for_log(resources: ReservedResources) -> str:
+    """Format reserved per-node resources for logging.
+
+    Each node is emitted as ``node_id: {...}``. Custom/zero-valued resources
+    are dropped via ``_format_resource_bundle_for_log``; nodes whose bundle
+    is empty after that are omitted.
+
+    Args:
+        resources: Mapping from node id to the resource bundle reserved on
+            that node.
+
+    Returns:
+        A human-readable string, e.g.
+        ``"[n1: {CPU: 1}, n2: {CPU: 1}, n3: {GPU: 1}]"``.
+
+    Example:
+        >>> _format_node_resources_for_log(
+        ...     {"n1": {"CPU": 1}, "n2": {"CPU": 1}, "n3": {"GPU": 1}}
+        ... )
+        '[n1: {CPU: 1}, n2: {CPU: 1}, n3: {GPU: 1}]'
+    """
+    entries = []
+    for node_id, resource in resources.items():
+        bundle = _format_resource_bundle_for_log(resource)
+        if bundle == "{}":
+            continue
+        entries.append(f"{node_id}: {bundle}")
+
+    return "[" + ", ".join(entries) + "]"
+
+
 @dataclass
 class OngoingRequest:
     """Represents an ongoing resource request from a requester."""
@@ -124,17 +160,40 @@ class OngoingRequest:
     requested_resources: List[ResourceDict]
     # The expiration time of the request.
     expiration_time: float
-    # If true, after reserving requested resources to each requester,
-    # remaining resources will also be reserved to this requester.
-    request_remaining: bool
+    # Resource types for which leftover cluster capacity should also be
+    # reserved. Empty means do not reserve leftovers.
+    request_remaining: FrozenSet[ResourceType]
     # The priority of the request, higher value means higher priority.
     priority: int
-    # Resources that are already reserved to the requester.
-    reserved_resources: List[ResourceDict]
+    # Resources that are reserved to the requester, keyed in the order bundles
+    # were placed. Callers rely on that order to work out which node holds
+    # which bundle (e.g. Ray Train subtracts its trainer bundle, always
+    # submitted first, from the first node it fits on), so don't reorder it.
+    reserved_resources: ReservedResources
     # Per-bundle label selectors, parallel to ``requested_resources``.
     # Empty dicts mean no label constraint on that bundle. Required to have
     # the same length as ``requested_resources``.
     requested_label_selectors: List[LabelSelector]
+    # NOTE: So `requested_label_selectors` will request which types of nodes
+    # will be requested. The strategy then places the bundles on that narrowed subset
+    # So if the user specifies `instance_type` or maybe `ray.io/accelerator-type`
+    # those will be the only type of nodes to be scheduled. Then a PACK will make sure
+    # to use the fewest nodes possible of that subset, while SPREAD will try to place
+    # them everywhere. This is supposed to mimic the ray core behavior we have now.
+    # NOTE: Remember that this only dictacts how nodes are reserved. This is what I mean:
+    # Suppose I request [{CPU: 8, GPU: 1}, {CPU: 16, GPU: 2}] and I want them to be
+    # on [{ray.io/accelerator-type: L4}, {ray.io/accelerator-type: H100}]. Then for spread,
+    # I will return both nodes. However, it is up to the caller for schedule the 1st bundle
+    # on 1st label key and so forth. I don't think this is an issue because train has uniform
+    # resource request, and data doesn't use label selectors.
+    strategy: ResourceRequestStrategy
+
+    def requested_resources_sum(self) -> ResourceDict:
+        bundle_sum: ResourceDict = {}
+        for bundle in self.requested_resources:
+            for key, val in bundle.items():
+                bundle_sum[key] = bundle_sum.get(key, 0) + val
+        return bundle_sum
 
     def __lt__(self, other):
         """Used to sort requests when reserving resources.
@@ -166,7 +225,7 @@ class DefaultAutoscalingCoordinator(AutoscalingCoordinator):
         # Label selector keyed by ``SUBCLUSTER_LABEL_KEY`` pinning this
         # requester to a single subcluster.
         self._subcluster_selector = subcluster_selector
-        self._cached_reserved_resources: List[ResourceDict] = []
+        self._cached_reserved_resources: ReservedResources = {}
         # In-flight get_reserved_resources ref, or None if no request is pending.
         self._pending_reserved_resources: Optional[ray.ObjectRef] = None
         if autoscaling_coordinator_actor is not None:
@@ -183,9 +242,10 @@ class DefaultAutoscalingCoordinator(AutoscalingCoordinator):
         self,
         resources: List[ResourceDict],
         expire_after_s: float,
-        request_remaining: bool = False,
+        request_remaining: Optional[List[ResourceType]] = None,
         priority: ResourceRequestPriority = ResourceRequestPriority.MEDIUM,
         label_selectors: Optional[List[LabelSelector]] = None,
+        strategy: ResourceRequestStrategy = ResourceRequestStrategy.PACK,
     ) -> None:
         """Fire-and-forget: submit a resource request to the coordinator actor.
 
@@ -199,6 +259,7 @@ class DefaultAutoscalingCoordinator(AutoscalingCoordinator):
             priority=priority,
             label_selectors=label_selectors,
             subcluster_selector=self._subcluster_selector,
+            strategy=strategy,
         )
 
     def cancel_request(self) -> None:
@@ -209,10 +270,10 @@ class DefaultAutoscalingCoordinator(AutoscalingCoordinator):
         rather than stale data from a prior pipeline run.
         """
         self._pending_reserved_resources = None
-        self._cached_reserved_resources = []
+        self._cached_reserved_resources = {}
         self._autoscaling_coordinator.cancel_request.remote(self._requester_id)
 
-    def get_reserved_resources(self) -> List[ResourceDict]:
+    def get_reserved_resources(self) -> ReservedResources:
         """Return reserved resources without blocking.
 
         Submits an async RPC and immediately returns the last cached result.
@@ -244,7 +305,7 @@ class DefaultAutoscalingCoordinator(AutoscalingCoordinator):
         if self._pending_reserved_resources is None:
             self._pending_reserved_resources = (
                 self._autoscaling_coordinator.get_reserved_resources.remote(
-                    self._requester_id,
+                    self._requester_id
                 )
             )
 
@@ -288,11 +349,9 @@ class _AutoscalingCoordinatorActor:
         self._subcluster_selectors: Dict[RequesterId, Optional[LabelSelector]] = {}
         # Node resources bucketed by their ``SUBCLUSTER_LABEL_KEY`` value.
         # Nodes without the key fall under ``DEFAULT_SUBCLUSTER``.
-        self._cluster_node_resources: Dict[
-            Optional[LabelValue], List[ResourceDict]
-        ] = {}
+        self._cluster_node_resources: Dict[Optional[LabelValue], NodeResources] = {}
         # Lock for thread-safe access to shared state from the background
-        self._lock = threading.Lock()
+        self._lock = threading.RLock()
         self._update_cluster_node_resources()
 
         # This is an actor, so the following check should always be True.
@@ -309,29 +368,48 @@ class _AutoscalingCoordinatorActor:
 
     def _tick(self):
         """Used to perform periodical operations, e.g., purge expired requests,
-        merge and send requests, check cluster resource updates, etc."""
-        with self._lock:
-            self._merge_and_send_requests()
-            self._update_cluster_node_resources()
-            self._rereserve_resources()
+        merge and send requests, check cluster resource updates, etc.
+
+        Never raises. This runs on a bare background thread, where an escaping
+        exception would kill the thread and silently stop autoscaling for every
+        requester on the cluster, not just the one that misbehaved. Callers
+        that tick on demand see the previous reservation instead of an error.
+        """
+        try:
+            with self._lock:
+                self._merge_and_send_requests()
+                self._update_cluster_node_resources()
+                self._refresh_resource_reservations()
+        except Exception:
+            logger.warning(
+                "AutoscalingCoordinator tick failed; reservations may be stale"
+                f" until the next tick in {self.TICK_INTERVAL_S} seconds."
+                " If this error persists, file a GitHub issue.",
+                exc_info=RAY_DATA_AUTOSCALING_COORDINATOR_LOG_TRACEBACK,
+            )
 
     def request_resources(
         self,
         requester_id: RequesterId,
         resources: List[ResourceDict],
         expire_after_s: float,
-        request_remaining: bool = False,
+        request_remaining: Optional[List[ResourceType]] = None,
         priority: ResourceRequestPriority = ResourceRequestPriority.MEDIUM,
         label_selectors: Optional[List[LabelSelector]] = None,
         subcluster_selector: Optional[LabelSelector] = None,
+        strategy: ResourceRequestStrategy = ResourceRequestStrategy.PACK,
     ) -> None:
+        share_leftover_resource_types = frozenset(request_remaining or ())
         logger.debug(
             "Received request from %s: %s "
-            "(label_selectors=%s, subcluster_selector=%s).",
+            "(label_selectors=%s, subcluster_selector=%s, request_remaining=%s, "
+            "strategy=%s).",
             requester_id,
             resources,
             label_selectors,
             subcluster_selector,
+            share_leftover_resource_types,
+            strategy,
         )
         if label_selectors is None:
             label_selectors = [{} for _ in resources]
@@ -340,6 +418,7 @@ class _AutoscalingCoordinatorActor:
                 f"label_selectors length ({len(label_selectors)}) must match "
                 f"resources length ({len(resources)})."
             )
+        strategy = ResourceRequestStrategy(strategy)
         if subcluster_selector and label_selectors:
             req_subcluster = subcluster_selector.get(SUBCLUSTER_LABEL_KEY)
             for i, sel in enumerate(label_selectors):
@@ -359,12 +438,21 @@ class _AutoscalingCoordinatorActor:
             request_updated = False
             old_req = self._ongoing_reqs.get(requester_id)
             if old_req is not None:
-                if request_remaining != old_req.request_remaining:
+                if share_leftover_resource_types != old_req.request_remaining:
                     raise ValueError(
-                        "Cannot change request_remaining flag of an ongoing request."
+                        "Cannot change request_remaining of an ongoing request."
+                        f"Old: {old_req.request_remaining} New: {share_leftover_resource_types}"
                     )
                 if priority.value != old_req.priority:
                     raise ValueError("Cannot change priority of an ongoing request.")
+                if strategy != old_req.strategy:
+                    # Flipping the strategy would reshuffle every bundle onto
+                    # different nodes, out from under whatever the requester
+                    # already placed on the old reservation.
+                    raise ValueError(
+                        "Cannot change strategy of an ongoing request. "
+                        f"Old: {old_req.strategy} New: {strategy}"
+                    )
                 if (
                     requester_id in self._subcluster_selectors
                     and self._subcluster_selectors[requester_id] != subcluster_selector
@@ -388,10 +476,11 @@ class _AutoscalingCoordinatorActor:
                     first_request_time=now,
                     requested_resources=resources,
                     requested_label_selectors=label_selectors,
-                    request_remaining=request_remaining,
+                    request_remaining=share_leftover_resource_types,
                     priority=priority.value,
                     expiration_time=now + expire_after_s,
-                    reserved_resources=[],
+                    reserved_resources={},
+                    strategy=strategy,
                 )
             # Write subcluster after all validations so a rejected call
             # never leaves the registry on a new subcluster.
@@ -400,7 +489,7 @@ class _AutoscalingCoordinatorActor:
                 # If the request has updated, immediately send
                 # a new request and rereserve resources.
                 self._merge_and_send_requests()
-                self._rereserve_resources()
+                self._refresh_resource_reservations()
 
     def cancel_request(
         self,
@@ -413,7 +502,7 @@ class _AutoscalingCoordinatorActor:
             del self._ongoing_reqs[requester_id]
             self._subcluster_selectors.pop(requester_id, None)
             self._merge_and_send_requests()
-            self._rereserve_resources()
+            self._refresh_resource_reservations()
 
     def _purge_expired_requests(self):
         now = self._get_current_time()
@@ -434,36 +523,61 @@ class _AutoscalingCoordinatorActor:
         ``subcluster_selector``. The subcluster pin wins on key conflict,
         so the autoscaler always sees the correct subcluster regardless
         of what the per-bundle selectors contain.
+
+        ``STRICT_PACK`` bundles are collapsed into a single bundle of their
+        sum, so the autoscaler is asked for one node big enough to hold all of
+        them rather than several it is free to scatter. Bundles and selectors
+        are parallel lists that the SDK requires to be the same length, so the
+        selectors collapse with them.
         """
         self._purge_expired_requests()
         merged_req: List[ResourceDict] = []
         merged_selectors: List[LabelSelector] = []
         for requester_id, req in self._ongoing_reqs.items():
-            merged_req.extend(req.requested_resources)
+            requested_resources = req.requested_resources
             subcluster_selector = self._subcluster_selectors.get(requester_id) or {}
-            for per_bundle in req.requested_label_selectors:
+            requested_label_selectors = req.requested_label_selectors
+            if req.strategy is ResourceRequestStrategy.STRICT_PACK and (
+                requested_resources
+            ):
+                requested_resources = [req.requested_resources_sum()]
+                # A single node has to satisfy every bundle's selector, so the
+                # collapsed bundle carries all of their constraints.
+                merged: LabelSelector = {}
+                for label_selectors in req.requested_label_selectors:
+                    merged.update(label_selectors)
+                requested_label_selectors = [merged]
+            merged_req.extend(requested_resources)
+            for per_bundle in requested_label_selectors:
                 merged_selectors.append({**per_bundle, **subcluster_selector})
         if any(merged_selectors):
             self._send_resources_request(merged_req, label_selectors=merged_selectors)
         else:
             self._send_resources_request(merged_req)
 
-    def get_reserved_resources(self, requester_id: RequesterId) -> List[ResourceDict]:
-        """Get the reserved resources for the requester."""
-        with self._lock:
-            if requester_id not in self._ongoing_reqs:
-                return []
-            return self._ongoing_reqs[requester_id].reserved_resources
+    def get_reserved_resources(
+        self, requester_id: RequesterId, recompute: bool = False
+    ) -> ReservedResources:
+        """Get the reserved resources for the requester.
 
-    def _maybe_subtract_resources(self, res1: ResourceDict, res2: ResourceDict) -> bool:
-        """If res2<=res1, subtract res2 from res1 in-place, and return True.
-        Otherwise return False."""
-        if any(res1.get(key, 0) < res2[key] for key in res2):
-            return False
-        for key in res2:
-            if key in res1:
-                res1[key] -= res2[key]
-        return True
+        Args:
+            requester_id: The requester to answer for.
+            recompute: Recompute against a fresh view of the cluster first. Callers
+                that turn the answer into node pins want this, so they don't
+                pin to a node that has died since the last tick. It costs a
+                full tick, so leave it off for polling callers.
+
+        Returns:
+            The resources reserved to ``requester_id``, keyed by node id. Empty
+            if the requester has no ongoing request.
+        """
+        with self._lock:
+            if recompute:
+                # `self._lock` is reentrant, so ticking from in here is safe.
+                self._tick()
+            if requester_id not in self._ongoing_reqs:
+                return {}
+            return self._ongoing_reqs[requester_id].reserved_resources
 
     def _update_cluster_node_resources(self) -> bool:
         """Update cluster resources bucketed by subcluster. Return True if changed."""
@@ -482,29 +596,44 @@ class _AutoscalingCoordinatorActor:
             return True
 
         nodes = list(filter(_is_node_eligible, self._get_cluster_nodes()))
-        nodes = sorted(nodes, key=lambda node: node.get("NodeID", ""))
-        cluster_node_resources: Dict[Optional[LabelValue], List[ResourceDict]] = {}
+
+        def _sort_key(node):
+            # Mirrors Ray Core's bundle ordering in scarcest resource first, most of it first.
+            # Core also ranks custom resources (between GPU and object store
+            # memory); we skip them, since it's opaque to us. NodeID breaks ties so
+            # the order is stable across ticks.
+            resources = node.get("Resources", {})
+            return (
+                -resources.get("GPU", 0),
+                -resources.get("object_store_memory", 0),
+                -resources.get("memory", 0),
+                -resources.get("CPU", 0),
+                node.get("NodeID", ""),
+            )
+
+        nodes = sorted(nodes, key=_sort_key)
+        cluster_node_resources: Dict[Optional[LabelValue], NodeResources] = {}
         for node in nodes:
             # Safeguard against case where the value of Labels is None.
             labels = node.get("Labels") or {}
             subcluster = labels.get(SUBCLUSTER_LABEL_KEY, DEFAULT_SUBCLUSTER)
-            cluster_node_resources.setdefault(subcluster, []).append(node["Resources"])
+            node_id = node.get("NodeID", "")
+            per_node_resource = cluster_node_resources.setdefault(subcluster, {})
+            per_node_resource[node_id] = node["Resources"]
         if cluster_node_resources == self._cluster_node_resources:
             return False
         logger.debug("Cluster resources updated: %s.", cluster_node_resources)
         self._cluster_node_resources = cluster_node_resources
         return True
 
-    def _rereserve_resources(self):
+    def _refresh_resource_reservations(self):
         """Rereserve cluster resources.
 
         Each requester's subcluster comes from its ``subcluster_selector``.
         A requester without one is eligible only for the ``None`` bucket.
         """
         now = self._get_current_time()
-        cluster_node_resources: Dict[
-            Optional[LabelValue], List[ResourceDict]
-        ] = copy.deepcopy(self._cluster_node_resources)
+        cluster_node_resources = copy.deepcopy(self._cluster_node_resources)
         live_items = [
             (req_id, req)
             for req_id, req in self._ongoing_reqs.items()
@@ -518,20 +647,27 @@ class _AutoscalingCoordinatorActor:
 
         # TODO(hchen): Optimize the following triple loop.
         for requester_id, ongoing_req in live_items:
-            ongoing_req.reserved_resources = []
+            ongoing_req.reserved_resources = {}
             subcluster = _subcluster_of(requester_id)
-            for bundle in ongoing_req.requested_resources:
-                for node_resource in cluster_node_resources.get(subcluster, []):
-                    if self._maybe_subtract_resources(node_resource, bundle):
-                        ongoing_req.reserved_resources.append(bundle)
-                        break
+            node_resources = cluster_node_resources.get(subcluster, {})
+            reservations = _compute_reservations(
+                ongoing_request=ongoing_req,
+                node_resources=node_resources,
+            )
+            for node_id, bundle in reservations.items():
+                _subtract_bundle_in_place(node_resources[node_id], bundle)
+                _add_bundle_in_place(
+                    ongoing_req.reserved_resources.setdefault(node_id, {}),
+                    bundle,
+                )
 
-        # Reserve remaining resources. Multiple concurrent requesters in
-        # the same subcluster split that subcluster's leftovers equally.
+        # Reserve remaining resources. For each resource type, concurrent
+        # requesters in the same subcluster that asked for that type, split
+        # the leftover equally.
         remaining_items = [
             (req_id, req) for req_id, req in live_items if req.request_remaining
         ]
-        for subcluster, node_resources in cluster_node_resources.items():
+        for subcluster, node_resources_leftover in cluster_node_resources.items():
             eligible = [
                 req
                 for req_id, req in remaining_items
@@ -539,22 +675,128 @@ class _AutoscalingCoordinatorActor:
             ]
             if not eligible:
                 continue
-            for node_resource in node_resources:
-                # Integer division may leave some resources unreserved.
-                divided = {k: v // len(eligible) for k, v in node_resource.items()}
-                if not any(v > 0 for v in divided.values()):
-                    continue
-                for r in eligible:
-                    r.reserved_resources.append(divided)
+            for node_id, node_resource_leftover in node_resources_leftover.items():
+                for res_type, amount in node_resource_leftover.items():
+                    if amount <= 0:
+                        continue
+                    type_eligible = [
+                        req for req in eligible if res_type in req.request_remaining
+                    ]
+                    if not type_eligible:
+                        continue
+                    # Integer division may leave some resources unreserved.
+                    share = amount // len(type_eligible)
+                    if share <= 0:
+                        continue
+                    for r in type_eligible:
+                        _add_bundle_in_place(
+                            r.reserved_resources.setdefault(node_id, {}),
+                            {res_type: share},
+                        )
 
         if logger.isEnabledFor(logging.DEBUG):
             msg = "Reserved resources:\n"
             for requester_id, ongoing_req in self._ongoing_reqs.items():
-                reserved_resources_log_str = _format_resources_for_log(
+                requested_resources_log_str = _format_resource_bundles_for_log(
+                    ongoing_req.requested_resources
+                )
+                reserved_resources_log_str = _format_node_resources_for_log(
                     ongoing_req.reserved_resources
                 )
-                msg += f"Requester {requester_id}: {reserved_resources_log_str}\n"
+                msg += (
+                    f"Requester {requester_id}: wants {requested_resources_log_str}, "
+                    f"has {reserved_resources_log_str}\n"
+                )
             logger.debug(msg)
+
+
+def _compute_reservations(
+    ongoing_request: OngoingRequest,
+    node_resources: NodeResources,
+) -> ReservedResources:
+    """Compute per-node reservations for ``ongoing_request`` without mutating inputs.
+
+    Reservation is best effort in all strategies: a bundle that fits nowhere is
+    skipped and the remaining bundles are still attempted, so a partially
+    satisfiable request still makes progress. Callers detect the shortfall by
+    comparing what came back against what they asked for.
+
+    Args:
+        ongoing_request: The request to place.
+        node_resources: Remaining per-node capacity. Not mutated; a working copy
+            is used so later bundles in this request see prior placements.
+
+    Returns:
+        Resources to reserve, keyed by node id.
+    """
+    # Working copy so placement can account for earlier bundles in this request
+    # without mutating the caller's remaining capacity.
+    available = {
+        node_id: dict(resources) for node_id, resources in node_resources.items()
+    }
+    node_items = list(available.items())
+    if not node_items or not ongoing_request.requested_resources:
+        return {}
+
+    strategy = ongoing_request.strategy
+    reservations: ReservedResources = {}
+
+    if strategy is ResourceRequestStrategy.STRICT_PACK:
+        for node_id, node_resource in node_items:
+            bundle = ongoing_request.requested_resources_sum()
+            if _bundle_can_fit_on_node(bundle=bundle, node=node_resource):
+                _subtract_bundle_in_place(node_resource, bundle)
+                _add_bundle_in_place(
+                    reservations.setdefault(node_id, {}),
+                    bundle,
+                )
+                return reservations
+        # No node could hold the full request.
+        return {}
+
+    used_node_ids: Set[NodeIdStr] = set()
+    scan_start: int = 0
+    for bundle in ongoing_request.requested_resources:
+        for offset in range(len(node_items)):
+            idx = (scan_start + offset) % len(node_items)
+            node_id, node_resource = node_items[idx]
+            if (
+                strategy is ResourceRequestStrategy.STRICT_SPREAD
+                and node_id in used_node_ids
+            ):
+                # NOTE: since strict_spread, we cannot reuse this node_id
+                continue
+            if _bundle_can_fit_on_node(bundle=bundle, node=node_resource):
+                _subtract_bundle_in_place(node_resource, bundle)
+                _add_bundle_in_place(
+                    reservations.setdefault(node_id, {}),
+                    bundle,
+                )
+                used_node_ids.add(node_id)
+                scan_start = idx
+                if strategy.is_spread_like():
+                    scan_start += 1
+                break
+
+    return reservations
+
+
+def _bundle_can_fit_on_node(bundle: ResourceDict, node: ResourceDict) -> bool:
+    return not any(node.get(key, 0) < bundle[key] for key in bundle)
+
+
+def _subtract_bundle_in_place(target: ResourceDict, bundle: ResourceDict) -> None:
+    """Subtract ``bundle`` from ``target`` in place."""
+    for key, amount in bundle.items():
+        if key in target:
+            target[key] -= amount
+
+
+def _add_bundle_in_place(target: ResourceDict, bundle: ResourceDict) -> None:
+    """Add ``bundle`` into ``target`` in place."""
+    for key, amount in bundle.items():
+        if amount:
+            target[key] = target.get(key, 0) + amount
 
 
 _get_or_create_lock = threading.Lock()

--- a/python/ray/data/_internal/cluster_autoscaler/default_cluster_autoscaler_v2.py
+++ b/python/ray/data/_internal/cluster_autoscaler/default_cluster_autoscaler_v2.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional
 
 import ray
 from .base_autoscaling_coordinator import (
+    STANDARD_RESOURCE_TYPES,
     AutoscalingCoordinator,
     LabelSelector,
     LabelValue,
@@ -397,7 +398,7 @@ class DefaultClusterAutoscalerV2(ClusterAutoscaler):
         self._autoscaling_coordinator.request_resources(
             resources=resource_request,
             expire_after_s=self.AUTOSCALING_REQUEST_EXPIRE_TIME_S,
-            request_remaining=True,
+            request_remaining=STANDARD_RESOURCE_TYPES,
         )
         if resource_request and update_non_empty_request_state:
             self._last_non_empty_resource_request = [
@@ -428,6 +429,6 @@ class DefaultClusterAutoscalerV2(ClusterAutoscaler):
         """Get total resources available from the autoscaling coordinator."""
         resources = self._autoscaling_coordinator.get_reserved_resources()
         total = ExecutionResources.zero()
-        for res in resources:
+        for res in resources.values():
             total = total.add(ExecutionResources.from_resource_dict(res))
         return total

--- a/python/ray/data/_internal/cluster_autoscaler/fake_autoscaling_coordinator.py
+++ b/python/ray/data/_internal/cluster_autoscaler/fake_autoscaling_coordinator.py
@@ -1,12 +1,15 @@
 import time
 from dataclasses import dataclass
-from typing import Callable, List, Optional
+from typing import Callable, FrozenSet, List, Optional
 
 from .base_autoscaling_coordinator import (
     AutoscalingCoordinator,
     LabelSelector,
+    NodeResources,
     ResourceDict,
     ResourceRequestPriority,
+    ResourceRequestStrategy,
+    ResourceType,
 )
 
 
@@ -21,7 +24,8 @@ class FakeAutoscalingCoordinator(AutoscalingCoordinator):
     class Allocation:
         resources: List[ResourceDict]
         expiration_time_s: float
-        request_remaining: bool
+        request_remaining: FrozenSet[ResourceType]
+        strategy: ResourceRequestStrategy = ResourceRequestStrategy.PACK
 
     def __init__(
         self,
@@ -34,8 +38,9 @@ class FakeAutoscalingCoordinator(AutoscalingCoordinator):
             get_time: A function that returns the current time in seconds. This is a
                 seam for testing.
             initial_cluster_resources: If the requester sends an empty request and
-                ``request_remaining`` is True, the coordinator allocates these resources
-                to the requester. Otherwise, the coordinator allocates the requested
+                ``request_remaining`` is non-empty, the coordinator reserves these
+                resources (filtered to the requested remaining types) to the
+                requester. Otherwise, the coordinator reserves the requested
                 resources.
         """
         if initial_cluster_resources is None:
@@ -49,36 +54,42 @@ class FakeAutoscalingCoordinator(AutoscalingCoordinator):
         self,
         resources: List[ResourceDict],
         expire_after_s: float,
-        request_remaining: bool = False,
+        request_remaining: Optional[List[ResourceType]] = None,
         priority: ResourceRequestPriority = ResourceRequestPriority.MEDIUM,
         label_selectors: Optional[List[LabelSelector]] = None,
-        subcluster_selector: Optional[LabelSelector] = None,
+        strategy: ResourceRequestStrategy = ResourceRequestStrategy.PACK,
     ) -> None:
         if priority != ResourceRequestPriority.MEDIUM:
             raise NotImplementedError(
                 "This fake implementation doesn't support the `priority` parameter."
             )
 
-        if not resources and request_remaining:
-            resources = [r.copy() for r in self._initial_cluster_resources]
+        remaining_types = frozenset(request_remaining or ())
+        if not resources and remaining_types:
+            resources = []
+            for r in self._initial_cluster_resources:
+                filtered = {k: v for k, v in r.items() if k in remaining_types and v}
+                if filtered:
+                    resources.append(filtered)
 
         # Always accept the request and record it.
         self._allocation = self.Allocation(
             resources=resources,
             expiration_time_s=self._get_time() + expire_after_s,
-            request_remaining=request_remaining,
+            request_remaining=remaining_types,
+            strategy=strategy,
         )
 
     def cancel_request(self) -> None:
         self._allocation = None
 
-    def get_reserved_resources(self) -> List[ResourceDict]:
+    def get_reserved_resources(self) -> NodeResources:
         """Return the reserved resources if they haven't expired."""
         if self._allocation is None:
-            return []
+            return {}
 
         if self._allocation.expiration_time_s < self._get_time():
             self._allocation = None
-            return []
+            return {}
 
-        return [r.copy() for r in self._allocation.resources]
+        return {f"node_{i}": r.copy() for i, r in enumerate(self._allocation.resources)}

--- a/python/ray/data/_internal/cluster_autoscaler/placement_group_cluster_autoscaler.py
+++ b/python/ray/data/_internal/cluster_autoscaler/placement_group_cluster_autoscaler.py
@@ -111,7 +111,7 @@ class PlacementGroupClusterAutoscaler(ClusterAutoscaler):
         self._autoscaling_coordinator.request_resources(
             resources=resource_request.copy(),
             expire_after_s=self._autoscaling_request_expire_time_s,
-            request_remaining=False,
+            request_remaining=None,
         )
         self._last_request_time = time.monotonic()
 

--- a/python/ray/data/tests/test_autoscaling_coordinator.py
+++ b/python/ray/data/tests/test_autoscaling_coordinator.py
@@ -1,14 +1,19 @@
+import copy
 from unittest.mock import Mock
 
 import pytest
 
 import ray
 from ray.cluster_utils import Cluster
+from ray.data._internal.cluster_autoscaler.base_autoscaling_coordinator import (
+    STANDARD_RESOURCE_TYPES,
+    ResourceRequestStrategy,
+)
 from ray.data._internal.cluster_autoscaler.default_autoscaling_coordinator import (
     HEAD_NODE_RESOURCE_LABEL,
     DefaultAutoscalingCoordinator,
     _AutoscalingCoordinatorActor,
-    _format_resources_for_log,
+    _format_node_resources_for_log,
     get_or_create_autoscaling_coordinator,
 )
 from ray.data._internal.util import GiB
@@ -17,6 +22,7 @@ from ray.tests.conftest import wait_for_condition
 CLUSTER_NODES_WITH_HEAD = [
     # Head node should be included if it has non-zero CPUs or GPUs.
     {
+        "NodeID": "n1",
         "Resources": {
             "CPU": 10,
             "GPU": 5,
@@ -27,6 +33,7 @@ CLUSTER_NODES_WITH_HEAD = [
     },
     # Dead node should be excluded.
     {
+        "NodeID": "n-dead",
         "Resources": {
             "CPU": 10,
             "GPU": 5,
@@ -38,11 +45,13 @@ CLUSTER_NODES_WITH_HEAD = [
 
 CLUSTER_NODES_WITHOUT_HEAD = [
     {
+        "NodeID": "n1",
         "Resources": {"CPU": 10, "GPU": 5, "object_store_memory": 1000},
         "Alive": True,
     },
     # Head node should be excluded if CPUs and GPUs are both 0.
     {
+        "NodeID": "n-head-zero",
         "Resources": {
             "CPU": 0,
             "GPU": 0,
@@ -80,14 +89,7 @@ def test_basic(cluster_nodes):
     )
     mock_request_resources.assert_called_once_with(req1)
     res1 = as_coordinator.get_reserved_resources("requester1")
-
-    def _remove_head_node_resources(res):
-        for r in res:
-            if HEAD_NODE_RESOURCE_LABEL in r:
-                del r[HEAD_NODE_RESOURCE_LABEL]
-
-    _remove_head_node_resources(res1)
-    assert res1 == req1
+    assert res1 == {"n1": {"CPU": 3, "GPU": 1, "object_store_memory": 100}}
 
     # Send the same request again. `mock_request_resources` won't be called
     # since the request is not updated.
@@ -98,20 +100,20 @@ def test_basic(cluster_nodes):
     )
     assert mock_request_resources.call_count == 1
 
-    # Send a request from requester2, with request_remaining=True.
-    # requester2 should get the requested + the remaining resources.
+    # Send a request from requester2, with request_remaining=STANDARD_RESOURCE_TYPES.
+    # requester2 should get the requested + the remaining resources (merged per node).
     req2 = [{"CPU": 2, "GPU": 1, "object_store_memory": 100}]
     req2_timeout = 20
     as_coordinator.request_resources(
         requester_id="requester2",
         resources=req2,
         expire_after_s=req2_timeout,
-        request_remaining=True,
+        request_remaining=STANDARD_RESOURCE_TYPES,
     )
     mock_request_resources.assert_called_with(req1 + req2)
     res2 = as_coordinator.get_reserved_resources("requester2")
-    _remove_head_node_resources(res2)
-    assert res2 == req2 + [{"CPU": 5, "GPU": 3, "object_store_memory": 800}]
+    # req2 explicit (2/1/100) + remaining (5/3/800) merged on same node.
+    assert res2 == {"n1": {"CPU": 7, "GPU": 4, "object_store_memory": 900}}
 
     # Test updating req1
     req1_updated = [{"CPU": 4, "GPU": 2, "object_store_memory": 300}]
@@ -122,11 +124,10 @@ def test_basic(cluster_nodes):
     )
     mock_request_resources.assert_called_with(req1_updated + req2)
     res1 = as_coordinator.get_reserved_resources("requester1")
-    _remove_head_node_resources(res1)
-    assert res1 == req1_updated
+    assert res1 == {"n1": {"CPU": 4, "GPU": 2, "object_store_memory": 300}}
     res2 = as_coordinator.get_reserved_resources("requester2")
-    _remove_head_node_resources(res2)
-    assert res2 == req2 + [{"CPU": 4, "GPU": 2, "object_store_memory": 600}]
+    # req2 explicit (2/1/100) + remaining after req1_updated (4/2/600) merged.
+    assert res2 == {"n1": {"CPU": 6, "GPU": 3, "object_store_memory": 700}}
 
     # After req1_timeout, req1 should be expired.
     mocked_time = req1_timeout + 0.1
@@ -134,10 +135,9 @@ def test_basic(cluster_nodes):
     mock_request_resources.assert_called_with(req2)
     res1 = as_coordinator.get_reserved_resources("requester1")
     res2 = as_coordinator.get_reserved_resources("requester2")
-    _remove_head_node_resources(res1)
-    _remove_head_node_resources(res2)
-    assert res1 == []
-    assert res2 == req2 + [{"CPU": 8, "GPU": 4, "object_store_memory": 900}]
+    assert res1 == {}
+    # req2 explicit (2/1/100) + full remaining (8/4/900) merged.
+    assert res2 == {"n1": {"CPU": 10, "GPU": 5, "object_store_memory": 1000}}
 
     # After req2_timeout, req2 should be expired.
     mocked_time = req2_timeout + 0.1
@@ -145,20 +145,17 @@ def test_basic(cluster_nodes):
     mock_request_resources.assert_called_with([])
     res1 = as_coordinator.get_reserved_resources("requester1")
     res2 = as_coordinator.get_reserved_resources("requester2")
-    _remove_head_node_resources(res1)
-    _remove_head_node_resources(res2)
-    assert res1 == []
-    assert res2 == []
+    assert res1 == {}
+    assert res2 == {}
 
     # Test canceling a request
     as_coordinator.cancel_request("requester2")
     res2 = as_coordinator.get_reserved_resources("requester2")
-    _remove_head_node_resources(res2)
-    assert res2 == []
+    assert res2 == {}
 
 
 def test_double_allocation_with_multiple_request_remaining():
-    """Test fair allocation when multiple requesters have request_remaining=True."""
+    """Test fair allocation when multiple requesters have request_remaining=STANDARD_RESOURCE_TYPES."""
     cluster_nodes = [
         {
             "Resources": {
@@ -178,49 +175,93 @@ def test_double_allocation_with_multiple_request_remaining():
         get_cluster_nodes=lambda: cluster_nodes,
     )
 
-    # Requester1: asks for CPU=2, GPU=1 with request_remaining=True
+    # Requester1: asks for CPU=2, GPU=1 with request_remaining=STANDARD_RESOURCE_TYPES
     req1 = [{"CPU": 2, "GPU": 1, "object_store_memory": 100}]
     coordinator.request_resources(
         requester_id="requester1",
         resources=req1,
         expire_after_s=100,
-        request_remaining=True,
+        request_remaining=STANDARD_RESOURCE_TYPES,
     )
 
-    # Requester2: asks for CPU=3, GPU=1 with request_remaining=True
+    # Requester2: asks for CPU=3, GPU=1 with request_remaining=STANDARD_RESOURCE_TYPES
     req2 = [{"CPU": 3, "GPU": 1, "object_store_memory": 200}]
     coordinator.request_resources(
         requester_id="requester2",
         resources=req2,
         expire_after_s=100,
-        request_remaining=True,
+        request_remaining=STANDARD_RESOURCE_TYPES,
     )
 
-    # Get allocated resources
+    # Get reserved resources (per-node dict, explicit + remaining merged per node)
     res1 = coordinator.get_reserved_resources("requester1")
     res2 = coordinator.get_reserved_resources("requester2")
 
     # After allocating specific requests (req1 and req2):
     # Remaining = CPU: 10-2-3=5, GPU: 5-1-1=3, memory: 1000-100-200=700
-    # With fair allocation, each requester gets 1/2 of remaining resources
-    expected_remaining_per_requester = {
-        "CPU": 5 // 2,  # = 2
-        "GPU": 3 // 2,  # = 1
-        "object_store_memory": 700 // 2,  # = 350
-    }
-
-    # Both requesters should get their specific requests + fair share of remaining
-    assert res1 == req1 + [expected_remaining_per_requester]
-    assert res2 == req2 + [expected_remaining_per_requester]
+    # With fair allocation, each requester gets 1/2 of remaining resources.
+    # Explicit + remaining are merged on the same (single) node keyed by "n1".
+    assert res1 == {"": {"CPU": 2 + 2, "GPU": 1 + 1, "object_store_memory": 100 + 350}}
+    assert res2 == {"": {"CPU": 3 + 2, "GPU": 1 + 1, "object_store_memory": 200 + 350}}
 
 
-def test_format_resources_for_log():
-    # Two bundles that are identical except for sub-precision differences in
-    # object_store_memory (8.96 vs 9.04 GiB), plus custom labels and a GPU: 0
-    # entry. They should aggregate into a single entry, with custom/zero
-    # resources dropped.
-    resources = [
+def test_request_remaining_records_leftover_types_not_in_bundles():
+    """Leftovers are reserved for types in ``request_remaining``, not bundle keys."""
+    cluster_nodes = [
         {
+            "Resources": {"CPU": 10, "object_store_memory": 1000, "GPU": 2},
+            "Alive": True,
+        }
+    ]
+    coordinator = _AutoscalingCoordinatorActor(
+        get_current_time=lambda: 0,
+        send_resources_request=Mock(),
+        get_cluster_nodes=lambda: cluster_nodes,
+    )
+
+    coordinator.request_resources(
+        requester_id="requester1",
+        resources=[{"CPU": 2}],
+        expire_after_s=100,
+        # Ask for CPU + object_store leftovers, but not GPU.
+        request_remaining=["CPU", "object_store_memory"],
+    )
+
+    res = coordinator.get_reserved_resources("requester1")
+    assert res == {"": {"CPU": 10, "object_store_memory": 1000}}
+
+
+def test_request_remaining_empty_means_no_leftovers():
+    """An empty ``request_remaining`` set does not reserve leftover capacity."""
+    cluster_nodes = [
+        {
+            "Resources": {"CPU": 10, "object_store_memory": 1000},
+            "Alive": True,
+        }
+    ]
+    coordinator = _AutoscalingCoordinatorActor(
+        get_current_time=lambda: 0,
+        send_resources_request=Mock(),
+        get_cluster_nodes=lambda: cluster_nodes,
+    )
+
+    coordinator.request_resources(
+        requester_id="requester1",
+        resources=[{"CPU": 2}],
+        expire_after_s=100,
+        request_remaining=[],
+    )
+
+    res = coordinator.get_reserved_resources("requester1")
+    assert res == {"": {"CPU": 2}}
+
+
+def test_format_node_resources_for_log():
+    # Two nodes with standard resources (plus custom labels and GPU: 0) and
+    # one node with only custom/zero resources. Custom/zero resources are
+    # dropped; the empty node is omitted; each remaining node is listed.
+    resources = {
+        "n1": {
             "CPU": 8,
             "GPU": 0,
             "memory": 32 * GiB,
@@ -229,7 +270,7 @@ def test_format_resources_for_log():
             "anyscale/region:us-west-2": 1.0,
             "node:10.0.193.159": 1.0,
         },
-        {
+        "n2": {
             "CPU": 8,
             "GPU": 0,
             "memory": 32 * GiB,
@@ -238,7 +279,7 @@ def test_format_resources_for_log():
             "anyscale/region:us-west-2": 1.0,
             "node:10.0.241.173": 1.0,
         },
-        {
+        "n3": {
             "CPU": 0,
             "GPU": 0,
             "memory": 0,
@@ -246,15 +287,17 @@ def test_format_resources_for_log():
             "anyscale/cpu_only:true": 1.0,
             "node:10.0.252.14": 1.0,
         },
-    ]
+    }
 
-    log_message = _format_resources_for_log(resources)
+    log_message = _format_node_resources_for_log(resources)
     assert log_message == (
-        "[2 x {CPU: 8, memory: 32.0GiB, object_store_memory: 9.0GiB}]"
+        "[n1: {CPU: 8, memory: 32.0GiB, object_store_memory: 9.0GiB}, "
+        "n2: {CPU: 8, memory: 32.0GiB, object_store_memory: 9.0GiB}]"
     )
     assert "anyscale/" not in log_message
     assert "node:" not in log_message
     assert "GPU" not in log_message
+    assert "n3" not in log_message
 
 
 @pytest.fixture
@@ -308,23 +351,34 @@ def test_autoscaling_coordinator_e2e(cluster, gpu_tasks_include_cpu):
         )
 
         def check_allocated_resources():
-            allocated = ray.get(
+            reserved = ray.get(
                 as_coordinator.get_reserved_resources.remote(requester_id)
             )
-            allocated = [
-                {
-                    k: int(v)
-                    for k, v in r.items()
-                    if k in ["CPU", "GPU", "object_store_memory"] and v != 0
-                }
-                for r in allocated
-                if "node:__internal_head__" not in r
-            ]
-            allocated = [r for r in allocated if len(r) > 0]
-            if allocated != expected:
+            # Convert per-node dict to a sorted list of resource dicts for comparison.
+            # Only keep keys present in expected; real nodes also carry "memory"
+            # (physical RAM) which doesn't appear in the expected bundles.
+            _KEEP = {"CPU", "GPU", "object_store_memory"}
+            _sort_key = lambda r: sorted(r.items())  # noqa: E731
+            allocated = sorted(
+                [
+                    r
+                    for node_res in reserved.values()
+                    for r in [
+                        {
+                            k: int(v)
+                            for k, v in node_res.items()
+                            if k in _KEEP and v != 0
+                        }
+                    ]
+                    if r
+                ],
+                key=_sort_key,
+            )
+            expected_sorted = sorted(expected, key=_sort_key)
+            if allocated != expected_sorted:
                 print(
                     f"{requester_id}: Allocated resources: {allocated}, "
-                    f"expected: {expected}. Retrying."
+                    f"expected: {expected_sorted}. Retrying."
                 )
                 return False
             else:
@@ -362,13 +416,13 @@ def test_autoscaling_coordinator_e2e(cluster, gpu_tasks_include_cpu):
         requester_id="requester1",
         resources=res1_resources,
         expected=res1_resources + remaining,
-        request_remaining=True,
+        request_remaining=STANDARD_RESOURCE_TYPES,
     )
     res2 = request_and_check_resources.remote(
         requester_id="requester2",
         resources=req2_resources,
         expected=req2_resources,
-        request_remaining=False,
+        request_remaining=None,
     )
 
     assert ray.get([res1, res2]) == ["ok"] * 2
@@ -396,7 +450,7 @@ def test_get_reserved_resources_eventually_consistent(autoscaling_coordinator_ac
     coordinator.request_resources(resources=[{"CPU": 1}], expire_after_s=60)
 
     wait_for_condition(
-        lambda: coordinator.get_reserved_resources() == [{"CPU": 1}],
+        lambda: coordinator.get_reserved_resources() == {"n1": {"CPU": 1}},
         retry_interval_ms=100,
         timeout=5,
     )
@@ -412,7 +466,7 @@ def test_get_reserved_resources_returns_cached_while_pending(
 
     coordinator.request_resources(resources=[{"CPU": 1}], expire_after_s=60)
     wait_for_condition(
-        lambda: coordinator.get_reserved_resources() == [{"CPU": 1}],
+        lambda: coordinator.get_reserved_resources() == {"n1": {"CPU": 1}},
         retry_interval_ms=100,
         timeout=5,
     )
@@ -425,7 +479,7 @@ def test_get_reserved_resources_returns_cached_while_pending(
 
     coordinator.request_resources(resources=[{"CPU": 2}], expire_after_s=60)
     # Should return the stale cached value, not block.
-    assert coordinator.get_reserved_resources() == [{"CPU": 1}]
+    assert coordinator.get_reserved_resources() == {"n1": {"CPU": 1}}
 
 
 def test_get_reserved_resources_returns_cached_on_actor_error(
@@ -441,7 +495,7 @@ def test_get_reserved_resources_returns_cached_on_actor_error(
 
     coordinator.request_resources(resources=[{"CPU": 1}], expire_after_s=60)
     wait_for_condition(
-        lambda: coordinator.get_reserved_resources() == [{"CPU": 1}],
+        lambda: coordinator.get_reserved_resources() == {"n1": {"CPU": 1}},
         retry_interval_ms=100,
         timeout=5,
     )
@@ -454,35 +508,35 @@ def test_get_reserved_resources_returns_cached_on_actor_error(
     monkeypatch.setattr(ray, "get", Mock(side_effect=ray.exceptions.RayActorError()))
 
     # Must return the last cached value, not raise.
-    assert coordinator.get_reserved_resources() == [{"CPU": 1}]
+    assert coordinator.get_reserved_resources() == {"n1": {"CPU": 1}}
 
     # Recovery: submit a new request after the error and verify it eventually
     # resolves, proving the coordinator can communicate with the actor again.
     monkeypatch.undo()
     coordinator.request_resources(resources=[{"CPU": 2}], expire_after_s=60)
     wait_for_condition(
-        lambda: coordinator.get_reserved_resources() == [{"CPU": 2}],
+        lambda: coordinator.get_reserved_resources() == {"n1": {"CPU": 2}},
         retry_interval_ms=100,
         timeout=5,
     )
 
 
 def test_cancel_request_makes_get_return_empty(autoscaling_coordinator_actor):
-    """After cancel_request, get_reserved_resources eventually returns []."""
+    """After cancel_request, get_reserved_resources eventually returns {}."""
     coordinator = DefaultAutoscalingCoordinator(
         "test", autoscaling_coordinator_actor=autoscaling_coordinator_actor
     )
 
     coordinator.request_resources(resources=[{"CPU": 1}], expire_after_s=60)
     wait_for_condition(
-        lambda: coordinator.get_reserved_resources() == [{"CPU": 1}],
+        lambda: coordinator.get_reserved_resources() == {"n1": {"CPU": 1}},
         retry_interval_ms=100,
         timeout=5,
     )
 
     coordinator.cancel_request()
     wait_for_condition(
-        lambda: coordinator.get_reserved_resources() == [],
+        lambda: coordinator.get_reserved_resources() == {},
         retry_interval_ms=100,
         timeout=5,
     )
@@ -499,7 +553,7 @@ def test_non_ray_errors_propagate(autoscaling_coordinator_actor, monkeypatch):
 
     coordinator.request_resources(resources=[{"CPU": 1}], expire_after_s=60)
     wait_for_condition(
-        lambda: coordinator.get_reserved_resources() == [{"CPU": 1}],
+        lambda: coordinator.get_reserved_resources() == {"n1": {"CPU": 1}},
         retry_interval_ms=100,
         timeout=5,
     )
@@ -524,8 +578,9 @@ def test_coordinator_accepts_zero_resource_for_missing_resource_type(
 
     coordinator.request_resources(resources=[{"CPU": 1, "GPU": 0}], expire_after_s=1)
 
+    # GPU: 0 is a no-op; only CPU: 1 ends up reserved.
     wait_for_condition(
-        lambda: coordinator.get_reserved_resources() == [{"CPU": 1, "GPU": 0}],
+        lambda: coordinator.get_reserved_resources() == {"n1": {"CPU": 1}},
         retry_interval_ms=100,
         timeout=5,
     )
@@ -726,6 +781,289 @@ def _make_coordinator(nodes):
     )
 
 
+STRATEGY_CLUSTER_NODES = [
+    {"NodeID": "n1", "Resources": {"GPU": 4}, "Alive": True},
+    {"NodeID": "n2", "Resources": {"GPU": 4}, "Alive": True},
+]
+
+
+def _nodes(**node_id_to_resources):
+    return [
+        {"NodeID": node_id, "Resources": resources, "Alive": True}
+        for node_id, resources in node_id_to_resources.items()
+    ]
+
+
+# ``strategy`` is omitted from the request entirely when it is ``None``, which
+# is how the PACK-by-default case is expressed.
+RESERVATION_LAYOUTS = [
+    pytest.param(
+        STRATEGY_CLUSTER_NODES,
+        ResourceRequestStrategy.PACK,
+        [{"GPU": 1}] * 4,
+        {"n1": {"GPU": 4}},
+        id="pack_fills_a_node_before_moving_on",
+    ),
+    pytest.param(
+        STRATEGY_CLUSTER_NODES,
+        None,
+        [{"GPU": 1}] * 4,
+        {"n1": {"GPU": 4}},
+        id="pack_is_the_default",
+    ),
+    pytest.param(
+        STRATEGY_CLUSTER_NODES,
+        ResourceRequestStrategy.SPREAD,
+        [{"GPU": 1}] * 4,
+        {"n1": {"GPU": 2}, "n2": {"GPU": 2}},
+        id="spread_round_robins",
+    ),
+    pytest.param(
+        _nodes(n1={"GPU": 3}, n2={"GPU": 1}),
+        ResourceRequestStrategy.SPREAD,
+        [{"GPU": 1}] * 4,
+        {"n1": {"GPU": 3}, "n2": {"GPU": 1}},
+        # SPREAD is best effort: once n2 is full the rest fall back to n1
+        # rather than going unreserved.
+        id="spread_falls_back_to_a_node_with_room",
+    ),
+    pytest.param(
+        STRATEGY_CLUSTER_NODES,
+        ResourceRequestStrategy.STRICT_PACK,
+        [{"GPU": 1}] * 4,
+        {"n1": {"GPU": 4}},
+        id="strict_pack_puts_every_bundle_on_one_node",
+    ),
+    pytest.param(
+        _nodes(n1={"GPU": 3}, n2={"GPU": 3}),
+        ResourceRequestStrategy.STRICT_PACK,
+        [{"GPU": 1}] * 4,
+        {},
+        # All or nothing: splitting over two nodes is what STRICT_PACK forbids,
+        # so a cluster with no node big enough reserves nothing at all.
+        id="strict_pack_reserves_nothing_when_no_node_fits",
+    ),
+    pytest.param(
+        STRATEGY_CLUSTER_NODES,
+        ResourceRequestStrategy.STRICT_SPREAD,
+        [{"GPU": 1}] * 4,
+        {"n1": {"GPU": 1}, "n2": {"GPU": 1}},
+        # Only 2 of the 4 bundles can be placed on a 2-node cluster.
+        id="strict_spread_places_one_bundle_per_node",
+    ),
+    pytest.param(
+        _nodes(n1={"GPU": 8}, n2={"GPU": 1}),
+        ResourceRequestStrategy.STRICT_SPREAD,
+        [{"GPU": 4}] * 2,
+        {"n1": {"GPU": 4}},
+        # n1 has room for the second bundle but is off limits, and n2 is too
+        # small -- coming back short is what tells the caller to wait.
+        id="strict_spread_refuses_to_stack_even_with_room",
+    ),
+    pytest.param(
+        _nodes(n1={"CPU": 2, "GPU": 1}),
+        ResourceRequestStrategy.PACK,
+        [{"CPU": 8}, {"GPU": 1}],
+        {"n1": {"GPU": 1}},
+        id="pack_skips_a_bundle_that_fits_nowhere",
+    ),
+    pytest.param(
+        _nodes(n1={"CPU": 2, "GPU": 1}),
+        ResourceRequestStrategy.SPREAD,
+        [{"CPU": 8}, {"GPU": 1}],
+        {"n1": {"GPU": 1}},
+        # The unplaceable bundle must not strand the one behind it, which asks
+        # for a different resource type entirely.
+        id="spread_skips_a_bundle_that_fits_nowhere",
+    ),
+    pytest.param(
+        # Node ids run the opposite way round from capacity, so reserving on
+        # the large node can only come from the capacity ordering.
+        _nodes(**{"a-small": {"CPU": 4}, "z-large": {"CPU": 16}}),
+        None,
+        [{"CPU": 2}],
+        {"z-large": {"CPU": 2}},
+        id="largest_node_is_offered_first",
+    ),
+]
+
+
+def _request_resources(coord, strategy, resources, requester_id="train"):
+    kwargs = {} if strategy is None else {"strategy": strategy}
+    coord.request_resources(
+        requester_id=requester_id,
+        resources=resources,
+        expire_after_s=10,
+        **kwargs,
+    )
+
+
+@pytest.mark.parametrize("nodes,strategy,resources,expected", RESERVATION_LAYOUTS)
+def test_reservation_layout(nodes, strategy, resources, expected):
+    """Which nodes a requester's bundles land on -- not just the total -- is
+    determined by its strategy and by what the cluster can actually fit."""
+    coord = _make_coordinator(nodes)
+    _request_resources(coord, strategy, resources)
+
+    assert coord.get_reserved_resources("train") == expected
+
+
+@pytest.mark.parametrize("strategy", list(ResourceRequestStrategy))
+def test_strategy_accepts_the_plain_string_form(strategy):
+    """``ScalingConfig.placement_strategy`` is a plain ``str``, so the bare
+    string has to behave exactly like the enum member."""
+    resources = [{"GPU": 1}] * 4
+
+    from_enum = _make_coordinator(STRATEGY_CLUSTER_NODES)
+    _request_resources(from_enum, strategy, resources)
+
+    from_string = _make_coordinator(STRATEGY_CLUSTER_NODES)
+    _request_resources(from_string, strategy.value, resources)
+
+    assert from_string.get_reserved_resources(
+        "train"
+    ) == from_enum.get_reserved_resources("train")
+
+
+@pytest.mark.parametrize("strategy", list(ResourceRequestStrategy))
+def test_resending_an_unchanged_request_is_a_noop(strategy):
+    """Requesters refresh on a timer, so an unchanged re-send must leave the
+    reservation alone and not look like an update worth re-forwarding."""
+    coord = _make_coordinator(STRATEGY_CLUSTER_NODES)
+
+    def send():
+        # Fresh dicts each time: a requester re-sending its request is not
+        # expected to hand back the same objects.
+        _request_resources(coord, strategy, [{"GPU": 1} for _ in range(4)])
+
+    send()
+    reserved_after_first = copy.deepcopy(coord.get_reserved_resources("train"))
+    sends_after_first = coord._send_resources_request.call_count
+
+    send()
+    send()
+
+    assert coord.get_reserved_resources("train") == reserved_after_first
+    assert coord._send_resources_request.call_count == sends_after_first
+
+
+def test_request_rejects_changing_strategy():
+    """Flipping strategy mid-run would reshuffle bundles under a live
+    placement group, so an ongoing request pins it."""
+    coord = _make_coordinator(STRATEGY_CLUSTER_NODES)
+    coord.request_resources(
+        requester_id="train",
+        resources=[{"GPU": 1}] * 4,
+        expire_after_s=10,
+        strategy=ResourceRequestStrategy.PACK,
+    )
+
+    with pytest.raises(ValueError, match="Cannot change strategy"):
+        coord.request_resources(
+            requester_id="train",
+            resources=[{"GPU": 1}] * 4,
+            expire_after_s=10,
+            strategy=ResourceRequestStrategy.SPREAD,
+        )
+
+    # The rejected call must leave the existing reservation intact.
+    assert coord.get_reserved_resources("train") == {"n1": {"GPU": 4}}
+
+
+def test_strict_pack_forwards_one_summed_bundle_to_the_autoscaler():
+    """The autoscaler has to be told a single node must hold everything, or it
+    is free to satisfy the request by adding several small nodes.
+
+    Bundles and selectors are parallel lists that the SDK requires to be the
+    same length, so collapsing the bundles has to collapse the selectors too.
+    """
+    coord = _make_coordinator(STRATEGY_CLUSTER_NODES)
+    coord.request_resources(
+        requester_id="train",
+        resources=[{"GPU": 1, "CPU": 2}] * 3,
+        label_selectors=[{"zone": "a"}, {"zone": "a"}, {"market": "spot"}],
+        expire_after_s=10,
+        strategy=ResourceRequestStrategy.STRICT_PACK,
+    )
+
+    call = coord._send_resources_request.call_args
+    assert call.args[0] == [{"GPU": 3, "CPU": 6}]
+    # One node has to satisfy every bundle's selector, so the collapsed bundle
+    # carries all of their constraints.
+    assert call.kwargs["label_selectors"] == [{"zone": "a", "market": "spot"}]
+
+
+def test_tick_survives_a_failing_request():
+    """`_tick` runs on a bare thread, so an exception escaping it would
+    silently stop autoscaling for every requester on the cluster."""
+    failing_send = Mock(side_effect=RuntimeError("autoscaler rejected the request"))
+    coord = _AutoscalingCoordinatorActor(
+        get_current_time=lambda: 0,
+        send_resources_request=failing_send,
+        get_cluster_nodes=lambda: STRATEGY_CLUSTER_NODES,
+    )
+
+    coord._tick()
+
+    assert failing_send.called
+
+
+def test_forced_read_drops_a_node_that_has_since_died():
+    """Callers turn reservations into node pins, so ``force`` re-reserves
+    against a fresh view rather than handing back a node that is gone."""
+    nodes = _nodes(n1={"GPU": 1}, n2={"GPU": 1})
+    coord = _make_coordinator(nodes)
+    coord.request_resources(
+        requester_id="train",
+        resources=[{"GPU": 1}] * 2,
+        expire_after_s=10,
+        strategy=ResourceRequestStrategy.SPREAD,
+    )
+    assert coord.get_reserved_resources("train") == {
+        "n1": {"GPU": 1},
+        "n2": {"GPU": 1},
+    }
+
+    nodes[1]["Alive"] = False
+
+    # An unforced read is allowed to be stale; a forced one must not be.
+    assert coord.get_reserved_resources("train") == {
+        "n1": {"GPU": 1},
+        "n2": {"GPU": 1},
+    }
+    assert coord.get_reserved_resources("train", recompute=True) == {"n1": {"GPU": 1}}
+
+
+def test_strategy_is_per_requester():
+    """Two requesters in the same cluster each get their own layout."""
+    coord = _make_coordinator(
+        [
+            {"NodeID": "n1", "Resources": {"GPU": 4}, "Alive": True},
+            {"NodeID": "n2", "Resources": {"GPU": 4}, "Alive": True},
+        ]
+    )
+    coord.request_resources(
+        requester_id="packer",
+        resources=[{"GPU": 1}] * 2,
+        expire_after_s=10,
+        strategy=ResourceRequestStrategy.PACK,
+    )
+    coord.request_resources(
+        requester_id="spreader",
+        resources=[{"GPU": 1}] * 2,
+        expire_after_s=10,
+        strategy=ResourceRequestStrategy.SPREAD,
+    )
+
+    assert coord.get_reserved_resources("packer") == {"n1": {"GPU": 2}}
+    # The spreader starts scanning at n1 (which has 2 GPU left after the
+    # packer) and then rotates to n2.
+    assert coord.get_reserved_resources("spreader") == {
+        "n1": {"GPU": 1},
+        "n2": {"GPU": 1},
+    }
+
+
 def test_label_selector_disjoint_requesters_dont_cross_talk():
     coord = _make_coordinator(LABELED_CLUSTER_NODES)
     coord.request_resources(
@@ -733,30 +1071,29 @@ def test_label_selector_disjoint_requesters_dont_cross_talk():
         resources=[{"CPU": 4}],
         subcluster_selector={"ray-subcluster": "training"},
         expire_after_s=10,
-        request_remaining=True,
+        request_remaining=STANDARD_RESOURCE_TYPES,
     )
     coord.request_resources(
         requester_id="val",
         resources=[{"CPU": 4}],
         subcluster_selector={"ray-subcluster": "validation"},
         expire_after_s=10,
-        request_remaining=True,
+        request_remaining=STANDARD_RESOURCE_TYPES,
     )
 
     train = coord.get_reserved_resources("train")
     val = coord.get_reserved_resources("val")
-    assert {"CPU": 4} in train and {"CPU": 4} in val
-    # Training bucket: 2 x 8 - 4 explicit = 12 leftover, all to train.
-    assert sum(a["CPU"] for a in train if a != {"CPU": 4}) == 12
-    # Validation bucket: 4 - 4 explicit = 0 leftover.
-    assert sum(a["CPU"] for a in val if a != {"CPU": 4}) == 0
+    # Training bucket: 2 x 8 = 16 CPU (4 explicit + 12 leftover), all to train.
+    assert sum(v.get("CPU", 0) for v in train.values()) == 16
+    # Validation bucket: 4 CPU (4 explicit, 0 leftover of CPU).
+    assert sum(v.get("CPU", 0) for v in val.values()) == 4
 
 
 def test_unlabeled_requester_only_sees_none_bucket():
     """An unlabeled requester is only eligible for nodes in the ``None``
     bucket (no subcluster label). It must not get explicit allocations or
     leftover share from any labeled subcluster, even when it has
-    ``request_remaining=True``."""
+    ``request_remaining=STANDARD_RESOURCE_TYPES``."""
     coord = _make_coordinator(LABELED_CLUSTER_NODES)
     coord.request_resources(
         requester_id="anon",
@@ -764,11 +1101,11 @@ def test_unlabeled_requester_only_sees_none_bucket():
         # No label_selector -> effective subcluster = None -> only the
         # default-labeled node (2 CPU).
         expire_after_s=10,
-        request_remaining=True,
+        request_remaining=STANDARD_RESOURCE_TYPES,
     )
 
     alloc = coord.get_reserved_resources("anon")
-    total_cpu = sum(a["CPU"] for a in alloc)
+    total_cpu = sum(v.get("CPU", 0) for v in alloc.values())
     assert total_cpu == 2, (
         f"unlabeled requester should only see the 2-CPU None bucket; got "
         f"{total_cpu} (alloc={alloc})"
@@ -782,17 +1119,21 @@ def test_labeled_and_unlabeled_requesters_are_isolated():
         resources=[{"CPU": 1}],
         subcluster_selector={"ray-subcluster": "training"},
         expire_after_s=10,
-        request_remaining=True,
+        request_remaining=STANDARD_RESOURCE_TYPES,
     )
     coord.request_resources(
         requester_id="anon",
         resources=[{"CPU": 1}],
         expire_after_s=10,
-        request_remaining=True,
+        request_remaining=STANDARD_RESOURCE_TYPES,
     )
 
-    train_total = sum(a["CPU"] for a in coord.get_reserved_resources("train"))
-    anon_total = sum(a["CPU"] for a in coord.get_reserved_resources("anon"))
+    train_total = sum(
+        v.get("CPU", 0) for v in coord.get_reserved_resources("train").values()
+    )
+    anon_total = sum(
+        v.get("CPU", 0) for v in coord.get_reserved_resources("anon").values()
+    )
     # Training bucket: 2 x 8 = 16 CPU; anon gets none of it.
     assert train_total == 16
     # Default bucket: 1 x 2 = 2 CPU; train gets none of it.
@@ -808,9 +1149,9 @@ def test_label_selector_unmatched_yields_no_allocation():
         resources=[{"CPU": 1}],
         subcluster_selector={"ray-subcluster": "nonexistent"},
         expire_after_s=10,
-        request_remaining=True,
+        request_remaining=STANDARD_RESOURCE_TYPES,
     )
-    assert coord.get_reserved_resources("ghost") == []
+    assert coord.get_reserved_resources("ghost") == {}
 
 
 def test_label_selector_partial_fit_when_demand_exceeds_capacity():
@@ -824,7 +1165,7 @@ def test_label_selector_partial_fit_when_demand_exceeds_capacity():
         expire_after_s=10,
     )
     # Validation has one 4-CPU node; only the first 3-CPU bundle fits.
-    assert coord.get_reserved_resources("val") == [{"CPU": 3}]
+    assert coord.get_reserved_resources("val") == {"n-val-1": {"CPU": 3}}
 
 
 def test_full_tick_exercises_update_merge_reallocate():
@@ -849,11 +1190,13 @@ def test_full_tick_exercises_update_merge_reallocate():
         resources=[{"CPU": 1}],
         subcluster_selector={"ray-subcluster": "training"},
         expire_after_s=10,
-        request_remaining=True,
+        request_remaining=STANDARD_RESOURCE_TYPES,
     )
     # Before the join: only 4 CPU in the training bucket; 1 used explicitly,
     # 3 leftover go to train.
-    train_total = sum(a["CPU"] for a in coord.get_reserved_resources("train"))
+    train_total = sum(
+        v.get("CPU", 0) for v in coord.get_reserved_resources("train").values()
+    )
     assert train_total == 4
 
     # A new training node joins the cluster.
@@ -867,13 +1210,15 @@ def test_full_tick_exercises_update_merge_reallocate():
     )
     # Without a tick, the coordinator still sees the old snapshot.
     coord._tick()
-    train_total = sum(a["CPU"] for a in coord.get_reserved_resources("train"))
+    train_total = sum(
+        v.get("CPU", 0) for v in coord.get_reserved_resources("train").values()
+    )
     # Now: 4 + 8 = 12 total; 1 explicit + 11 leftover.
     assert train_total == 12
 
 
 def test_labeled_requester_with_empty_resources_stays_pinned():
-    """A labeled requester with empty resources + request_remaining=True is
+    """A labeled requester with empty resources + request_remaining=STANDARD_RESOURCE_TYPES is
     eligible only for leftovers from its own subcluster."""
     coord = _make_coordinator(LABELED_CLUSTER_NODES)
 
@@ -884,7 +1229,7 @@ def test_labeled_requester_with_empty_resources_stays_pinned():
         resources=[],
         subcluster_selector={"ray-subcluster": "training"},
         expire_after_s=10,
-        request_remaining=True,
+        request_remaining=STANDARD_RESOURCE_TYPES,
     )
     # Active "val" requester: asks for 2 CPU on validation. After explicit
     # allocation, validation has 2 CPU of leftover.
@@ -893,21 +1238,21 @@ def test_labeled_requester_with_empty_resources_stays_pinned():
         resources=[{"CPU": 2}],
         subcluster_selector={"ray-subcluster": "validation"},
         expire_after_s=10,
-        request_remaining=True,
+        request_remaining=STANDARD_RESOURCE_TYPES,
     )
 
     train_idle_alloc = coord.get_reserved_resources("train_idle")
     val_active_alloc = coord.get_reserved_resources("val_active")
 
     # Training bucket: 2 x 8 = 16 CPU, all leftover, all to train_idle.
-    train_idle_cpu = sum(a.get("CPU", 0) for a in train_idle_alloc)
+    train_idle_cpu = sum(v.get("CPU", 0) for v in train_idle_alloc.values())
     assert train_idle_cpu == 16, (
         f"train_idle should get exactly 16 CPU from training only, got "
         f"{train_idle_cpu} (alloc={train_idle_alloc})"
     )
     # Validation bucket: 4 - 2 explicit = 2 leftover, all to val_active.
     # Total = 2 explicit + 2 leftover = 4.
-    val_active_cpu = sum(a["CPU"] for a in val_active_alloc)
+    val_active_cpu = sum(v.get("CPU", 0) for v in val_active_alloc.values())
     assert val_active_cpu == 4, (
         f"val_active should get 2 explicit + 2 leftover = 4 CPU, got "
         f"{val_active_cpu} (alloc={val_active_alloc})"
@@ -939,7 +1284,9 @@ def test_proxy_forwards_label_selector_on_empty_resources():
         autoscaling_coordinator_actor=mock_actor,
         subcluster_selector={"ray-subcluster": "training"},
     )
-    proxy.request_resources(resources=[], expire_after_s=10, request_remaining=True)
+    proxy.request_resources(
+        resources=[], expire_after_s=10, request_remaining=STANDARD_RESOURCE_TYPES
+    )
     kwargs = mock_actor.request_resources.remote.call_args.kwargs
     assert kwargs["resources"] == []
     assert kwargs["subcluster_selector"] == {"ray-subcluster": "training"}

--- a/python/ray/train/v2/_internal/execution/scaling_policy/elastic.py
+++ b/python/ray/train/v2/_internal/execution/scaling_policy/elastic.py
@@ -1,9 +1,9 @@
 import logging
-from typing import List, Optional
+from typing import Optional
 
 import ray
 from ray.data._internal.cluster_autoscaler.base_autoscaling_coordinator import (
-    ResourceDict,
+    ReservedResources,
 )
 from ray.train.v2._internal.execution.scaling_policy import (
     NoopDecision,
@@ -37,12 +37,12 @@ class ElasticScalingPolicy(ScalingPolicy):
         self._latest_monitor_time = float("-inf")
         self._latest_insufficient_workers_warning_time = float("-inf")
         self._latest_reserved_resources_query_time = float("-inf")
-        self._latest_reserved_resources: Optional[List[ResourceDict]] = None
+        self._latest_reserved_resources: Optional[ReservedResources] = None
 
     def _get_num_workers_for_resource_request(self) -> int:
         return self.scaling_config.max_workers
 
-    def _count_possible_workers(self, reserved_resources: List[ResourceDict]) -> int:
+    def _count_possible_workers(self, reserved_resources: ReservedResources) -> int:
         """Count the number of workers that can be started/restarted with the given
         the list of node resources. The returned number is capped at the maximum
         number of workers.
@@ -65,7 +65,7 @@ class ElasticScalingPolicy(ScalingPolicy):
         if sum(single_worker_resources.values()) == 0:
             return self.scaling_config.max_workers
 
-        for resources in reserved_resources:
+        for resources in reserved_resources.values():
             num_workers = min(
                 [
                     resources.get(resource, 0.0) // single_worker_resources[resource]
@@ -254,7 +254,7 @@ class ElasticScalingPolicy(ScalingPolicy):
     # Methods for interacting with AutoscalingCoordinator
     # ---------------------------------------------------
 
-    def _get_reserved_resources(self) -> Optional[List[ResourceDict]]:
+    def _get_reserved_resources(self) -> Optional[ReservedResources]:
         """Get reserved resources from AutoscalingCoordinator.
         Return None if there is an error."""
         now = time_monotonic()

--- a/python/ray/train/v2/tests/test_elastic_scaling_policy.py
+++ b/python/ray/train/v2/tests/test_elastic_scaling_policy.py
@@ -5,6 +5,10 @@ from unittest.mock import MagicMock, patch
 import pytest
 from freezegun import freeze_time
 
+from ray.data._internal.cluster_autoscaler.base_autoscaling_coordinator import (
+    ReservedResources,
+    ResourceDict,
+)
 from ray.data._internal.cluster_autoscaler.default_autoscaling_coordinator import (
     ResourceRequestPriority,
 )
@@ -54,13 +58,15 @@ def _start_scaling_policy(policy, run_id: str = "test-run") -> None:
     policy.after_controller_start(MagicMock(run_id=run_id))
 
 
-def _make_reserved(resources_per_worker: dict, num_nodes: int) -> list:
-    """Build a list of reserved resource bundles with ``num_nodes`` entries.
+def _make_reserved(
+    resources_per_worker: ResourceDict, num_nodes: int
+) -> ReservedResources:
+    """Build per-node reserved resources with ``num_nodes`` entries.
 
-    Mirrors the ``List[ResourceDict]`` returned by
+    Mirrors the ``ReservedResources`` returned by
     ``AutoscalingCoordinator.get_reserved_resources``.
     """
-    return [dict(resources_per_worker) for _ in range(num_nodes)]
+    return {f"n{i}": dict(resources_per_worker) for i in range(num_nodes)}
 
 
 def _get_mock_worker_group_status(num_workers: int) -> WorkerGroupPollStatus:
@@ -387,7 +393,7 @@ def test_count_possible_workers():
     policy = ElasticScalingPolicy(scaling_config)
 
     # No resources
-    assert policy._count_possible_workers([]) == 0
+    assert policy._count_possible_workers({}) == 0
 
     # Single node
     assert policy._count_possible_workers(_make_reserved({"CPU": 8, "GPU": 1}, 1)) == 1
@@ -415,7 +421,7 @@ def test_count_possible_workers_with_zero_resources():
     policy = ElasticScalingPolicy(scaling_config)
 
     assert (
-        policy._count_possible_workers([{"CPU": 1, "GPU": 1, "memory": 1}])
+        policy._count_possible_workers({"n0": {"CPU": 1, "GPU": 1, "memory": 1}})
         == max_workers
     )
 


### PR DESCRIPTION
The autoscaling coordinator reserved resources as a flat list of bundles,
which told a requester how much it had but not where. Callers that want to
pin work to the capacity reserved for them (Ray Train, next in this stack)
can't do that without node identity.

Key the reservation by node id instead:

- `get_reserved_resources()` returns `Dict[NodeIdStr, ResourceDict]`, keyed
  in the order bundles were placed so callers can tell which node holds which bundle.
- `request_resources()` takes a `strategy` (PACK/SPREAD/STRICT_PACK/ STRICT_SPREAD) controlling how a requester's bundles are distributed over
nodes. STRICT_PACK collapses the bundles into one sum so the autoscaler is
asked for a single node big enough to hold them. The strategy is fixed for
the lifetime of a request: flipping it would reshuffle every bundle out
  from under whatever the requester already placed.
- `request_remaining` becomes a list of resource types rather than a bool,
so leftovers are split per type among the requesters that asked for that
  type instead of all-or-nothing.
- `get_reserved_resources(force=True)` recomputes against a fresh view of
the cluster, for callers that turn the answer into node pins and must not
  pin to a node that has since died.
- Nodes are scanned largest-CPU-first so packing prefers big nodes.
- `_tick` no longer lets an exception escape: it runs on a bare background
thread, where that would silently stop autoscaling for every requester on
  the cluster.

Train V2's `_count_possible_workers` is updated for the new return type; its coordinator integration lands in the next commit in this stack.

Test: pytest python/ray/data/tests/test_autoscaling_coordinator.py


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core reservation and leftover-sharing logic used by Ray Data
autoscaling and Train worker counting; incorrect placement or stale `recompute` behavior could mis-size clusters or pin to dead nodes.
>
> **Overview**
> Ray Data’s autoscaling coordinator now reports **where** capacity is
reserved, not just **how much**, and exposes finer control over leftovers and bundle placement.
>
> **`get_reserved_resources()`** returns a per-node map (`node_id →
resource bundle`) instead of a flat bundle list. Ray Data autoscalers and Ray Train’s elastic scaling policy sum over `.values()` when computing totals; Train can use node identity for pinning in follow-up work.
>
> **`request_resources()`** gains a **`strategy`** (`PACK` / `SPREAD` /
`STRICT_PACK` / `STRICT_SPREAD`) that drives `_compute_reservations` when rereserving cluster capacity. **`STRICT_PACK`** also collapses requested bundles (and label selectors) into one summed bundle when forwarding to the autoscaler SDK. Strategy and **`request_remaining`** cannot change mid-request.
>
> **`request_remaining`** is no longer a boolean: callers pass a list of
resource types (e.g. **`STANDARD_RESOURCE_TYPES`**) so leftover CPU/GPU/memory/object store is split **per type** among requesters that asked for that type, merged onto the same node keys as explicit reservations.
>
> Other coordinator behavior: nodes are ordered for placement like Ray
Core (largest capacity first); actor **`get_reserved_resources(..., recompute=True)`** runs a full tick before answering; background **`_tick`** swallows exceptions so one failure does not stop cluster-wide autoscaling.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit
5f1e10f943716edad17f470566729c1ad26bfc87. Bugbot is set up for automated code reviews on this repo. Configure
[here](https://www.cursor.com/dashboard/bugbot).</sup> <!-- /CURSOR_SUMMARY -->

---------

> Thank you for contributing to Ray! 🚀
> Please review the [Ray Contribution Guide](https://docs.ray.io/en/master/ray-contribute/getting-involved.html) before opening a pull request.

> ⚠️ Remove these instructions before submitting your PR.

> 💡 Tip: Mark as draft if you want early feedback, or ready for review when it's complete.

## Description
> Briefly describe what this PR accomplishes and why it's needed.

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
