### PR TITLE
[train] Pin Train V2 workers to autoscaling coordinator reservations …

### DIFF
--- a/python/ray/train/_internal/autoscaling_coordinator_client.py
+++ b/python/ray/train/_internal/autoscaling_coordinator_client.py
@@ -1,14 +1,23 @@
+import copy
+import math
 import threading
 from typing import TYPE_CHECKING, List, Optional, Tuple
 
 from ray.data._internal.cluster_autoscaler.base_autoscaling_coordinator import (
     LabelSelector,
     RequesterId,
+    ReservedResources,
     ResourceDict,
 )
 
 if TYPE_CHECKING:
     from ray.air.config import ScalingConfig
+
+
+# Relative slack absorbed before flooring a reserved amount into worker slots.
+# Large enough to cover accumulated float error over thousands of bundles, far
+# smaller than any real fraction of a worker.
+_SLOT_EPSILON = 1e-6
 
 
 def build_train_resource_request(
@@ -18,7 +27,9 @@ def build_train_resource_request(
     """Build coordinator bundles for worker resources and optional trainer resources.
 
     Trainer bundles are included when ``scaling_config._trainer_resources_not_none``
-    is non-empty (Ray Train V1). Ray Train V2 overrides this to ``{}``.
+    is non-empty (Ray Train V1). Ray Train V2 overrides this to ``{}``. Returns a 2 items:
+    one for the resources for [coordinator, worker1, ..., workerN] and a label selector
+    that dictates the locations of the workers (NOT coordinator)
     """
     resources_per_worker = scaling_config._resources_per_worker_not_none
     worker_bundles = [resources_per_worker] * num_workers
@@ -31,7 +42,84 @@ def build_train_resource_request(
     label_selectors = scaling_config._label_selector_per_worker(num_workers)
     if trainer_resources and label_selectors is not None:
         label_selectors = [{}] + label_selectors
+    assert label_selectors is None or len(resources) == len(label_selectors)
     return resources, label_selectors
+
+
+def _subtract_trainer_resources_from_reserved(
+    reserved_resources: ReservedResources,
+    trainer_resources: ResourceDict,
+) -> ReservedResources:
+    """Remove trainer bundle reservation from per-node totals before counting workers.
+
+    The coordinator merges trainer and worker bundles into the same per-node totals,
+    so the trainer's share has to come back off before the remainder can be divided
+    into worker slots.
+
+    ``reserved_resources`` is keyed in the order the coordinator placed bundles, and
+    the trainer is submitted as the first bundle (see ``build_train_resource_request``),
+    so the trainer's node is the first key that can satisfy it. Do not sort here: the
+    coordinator scans nodes largest-first, not by ``node_id``, so subtracting from the
+    alphabetically-first node instead takes the resources off a node the trainer never
+    landed on. Integer division then rounds a worker slot away and the caller sees
+    fewer slots than were actually reserved.
+    """
+    trainer_resources = {k: v for k, v in trainer_resources.items() if v > 0}
+    if not trainer_resources:
+        return reserved_resources
+
+    adjusted = copy.deepcopy(reserved_resources)
+    for node_resources in adjusted.values():
+        if all(node_resources.get(k, 0.0) >= v for k, v in trainer_resources.items()):
+            for k, v in trainer_resources.items():
+                node_resources[k] -= v
+            break
+    return adjusted
+
+
+def _floor_slots(reserved: float, per_worker: float) -> int:
+    """How many whole ``per_worker`` slots fit in ``reserved``, tolerant of float drift.
+
+    The coordinator builds a node's reserved total by adding the per-worker bundle
+    once per worker, so the total is not exactly ``n * per_worker`` for fractional
+    resources -- five ``0.1`` GPU bundles sum to a float whose ``// 0.1`` is 4, not 5.
+    A single slot lost that way makes a fully reserved worker group look unready
+    forever, so nudge by a relative epsilon before flooring.
+    """
+    return math.floor(reserved / per_worker + _SLOT_EPSILON)
+
+
+def _reserved_resources_to_bundle_label_selectors(
+    reserved_resources: ReservedResources,
+    resources_per_worker: ResourceDict,
+    trainer_resources: Optional[ResourceDict] = None,
+) -> List[LabelSelector]:
+    """Convert per-node reserved resources to a per-bundle list of label selectors.
+
+    Each entry pins one resource bundle to its reserved node.
+    """
+    import ray._raylet
+
+    assert (
+        sum(resources_per_worker.values()) > 0
+    ), "resources per worker should have at least one non-zero"
+
+    worker_reserved_resources = _subtract_trainer_resources_from_reserved(
+        reserved_resources=reserved_resources,
+        trainer_resources=trainer_resources or {},
+    )
+
+    label_selectors: List[LabelSelector] = []
+    for node_id, node_resources in worker_reserved_resources.items():
+        num_workers_on_node = min(
+            _floor_slots(node_resources.get(r, 0.0), resources_per_worker[r])
+            for r in resources_per_worker
+            if resources_per_worker[r] > 0
+        )
+        label_selectors.extend(
+            [{ray._raylet.RAY_NODE_ID_KEY: node_id}] * num_workers_on_node
+        )
+    return label_selectors
 
 
 class TrainV1ResourceReservation:
@@ -55,16 +143,29 @@ class TrainV1ResourceReservation:
         self._scaling_config = scaling_config
         self._num_workers = num_workers
         self._refresh_interval_s = AUTOSCALING_REQUESTS_INTERVAL_S
-        # 1 seconda more, since a send_resource_request could stall
+        # 1 second more, since a send_resource_request could stall
         # up to AUTOSCALING_REQUESTS_GET_TIMEOUT_S seconds
         self._refresh_join_timeout_s = AUTOSCALING_REQUESTS_GET_TIMEOUT_S + 1
         self._stop_event = threading.Event()
         self._refresh_thread: Optional[threading.Thread] = None
 
+    def _send_request(self) -> None:
+        """Send (or refresh) this run's resource request to the coordinator."""
+        resources, label_selectors = build_train_resource_request(
+            scaling_config=self._scaling_config,
+            num_workers=self._num_workers,
+        )
+        self._client.send_resource_request(
+            resources=resources,
+            label_selectors=label_selectors,
+        )
+
     def __enter__(self) -> "TrainV1ResourceReservation":
-        self._client.send_resource_request(self._scaling_config, self._num_workers)
+        self._send_request()
         self._refresh_thread = threading.Thread(
-            target=self._refresh_loop, daemon=True, name="train-resource-reservation"
+            target=self._refresh_loop,
+            daemon=True,
+            name="train-resource-reservation",
         )
         self._refresh_thread.start()
         return self
@@ -77,4 +178,4 @@ class TrainV1ResourceReservation:
 
     def _refresh_loop(self) -> None:
         while not self._stop_event.wait(self._refresh_interval_s):
-            self._client.send_resource_request(self._scaling_config, self._num_workers)
+            self._send_request()

--- a/python/ray/train/tests/test_autoscaling_coordinator_client.py
+++ b/python/ray/train/tests/test_autoscaling_coordinator_client.py
@@ -2,6 +2,7 @@ import pytest
 
 import ray.air
 from ray.train._internal.autoscaling_coordinator_client import (
+    _reserved_resources_to_bundle_label_selectors,
     build_train_resource_request,
 )
 
@@ -46,6 +47,86 @@ def test_build_train_resource_request_prepends_trainer_label_selector_v1():
 
     assert resources == [{"CPU": 1}, {"CPU": 1}, {"CPU": 1}]
     assert label_selectors is None
+
+
+@pytest.mark.parametrize(
+    "reserved_resources,trainer_resources,resources_per_worker,expected_nodes",
+    [
+        pytest.param(
+            {"n1": {"CPU": 3}}, {"CPU": 1}, {"CPU": 1}, ["n1", "n1"], id="single_node"
+        ),
+        pytest.param(
+            # The coordinator scans nodes largest-first, so the trainer landed
+            # on "z-big" -- and it keys ``reserved_resources`` in placement
+            # order, so "z-big" comes first. Subtracting from the
+            # alphabetically-first node instead would take 3 CPU off "a-small",
+            # rounding it down to zero worker slots and reporting one worker
+            # where two were reserved.
+            {"z-big": {"CPU": 7}, "a-small": {"CPU": 4}},
+            {"CPU": 3},
+            {"CPU": 4},
+            ["z-big", "a-small"],
+            id="multi_node_placement_order_is_not_alphabetical",
+        ),
+    ],
+)
+def test_reserved_resources_to_bundle_label_selectors_subtracts_trainer_bundle(
+    reserved_resources, trainer_resources, resources_per_worker, expected_nodes
+):
+    """The trainer bundle is merged into the node totals, so it has to come
+    back off -- on the node that actually holds it -- before the remainder is
+    divided into worker slots."""
+    import ray._raylet
+
+    node_id_key = ray._raylet.RAY_NODE_ID_KEY
+    label_selectors = _reserved_resources_to_bundle_label_selectors(
+        reserved_resources=reserved_resources,
+        resources_per_worker=resources_per_worker,
+        trainer_resources=trainer_resources,
+    )
+
+    assert label_selectors == [{node_id_key: node} for node in expected_nodes]
+
+
+@pytest.mark.parametrize(
+    "per_worker_gpu, num_workers",
+    [(0.1, 5), (0.1, 10), (0.2, 5), (0.3, 3), (0.7, 3), (0.25, 4)],
+)
+def test_reserved_resources_to_bundle_label_selectors_fractional_resources(
+    per_worker_gpu, num_workers
+):
+    """Fractional per-worker resources must not lose a slot to float error.
+
+    The coordinator accumulates a node's reserved total one bundle at a time, so
+    the total is not exactly ``num_workers * per_worker_gpu``. Flooring that with
+    plain ``//`` drops a slot (0.1 GPU x 5 sums to a float that ``// 0.1`` reads as
+    4), which makes a fully reserved worker group look permanently unready.
+    """
+    import ray._raylet
+
+    # Mirror how the coordinator builds the per-node total: repeated addition.
+    reserved_gpu = 0.0
+    for _ in range(num_workers):
+        reserved_gpu = reserved_gpu + per_worker_gpu
+
+    label_selectors = _reserved_resources_to_bundle_label_selectors(
+        reserved_resources={"node-a": {"GPU": reserved_gpu}},
+        resources_per_worker={"GPU": per_worker_gpu},
+        trainer_resources={},
+    )
+
+    assert label_selectors == [{ray._raylet.RAY_NODE_ID_KEY: "node-a"}] * num_workers
+
+
+def test_reserved_resources_to_bundle_label_selectors_ignores_partial_slot():
+    """Tolerating float drift must not invent a slot out of a real shortfall."""
+    label_selectors = _reserved_resources_to_bundle_label_selectors(
+        reserved_resources={"node-a": {"GPU": 0.9}},
+        resources_per_worker={"GPU": 1},
+        trainer_resources={},
+    )
+
+    assert label_selectors == []
 
 
 if __name__ == "__main__":

--- a/python/ray/train/v2/_internal/execution/controller/controller.py
+++ b/python/ray/train/v2/_internal/execution/controller/controller.py
@@ -19,6 +19,7 @@ from ray.train.v2._internal.constants import (
     ENABLE_PREEMPTION_WATCHER_ENV_VAR,
     HEALTH_CHECK_INTERVAL_S_ENV_VAR,
 )
+from ray.train.v2._internal.exceptions import WorkerGroupStartupTimeoutError
 from ray.train.v2._internal.execution.callback import (
     ControllerCallback,
     ReportCallback,
@@ -446,6 +447,8 @@ class TrainController:
 
         Raises:
             Exception: If the worker group failed to start.
+            WorkerGroupStartupTimeoutError: If coordinator reservations are
+                not ready yet for positive-resource workers (controller retries).
         """
         placement_strategy = self._scaling_policy.scaling_config.placement_strategy
         scaling_config = self._train_run_context.scaling_config
@@ -463,6 +466,39 @@ class TrainController:
                         f"with label_selector returned by user-specified callback {selector}"
                     )
                 label_selector = [selector.copy() for _ in range(num_workers)]
+
+        # Pin workers to AutoscalingCoordinator reservations, so that two
+        # concurrent runs aren't both scheduled onto the same capacity.
+        # Skipped when:
+        # - Workers request no resources: nothing to reserve, and they fit
+        #   anywhere, so there is nothing to wait for.
+        # - TPU: `SlicePlacementGroup` does its own reservation below and
+        #   ignores `label_selector`, so pins would only add latency.
+        # - A `label_selector` is set: the coordinator picks nodes by resource
+        #   fit and never matches `label_selectors` against node labels, so its
+        #   pins can name a node that violates the selector. Combining the two
+        #   would produce an unsatisfiable selector and a placement group that
+        #   never becomes ready, so the user's selector wins and placement is
+        #   left to the placement group.
+        #   TODO: Reconcile w/ ray core later
+        can_pin_to_reservation = (
+            not scaling_config.use_tpu
+            and sum(resources_per_worker.values()) > 0
+            and not label_selector
+        )
+        if can_pin_to_reservation:
+            reserved_node_label_selectors = (
+                self._scaling_policy.get_reserved_bundle_label_selectors(num_workers)
+            )
+            if reserved_node_label_selectors is None:
+                # Waited for reserved capacity (same idea as pg.wait()) and it
+                # still isn't ready. Retry via SCHEDULING -> RESCHEDULING.
+                raise WorkerGroupStartupTimeoutError(num_workers=num_workers)
+            # `placement_strategy` is deliberately left alone: the pins already
+            # determine the layout, and keeping the strategy lets the placement
+            # group reject a layout that contradicts it rather than silently
+            # downgrading e.g. STRICT_SPREAD to co-located workers.
+            label_selector = reserved_node_label_selectors
 
         # Calculate num_slices for the worker group if using TPU.
         num_slices = 1

--- a/python/ray/train/v2/_internal/execution/scaling_policy/autoscaling_coordinator_client.py
+++ b/python/ray/train/v2/_internal/execution/scaling_policy/autoscaling_coordinator_client.py
@@ -1,23 +1,23 @@
 import logging
 import time
 from functools import cached_property
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, List, Optional
 
 import ray
 from ray.data._internal.cluster_autoscaler.base_autoscaling_coordinator import (
+    LabelSelector,
     RequesterId,
+    ReservedResources,
+    ResourceDict,
 )
 from ray.data._internal.cluster_autoscaler.default_autoscaling_coordinator import (
     ResourceRequestPriority,
+    ResourceRequestStrategy,
     get_or_create_autoscaling_coordinator,
-)
-from ray.train._internal.autoscaling_coordinator_client import (
-    build_train_resource_request,
 )
 
 if TYPE_CHECKING:
     from ray.actor import ActorProxy
-    from ray.air.config import ScalingConfig
     from ray.data._internal.cluster_autoscaler.default_autoscaling_coordinator import (
         _AutoscalingCoordinatorActor,
     )
@@ -37,9 +37,14 @@ class TrainAutoscalingCoordinatorClient:
 
     This is the train version, the data version is called `DefaultAutoscalingCoordinator`"""
 
+    # Minimum interval in seconds between querying the AutoscalingCoordinator for reserved resources.
+    GET_RESERVED_RESOURCES_INTERVAL_S = 1
+
     def __init__(self, requester_id: RequesterId):
         self._requester_id = requester_id
         self._latest_autoscaling_request_time = float("-inf")
+        self._latest_reserved_resources_query_time = float("-inf")
+        self._latest_reserved_resources: ReservedResources = {}
 
     @cached_property
     def _autoscaling_coordinator(self) -> "ActorProxy[_AutoscalingCoordinatorActor]":
@@ -47,13 +52,11 @@ class TrainAutoscalingCoordinatorClient:
 
     def send_resource_request(
         self,
-        scaling_config: "ScalingConfig",
-        num_workers: int,
+        resources: List[ResourceDict],
+        label_selectors: Optional[List[LabelSelector]],
+        strategy: ResourceRequestStrategy = ResourceRequestStrategy.PACK,
     ) -> None:
         """Register training resources with the AutoscalingCoordinator."""
-        resources, label_selectors = build_train_resource_request(
-            scaling_config, num_workers
-        )
         try:
             ray.get(
                 self._autoscaling_coordinator.request_resources.remote(
@@ -62,6 +65,7 @@ class TrainAutoscalingCoordinatorClient:
                     label_selectors=label_selectors,
                     expire_after_s=AUTOSCALING_REQUESTS_EXPIRE_TIME_S,
                     priority=ResourceRequestPriority.HIGH,
+                    strategy=strategy,
                 ),
                 timeout=AUTOSCALING_REQUESTS_GET_TIMEOUT_S,
             )
@@ -77,8 +81,9 @@ class TrainAutoscalingCoordinatorClient:
 
     def maybe_send_resource_request(
         self,
-        scaling_config: "ScalingConfig",
-        num_workers: int,
+        resources: List[ResourceDict],
+        label_selectors: Optional[List[LabelSelector]],
+        strategy: ResourceRequestStrategy = ResourceRequestStrategy.PACK,
     ) -> None:
         now = time.monotonic()
         if (
@@ -86,7 +91,43 @@ class TrainAutoscalingCoordinatorClient:
             < AUTOSCALING_REQUESTS_INTERVAL_S
         ):
             return
-        self.send_resource_request(scaling_config, num_workers)
+        self.send_resource_request(
+            resources=resources,
+            label_selectors=label_selectors,
+            strategy=strategy,
+        )
+
+    def get_reserved_resources(self, *, recompute: bool = False) -> ReservedResources:
+        """Get reserved resources for this requester.
+
+        Returns a cached value if queried within
+        ``GET_RESERVED_RESOURCES_INTERVAL_S`` unless ``recompute`` is True.
+        """
+        now = time.monotonic()
+        if (
+            not recompute
+            and now - self._latest_reserved_resources_query_time
+            < self.GET_RESERVED_RESOURCES_INTERVAL_S
+        ):
+            return self._latest_reserved_resources
+
+        try:
+            reserved_resources = ray.get(
+                self._autoscaling_coordinator.get_reserved_resources.remote(
+                    self._requester_id, recompute=recompute
+                ),
+                timeout=AUTOSCALING_REQUESTS_GET_TIMEOUT_S,
+            )
+        except Exception:
+            logger.debug(
+                f"Failed to get reserved resources for {self._requester_id}.",
+                exc_info=True,
+            )
+            reserved_resources = self._latest_reserved_resources
+
+        self._latest_reserved_resources_query_time = time.monotonic()
+        self._latest_reserved_resources = reserved_resources
+        return reserved_resources
 
     def cancel_resource_request(self) -> None:
         try:

--- a/python/ray/train/v2/_internal/execution/scaling_policy/elastic.py
+++ b/python/ray/train/v2/_internal/execution/scaling_policy/elastic.py
@@ -1,18 +1,14 @@
 import logging
-from typing import Optional
 
-import ray
 from ray.data._internal.cluster_autoscaler.base_autoscaling_coordinator import (
     ReservedResources,
 )
+from ray.train._internal.autoscaling_coordinator_client import _floor_slots
 from ray.train.v2._internal.execution.scaling_policy import (
     NoopDecision,
     ResizeDecision,
     ScalingDecision,
     ScalingPolicy,
-)
-from ray.train.v2._internal.execution.scaling_policy.autoscaling_coordinator_client import (  # noqa: E501
-    AUTOSCALING_REQUESTS_GET_TIMEOUT_S,
 )
 from ray.train.v2._internal.execution.worker_group import (
     WorkerGroupPollStatus,
@@ -26,8 +22,6 @@ logger = logging.getLogger(__name__)
 
 class ElasticScalingPolicy(ScalingPolicy):
 
-    # Minimum interval in seconds between querying the AutoscalingCoordinator for reserved resources.
-    GET_RESERVED_RESOURCES_INTERVAL_S = 1
     # Minimum interval in seconds between logging warnings about insufficient workers.
     INSUFFICIENT_WORKERS_WARNING_INTERVAL_S = 30
 
@@ -36,8 +30,6 @@ class ElasticScalingPolicy(ScalingPolicy):
 
         self._latest_monitor_time = float("-inf")
         self._latest_insufficient_workers_warning_time = float("-inf")
-        self._latest_reserved_resources_query_time = float("-inf")
-        self._latest_reserved_resources: Optional[ReservedResources] = None
 
     def _get_num_workers_for_resource_request(self) -> int:
         return self.scaling_config.max_workers
@@ -46,6 +38,12 @@ class ElasticScalingPolicy(ScalingPolicy):
         """Count the number of workers that can be started/restarted with the given
         the list of node resources. The returned number is capped at the maximum
         number of workers.
+
+        Reserved amounts are accumulated one bundle at a time by the coordinator,
+        so for fractional per-worker resources they are not exactly
+        ``n * per_worker``; ``_floor_slots`` absorbs that drift instead of
+        silently dropping a worker (and, if the count falls under
+        ``min_workers``, refusing to start at all).
 
         For GPUs, this divides raw reserved resources by per-worker requirements.
         For TPUs, an additional check ensures workers align with physically intact
@@ -57,7 +55,6 @@ class ElasticScalingPolicy(ScalingPolicy):
         Returns:
             The number of workers that can be started/restarted with the current resources.
         """
-        # TODO: Fractional resources do not work well here.
         single_worker_resources = self.scaling_config._resources_per_worker_not_none
         total_num_workers = 0
 
@@ -68,14 +65,17 @@ class ElasticScalingPolicy(ScalingPolicy):
         for resources in reserved_resources.values():
             num_workers = min(
                 [
-                    resources.get(resource, 0.0) // single_worker_resources[resource]
+                    _floor_slots(
+                        resources.get(resource, 0.0),
+                        single_worker_resources[resource],
+                    )
                     for resource in single_worker_resources
                     if single_worker_resources[resource] > 0
                 ]
             )
             total_num_workers += num_workers
 
-        total_num_workers = min(int(total_num_workers), self.scaling_config.max_workers)
+        total_num_workers = min(total_num_workers, self.scaling_config.max_workers)
 
         # Multi-host TPUs are scheduled atomically in interconnected slices defined by a topology.
         if (
@@ -162,7 +162,7 @@ class ElasticScalingPolicy(ScalingPolicy):
         self._maybe_send_resource_request()
 
         reserved_resources = self._get_reserved_resources()
-        if reserved_resources is None:
+        if not reserved_resources:
             return NoopDecision()
 
         num_workers = self._count_possible_workers(reserved_resources)
@@ -254,34 +254,8 @@ class ElasticScalingPolicy(ScalingPolicy):
     # Methods for interacting with AutoscalingCoordinator
     # ---------------------------------------------------
 
-    def _get_reserved_resources(self) -> Optional[ReservedResources]:
+    def _get_reserved_resources(self) -> ReservedResources:
         """Get reserved resources from AutoscalingCoordinator.
         Return None if there is an error."""
-        now = time_monotonic()
-        time_since_last_call = now - self._latest_reserved_resources_query_time
-
-        if time_since_last_call < self.GET_RESERVED_RESOURCES_INTERVAL_S:
-            return self._latest_reserved_resources
-
-        reserved_resources = None
-        try:
-            reserved_resources = ray.get(
-                self._autoscaling_coordinator.get_reserved_resources.remote(
-                    self._requester_id
-                ),
-                timeout=AUTOSCALING_REQUESTS_GET_TIMEOUT_S,
-            )
-        except Exception:
-            msg = (
-                f"Failed to get reserved resources for {self._requester_id}."
-                " Will not resize the worker group."
-                " If this only happens transiently during network partition or"
-                " CPU being overloaded, it's safe to ignore this error."
-                " If this error persists, file a GitHub issue."
-            )
-            logger.warning(msg, exc_info=True)
-        finally:
-            self._latest_reserved_resources_query_time = time_monotonic()
-            self._latest_reserved_resources = reserved_resources
-
-        return self._latest_reserved_resources
+        assert self._coordinator_client is not None
+        return self._coordinator_client.get_reserved_resources()

--- a/python/ray/train/v2/_internal/execution/scaling_policy/scaling_policy.py
+++ b/python/ray/train/v2/_internal/execution/scaling_policy/scaling_policy.py
@@ -1,10 +1,21 @@
 import abc
 import logging
+import os
+import time
 from dataclasses import dataclass
-from typing import Dict, Optional
+from typing import Dict, List, Optional
 
 from ray.data._internal.cluster_autoscaler.base_autoscaling_coordinator import (
+    LabelSelector,
+)
+from ray.train._internal.autoscaling_coordinator_client import (
     RequesterId,
+    _reserved_resources_to_bundle_label_selectors,
+    build_train_resource_request,
+)
+from ray.train.v2._internal.constants import (
+    DEFAULT_WORKER_GROUP_START_TIMEOUT_S,
+    WORKER_GROUP_START_TIMEOUT_S_ENV_VAR,
 )
 from ray.train.v2._internal.execution.callback import ControllerCallback
 from ray.train.v2._internal.execution.context import TrainRunContext
@@ -90,17 +101,27 @@ class ScalingPolicy(abc.ABC, ControllerCallback):
         """Send a resource request to AutoscalingCoordinator,
         if AUTOSCALING_REQUESTS_INTERVAL_S has passed since the last send."""
         assert self._coordinator_client is not None
+        resources, label_selectors = build_train_resource_request(
+            scaling_config=self.scaling_config,
+            num_workers=self._get_num_workers_for_resource_request(),
+        )
         self._coordinator_client.maybe_send_resource_request(
-            self.scaling_config,
-            self._get_num_workers_for_resource_request(),
+            resources=resources,
+            label_selectors=label_selectors,
+            strategy=self.scaling_config.placement_strategy,
         )
 
     def _send_resource_request(self):
         """Register training resources with the AutoscalingCoordinator."""
         assert self._coordinator_client is not None
+        resources, label_selectors = build_train_resource_request(
+            scaling_config=self.scaling_config,
+            num_workers=self._get_num_workers_for_resource_request(),
+        )
         self._coordinator_client.send_resource_request(
-            self.scaling_config,
-            self._get_num_workers_for_resource_request(),
+            resources=resources,
+            label_selectors=label_selectors,
+            strategy=self.scaling_config.placement_strategy,
         )
 
     def _cancel_resource_request(self):
@@ -112,6 +133,101 @@ class ScalingPolicy(abc.ABC, ControllerCallback):
         if self._coordinator_client is None:
             return
         self._coordinator_client.cancel_resource_request()
+
+    def get_reserved_bundle_label_selectors(
+        self, num_workers: int
+    ) -> Optional[List[LabelSelector]]:
+        """Convert coordinator reservations into per-worker node-id label selectors.
+
+        Polls the coordinator until the reservation covers every worker or
+        the worker-group start timeout elapses, analogous to
+        ``placement_group.wait()``. The timeout is
+        ``RAY_TRAIN_WORKER_GROUP_START_TIMEOUT_S`` (default 60s).
+
+        Args:
+            num_workers: The number of workers the worker group will start.
+
+        Returns:
+            One node-pinning label selector per worker, or ``None`` if the
+            coordinator has not reserved enough capacity to place every worker
+            within the start timeout. ``None`` means "not ready", not "no
+            constraint": the caller must not start a partially pinned worker
+            group.
+        """
+        if self._coordinator_client is None:
+            return None
+
+        resources_per_worker = self.scaling_config._resources_per_worker_not_none
+        if sum(resources_per_worker.values()) <= 0:
+            # Nothing to reserve, so there is nothing to pin to. Let the worker
+            # group schedule normally.
+            return None
+
+        timeout_s = float(
+            os.environ.get(
+                WORKER_GROUP_START_TIMEOUT_S_ENV_VAR,
+                DEFAULT_WORKER_GROUP_START_TIMEOUT_S,
+            )
+        )
+        deadline = time.monotonic() + timeout_s
+        while True:
+            selectors = self._try_get_selectors(num_workers)
+            if selectors is not None:
+                return selectors
+            if time.monotonic() >= deadline:
+                return None
+            time.sleep(1)
+
+    def _try_get_selectors(self, num_workers: int) -> Optional[List[LabelSelector]]:
+        """One-shot lookup of per-worker reservation pins, or ``None`` if not ready."""
+        reserved_resources = self._coordinator_client.get_reserved_resources(
+            recompute=True
+        )
+        if not reserved_resources:
+            return None
+
+        label_selectors = _reserved_resources_to_bundle_label_selectors(
+            reserved_resources=reserved_resources,
+            resources_per_worker=self.scaling_config._resources_per_worker_not_none,
+            trainer_resources=self.scaling_config._trainer_resources_not_none,
+        )
+        if len(label_selectors) != num_workers:
+            logger.debug(
+                "Reserved capacity covers %s workers but %s are required; "
+                "not ready to pin the worker group yet.",
+                len(label_selectors),
+                num_workers,
+            )
+            return None
+
+        # The reservation has to actually satisfy the requested placement, or
+        # pinning to it would quietly violate the strategy the user asked for
+        # -- e.g. STRICT_SPREAD workers all landing on one node. The
+        # coordinator honors both strategies, so a mismatch means its view of
+        # the cluster moved; wait for it to settle rather than pin to a layout
+        # that contradicts the placement group we are about to create.
+        placement_strategy = self.scaling_config.placement_strategy
+        num_distinct_nodes = len(
+            {frozenset(selector.items()) for selector in label_selectors}
+        )
+        expected_distinct_nodes = {
+            "STRICT_PACK": 1,
+            "STRICT_SPREAD": num_workers,
+        }.get(placement_strategy)
+        if (
+            expected_distinct_nodes is not None
+            and num_distinct_nodes != expected_distinct_nodes
+        ):
+            logger.debug(
+                "Reserved capacity spans %s nodes but %s requires %s; "
+                "not ready to pin the worker group yet.",
+                num_distinct_nodes,
+                placement_strategy,
+                expected_distinct_nodes,
+            )
+            return None
+
+        return label_selectors
 
     @property
     def _autoscaling_coordinator(self):

--- a/python/ray/train/v2/tests/test_autoscaling_coordinator_client.py
+++ b/python/ray/train/v2/tests/test_autoscaling_coordinator_client.py
@@ -1,9 +1,168 @@
 import pytest
 
+import ray._raylet
 import ray.train
 from ray.train._internal.autoscaling_coordinator_client import (
     build_train_resource_request,
 )
+from ray.train.v2._internal.constants import WORKER_GROUP_START_TIMEOUT_S_ENV_VAR
+from ray.train.v2._internal.execution.scaling_policy.fixed import FixedScalingPolicy
+
+NODE_ID_KEY = ray._raylet.RAY_NODE_ID_KEY
+
+
+class _StubCoordinatorClient:
+    """Stands in for ``TrainAutoscalingCoordinatorClient`` with a fixed answer."""
+
+    def __init__(self, reserved_resources):
+        self._reserved_resources = reserved_resources
+
+    def get_reserved_resources(self, **kwargs):
+        return self._reserved_resources
+
+
+def _policy_with_reservation(reserved_resources, **scaling_config_kwargs):
+    policy = FixedScalingPolicy(ray.train.ScalingConfig(**scaling_config_kwargs))
+    policy._coordinator_client = _StubCoordinatorClient(reserved_resources)
+    return policy
+
+
+def test_reserved_resources_become_one_node_pin_per_worker():
+    policy = _policy_with_reservation(
+        {"node-a": {"CPU": 2}, "node-b": {"CPU": 1}},
+        num_workers=3,
+        resources_per_worker={"CPU": 1},
+    )
+
+    assert policy.get_reserved_bundle_label_selectors(3) == [
+        {NODE_ID_KEY: "node-a"},
+        {NODE_ID_KEY: "node-a"},
+        {NODE_ID_KEY: "node-b"},
+    ]
+
+
+@pytest.mark.parametrize(
+    "reserved_resources,resources_per_worker",
+    [
+        pytest.param({}, {"CPU": 1}, id="nothing_reserved"),
+        pytest.param({"node-a": {"CPU": 1}}, {"CPU": 1}, id="covers_one_of_two"),
+        pytest.param({"node-a": {"CPU": 5}}, {"CPU": 1}, id="covers_more_than_asked"),
+        # Nothing to reserve for a zero-resource worker, so there is nothing to
+        # pin to either -- and nothing to wait for.
+        pytest.param({}, {"CPU": 0}, id="zero_resource_workers"),
+    ],
+)
+def test_no_pins_unless_the_reservation_covers_every_worker(
+    reserved_resources, resources_per_worker, monkeypatch
+):
+    """Pinning only some workers would leave the rest to schedule anywhere, so
+    anything short of full coverage yields no pins at all."""
+    monkeypatch.setenv(WORKER_GROUP_START_TIMEOUT_S_ENV_VAR, "0")
+    policy = _policy_with_reservation(
+        reserved_resources,
+        num_workers=2,
+        resources_per_worker=resources_per_worker,
+    )
+
+    assert policy.get_reserved_bundle_label_selectors(2) is None
+
+
+@pytest.mark.parametrize(
+    "placement_strategy,reserved_resources,is_ready",
+    [
+        pytest.param(
+            "STRICT_PACK", {"node-a": {"CPU": 2}}, True, id="strict_pack_one_node"
+        ),
+        pytest.param(
+            "STRICT_PACK",
+            {"node-a": {"CPU": 1}, "node-b": {"CPU": 1}},
+            False,
+            id="strict_pack_split_over_two_nodes",
+        ),
+        pytest.param(
+            "STRICT_SPREAD",
+            {"node-a": {"CPU": 1}, "node-b": {"CPU": 1}},
+            True,
+            id="strict_spread_distinct_nodes",
+        ),
+        pytest.param(
+            "STRICT_SPREAD",
+            {"node-a": {"CPU": 2}},
+            False,
+            id="strict_spread_stacked_on_one_node",
+        ),
+        # The non-strict strategies place no constraint on the node count.
+        pytest.param("PACK", {"node-a": {"CPU": 2}}, True, id="pack_one_node"),
+        pytest.param(
+            "SPREAD",
+            {"node-a": {"CPU": 1}, "node-b": {"CPU": 1}},
+            True,
+            id="spread_two_nodes",
+        ),
+    ],
+)
+def test_reservation_must_satisfy_the_requested_placement_strategy(
+    placement_strategy, reserved_resources, is_ready, monkeypatch
+):
+    """Pinning to a layout that contradicts the strategy would silently
+    downgrade it -- e.g. STRICT_SPREAD workers landing on the same node."""
+    monkeypatch.setenv(WORKER_GROUP_START_TIMEOUT_S_ENV_VAR, "0")
+    policy = _policy_with_reservation(
+        reserved_resources,
+        num_workers=2,
+        resources_per_worker={"CPU": 1},
+        placement_strategy=placement_strategy,
+    )
+
+    selectors = policy.get_reserved_bundle_label_selectors(2)
+
+    assert (selectors is not None) == is_ready
+
+
+def test_reservation_wait_polls_until_ready(monkeypatch):
+    """Like pg.wait(), keep querying until reserved nodes show up."""
+    policy = _policy_with_reservation(
+        {},
+        num_workers=2,
+        resources_per_worker={"CPU": 1},
+    )
+    answers = iter(
+        [
+            {},
+            {"node-a": {"CPU": 1}, "node-b": {"CPU": 1}},
+        ]
+    )
+    policy._coordinator_client.get_reserved_resources = lambda **kwargs: next(answers)
+    monkeypatch.setattr(
+        "ray.train.v2._internal.execution.scaling_policy.scaling_policy.time.sleep",
+        lambda _: None,
+    )
+
+    assert policy.get_reserved_bundle_label_selectors(2) == [
+        {NODE_ID_KEY: "node-a"},
+        {NODE_ID_KEY: "node-b"},
+    ]
+
+
+def test_reservation_wait_returns_none_after_timeout(monkeypatch):
+    """Give up after the start timeout rather than blocking the worker-group start."""
+    monkeypatch.setenv(WORKER_GROUP_START_TIMEOUT_S_ENV_VAR, "3")
+    policy = _policy_with_reservation(
+        {},
+        num_workers=2,
+        resources_per_worker={"CPU": 1},
+    )
+    fake_now = [0.0]
+    monkeypatch.setattr(
+        "ray.train.v2._internal.execution.scaling_policy.scaling_policy.time.monotonic",
+        lambda: fake_now[0],
+    )
+    monkeypatch.setattr(
+        "ray.train.v2._internal.execution.scaling_policy.scaling_policy.time.sleep",
+        lambda seconds: fake_now.__setitem__(0, fake_now[0] + seconds),
+    )
+
+    assert policy.get_reserved_bundle_label_selectors(2) is None
 
 
 def test_build_train_resource_request_excludes_trainer_bundle_v2():

--- a/python/ray/train/v2/tests/test_controller.py
+++ b/python/ray/train/v2/tests/test_controller.py
@@ -1008,6 +1008,139 @@ async def test_abort_resilient_to_callback_failure(monkeypatch):
     assert isinstance(controller.get_state(), AbortedState)
 
 
+class _CapturingWorkerGroup(DummyWorkerGroup):
+    """DummyWorkerGroup that records the context it was created with."""
+
+    contexts = []
+
+    def __init__(self, train_run_context, worker_group_context, callbacks=None):
+        type(self).contexts.append(worker_group_context)
+        super().__init__(train_run_context, worker_group_context, callbacks)
+
+
+class _StubReservationScalingPolicy(MockScalingPolicy):
+    """Scaling policy whose reservation answer is fixed by the test."""
+
+    def __init__(self, scaling_config, reserved_label_selectors):
+        super().__init__(scaling_config)
+        self._reserved_label_selectors = reserved_label_selectors
+        self.reservation_queries = 0
+
+    def get_reserved_bundle_label_selectors(self, num_workers):
+        self.reservation_queries += 1
+        return self._reserved_label_selectors
+
+
+def _reservation_controller(monkeypatch, reserved_label_selectors, **scaling_kwargs):
+    monkeypatch.setattr(TrainController, "worker_group_cls", _CapturingWorkerGroup)
+    _CapturingWorkerGroup.contexts = []
+    # `_start_worker_group` reads `placement_strategy` off the scaling policy but
+    # `label_selector`/`use_tpu` off the run context, so both need the config.
+    scaling_config = ScalingConfig(**scaling_kwargs)
+    scaling_policy = _StubReservationScalingPolicy(
+        scaling_config=scaling_config,
+        reserved_label_selectors=reserved_label_selectors,
+    )
+    controller = TrainController(
+        train_fn_ref=DummyObjectRefWrapper(lambda: None),
+        train_run_context=create_dummy_run_context(scaling_config=scaling_config),
+        scaling_policy=scaling_policy,
+        failure_policy=MockFailurePolicy(failure_config=None),
+    )
+    return controller, scaling_policy
+
+
+def test_worker_group_start_waits_for_the_reservation(monkeypatch):
+    """Starting unpinned while a reservation is pending would place workers
+    on nodes the coordinator has promised to somebody else."""
+    controller, _ = _reservation_controller(
+        monkeypatch, reserved_label_selectors=None, num_workers=2
+    )
+
+    with pytest.raises(WorkerGroupStartupTimeoutError):
+        controller._start_worker_group(num_workers=2, resources_per_worker={"CPU": 1})
+
+    assert _CapturingWorkerGroup.contexts == []
+
+
+def test_worker_group_start_pins_to_the_reservation(monkeypatch):
+    """The reserved nodes become the worker label selectors, and the
+    requested placement strategy is preserved so the placement group still
+    enforces it."""
+    pins = [{"ray.io/node-id": "node-a"}, {"ray.io/node-id": "node-b"}]
+    controller, _ = _reservation_controller(
+        monkeypatch,
+        reserved_label_selectors=pins,
+        num_workers=2,
+        placement_strategy="STRICT_SPREAD",
+    )
+
+    controller._start_worker_group(num_workers=2, resources_per_worker={"CPU": 1})
+
+    (context,) = _CapturingWorkerGroup.contexts
+    assert context.label_selector == pins
+    assert context.placement_strategy == "STRICT_SPREAD"
+
+
+@pytest.mark.parametrize(
+    "num_workers,scaling_kwargs,resources_per_worker,expected_label_selector",
+    [
+        pytest.param(
+            2,
+            {},
+            {},
+            None,
+            # Zero-resource workers fit anywhere, so there is nothing to
+            # reserve and nothing to wait for.
+            id="zero_resource_workers",
+        ),
+        pytest.param(
+            2,
+            {"label_selector": {"subcluster": "mine"}},
+            {"CPU": 1},
+            [{"subcluster": "mine"}] * 2,
+            # The coordinator picks nodes by resource fit and never matches
+            # label selectors against node labels, so its pins can name a node
+            # that violates the selector. The user's selector wins.
+            id="user_label_selector",
+        ),
+        pytest.param(
+            1,
+            {"use_tpu": True, "resources_per_worker": {"TPU": 4}},
+            {"TPU": 4},
+            None,
+            # SlicePlacementGroup does its own reservation and ignores
+            # `label_selector`, so pins would only add latency.
+            id="tpu",
+        ),
+    ],
+)
+def test_worker_group_start_skips_pinning(
+    monkeypatch,
+    num_workers,
+    scaling_kwargs,
+    resources_per_worker,
+    expected_label_selector,
+):
+    """Cases where the coordinator's pins must not be applied. Each has to
+    start the worker group rather than block waiting for a reservation."""
+    pins = [{"ray.io/node-id": f"node-{i}"} for i in range(num_workers)]
+    controller, scaling_policy = _reservation_controller(
+        monkeypatch,
+        reserved_label_selectors=pins,
+        num_workers=num_workers,
+        **scaling_kwargs,
+    )
+
+    controller._start_worker_group(
+        num_workers=num_workers, resources_per_worker=resources_per_worker
+    )
+
+    assert scaling_policy.reservation_queries == 0
+    (context,) = _CapturingWorkerGroup.contexts
+    assert context.label_selector == expected_label_selector
+
+
 if __name__ == "__main__":
     import sys
 

--- a/python/ray/train/v2/tests/test_data_integration.py
+++ b/python/ray/train/v2/tests/test_data_integration.py
@@ -714,6 +714,7 @@ def test_fixed_scaling_policy_coordinator_lifecycle(
 
     from ray.data._internal.cluster_autoscaler.default_autoscaling_coordinator import (
         ResourceRequestPriority,
+        ResourceRequestStrategy,
     )
     from ray.train.v2._internal.execution.scaling_policy import (
         AUTOSCALING_REQUESTS_EXPIRE_TIME_S,
@@ -739,6 +740,7 @@ def test_fixed_scaling_policy_coordinator_lifecycle(
         label_selectors=expected_label_selectors,
         expire_after_s=AUTOSCALING_REQUESTS_EXPIRE_TIME_S,
         priority=ResourceRequestPriority.HIGH,
+        strategy=ResourceRequestStrategy.PACK,
     )
 
     with patch("ray.get", side_effect=lambda x, **_: x,), patch(

--- a/python/ray/train/v2/tests/test_elastic_scaling_policy.py
+++ b/python/ray/train/v2/tests/test_elastic_scaling_policy.py
@@ -11,6 +11,7 @@ from ray.data._internal.cluster_autoscaler.base_autoscaling_coordinator import (
 )
 from ray.data._internal.cluster_autoscaler.default_autoscaling_coordinator import (
     ResourceRequestPriority,
+    ResourceRequestStrategy,
 )
 from ray.train.v2._internal.execution.callback import ControllerCallback
 from ray.train.v2._internal.execution.scaling_policy import (
@@ -18,6 +19,9 @@ from ray.train.v2._internal.execution.scaling_policy import (
     AUTOSCALING_REQUESTS_INTERVAL_S,
     NoopDecision,
     ResizeDecision,
+)
+from ray.train.v2._internal.execution.scaling_policy.autoscaling_coordinator_client import (
+    TrainAutoscalingCoordinatorClient,
 )
 from ray.train.v2._internal.execution.scaling_policy.elastic import (
     ElasticScalingPolicy,
@@ -36,7 +40,7 @@ def mock_autoscaling_coordinator(monkeypatch):
     mock_coordinator = MagicMock()
     mock_coordinator._reserved_resources = None
     mock_coordinator.get_reserved_resources.remote = MagicMock(
-        side_effect=lambda _: mock_coordinator._reserved_resources
+        side_effect=lambda _, recompute=False: mock_coordinator._reserved_resources
     )
 
     monkeypatch.setattr(
@@ -88,7 +92,9 @@ def _get_mock_worker_group_state(
     )
 
 
-@patch.object(ElasticScalingPolicy, "GET_RESERVED_RESOURCES_INTERVAL_S", 0.0)
+@patch.object(
+    TrainAutoscalingCoordinatorClient, "GET_RESERVED_RESOURCES_INTERVAL_S", 0.0
+)
 def test_non_running_worker_group_decision():
     """Test decisions being made when the worker group is initializing/restarting.
     Ensures that the policy will resize the worker group as soon as resources are available.
@@ -157,7 +163,7 @@ def test_get_reserved_resources_interval():
     min_workers, max_workers = 4, 64
     resources_per_worker = {"CPU": 8, "GPU": 1}
     get_reserved_resources_interval_s = (
-        ElasticScalingPolicy.GET_RESERVED_RESOURCES_INTERVAL_S
+        TrainAutoscalingCoordinatorClient.GET_RESERVED_RESOURCES_INTERVAL_S
     )
 
     scaling_config = ScalingConfig(
@@ -218,7 +224,9 @@ def test_get_reserved_resources_interval():
         assert reserved_resources == _make_reserved(resources_per_worker, max_workers)
 
 
-@patch.object(ElasticScalingPolicy, "GET_RESERVED_RESOURCES_INTERVAL_S", 0.0)
+@patch.object(
+    TrainAutoscalingCoordinatorClient, "GET_RESERVED_RESOURCES_INTERVAL_S", 0.0
+)
 def test_running_worker_group_decision():
     """Test decisions being made when the worker group is running.
     Ensures that the policy will resize the worker group when there is a change
@@ -412,6 +420,41 @@ def test_count_possible_workers():
     )
 
 
+@pytest.mark.parametrize("per_worker_gpu, num_workers", [(0.1, 5), (0.2, 5), (0.3, 3)])
+def test_count_possible_workers_fractional_resources(per_worker_gpu, num_workers):
+    """Fractional per-worker resources must not lose a worker to float error.
+
+    The coordinator builds a node's reserved total by adding the per-worker
+    bundle once per worker, so the total is not exactly
+    ``num_workers * per_worker_gpu``. A plain ``//`` reads five 0.1-GPU bundles
+    as four workers, and if that undercount drops below ``min_workers`` the
+    policy never starts the run at all.
+    """
+    scaling_config = ScalingConfig(
+        num_workers=(num_workers, num_workers),
+        use_gpu=True,
+        resources_per_worker={"GPU": per_worker_gpu},
+    )
+    policy = ElasticScalingPolicy(scaling_config)
+
+    # Mirror how the coordinator accumulates the per-node total.
+    reserved_gpu = 0.0
+    for _ in range(num_workers):
+        reserved_gpu = reserved_gpu + per_worker_gpu
+
+    assert policy._count_possible_workers({"n0": {"GPU": reserved_gpu}}) == num_workers
+
+
+def test_count_possible_workers_ignores_partial_worker():
+    """Tolerating float drift must not invent a worker out of a real shortfall."""
+    scaling_config = ScalingConfig(
+        num_workers=(1, 8), use_gpu=True, resources_per_worker={"GPU": 1}
+    )
+    policy = ElasticScalingPolicy(scaling_config)
+
+    assert policy._count_possible_workers({"n0": {"GPU": 3.9}}) == 3
+
+
 def test_count_possible_workers_with_zero_resources():
     max_workers = 4
     scaling_config = ScalingConfig(
@@ -443,6 +486,7 @@ def test_request_and_clear():
             label_selectors=None,
             expire_after_s=AUTOSCALING_REQUESTS_EXPIRE_TIME_S,
             priority=ResourceRequestPriority.HIGH,
+            strategy=ResourceRequestStrategy.PACK,
         )
 
     with freeze_time() as frozen_time:

--- a/python/ray/train/v2/tests/test_failure_policy.py
+++ b/python/ray/train/v2/tests/test_failure_policy.py
@@ -119,7 +119,9 @@ def test_non_retryable_error():
 
 def test_infinite_controller_failure_retry():
     policy = create_failure_policy(FailureConfig(controller_failure_limit=-1))
-    controller_error = _controller_error(retryable=True)
+    controller_error = ControllerError(
+        controller_failure=WorkerGroupStartupTimeoutError(0)
+    )
     for _ in range(10):
         assert (
             policy.make_decision(training_failed_error=controller_error)


### PR DESCRIPTION

Train V2 asked the coordinator for capacity but then let the placement group
schedule wherever it liked. Two concurrent runs could therefore both be scheduled onto the same capacity, even though the coordinator had reserved
distinct nodes for each of them.

Now that reservations are keyed by node (previous commit in this stack), turn
them into per-worker node pins:

- `ScalingPolicy.get_reserved_bundle_label_selectors()` converts the reservation into one `ray.io/node-id` selector per worker. It returns None
-- meaning "ask again later", not "no constraint" -- unless the reservation
covers every worker, so a partially pinned worker group never starts. It
  also rejects a reservation whose layout contradicts the requested
  `placement_strategy` (e.g. STRICT_SPREAD workers stacked on one node)
  rather than silently downgrading it.
- `TrainController._start_worker_group` applies those pins, and raises the
new retryable `WorkerGroupReservationNotReadyError` while the reservation
is still pending. Pinning is skipped for zero-resource workers (nothing to
reserve), TPU (`SlicePlacementGroup` does its own reservation), and when the user set their own `label_selector` (the coordinator picks nodes by resource fit and never matches selectors against node labels, so its pins
  could contradict the user's).
- The reserved-resources query and its caching move from `ElasticScalingPolicy` into `TrainAutoscalingCoordinatorClient`, so both the elastic path and the new pinning path share one cache. The client now
  takes prebuilt bundles rather than a `ScalingConfig`, which also drops
  V2's import of a V1 module.

Test: pytest python/ray/train/v2/tests/test_controller.py
      python/ray/train/v2/tests/test_elastic_scaling_policy.py
      python/ray/train/v2/tests/test_autoscaling_coordinator_client.py
      python/ray/train/v2/tests/test_failure_policy.py
      python/ray/train/tests/test_autoscaling_coordinator_client.py


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core Train V2 scheduling and worker-group startup (blocking
wait, node pins, placement-strategy gating); mis-pinning or timeout behavior could delay or misplace runs under contention, though coverage is heavily tested.
> 
> **Overview**
> **Train V2 now waits for coordinator reservations and pins each worker
to the reserved node** via `ray.io/node-id` label selectors, so concurrent runs are less likely to land on the same capacity after the coordinator has already committed nodes.
> 
> `ScalingPolicy.get_reserved_bundle_label_selectors()` polls reserved
capacity (with timeout, like `placement_group.wait()`), returns **no pins unless every worker is covered**, and refuses layouts that would violate **STRICT_PACK** / **STRICT_SPREAD**. If reservations are still pending, `TrainController._start_worker_group` raises retryable **`WorkerGroupStartupTimeoutError`** instead of starting an unpinned group. Pinning is skipped for zero-resource workers, TPU runs, and user **`label_selector`** configs.
> 
> Supporting changes: **`TrainAutoscalingCoordinatorClient`** now
accepts prebuilt resource bundles (plus **`placement_strategy`** on requests), centralizes cached **`get_reserved_resources`**, and shared helpers **`_floor_slots`** /
**`_reserved_resources_to_bundle_label_selectors`** fix fractional-resource float drift and V1 trainer-bundle subtraction on the correct node. **Elastic** scaling reuses the same slot math and client cache.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit
d9214d0cb5c6eb24bd7d7561062bd7fab20df0fe. Bugbot is set up for automated code reviews on this repo. Configure
[here](https://www.cursor.com/dashboard/bugbot).</sup> <!-- /CURSOR_SUMMARY -->

---------

> Thank you for contributing to Ray! 🚀
> Please review the [Ray Contribution Guide](https://docs.ray.io/en/master/ray-contribute/getting-involved.html) before opening a pull request.

> ⚠️ Remove these instructions before submitting your PR.

> 💡 Tip: Mark as draft if you want early feedback, or ready for review when it's complete.

## Description
> Briefly describe what this PR accomplishes and why it's needed.

## Related issues
> Link related issues: "Fixes #1234", "Closes #1234", or "Related to #1234".

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
