### PR TITLE
[serve][llm] Add RunAI streamer release test

### DIFF
--- a/release/llm_tests/serve/configs/serve_llama_3dot2_1b_s3_runai_streamer.yaml
+++ b/release/llm_tests/serve/configs/serve_llama_3dot2_1b_s3_runai_streamer.yaml
@@ -1,0 +1,18 @@
+applications:
+  - args:
+      llm_configs:
+        - model_loading_config:
+            model_id: my_llama
+            model_source: s3://air-example-data/rayllm-ossci/meta-Llama-3.2-1B-Instruct
+          accelerator_type: L4
+          engine_kwargs:
+            max_model_len: 8192
+            tensor_parallel_size: 1
+            enforce_eager: true
+            load_format: runai_streamer
+          runtime_env:
+            env_vars:
+              RUNAI_STREAMER_S3_UNSIGNED: "1"
+    import_path: ray.serve.llm:build_openai_app
+    name: llm-endpoint
+    route_prefix: /

--- a/release/ray_release/byod/byod_llm_runai_streamer.sh
+++ b/release/ray_release/byod/byod_llm_runai_streamer.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# Install the optional S3 dependency used by the RunAI Streamer release test.
+
+set -exo pipefail
+
+pip3 install "runai-model-streamer[s3]==0.16.1"

--- a/release/release_tests.yaml
+++ b/release/release_tests.yaml
@@ -4861,6 +4861,28 @@
     long_running: false
     script: python run_llm_serve_test_and_bms.py --serve-config-file configs/serve_llama_3dot2_1b_s3.yaml --skip-hf-token true
 
+- name: llm_serve_llama_3dot2_1B_s3_runai_streamer
+  frequency: nightly
+  python: "3.12"
+  group: llm-serve
+  team: llm
+  working_dir: llm_tests/serve
+
+  cluster:
+    byod:
+      type: llm-cu130
+      post_build_script: byod_llm_runai_streamer.sh
+    anyscale_sdk_2026: true
+    cluster_compute: llm_auto_select_worker.yaml
+    # NOTE: Important for getting the correct secrets
+    cloud_id: cld_wy5a6nhazplvu32526ams61d98
+    project_id: prj_lhlrf1u5yv8qz9qg3xzw8fkiiq
+
+  run:
+    timeout: 3600
+    long_running: false
+    script: python run_llm_serve_test_and_bms.py --serve-config-file configs/serve_llama_3dot2_1b_s3_runai_streamer.yaml --skip-hf-token true
+
 - name: llm_serve_correctness
   frequency: nightly
   python: "3.12"


### PR DESCRIPTION
## Why

The existing nightly S3 Serve LLM release test exercises Ray's download-and-stage path, but no release test actually invokes vLLM's RunAI streamer. This leaves the remote streaming path vulnerable to regressions like #65477.

This PR adds a separate nightly test that:

- streams the existing public Llama 3.2 1B test model from S3 with `load_format: runai_streamer`;
- uses RunAI's unsigned-request mode for the public bucket; and
- installs `runai-model-streamer[s3]==0.16.1` in a test-specific BYOD layer.

The existing non-streaming S3 test remains unchanged.

## Duplicate check

I searched open PRs and issues for RunAI streamer release-test coverage and found no duplicate. #64996 addresses remote-URI routing and #65120 adds Azure scheme support; neither adds an end-to-end release test. This is follow-up regression coverage for #65477 rather than a duplicate implementation of that fix.

## Testing

- `PYTHONPATH=python:release .venv/bin/python -m pytest -q release/ray_release/tests/test_config.py::test_load_and_validate_test_collection_file` — passed (`1 passed`)
- `.venv/bin/pre-commit run --files release/release_tests.yaml release/llm_tests/serve/configs/serve_llama_3dot2_1b_s3_runai_streamer.yaml release/ray_release/byod/byod_llm_runai_streamer.sh` — passed
- Parsed the new YAML and validated its LLM entry with `LLMConfig.model_validate` — passed
- Installed `runai-model-streamer[s3]==0.16.1` in a Python 3.12 virtual environment and used unsigned S3 access to list the model's safetensors file and pull its JSON metadata/tokenizer files — passed
- Full GPU/Anyscale release test — not run locally; pending CI/manual release-test execution

## AI assistance

AI assistance was used to inspect existing coverage, implement the change, and run the checks above. Human review is pending before this draft is marked ready for review.
