### PR TITLE
[Data] Fix silent data loss when a file read retries mid-file

### DIFF
--- a/python/ray/data/_internal/datasource/json_datasource.py
+++ b/python/ray/data/_internal/datasource/json_datasource.py
@@ -209,8 +209,8 @@ class PandasJSONDatasource(FileBasedDatasource):
         if not f.seekable():
             return self._DEFAULT_CHUNK_SIZE
 
-        # ``_read_stream`` can be recreated on the same file handle when
-        # ``FileBasedDatasource`` retries a transient read error.
+        # Defensive: `FileBasedDatasource` opens a fresh handle for every read
+        # attempt, but a caller may still hand us an advanced one.
         f.seek(0)
 
         if self._target_output_size_bytes is None:
@@ -235,8 +235,8 @@ class PandasJSONDatasource(FileBasedDatasource):
 
             return chunksize
         finally:
-            # Reset file pointer to the beginning for the actual read and for any
-            # subsequent retry that reuses the same file handle.
+            # Sampling consumed part of the file. Rewind so the actual read in
+            # `_read_stream` starts at the first row.
             f.seek(0)
 
     def _open_input_source(

--- a/python/ray/data/_internal/util.py
+++ b/python/ray/data/_internal/util.py
@@ -1534,8 +1534,14 @@ def iterate_with_retry(
     If the iterable raises an exception, this function recreates and re-iterates
     through the iterable, while skipping the items that have already been yielded.
 
+    ``iterable_factory`` must therefore produce the same sequence from the start on
+    every call. A factory that resumes where the previous attempt stopped, such as
+    one that reads from an already-advanced file handle, silently drops data,
+    because the items skipped here are not the ones already yielded.
+
     Args:
-        iterable_factory: A no-argument function that creates the iterable.
+        iterable_factory: A no-argument function that creates the iterable. It must
+            replay the same items from the start on every call.
         description: An imperitive description of the function being retried. For
             example, "open the file".
         match: A list of patterns to match in the exception message. Each pattern

--- a/python/ray/data/datasource/file_based_datasource.py
+++ b/python/ray/data/datasource/file_based_datasource.py
@@ -283,21 +283,32 @@ class FileBasedDatasource(Datasource):
                     parse = PathPartitionParser(partitioning)
                     partitions = parse(read_path)
 
-                with RetryingContextManager(
-                    self._open_input_source(fs, read_path, **open_stream_args),
-                    context=self._data_context,
-                ) as f:
-                    for block in iterate_with_retry(
-                        lambda: self._read_stream(f, read_path),
-                        description="read stream iteratively",
-                        match=self._data_context.retried_io_errors,
-                    ):
-                        if partitions:
-                            block = _add_partitions(block, partitions)
-                        if self._include_paths:
-                            block_accessor = BlockAccessor.for_block(block)
-                            block = block_accessor.fill_column("path", read_path)
-                        yield block
+                # `iterate_with_retry` skips the blocks that a failed attempt
+                # already yielded, so every attempt has to replay the same blocks
+                # from the start of the file. Open the file inside the factory:
+                # reusing one handle would resume a retry from wherever the failure
+                # left the cursor, and the skip would then discard real data. The
+                # `with` lives inside the generator so each attempt's handle is
+                # closed as soon as that attempt ends, whether it raises or runs to
+                # completion.
+                def open_and_read_stream() -> Iterator[Block]:
+                    with RetryingContextManager(
+                        self._open_input_source(fs, read_path, **open_stream_args),
+                        context=self._data_context,
+                    ) as f:
+                        yield from self._read_stream(f, read_path)
+
+                for block in iterate_with_retry(
+                    open_and_read_stream,
+                    description="read stream iteratively",
+                    match=self._data_context.retried_io_errors,
+                ):
+                    if partitions:
+                        block = _add_partitions(block, partitions)
+                    if self._include_paths:
+                        block_accessor = BlockAccessor.for_block(block)
+                        block = block_accessor.fill_column("path", read_path)
+                    yield block
 
         def create_read_task_fn(read_paths, num_threads):
             def read_task_fn():

--- a/python/ray/data/tests/datasource/test_file_based_datasource.py
+++ b/python/ray/data/tests/datasource/test_file_based_datasource.py
@@ -401,6 +401,71 @@ def test_flaky_read_task_retries(ray_start_regular_shared, tmp_path):
     assert len(ds.take()) == 1
 
 
+def test_flaky_read_stream_retry_does_not_drop_data(ray_start_regular_shared, tmp_path):
+    """A retryable error partway through a file must not drop what was read before it.
+
+    `iterate_with_retry` skips the blocks that a failed attempt already yielded, so
+    every attempt has to replay the file from the start. If the retry reuses the
+    advanced file handle, it resumes mid-file and those skips discard real data
+    instead of duplicates.
+    """
+    CHUNK_SIZE = 1024
+    NUM_CHUNKS = 8
+    FAIL_AFTER_CHUNKS = 3
+    retried_error = ray.data.context.DEFAULT_RETRIED_IO_ERRORS[0]
+
+    path = tmp_path / "file.bin"
+    expected = bytes(i % 256 for i in range(CHUNK_SIZE * NUM_CHUNKS))
+    path.write_bytes(expected)
+
+    class FlakyInputStream:
+        """Raises one retryable error, before advancing the wrapped handle."""
+
+        fired = False
+
+        def __init__(self, file):
+            self._file = file
+            self._num_reads = 0
+
+        def read(self, num_bytes=-1):
+            self._num_reads += 1
+            if not FlakyInputStream.fired and self._num_reads > FAIL_AFTER_CHUNKS:
+                FlakyInputStream.fired = True
+                raise OSError(retried_error)
+            return self._file.read(num_bytes)
+
+        def __enter__(self):
+            self._file.__enter__()
+            return self
+
+        def __exit__(self, *args):
+            return self._file.__exit__(*args)
+
+    class ChunkedDatasource(FileBasedDatasource):
+        """Yields one block per `CHUNK_SIZE` bytes of the file."""
+
+        def _open_input_source(self, filesystem, path, **open_args):
+            return FlakyInputStream(
+                super()._open_input_source(filesystem, path, **open_args)
+            )
+
+        def _read_stream(self, f: "pyarrow.NativeFile", path: str) -> Iterator[Block]:
+            while True:
+                data = f.read(CHUNK_SIZE)
+                if not data:
+                    return
+                builder = DelegatingBlockBuilder()
+                builder.add({"data": data})
+                yield builder.build()
+
+    datasource = ChunkedDatasource(path)
+    rows = execute_read_tasks(datasource.get_read_tasks(1))
+
+    assert FlakyInputStream.fired, "the retry path was never exercised"
+    assert len(rows) == NUM_CHUNKS
+    assert b"".join(row["data"] for row in rows) == expected
+
+
 @pytest.mark.parametrize(
     "fs",
     [pyarrow.fs.S3FileSystem(), pyarrow.fs.LocalFileSystem()],


### PR DESCRIPTION
## Description

A retryable read error partway through a file silently drops data. No exception, exit code 0.

### Repro

A datasource that yields one block per 1 KiB of an 8 KiB file, with one transient error injected after the third read:

```python
class FlakyStream:
    fired = False

    def __init__(self, f):
        self._f, self._reads = f, 0

    def read(self, n=-1):
        self._reads += 1
        if not FlakyStream.fired and self._reads > 3:
            FlakyStream.fired = True
            raise OSError(DEFAULT_RETRIED_IO_ERRORS[0])   # transient network error
        return self._f.read(n)


class ChunkedDatasource(FileBasedDatasource):
    def _open_input_source(self, filesystem, path, **kw):
        return FlakyStream(super()._open_input_source(filesystem, path, **kw))

    def _read_stream(self, f, path):
        while (data := f.read(1024)):
            builder = DelegatingBlockBuilder()
            builder.add({"data": data})
            yield builder.build()
```

### Expected vs current

|                  | expected | current    | this PR |
| ---------------- | -------- | ---------- | ------- |
| blocks delivered | 8        | **5**      | 8       |
| bytes delivered  | 8192     | **5120**   | 8192    |
| data correct     | yes      | **no**     | yes     |
| error raised     | no       | no         | no      |

Current behavior loses 3072 bytes, 37.5% of the file, and the read reports success.

### Cause

`read_files` opens the file once, then passes a closure over that handle to `iterate_with_retry`:

```python
with RetryingContextManager(self._open_input_source(fs, read_path, ...)) as f:
    for block in iterate_with_retry(lambda: self._read_stream(f, read_path), ...):
```

`iterate_with_retry` recreates the iterable on a retryable error and skips the items the failed attempt already yielded, so the factory must replay the same sequence from the start. This one does not: it reuses the advanced handle, so attempt 2 resumes from wherever attempt 1 stopped, and the skip then discards real data instead of duplicates.

In the repro: attempt 1 yields 3 blocks and fails, attempt 2 resumes at byte 3072 and yields the remaining 5, and the first 3 of those are dropped as "already yielded". 3 + 2 = 5.

### Which formats are affected

Silent loss, cut at a record boundary with one injected error at ~50%:

| API                                 | current behavior                              |
| ----------------------------------- | --------------------------------------------- |
| `read_text`                         | silent, 1944 / 4000 rows                      |
| `read_binary_files`                 | silent, payload 32768 / 65536 bytes           |
| `read_csv` with `column_names`      | silent, 1501 / 4000 rows                      |
| `read_json` (Arrow)                 | silent, 1961 / 4000 rows                      |
| `read_csv` with inferred header     | raises `ValueError: ...check the CSV file has correct format` |
| `read_numpy`                        | raises `ValueError: contains pickled (object) data` |
| `read_json` (pandas JSONL)          | unaffected                                    |

All are correct after the fix. Whether CSV fails loudly is luck: Arrow takes the first surviving line as a header, which usually fails to parse. Supply `column_names` and the loss goes quiet.

Pandas JSONL escapes because #63233 added `f.seek(0)` to `_estimate_chunksize` in May 2026, which fixed an `AssertionError` there and incidentally restored replay-from-start for that one path. The general problem was not addressed.

Parquet is unaffected: it is not a `FileBasedDatasource`, and its read factory closes over a stateless fragment.

### Fix

Open the file inside the retry factory, with the `with` scoped inside a generator so each attempt's handle is closed as soon as that attempt ends, on both the success and the exception path:

```python
def open_and_read_stream() -> Iterator[Block]:
    with RetryingContextManager(
        self._open_input_source(fs, read_path, **open_stream_args),
        context=self._data_context,
    ) as f:
        yield from self._read_stream(f, read_path)

for block in iterate_with_retry(open_and_read_stream, ...):
```

Measured max 1 handle open at a time across a retry, with all handles closed on the clean, retried, and abandoned-midway paths.

Alternatives considered:

- **Rewind when the handle is seekable.** `_open_input_source` returns `open_input_stream`, whose `seekable()` is `False` even on a local filesystem. This would fix only ORC and uncompressed JSON and leave everything else failing silently.
- **`ExitStack` around the loop.** Correct, but a failed attempt's handle stays open for the remainder of that file's read, up to 10 at once.

Also documents the replay-from-start requirement on `iterate_with_retry`, and corrects two comments in `json_datasource.py` that asserted retries reuse the same handle.

### Behavior change worth noting

The open now sits inside `iterate_with_retry`, and the open path already retries at two levels (`RetryingPyFileSystem.open_input_file` and `RetryingContextManager.__enter__`, 10 attempts each). These multiply, so a persistently retryable open can now take roughly 10x as many attempts before giving up, with exponential backoff capped at 32s per attempt. Bounded, and only in a case that was already failing.

Retries are also more expensive by design: attempt 2 re-parses the blocks it will discard. Resuming was cheaper, and wrong.

## Related issues

None open. Searched open PRs and issues for `iterate_with_retry`, `file_based_datasource retry`, `_read_stream retry`, and `RetryingContextManager`. #63233 is merged and narrower, covering only the pandas JSONL chunksize path.

## Additional information

**Known follow-up, deliberately not in this PR.** `webdataset_datasource.py:439` wraps `_tar_file_iterator` in its own `iterate_with_retry` whose factory closes over the stream it was handed. That inner retry catches the error before the outer one can reopen, so a transient error there becomes `tarfile.ReadError: invalid header`, identically before and after this change. No regression, but it needs a separate fix. Removing a retry layer seemed like a maintainer's call.

**Tests.**

```
pytest python/ray/data/tests/datasource/test_file_based_datasource.py
  -> 32 passed, 3 skipped
```

New regression test `test_flaky_read_stream_retry_does_not_drop_data`: delivers 5 of 8 blocks on master, 8 of 8 with this change.

Wider run across the Data file-format suites (`test_text`, `test_csv`, `test_json`, `test_binary`, `test_image`, `test_avro`, `test_webdataset`, `test_numpy`, `test_parquet`), per file: 226 passed, 21 skipped, 30 failed. Set-differenced against the same run with this change reverted: zero new failures, one fixed. All 30 failures are missing optional imports in this environment (tensorflow x22, torch x4, decord x4) and fail identically on master.

`pre-commit run` is clean on the changed files.

**AI assistance was used** for this change: to build the repro, implement the fix, and write the tests and this description.
