### PR TITLE
[Data] filter(fn=...) silently converts Arrow dictionary-encoded columns to plain strings

### DIFF
--- a/python/ray/data/_internal/planner/plan_udf_map_op.py
+++ b/python/ray/data/_internal/planner/plan_udf_map_op.py
@@ -260,8 +260,26 @@ def plan_filter_op(
             compute=compute,
         )
 
-        transform_fn = RowMapTransformFn(
-            _generate_transform_fn_for_filter(filter_fn),
+        def filter_udf_block_fn(
+            blocks: Iterable[Block], ctx: TaskContext
+        ) -> Iterable[Block]:
+            for block in blocks:
+                block_accessor = BlockAccessor.for_block(block)
+                rows = block_accessor.iter_rows(public_row_format=True)
+                matching_indices = [i for i, row in enumerate(rows) if filter_fn(row)]
+                # Select the matching rows directly from the original block so
+                # column types (e.g. Arrow dictionary encoding) are preserved,
+                # rather than rebuilding a block from row values, which loses them.
+                if matching_indices:
+                    yield block_accessor.take(matching_indices)
+                else:
+                    # `take([])` breaks because indices with no elements are
+                    # inferred as an untyped Arrow array; slicing keeps the
+                    # schema without hitting that path.
+                    yield block_accessor.slice(0, 0)
+
+        transform_fn = BlockMapTransformFn(
+            filter_udf_block_fn,
             is_udf=True,
             output_block_size_option=output_block_size_option,
         )
@@ -740,17 +758,6 @@ def _generate_transform_fn_for_flat_map(
                 for out_row in fn(row):
                     _validate_row_output(out_row)
                     yield out_row
-
-    return transform_fn
-
-
-def _generate_transform_fn_for_filter(
-    fn: UserDefinedFunction,
-) -> MapTransformCallable[Row, Row]:
-    def transform_fn(rows: Iterable[Row], _: TaskContext) -> Iterable[Row]:
-        for row in rows:
-            if fn(row):
-                yield row
 
     return transform_fn
 

--- a/python/ray/data/tests/test_filter.py
+++ b/python/ray/data/tests/test_filter.py
@@ -537,6 +537,45 @@ def test_filter_expr_rejects_actor_pool(ray_start_regular_shared):
         ds.filter(expr=col("id") > 5, compute=ActorPoolStrategy(size=2))
 
 
+# https://github.com/ray-project/ray/issues/51217
+def test_filter_udf_preserves_dictionary_encoded_column_type(
+    ray_start_regular_shared, tmp_path
+):
+    """Filtering with a UDF (``fn=``) was silently converting Arrow
+    ``dictionary``-encoded columns to plain ``string``, changing the column's
+    on-disk type even though the values themselves were unchanged.
+
+    NOTE: ``Dataset.schema()`` doesn't catch this: ``Filter`` is tagged
+    ``LogicalOperatorPreservesSchema``, so ``schema()`` just echoes the input
+    schema instead of reflecting the materialized block. That makes ``schema()``
+    report the *original* (correct) type even if the physical block's type
+    has changed, so this test reads the actual output block's Arrow type
+    instead.
+    """
+    table = pa.table(
+        {
+            "id": pa.array([1, 2, 3], type=pa.int64()),
+            "category": pa.array(["a", "b", "a"]).dictionary_encode(),
+        }
+    )
+    parquet_file = tmp_path / "dictionary_data.parquet"
+    pq.write_table(table, parquet_file)
+
+    ds = ray.data.read_parquet(str(parquet_file))
+    original_type = ray.get(ds.to_arrow_refs()[0]).schema.field("category").type
+    assert pa.types.is_dictionary(original_type)
+
+    filtered_ds = ds.filter(lambda row: True)
+    filtered_type = (
+        ray.get(filtered_ds.to_arrow_refs()[0]).schema.field("category").type
+    )
+
+    assert filtered_type == original_type, (
+        f"filter() changed the on-disk type of 'category' from {original_type} "
+        f"to {filtered_type}"
+    )
+
+
 if __name__ == "__main__":
     import sys
 


### PR DESCRIPTION
## Description

Fixes #51217.

`Dataset.filter(fn=...)` evaluates the predicate row-by-row and rebuilds each
output block from the surviving rows. That rebuild path (`RowMapTransformFn`
+ `ArrowBlockBuilder._table_from_pydict`) infers each column's Arrow type
from the plain Python values it sees, so an Arrow `dictionary`-encoded
column (e.g. from `read_parquet` on a dictionary-encoded field) silently
comes out as plain `string` after filtering, even though no value changed.

This fix changes `plan_filter_op`'s UDF branch to select surviving rows
directly from the *original* block via `BlockAccessor.take()` instead of
reconstructing the block from Python row values — mirroring how the
sibling `expr=` branch in the same function already avoids this by calling
`block_accessor.filter(predicate_expr)` on the whole block. Because `take()`
gathers rows out of the already-typed source table, dictionary encoding
(and any other Arrow-specific type) survives unchanged. A `slice(0, 0)`
fallback handles the case where a block has no surviving rows, since
`take([])` raises `ArrowNotImplementedError` (an empty Python list of
indices gets inferred as an untyped Arrow array).

The now-unused `_generate_transform_fn_for_filter` helper was removed.

**Not a duplicate:** two earlier attempts at this ([#52058](https://github.com/ray-project/ray/pull/52058), [#52067](https://github.com/ray-project/ray/pull/52067)) were closed unmerged in 2025 without landing a fix, and no other open PR currently references #51217.

**Related, but explicitly out of scope:** while investigating I found that
`Dataset.schema()` no longer surfaces this bug at all — `Filter` is tagged
`LogicalOperatorPreservesSchema`, so `schema()` just echoes the input schema
rather than reflecting the materialized block, meaning `schema()` reports
the *original* (correct) type even when the physical data has silently
changed type. That's a separate, sharper problem I'm not addressing here;
happy to file a follow-up issue if maintainers agree it's worth tracking
separately.

## Tests

Added `test_filter_udf_preserves_dictionary_encoded_column_type` in
`python/ray/data/tests/test_filter.py`. It reads the actual output block's
Arrow type via `to_arrow_refs()` (not `.schema()`, for the reason above) and
asserts it matches the input's dictionary type after `filter()`.

### Validation limitation

This environment has no working Ray dev build (Bazel build not run, system
`pyarrow` install is broken independent of this repo). I validated by
applying this exact source change to a pip-installed `ray[data]==2.58.0` in
an isolated virtualenv and running:

- the new regression test directly — fails without the fix
  (`AssertionError: filter() changed the on-disk type of 'category' from
  dictionary<...> to string`), passes with it;
- a manual sanity sweep for regressions: plain lambda filters, callable-class
  filters (with and without actor-pool `fn_constructor_args`), the
  all-rows-filtered and no-rows-filtered edge cases, and multi-block
  datasets — all produce correct results with the fix applied.

CI will run the in-repo test suite against an actual source build.

## AI disclosure

AI tooling was used to help trace the root cause and draft this fix.

## Related issues

Fixes #51217

