### PR TITLE
[core] Honor unlimited task profile event cap in GCS

### DIFF
--- a/src/ray/gcs/gcs_task_manager.cc
+++ b/src/ray/gcs/gcs_task_manager.cc
@@ -181,7 +181,8 @@ void GcsTaskManager::GcsTaskManagerStorage::UpdateExistingTaskAttempt(
   // Truncate the profile events if needed.
   auto max_num_profile_events_per_task =
       RayConfig::instance().task_events_max_num_profile_events_per_task();
-  if (existing_task.profile_events().events_size() > max_num_profile_events_per_task) {
+  if (max_num_profile_events_per_task >= 0 &&
+      existing_task.profile_events().events_size() > max_num_profile_events_per_task) {
     auto to_drop =
         existing_task.profile_events().events_size() - max_num_profile_events_per_task;
     existing_task.mutable_profile_events()->mutable_events()->DeleteSubrange(0, to_drop);

--- a/src/ray/gcs/tests/gcs_task_manager_test.cc
+++ b/src/ray/gcs/tests/gcs_task_manager_test.cc
@@ -424,6 +424,18 @@ class GcsTaskManagerProfileEventsLimitTest : public GcsTaskManagerTest {
   }
 };
 
+class GcsTaskManagerUnlimitedProfileEventsTest : public GcsTaskManagerTest {
+ public:
+  GcsTaskManagerUnlimitedProfileEventsTest() : GcsTaskManagerTest() {
+    RayConfig::instance().initialize(
+        R"(
+{
+  "task_events_max_num_profile_events_per_task": -1
+}
+  )");
+  }
+};
+
 class GcsTaskManagerDroppedTaskAttemptsLimit : public GcsTaskManagerTest {
  public:
   GcsTaskManagerDroppedTaskAttemptsLimit() : GcsTaskManagerTest() {
@@ -1745,6 +1757,25 @@ TEST_F(GcsTaskManagerProfileEventsLimitTest, TestProfileEventsNoLeak) {
     EXPECT_EQ(task_manager->GetTotalNumProfileTaskEventsDropped(),
               100 - RayConfig::instance().task_events_max_num_profile_events_per_task());
   }
+}
+
+TEST_F(GcsTaskManagerUnlimitedProfileEventsTest, TestUnlimitedProfileEvents) {
+  auto task = GenTaskIDs(1)[0];
+  for (int i = 0; i < 2; i++) {
+    auto events = GenTaskEvents({task},
+                                /* attempt_number */ 0,
+                                /* job_id */ 0,
+                                GenProfileEvents("event", i, i));
+    SyncAddTaskEventData(GenTaskEventsData(events));
+  }
+
+  auto reply = SyncGetTaskEvents({});
+  ASSERT_EQ(reply.events_by_task_size(), 1);
+  const auto &profile_events = reply.events_by_task(0).profile_events().events();
+  ASSERT_EQ(profile_events.size(), 2);
+  EXPECT_EQ(profile_events[0].start_time(), 0);
+  EXPECT_EQ(profile_events[1].start_time(), 1);
+  EXPECT_EQ(reply.num_profile_task_events_dropped(), 0);
 }
 
 TEST_F(GcsTaskManagerMemoryLimitedTest, TestLimitGcPriorityBased) {


### PR DESCRIPTION
## Summary

Honor `task_events_max_num_profile_events_per_task=-1` in GCS by bypassing profile-event truncation for negative limits. Nonnegative limits retain the existing FIFO truncation behavior.

Add focused GCS TaskManager coverage that sends two profile-event updates for one task attempt under the unlimited configuration. The test verifies that both events are retained and no profile events are counted as dropped.

## Testing

- `bazel test //src/ray/gcs/tests:gcs_task_manager_test --test_filter=GcsTaskManagerUnlimitedProfileEventsTest.TestUnlimitedProfileEvents --test_output=errors`
- `git diff --check`
