### PR TITLE
[core] Support zero GCS observability history capacity

### DIFF
--- a/src/ray/common/ray_config_def.h
+++ b/src/ray/common/ray_config_def.h
@@ -471,7 +471,8 @@ RAY_CONFIG(uint32_t, gcs_create_actor_retry_interval_ms, 200)
 RAY_CONFIG(uint64_t, gcs_create_placement_group_retry_min_interval_ms, 100)
 RAY_CONFIG(uint64_t, gcs_create_placement_group_retry_max_interval_ms, 1000)
 RAY_CONFIG(double, gcs_create_placement_group_retry_multiplier, 1.5)
-/// Maximum number of destroyed actors in GCS server memory cache.
+/// Maximum number of destroyed actors retained for observability in GCS memory
+/// and persistent storage. Set to 0 to retain no destroyed-actor history.
 /// ActorTableData entry ≈ 200-400B serialized (~600B-1.5KB deserialized),
 /// plus `previous_incarnations` for actors that have restarted: up to ~600B
 /// serialized (~2KB deserialized) at the default
@@ -493,7 +494,8 @@ RAY_CONFIG(uint32_t, maximum_gcs_dead_worker_cached_count, 100000)
 /// `maximum_gcs_destroyed_actor_cached_count` in the GCS destroyed-actor
 /// cache — see the footprint note there before raising this.
 RAY_CONFIG(uint32_t, maximum_actor_previous_incarnations, 10)
-/// Maximum number of dead nodes in GCS server memory cache.
+/// Maximum number of dead nodes retained for observability in GCS memory and
+/// persistent storage. Set to 0 to retain no dead-node history.
 /// GcsNodeInfo entry ≈ ~150-250 bytes serialized (~500B-1KB deserialized).
 /// Worst-case footprint: 1,000 x ~500B-1KB =~ 0.5-1MB
 RAY_CONFIG(uint32_t, maximum_gcs_dead_node_cached_count, 1000)

--- a/src/ray/common/tests/ray_config_test.cc
+++ b/src/ray/common/tests/ray_config_test.cc
@@ -31,4 +31,12 @@ TEST_F(RayConfigTest, ConvertValueTrimsVectorElements) {
   ASSERT_EQ(output, expected_output);
 }
 
+TEST_F(RayConfigTest, AcceptsZeroObservabilityCacheCapacities) {
+  RayConfig::instance().initialize(R"({"maximum_gcs_dead_node_cached_count": 0,)"
+                                   R"("maximum_gcs_destroyed_actor_cached_count": 0})");
+
+  EXPECT_EQ(RayConfig::instance().maximum_gcs_dead_node_cached_count(), 0u);
+  EXPECT_EQ(RayConfig::instance().maximum_gcs_destroyed_actor_cached_count(), 0u);
+}
+
 }  // namespace ray

--- a/src/ray/gcs/actor/gcs_actor_manager.cc
+++ b/src/ray/gcs/actor/gcs_actor_manager.cc
@@ -1103,8 +1103,9 @@ void GcsActorManager::DestroyActor(const ActorID &actor_id,
   mutable_actor_table_data->set_timestamp(time);
 
   const bool is_restartable = IsActorRestartable(*mutable_actor_table_data);
+  bool actor_retained = false;
   if (!is_restartable) {
-    AddDestroyedActorObservabilityData(*it->second);
+    actor_retained = AddDestroyedActorObservabilityData(*it->second);
     // Now that the lightweight observability snapshot is stored, drop the
     // shared_ptr in registered_actors_. The heavy GcsActor (with task_spec_
     // and lease_spec_) is freed at this point since it has no other owner.
@@ -1130,12 +1131,16 @@ void GcsActorManager::DestroyActor(const ActorID &actor_id,
         actor_id,
         actor_table_data,
         is_restartable,
+        actor_retained,
         done_callback = std::move(done_callback)](Status status) {
          if (done_callback) {
            done_callback();
          }
          gcs_publisher_->PublishActor(actor_id,
                                       GenActorDataOnlyWithStates(*actor_table_data));
+         if (!is_restartable && !actor_retained) {
+           gcs_table_storage_->ActorTable().Delete(actor_id, {[](auto) {}, io_context_});
+         }
          if (!is_restartable) {
            gcs_table_storage_->ActorTaskSpecTable().Delete(actor_id,
                                                            {[](auto) {}, io_context_});
@@ -1760,6 +1765,7 @@ void GcsActorManager::Initialize(const GcsInitData &gcs_init_data) {
   const auto &actor_task_specs = gcs_init_data.ActorTaskSpecs();
   absl::flat_hash_map<NodeID, std::vector<WorkerID>> node_to_workers;
   std::vector<ActorID> dead_actors;
+  std::vector<std::pair<ActorID, const rpc::ActorTableData *>> actor_history;
   for (const auto &[actor_id, actor_table_data] : gcs_init_data.Actors()) {
     // We only load actors which are supposed to be alive:
     //   - Actors whose state != DEAD.
@@ -1820,13 +1826,29 @@ void GcsActorManager::Initialize(const GcsInitData &gcs_init_data) {
       }
     } else {
       dead_actors.push_back(actor_id);
-      // Populate the observability cache from persisted actors. Bump the state counter.
-      destroyed_actor_observability_data_.emplace(actor_id, actor_table_data);
-      actor_state_counter_->Increment(
-          {actor_table_data.state(), actor_table_data.class_name()});
-      sorted_destroyed_actor_observability_list_.emplace_back(
-          actor_id, static_cast<int64_t>(actor_table_data.timestamp()));
+      actor_history.emplace_back(actor_id, &actor_table_data);
     }
+  }
+  std::sort(actor_history.begin(),
+            actor_history.end(),
+            [](const auto &left, const auto &right) {
+              return left.second->timestamp() < right.second->timestamp();
+            });
+  const size_t capacity =
+      RayConfig::instance().maximum_gcs_destroyed_actor_cached_count();
+  const size_t first_retained_index =
+      actor_history.size() - std::min(capacity, actor_history.size());
+  for (size_t index = first_retained_index; index < actor_history.size(); ++index) {
+    const auto &[actor_id, actor_table_data] = actor_history[index];
+    destroyed_actor_observability_data_.emplace(actor_id, *actor_table_data);
+    actor_state_counter_->Increment(
+        {actor_table_data->state(), actor_table_data->class_name()});
+    sorted_destroyed_actor_observability_list_.emplace_back(
+        actor_id, static_cast<int64_t>(actor_table_data->timestamp()));
+  }
+  for (size_t index = 0; index < first_retained_index; ++index) {
+    const auto &[actor_id, actor_table_data] = actor_history[index];
+    gcs_table_storage_->ActorTable().Delete(actor_id, {[](auto) {}, io_context_});
   }
   if (!dead_actors.empty()) {
     gcs_table_storage_->ActorTaskSpecTable().BatchDelete(dead_actors,
@@ -1981,9 +2003,16 @@ void GcsActorManager::KillActor(const ActorID &actor_id, bool force_kill) {
   }
 }
 
-void GcsActorManager::AddDestroyedActorObservabilityData(const GcsActor &actor) {
-  if (destroyed_actor_observability_data_.size() >=
-      RayConfig::instance().maximum_gcs_destroyed_actor_cached_count()) {
+bool GcsActorManager::AddDestroyedActorObservabilityData(const GcsActor &actor) {
+  const size_t capacity =
+      RayConfig::instance().maximum_gcs_destroyed_actor_cached_count();
+  if (capacity == 0) {
+    return false;
+  }
+  if (destroyed_actor_observability_data_.size() >= capacity) {
+    RAY_CHECK_EQ(destroyed_actor_observability_data_.size(),
+                 sorted_destroyed_actor_observability_list_.size());
+    RAY_CHECK(!sorted_destroyed_actor_observability_list_.empty());
     const auto &evict_id = sorted_destroyed_actor_observability_list_.front().first;
 
     // Mirror GcsActor::~GcsActor: decrement the counter for non-DEAD states on eviction.
@@ -2000,11 +2029,12 @@ void GcsActorManager::AddDestroyedActorObservabilityData(const GcsActor &actor) 
   }
 
   const auto &actor_id = actor.GetActorID();
-  if (destroyed_actor_observability_data_.emplace(actor_id, actor.GetActorTableData())
-          .second) {
-    sorted_destroyed_actor_observability_list_.emplace_back(
-        actor_id, static_cast<int64_t>(actor.GetActorTableData().timestamp()));
-  }
+  RAY_CHECK(
+      destroyed_actor_observability_data_.emplace(actor_id, actor.GetActorTableData())
+          .second);
+  sorted_destroyed_actor_observability_list_.emplace_back(
+      actor_id, static_cast<int64_t>(actor.GetActorTableData().timestamp()));
+  return true;
 }
 
 void GcsActorManager::CancelActorInScheduling(const std::shared_ptr<GcsActor> &actor) {

--- a/src/ray/gcs/actor/gcs_actor_manager.h
+++ b/src/ray/gcs/actor/gcs_actor_manager.h
@@ -373,7 +373,8 @@ class GcsActorManager : public rpc::ActorInfoGcsServiceHandler,
   /// entry is evicted.
   ///
   /// \param actor The killed actor to snapshot.
-  void AddDestroyedActorObservabilityData(const GcsActor &actor);
+  /// \return Whether the actor was retained.
+  bool AddDestroyedActorObservabilityData(const GcsActor &actor);
 
   rpc::ActorTableData GenActorDataOnlyWithStates(const rpc::ActorTableData &actor) {
     rpc::ActorTableData actor_delta;

--- a/src/ray/gcs/actor/tests/gcs_actor_manager_test.cc
+++ b/src/ray/gcs/actor/tests/gcs_actor_manager_test.cc
@@ -227,6 +227,11 @@ class GcsActorManagerTest : public ::testing::Test {
                : nullptr;
   }
 
+  Status CreateActor(const rpc::CreateActorRequest &request,
+                     gcs::CreateActorCallback callback) {
+    return gcs_actor_manager_->CreateActor(request, std::move(callback));
+  }
+
   void OnNodeDead(const NodeID &node_id) {
     auto node_info = std::make_shared<rpc::GcsNodeInfo>();
     node_info->set_node_id(node_id.Binary());
@@ -273,6 +278,11 @@ class GcsActorManagerTest : public ::testing::Test {
 
   size_t RegisteredActorCount(const gcs::GcsActorManager &actor_manager) const {
     return actor_manager.registered_actors_.size();
+  }
+
+  bool DestroyedActorHistoryEmpty(const gcs::GcsActorManager &actor_manager) const {
+    return actor_manager.destroyed_actor_observability_data_.empty() &&
+           actor_manager.sorted_destroyed_actor_observability_list_.empty();
   }
 
   std::shared_ptr<gcs::GcsActor> GetRegisteredActor(
@@ -580,6 +590,75 @@ TEST_F(GcsActorManagerTest, TestNonDeadEntryEvictionDecrementsCounter) {
 
   // Cache is still at the configured cap.
   ASSERT_EQ(gcs_actor_manager_->destroyed_actor_observability_data_.size(), 10u);
+}
+
+TEST_F(GcsActorManagerTest, TestZeroDestroyedActorRetention) {
+  RayConfig::instance().initialize(R"({"maximum_gcs_destroyed_actor_cached_count": 0})");
+  auto registered_actor = RegisterActor(JobID::FromInt(1));
+  rpc::CreateActorRequest create_actor_request;
+  create_actor_request.mutable_task_spec()->CopyFrom(
+      registered_actor->GetCreationTaskSpecification().GetMessage());
+  RAY_CHECK_OK(CreateActor(create_actor_request,
+                           [](const std::shared_ptr<gcs::GcsActor> &,
+                              const rpc::PushTaskReply &,
+                              const Status &) {}));
+  auto actor = mock_actor_scheduler_->actors.back();
+  mock_actor_scheduler_->actors.pop_back();
+  actor->UpdateAddress(RandomAddress());
+  gcs_actor_manager_->OnActorCreationSuccess(actor, rpc::PushTaskReply());
+  io_service_.run_one();
+  const ActorID actor_id = actor->GetActorID();
+
+  ASSERT_TRUE(worker_client_->Reply());
+  drain_io_context();
+
+  EXPECT_TRUE(DestroyedActorHistoryEmpty(*gcs_actor_manager_));
+  bool checked = false;
+  gcs_table_storage_->ActorTable().Get(
+      actor_id,
+      {[&checked](Status status, std::optional<rpc::ActorTableData> actor_data) {
+         EXPECT_TRUE(status.ok());
+         EXPECT_FALSE(actor_data.has_value());
+         checked = true;
+       },
+       io_service_});
+  drain_io_context();
+  EXPECT_TRUE(checked);
+  RayConfig::instance().initialize(R"({"maximum_gcs_destroyed_actor_cached_count": 10})");
+}
+
+TEST_F(GcsActorManagerTest, TestInitializeWithZeroDestroyedActorRetention) {
+  RayConfig::instance().initialize(R"({"maximum_gcs_destroyed_actor_cached_count": 0})");
+  const JobID job_id = JobID::FromInt(1);
+  const ActorID actor_id = ActorID::Of(job_id, TaskID::FromRandom(job_id), /*counter=*/0);
+  rpc::ActorTableData actor_data;
+  actor_data.set_actor_id(actor_id.Binary());
+  actor_data.set_state(rpc::ActorTableData::DEAD);
+  actor_data.set_max_restarts(0);
+  actor_data.set_timestamp(1);
+  gcs_table_storage_->ActorTable().Put(
+      actor_id, actor_data, {[](const auto &) {}, io_service_});
+  drain_io_context();
+
+  TestGcsInitData init_data(*gcs_table_storage_);
+  init_data.SetActorTableData({{actor_id, actor_data}});
+  auto actor_manager = CreateActorManagerForInitializeTest();
+  actor_manager->Initialize(init_data);
+  drain_io_context();
+
+  EXPECT_TRUE(DestroyedActorHistoryEmpty(*actor_manager));
+  bool checked = false;
+  gcs_table_storage_->ActorTable().Get(
+      actor_id,
+      {[&checked](Status status, std::optional<rpc::ActorTableData> actor_data) {
+         EXPECT_TRUE(status.ok());
+         EXPECT_FALSE(actor_data.has_value());
+         checked = true;
+       },
+       io_service_});
+  drain_io_context();
+  EXPECT_TRUE(checked);
+  RayConfig::instance().initialize(R"({"maximum_gcs_destroyed_actor_cached_count": 10})");
 }
 
 TEST_F(GcsActorManagerTest, TestActorCreationRaceWithRestart) {

--- a/src/ray/gcs/gcs_node_manager.cc
+++ b/src/ray/gcs/gcs_node_manager.cc
@@ -184,7 +184,7 @@ void GcsNodeManager::HandleUnregisterNode(rpc::UnregisterNodeRequest request,
     return;
   }
 
-  AddDeadNodeToCache(node);
+  const bool node_retained = AddDeadNodeToCache(node);
   auto node_info_delta = std::make_shared<rpc::GcsNodeInfo>();
   node_info_delta->set_node_id(node->node_id());
   node_info_delta->mutable_death_info()->CopyFrom(request.node_death_info());
@@ -204,8 +204,11 @@ void GcsNodeManager::HandleUnregisterNode(rpc::UnregisterNodeRequest request,
       },
       "GcsNodeManager.PublishNodeDeathOnUnregister");
 
-  auto on_put_done = [this, node](const Status &status) {
+  auto on_put_done = [this, node, node_id, node_retained](const Status &status) {
     WriteNodeExportEvent(*node, /*is_register_event*/ false);
+    if (!node_retained) {
+      gcs_table_storage_->NodeTable().Delete(node_id, {[](const auto &) {}, io_context_});
+    }
   };
   gcs_table_storage_->NodeTable().Put(node_id, *node, {on_put_done, io_context_});
   GCS_RPC_SEND_REPLY(send_reply_callback, reply, Status::OK());
@@ -707,7 +710,7 @@ void GcsNodeManager::InternalOnNodeFailure(
     auto node = RemoveNodeFromCache(
         node_id, death_info, rpc::GcsNodeInfo::DEAD, clock_.NowUnixMillis());
 
-    AddDeadNodeToCache(node);
+    const bool node_retained = AddDeadNodeToCache(node);
     rpc::GcsNodeInfo node_info_delta;
     node_info_delta.set_node_id(node->node_id());
     node_info_delta.set_state(node->state());
@@ -742,13 +745,17 @@ void GcsNodeManager::InternalOnNodeFailure(
         },
         "GcsNodeManager.PublishNodeDeathOnFailure");
 
-    auto on_done =
-        [this, node_table_updated_callback, node](const Status &status) mutable {
-          WriteNodeExportEvent(*node, /*is_register_event*/ false);
-          if (node_table_updated_callback != nullptr) {
-            node_table_updated_callback();
-          }
-        };
+    auto on_done = [this, node_table_updated_callback, node, node_id, node_retained](
+                       const Status &status) mutable {
+      WriteNodeExportEvent(*node, /*is_register_event*/ false);
+      if (!node_retained) {
+        gcs_table_storage_->NodeTable().Delete(node_id,
+                                               {[](const auto &) {}, io_context_});
+      }
+      if (node_table_updated_callback != nullptr) {
+        node_table_updated_callback();
+      }
+    };
     gcs_table_storage_->NodeTable().Put(
         node_id, *node, {std::move(on_done), io_context_});
   } else if (node_table_updated_callback != nullptr) {
@@ -789,18 +796,36 @@ void GcsNodeManager::Initialize(const GcsInitData &gcs_init_data) {
       sorted_dead_node_list_.begin(),
       sorted_dead_node_list_.end(),
       [](const auto &left, const auto &right) { return left.second < right.second; });
+  const size_t capacity = RayConfig::instance().maximum_gcs_dead_node_cached_count();
+  while (dead_nodes_.size() > capacity) {
+    RAY_CHECK_EQ(dead_nodes_.size(), sorted_dead_node_list_.size());
+    RAY_CHECK(!sorted_dead_node_list_.empty());
+    const NodeID node_id = sorted_dead_node_list_.front().first;
+    RAY_CHECK(dead_nodes_.contains(node_id));
+    gcs_table_storage_->NodeTable().Delete(node_id, {[](const auto &) {}, io_context_});
+    dead_nodes_.erase(node_id);
+    sorted_dead_node_list_.pop_front();
+  }
 }
 
-void GcsNodeManager::AddDeadNodeToCache(std::shared_ptr<const rpc::GcsNodeInfo> node) {
-  if (dead_nodes_.size() >= RayConfig::instance().maximum_gcs_dead_node_cached_count()) {
-    const auto &node_id = sorted_dead_node_list_.front().first;
+bool GcsNodeManager::AddDeadNodeToCache(std::shared_ptr<const rpc::GcsNodeInfo> node) {
+  const size_t capacity = RayConfig::instance().maximum_gcs_dead_node_cached_count();
+  if (capacity == 0) {
+    return false;
+  }
+  if (dead_nodes_.size() >= capacity) {
+    RAY_CHECK_EQ(dead_nodes_.size(), sorted_dead_node_list_.size());
+    RAY_CHECK(!sorted_dead_node_list_.empty());
+    const NodeID node_id = sorted_dead_node_list_.front().first;
+    RAY_CHECK(dead_nodes_.contains(node_id));
     gcs_table_storage_->NodeTable().Delete(node_id, {[](const auto &) {}, io_context_});
-    dead_nodes_.erase(sorted_dead_node_list_.front().first);
+    dead_nodes_.erase(node_id);
     sorted_dead_node_list_.pop_front();
   }
   auto node_id = NodeID::FromBinary(node->node_id());
-  dead_nodes_.emplace(node_id, node);
+  RAY_CHECK(dead_nodes_.emplace(node_id, node).second);
   sorted_dead_node_list_.emplace_back(node_id, node->end_time_ms());
+  return true;
 }
 
 void GcsNodeManager::PublishNodeInfoToPubsub(const NodeID &node_id,

--- a/src/ray/gcs/gcs_node_manager.h
+++ b/src/ray/gcs/gcs_node_manager.h
@@ -263,7 +263,8 @@ class GcsNodeManager : public rpc::NodeInfoGcsServiceHandler {
   /// evicted.
   ///
   /// \param node The node which is dead.
-  void AddDeadNodeToCache(std::shared_ptr<const rpc::GcsNodeInfo> node)
+  /// \return Whether the node was retained.
+  bool AddDeadNodeToCache(std::shared_ptr<const rpc::GcsNodeInfo> node)
       ABSL_EXCLUSIVE_LOCKS_REQUIRED(mutex_);
 
   /// Remove a node from alive nodes cache. The node's death information will also be set.

--- a/src/ray/gcs/tests/gcs_node_manager_test.cc
+++ b/src/ray/gcs/tests/gcs_node_manager_test.cc
@@ -24,6 +24,7 @@
 #include "mock/ray/pubsub/publisher.h"
 #include "ray/common/ray_config.h"
 #include "ray/common/test_utils.h"
+#include "ray/gcs/gcs_init_data.h"
 #include "ray/gcs/store_client/in_memory_store_client.h"
 #include "ray/observability/fake_ray_event_recorder.h"
 #include "ray/pubsub/fake_publisher.h"
@@ -43,6 +44,15 @@ class RecordingPublisher : public pubsub::FakePublisher {
 
  private:
   std::atomic_int *publish_count_;
+};
+
+class TestGcsInitData : public gcs::GcsInitData {
+ public:
+  using gcs::GcsInitData::GcsInitData;
+
+  void SetNodeTableData(absl::flat_hash_map<NodeID, rpc::GcsNodeInfo> node_data) {
+    node_table_data_ = std::move(node_data);
+  }
 };
 
 class GcsNodeManagerTest : public ::testing::Test {
@@ -272,6 +282,93 @@ TEST_F(GcsNodeManagerTest, TestUnregisterNodePublishesDeathBeforePersist) {
   while (io_context_->poll() > 0) {
   }
   ASSERT_FALSE(fake_ray_event_recorder_->FlushBuffer().empty());
+}
+
+TEST_F(GcsNodeManagerTest, TestZeroDeadNodeRetention) {
+  RayConfig::instance().initialize(R"({"maximum_gcs_dead_node_cached_count": 0})");
+  gcs::GcsNodeManager node_manager(gcs_publisher_.get(),
+                                   gcs_table_storage_.get(),
+                                   *io_context_,
+                                   client_pool_.get(),
+                                   ClusterID::Nil(),
+                                   *fake_ray_event_recorder_,
+                                   "test_session_name",
+                                   observability_publisher_.get(),
+                                   clock_);
+  auto node = GenNodeInfo();
+  const NodeID node_id = NodeID::FromBinary(node->node_id());
+  node_manager.AddNode(node);
+  while (io_context_->poll() > 0) {
+  }
+
+  rpc::UnregisterNodeRequest request;
+  request.set_node_id(node->node_id());
+  request.mutable_node_death_info()->set_reason(rpc::NodeDeathInfo::EXPECTED_TERMINATION);
+  rpc::UnregisterNodeReply reply;
+  node_manager.HandleUnregisterNode(
+      request,
+      &reply,
+      [](ray::Status, std::function<void()>, std::function<void()>) {},
+      "");
+  while (io_context_->poll() > 0) {
+  }
+
+  EXPECT_TRUE(node_manager.GetAllDeadNodes().empty());
+  bool checked = false;
+  gcs_table_storage_->NodeTable().Get(
+      node_id,
+      {[&checked](Status status, std::optional<rpc::GcsNodeInfo> node_info) {
+         EXPECT_TRUE(status.ok());
+         EXPECT_FALSE(node_info.has_value());
+         checked = true;
+       },
+       *io_context_});
+  while (io_context_->poll() > 0) {
+  }
+  EXPECT_TRUE(checked);
+  RayConfig::instance().initialize("");
+}
+
+TEST_F(GcsNodeManagerTest, TestInitializeWithZeroDeadNodeRetention) {
+  RayConfig::instance().initialize(R"({"maximum_gcs_dead_node_cached_count": 0})");
+  auto node = GenNodeInfo();
+  node->set_state(rpc::GcsNodeInfo::DEAD);
+  node->set_end_time_ms(1);
+  const NodeID node_id = NodeID::FromBinary(node->node_id());
+  gcs_table_storage_->NodeTable().Put(
+      node_id, *node, {[](const auto &) {}, *io_context_});
+  while (io_context_->poll() > 0) {
+  }
+
+  TestGcsInitData init_data(*gcs_table_storage_);
+  init_data.SetNodeTableData({{node_id, *node}});
+  gcs::GcsNodeManager node_manager(gcs_publisher_.get(),
+                                   gcs_table_storage_.get(),
+                                   *io_context_,
+                                   client_pool_.get(),
+                                   ClusterID::Nil(),
+                                   *fake_ray_event_recorder_,
+                                   "test_session_name",
+                                   observability_publisher_.get(),
+                                   clock_);
+  node_manager.Initialize(init_data);
+  while (io_context_->poll() > 0) {
+  }
+
+  EXPECT_TRUE(node_manager.GetAllDeadNodes().empty());
+  bool checked = false;
+  gcs_table_storage_->NodeTable().Get(
+      node_id,
+      {[&checked](Status status, std::optional<rpc::GcsNodeInfo> node_info) {
+         EXPECT_TRUE(status.ok());
+         EXPECT_FALSE(node_info.has_value());
+         checked = true;
+       },
+       *io_context_});
+  while (io_context_->poll() > 0) {
+  }
+  EXPECT_TRUE(checked);
+  RayConfig::instance().initialize("");
 }
 
 TEST_F(GcsNodeManagerTest, TestManagement) {


### PR DESCRIPTION
## Summary

- Support `maximum_gcs_dead_node_cached_count=0` and `maximum_gcs_destroyed_actor_cached_count=0` as no-retention modes instead of rejecting the configuration.
- Avoid calling `front()` on an empty eviction deque when the capacity is zero.
- Chain live same-key cleanup after the corresponding `NodeTable` or `ActorTable` `Put` completes, so an asynchronous write cannot recreate a record that should not be retained.
- Apply the configured retention limit during GCS restart initialization, keeping the newest records for positive capacities and clearing history at zero.
- Preserve existing node death publication timing and actor persistence/publication ordering.

## Test plan

- `bazel test --jobs=2 --local_resources=cpu=2 //src/ray/common/tests:ray_config_test --test_output=errors`
- `bazel test --jobs=2 --local_resources=cpu=2 //src/ray/gcs/tests:gcs_node_manager_test --test_output=errors`
- `bazel test --jobs=2 --local_resources=cpu=2 //src/ray/gcs/actor/tests:gcs_actor_manager_test --test_output=errors`
- `git diff --check`
