### PR TITLE
[Core] Track actor task cancellation per attempt, not per task id

### DIFF
--- a/src/ray/core_worker/task_execution/ordered_actor_task_execution_queue.cc
+++ b/src/ray/core_worker/task_execution/ordered_actor_task_execution_queue.cc
@@ -51,7 +51,8 @@ void OrderedActorTaskExecutionQueue::CancelAllQueuedTasks(const std::string &msg
     while (!group_state.pending_tasks.empty()) {
       auto head = group_state.pending_tasks.begin();
       cancel_task_(head->second, status);
-      pending_task_id_to_is_canceled.erase(head->second.TaskID());
+      pending_task_attempt_to_is_canceled.erase(
+          TaskAttempt{head->second.TaskID(), head->second.TaskSpec().AttemptNumber()});
       group_state.pending_tasks.erase(head);
     }
 
@@ -59,7 +60,8 @@ void OrderedActorTaskExecutionQueue::CancelAllQueuedTasks(const std::string &msg
     while (!group_state.pending_retry_tasks.empty()) {
       auto &req = group_state.pending_retry_tasks.front();
       cancel_task_(req, status);
-      pending_task_id_to_is_canceled.erase(req.TaskID());
+      pending_task_attempt_to_is_canceled.erase(
+          TaskAttempt{req.TaskID(), req.TaskSpec().AttemptNumber()});
       group_state.pending_retry_tasks.pop_front();
     }
   }
@@ -110,7 +112,8 @@ void OrderedActorTaskExecutionQueue::EnqueueTask(int64_t seq_no,
   }
   {
     absl::MutexLock lock(&mu_);
-    pending_task_id_to_is_canceled.emplace(task_spec.TaskId(), false);
+    pending_task_attempt_to_is_canceled.emplace(
+        TaskAttempt{task_spec.TaskId(), task_spec.AttemptNumber()}, false);
   }
 
   // Set the OnArgsReady callback. In the general case, this should be called
@@ -206,14 +209,18 @@ void OrderedActorTaskExecutionQueue::EnqueueTask(int64_t seq_no,
 
 bool OrderedActorTaskExecutionQueue::CancelTaskIfFound(TaskID task_id) {
   absl::MutexLock lock(&mu_);
-  if (pending_task_id_to_is_canceled.find(task_id) !=
-      pending_task_id_to_is_canceled.end()) {
-    // Mark the task is canceled.
-    pending_task_id_to_is_canceled[task_id] = true;
-    return true;
-  } else {
-    return false;
+  bool found = false;
+  // The map is keyed by attempt, so cancel every attempt of the task that is
+  // still queued or running: another attempt of the same task can be pending
+  // while one has already finished.
+  for (auto &[task_attempt, is_canceled] : pending_task_attempt_to_is_canceled) {
+    if (task_attempt.first == task_id) {
+      // Mark the task attempt as canceled.
+      is_canceled = true;
+      found = true;
+    }
   }
+  return found;
 }
 
 void OrderedActorTaskExecutionQueue::ExecuteQueuedTasks() {
@@ -234,7 +241,8 @@ void OrderedActorTaskExecutionQueue::ExecuteQueuedTasks() {
                           "intentionally discarded this task."));
       {
         absl::MutexLock lock(&mu_);
-        pending_task_id_to_is_canceled.erase(head->second.TaskID());
+        pending_task_attempt_to_is_canceled.erase(
+            TaskAttempt{head->second.TaskID(), head->second.TaskSpec().AttemptNumber()});
       }
       group_state.pending_tasks.erase(head);
     }
@@ -318,7 +326,8 @@ void OrderedActorTaskExecutionQueue::ExecuteQueuedTasks() {
                     std::max(group_state_in.next_seq_no, head->first + 1);
                 {
                   absl::MutexLock lock(&mu_);
-                  pending_task_id_to_is_canceled.erase(head->second.TaskID());
+                  pending_task_attempt_to_is_canceled.erase(TaskAttempt{
+                      head->second.TaskID(), head->second.TaskSpec().AttemptNumber()});
                 }
                 group_state_in.pending_tasks.erase(head);
               }
@@ -333,25 +342,25 @@ void OrderedActorTaskExecutionQueue::ExecuteQueuedTasks() {
 }
 
 void OrderedActorTaskExecutionQueue::ExecuteRequest(TaskToExecute &&request) {
-  auto task_id = request.TaskID();
+  TaskAttempt task_attempt{request.TaskID(), request.TaskSpec().AttemptNumber()};
   auto pool = pool_manager_->GetExecutor(request.ConcurrencyGroupName(),
                                          request.FunctionDescriptor());
   if (pool == nullptr) {
-    AcceptRequestOrRejectIfCanceled(task_id, request);
+    AcceptRequestOrRejectIfCanceled(task_attempt, request);
   } else {
-    pool->Post([this, request = std::move(request), task_id]() mutable {
-      AcceptRequestOrRejectIfCanceled(task_id, request);
+    pool->Post([this, request = std::move(request), task_attempt]() mutable {
+      AcceptRequestOrRejectIfCanceled(task_attempt, request);
     });
   }
 }
 
 void OrderedActorTaskExecutionQueue::AcceptRequestOrRejectIfCanceled(
-    TaskID task_id, TaskToExecute &request) {
+    const TaskAttempt &task_attempt, TaskToExecute &request) {
   bool is_canceled = false;
   {
     absl::MutexLock lock(&mu_);
-    auto it = pending_task_id_to_is_canceled.find(task_id);
-    if (it != pending_task_id_to_is_canceled.end()) {
+    auto it = pending_task_attempt_to_is_canceled.find(task_attempt);
+    if (it != pending_task_attempt_to_is_canceled.end()) {
       is_canceled = it->second;
     }
   }
@@ -365,7 +374,7 @@ void OrderedActorTaskExecutionQueue::AcceptRequestOrRejectIfCanceled(
   }
 
   absl::MutexLock lock(&mu_);
-  pending_task_id_to_is_canceled.erase(task_id);
+  pending_task_attempt_to_is_canceled.erase(task_attempt);
 }
 
 }  // namespace core

--- a/src/ray/core_worker/task_execution/ordered_actor_task_execution_queue.cc
+++ b/src/ray/core_worker/task_execution/ordered_actor_task_execution_queue.cc
@@ -112,8 +112,11 @@ void OrderedActorTaskExecutionQueue::EnqueueTask(int64_t seq_no,
   }
   {
     absl::MutexLock lock(&mu_);
+    // A cancel that arrived while another attempt of this task was pending applies to
+    // this attempt too, which the shared entry used to give for free.
+    bool is_canceled = IsTaskCanceledLocked(task_spec.TaskId());
     pending_task_attempt_to_is_canceled.emplace(
-        TaskAttempt{task_spec.TaskId(), task_spec.AttemptNumber()}, false);
+        TaskAttempt{task_spec.TaskId(), task_spec.AttemptNumber()}, is_canceled);
   }
 
   // Set the OnArgsReady callback. In the general case, this should be called
@@ -205,6 +208,15 @@ void OrderedActorTaskExecutionQueue::EnqueueTask(int64_t seq_no,
   }
 
   ExecuteQueuedTasks();
+}
+
+bool OrderedActorTaskExecutionQueue::IsTaskCanceledLocked(const TaskID &task_id) const {
+  for (const auto &[task_attempt, is_canceled] : pending_task_attempt_to_is_canceled) {
+    if (task_attempt.first == task_id && is_canceled) {
+      return true;
+    }
+  }
+  return false;
 }
 
 bool OrderedActorTaskExecutionQueue::CancelTaskIfFound(TaskID task_id) {

--- a/src/ray/core_worker/task_execution/ordered_actor_task_execution_queue.cc
+++ b/src/ray/core_worker/task_execution/ordered_actor_task_execution_queue.cc
@@ -51,8 +51,8 @@ void OrderedActorTaskExecutionQueue::CancelAllQueuedTasks(const std::string &msg
     while (!group_state.pending_tasks.empty()) {
       auto head = group_state.pending_tasks.begin();
       cancel_task_(head->second, status);
-      pending_task_attempt_to_is_canceled.erase(
-          TaskAttempt{head->second.TaskID(), head->second.TaskSpec().AttemptNumber()});
+      EraseTaskAttemptLocked(head->second.TaskID(),
+                             head->second.TaskSpec().AttemptNumber());
       group_state.pending_tasks.erase(head);
     }
 
@@ -60,8 +60,7 @@ void OrderedActorTaskExecutionQueue::CancelAllQueuedTasks(const std::string &msg
     while (!group_state.pending_retry_tasks.empty()) {
       auto &req = group_state.pending_retry_tasks.front();
       cancel_task_(req, status);
-      pending_task_attempt_to_is_canceled.erase(
-          TaskAttempt{req.TaskID(), req.TaskSpec().AttemptNumber()});
+      EraseTaskAttemptLocked(req.TaskID(), req.TaskSpec().AttemptNumber());
       group_state.pending_retry_tasks.pop_front();
     }
   }
@@ -115,8 +114,8 @@ void OrderedActorTaskExecutionQueue::EnqueueTask(int64_t seq_no,
     // A cancel that arrived while another attempt of this task was pending applies to
     // this attempt too, which the shared entry used to give for free.
     bool is_canceled = IsTaskCanceledLocked(task_spec.TaskId());
-    pending_task_attempt_to_is_canceled.emplace(
-        TaskAttempt{task_spec.TaskId(), task_spec.AttemptNumber()}, is_canceled);
+    pending_task_attempt_to_is_canceled[task_spec.TaskId()].emplace(
+        task_spec.AttemptNumber(), is_canceled);
   }
 
   // Set the OnArgsReady callback. In the general case, this should be called
@@ -211,28 +210,42 @@ void OrderedActorTaskExecutionQueue::EnqueueTask(int64_t seq_no,
 }
 
 bool OrderedActorTaskExecutionQueue::IsTaskCanceledLocked(const TaskID &task_id) const {
-  for (const auto &[task_attempt, is_canceled] : pending_task_attempt_to_is_canceled) {
-    if (task_attempt.first == task_id && is_canceled) {
+  auto it = pending_task_attempt_to_is_canceled.find(task_id);
+  if (it == pending_task_attempt_to_is_canceled.end()) {
+    return false;
+  }
+  for (const auto &[attempt_number, is_canceled] : it->second) {
+    if (is_canceled) {
       return true;
     }
   }
   return false;
 }
 
+void OrderedActorTaskExecutionQueue::EraseTaskAttemptLocked(const TaskID &task_id,
+                                                            int32_t attempt_number) {
+  auto it = pending_task_attempt_to_is_canceled.find(task_id);
+  if (it == pending_task_attempt_to_is_canceled.end()) {
+    return;
+  }
+  it->second.erase(attempt_number);
+  if (it->second.empty()) {
+    pending_task_attempt_to_is_canceled.erase(it);
+  }
+}
+
 bool OrderedActorTaskExecutionQueue::CancelTaskIfFound(TaskID task_id) {
   absl::MutexLock lock(&mu_);
-  bool found = false;
-  // The map is keyed by attempt, so cancel every attempt of the task that is
-  // still queued or running: another attempt of the same task can be pending
-  // while one has already finished.
-  for (auto &[task_attempt, is_canceled] : pending_task_attempt_to_is_canceled) {
-    if (task_attempt.first == task_id) {
-      // Mark the task attempt as canceled.
-      is_canceled = true;
-      found = true;
-    }
+  auto it = pending_task_attempt_to_is_canceled.find(task_id);
+  if (it == pending_task_attempt_to_is_canceled.end()) {
+    return false;
   }
-  return found;
+  // Cancel every attempt of the task that is still queued or running: another attempt
+  // can be pending while one has already finished.
+  for (auto &[attempt_number, is_canceled] : it->second) {
+    is_canceled = true;
+  }
+  return true;
 }
 
 void OrderedActorTaskExecutionQueue::ExecuteQueuedTasks() {
@@ -253,8 +266,8 @@ void OrderedActorTaskExecutionQueue::ExecuteQueuedTasks() {
                           "intentionally discarded this task."));
       {
         absl::MutexLock lock(&mu_);
-        pending_task_attempt_to_is_canceled.erase(
-            TaskAttempt{head->second.TaskID(), head->second.TaskSpec().AttemptNumber()});
+        EraseTaskAttemptLocked(head->second.TaskID(),
+                               head->second.TaskSpec().AttemptNumber());
       }
       group_state.pending_tasks.erase(head);
     }
@@ -338,8 +351,8 @@ void OrderedActorTaskExecutionQueue::ExecuteQueuedTasks() {
                     std::max(group_state_in.next_seq_no, head->first + 1);
                 {
                   absl::MutexLock lock(&mu_);
-                  pending_task_attempt_to_is_canceled.erase(TaskAttempt{
-                      head->second.TaskID(), head->second.TaskSpec().AttemptNumber()});
+                  EraseTaskAttemptLocked(head->second.TaskID(),
+                                         head->second.TaskSpec().AttemptNumber());
                 }
                 group_state_in.pending_tasks.erase(head);
               }
@@ -371,9 +384,12 @@ void OrderedActorTaskExecutionQueue::AcceptRequestOrRejectIfCanceled(
   bool is_canceled = false;
   {
     absl::MutexLock lock(&mu_);
-    auto it = pending_task_attempt_to_is_canceled.find(task_attempt);
+    auto it = pending_task_attempt_to_is_canceled.find(task_attempt.first);
     if (it != pending_task_attempt_to_is_canceled.end()) {
-      is_canceled = it->second;
+      auto attempt_it = it->second.find(task_attempt.second);
+      if (attempt_it != it->second.end()) {
+        is_canceled = attempt_it->second;
+      }
     }
   }
 
@@ -386,7 +402,7 @@ void OrderedActorTaskExecutionQueue::AcceptRequestOrRejectIfCanceled(
   }
 
   absl::MutexLock lock(&mu_);
-  pending_task_attempt_to_is_canceled.erase(task_attempt);
+  EraseTaskAttemptLocked(task_attempt.first, task_attempt.second);
 }
 
 }  // namespace core

--- a/src/ray/core_worker/task_execution/ordered_actor_task_execution_queue.h
+++ b/src/ray/core_worker/task_execution/ordered_actor_task_execution_queue.h
@@ -76,6 +76,11 @@ class OrderedActorTaskExecutionQueue : public ActorTaskExecutionQueueInterface {
   bool IsTaskCanceledLocked(const TaskID &task_id) const
       ABSL_EXCLUSIVE_LOCKS_REQUIRED(mu_);
 
+  /// Drop one attempt's cancellation entry, and the task's entry with it once no
+  /// attempt of that task is pending.
+  void EraseTaskAttemptLocked(const TaskID &task_id, int32_t attempt_number)
+      ABSL_EXCLUSIVE_LOCKS_REQUIRED(mu_);
+
   void ExecuteRequest(TaskToExecute &&request);
 
   /// Per-concurrency-group ordering state.
@@ -124,11 +129,13 @@ class OrderedActorTaskExecutionQueue : public ActorTaskExecutionQueueInterface {
   /// Mutex to protect attributes used for thread safe APIs.
   absl::Mutex mu_;
 
-  /// A map of actor task attempts -> is_canceled
-  /// Pending means tasks are queued or running. Keyed by (task id, attempt
-  /// number) so that two attempts of one task are tracked independently.
-  absl::flat_hash_map<TaskAttempt, bool> pending_task_attempt_to_is_canceled
-      ABSL_GUARDED_BY(mu_);
+  /// A map of actor task ids -> attempt number -> is_canceled
+  /// Pending means tasks are queued or running. Attempts of one task are tracked
+  /// independently, because two of them can be pending at the same time. A task's
+  /// entry is erased once none of its attempts is pending, so an entry that exists
+  /// always holds at least one attempt.
+  absl::flat_hash_map<TaskID, absl::flat_hash_map<int32_t, bool>>
+      pending_task_attempt_to_is_canceled ABSL_GUARDED_BY(mu_);
 
   friend class OrderedActorTaskExecutionQueueTest;
 };

--- a/src/ray/core_worker/task_execution/ordered_actor_task_execution_queue.h
+++ b/src/ray/core_worker/task_execution/ordered_actor_task_execution_queue.h
@@ -72,6 +72,10 @@ class OrderedActorTaskExecutionQueue : public ActorTaskExecutionQueueInterface {
   void AcceptRequestOrRejectIfCanceled(const TaskAttempt &task_attempt,
                                        TaskToExecute &request);
 
+  /// Whether any pending attempt of the given task is already marked canceled.
+  bool IsTaskCanceledLocked(const TaskID &task_id) const
+      ABSL_EXCLUSIVE_LOCKS_REQUIRED(mu_);
+
   void ExecuteRequest(TaskToExecute &&request);
 
   /// Per-concurrency-group ordering state.
@@ -127,9 +131,6 @@ class OrderedActorTaskExecutionQueue : public ActorTaskExecutionQueueInterface {
       ABSL_GUARDED_BY(mu_);
 
   friend class OrderedActorTaskExecutionQueueTest;
-
-  FRIEND_TEST(OrderedActorTaskExecutionQueueTest,
-              CancelTaskIfFoundCancelsRemainingAttempt);
 };
 
 }  // namespace core

--- a/src/ray/core_worker/task_execution/ordered_actor_task_execution_queue.h
+++ b/src/ray/core_worker/task_execution/ordered_actor_task_execution_queue.h
@@ -67,9 +67,10 @@ class OrderedActorTaskExecutionQueue : public ActorTaskExecutionQueueInterface {
   /// Executes as many queued tasks as are ready to execute.
   void ExecuteQueuedTasks();
 
-  /// Accept the given TaskToExecute or reject it if a task id is canceled via
-  /// CancelTaskIfFound.
-  void AcceptRequestOrRejectIfCanceled(TaskID task_id, TaskToExecute &request);
+  /// Accept the given TaskToExecute or reject it if the task attempt is
+  /// canceled via CancelTaskIfFound.
+  void AcceptRequestOrRejectIfCanceled(const TaskAttempt &task_attempt,
+                                       TaskToExecute &request);
 
   void ExecuteRequest(TaskToExecute &&request);
 
@@ -119,11 +120,16 @@ class OrderedActorTaskExecutionQueue : public ActorTaskExecutionQueueInterface {
   /// Mutex to protect attributes used for thread safe APIs.
   absl::Mutex mu_;
 
-  /// A map of actor task IDs -> is_canceled
-  /// Pending means tasks are queued or running.
-  absl::flat_hash_map<TaskID, bool> pending_task_id_to_is_canceled ABSL_GUARDED_BY(mu_);
+  /// A map of actor task attempts -> is_canceled
+  /// Pending means tasks are queued or running. Keyed by (task id, attempt
+  /// number) so that two attempts of one task are tracked independently.
+  absl::flat_hash_map<TaskAttempt, bool> pending_task_attempt_to_is_canceled
+      ABSL_GUARDED_BY(mu_);
 
   friend class OrderedActorTaskExecutionQueueTest;
+
+  FRIEND_TEST(OrderedActorTaskExecutionQueueTest,
+              CancelTaskIfFoundCancelsRemainingAttempt);
 };
 
 }  // namespace core

--- a/src/ray/core_worker/task_execution/tests/actor_task_execution_queue_test.cc
+++ b/src/ray/core_worker/task_execution/tests/actor_task_execution_queue_test.cc
@@ -450,10 +450,71 @@ TEST(OrderedActorTaskExecutionQueueTest, CancelTaskIfFoundCancelsRemainingAttemp
 
   ASSERT_EQ(n_executed.load(), 0);
   ASSERT_EQ(n_rejected.load(), 1);
-  {
-    absl::MutexLock lock(&queue.mu_);
-    ASSERT_TRUE(queue.pending_task_attempt_to_is_canceled.empty());
-  }
+  // The rejected attempt took its own entry with it, so nothing is left to cancel.
+  ASSERT_FALSE(queue.CancelTaskIfFound(task_id));
+
+  queue.Stop();
+}
+
+// A cancel also applies to an attempt that arrives after it, as long as an earlier
+// attempt of the same task is still pending: the shared entry used to give that for
+// free, and the per-attempt entry now inherits the mark instead.
+TEST(OrderedActorTaskExecutionQueueTest, CancelTaskIfFoundMarksLaterAttempt) {
+  instrumented_io_context io_service;
+  MockWaiter waiter;
+  MockTaskEventBuffer task_event_buffer;
+  [[maybe_unused]] ray::observability::FakeRayEventRecorder ray_task_event_recorder;
+
+  std::vector<ConcurrencyGroup> concurrency_groups{ConcurrencyGroup{"io", 1, {}}};
+  auto pool_manager =
+      std::make_shared<ConcurrencyGroupManager<BoundedExecutor>>(concurrency_groups);
+
+  std::atomic<int> n_executed(0);
+  std::atomic<int> n_rejected(0);
+  auto execute_task = [&n_executed](TaskToExecute &task) { n_executed++; };
+  auto cancel_task = [&n_rejected](const TaskToExecute &task, const Status &status) {
+    if (status.IsSchedulingCancelled()) {
+      n_rejected.fetch_add(1);
+    }
+  };
+
+  OrderedActorTaskExecutionQueue queue(io_service,
+                                       waiter,
+                                       task_event_buffer,
+                                       ray_task_event_recorder,
+                                       pool_manager,
+                                       1,
+                                       execute_task,
+                                       cancel_task);
+  JobID job_id = JobID::FromInt(1);
+  TaskID task_id = TaskID::FromRandom(job_id);
+
+  // Attempt 0 stays queued waiting for its dependencies, and is canceled there.
+  TaskSpecification task_spec_attempt_0;
+  task_spec_attempt_0.GetMutableMessage().set_type(TaskType::ACTOR_TASK);
+  task_spec_attempt_0.GetMutableMessage().set_task_id(task_id.Binary());
+  task_spec_attempt_0.GetMutableMessage().set_attempt_number(0);
+  task_spec_attempt_0.GetMutableMessage().add_args()->mutable_object_ref()->set_object_id(
+      ObjectID::FromRandom().Binary());
+  EnqueueWithFetch(queue, waiter, 0, -1, MakeTaskToExecute(task_spec_attempt_0));
+  ASSERT_TRUE(queue.CancelTaskIfFound(task_id));
+
+  // A retry of the same task arrives after the cancel.
+  TaskSpecification task_spec_attempt_1;
+  task_spec_attempt_1.GetMutableMessage().set_type(TaskType::ACTOR_TASK);
+  task_spec_attempt_1.GetMutableMessage().set_task_id(task_id.Binary());
+  task_spec_attempt_1.GetMutableMessage().set_attempt_number(1);
+  task_spec_attempt_1.GetMutableMessage().add_args()->mutable_object_ref()->set_object_id(
+      ObjectID::FromRandom().Binary());
+  EnqueueWithFetch(queue, waiter, 1, -1, MakeTaskToExecute(task_spec_attempt_1));
+
+  // Its dependencies arrive; it must be rejected rather than executed.
+  waiter.Complete(1);
+  auto default_executor = pool_manager->GetDefaultExecutor();
+  default_executor->Join();
+
+  ASSERT_EQ(n_executed.load(), 0);
+  ASSERT_EQ(n_rejected.load(), 1);
 
   queue.Stop();
 }

--- a/src/ray/core_worker/task_execution/tests/actor_task_execution_queue_test.cc
+++ b/src/ray/core_worker/task_execution/tests/actor_task_execution_queue_test.cc
@@ -384,6 +384,80 @@ TEST(OrderedActorTaskExecutionQueueTest, ShutdownCancelsQueuedAndWaitsForRunning
   ASSERT_EQ(n_rejected.load(), 1);
 }
 
+TEST(OrderedActorTaskExecutionQueueTest, CancelTaskIfFoundCancelsRemainingAttempt) {
+  // Two attempts of one task can be pending at the same time (e.g. a retry
+  // submitted before the original attempt's RPC arrived, as in
+  // UnorderedActorTaskExecutionQueueTest.TestSameTaskMultipleAttemptsCancellation).
+  // Cancellation bookkeeping is per attempt, so discarding one attempt must
+  // not hide the other one from CancelTaskIfFound.
+  instrumented_io_context io_service;
+  MockWaiter waiter;
+  MockTaskEventBuffer task_event_buffer;
+  [[maybe_unused]] ray::observability::FakeRayEventRecorder ray_task_event_recorder;
+
+  std::vector<ConcurrencyGroup> concurrency_groups{ConcurrencyGroup{"io", 1, {}}};
+  auto pool_manager =
+      std::make_shared<ConcurrencyGroupManager<BoundedExecutor>>(concurrency_groups);
+
+  std::atomic<int> n_executed(0);
+  std::atomic<int> n_rejected(0);
+  auto execute_task = [&n_executed](TaskToExecute &task) { n_executed++; };
+  auto cancel_task = [&n_rejected](const TaskToExecute &task, const Status &status) {
+    if (status.IsSchedulingCancelled()) {
+      n_rejected.fetch_add(1);
+    }
+  };
+
+  OrderedActorTaskExecutionQueue queue(io_service,
+                                       waiter,
+                                       task_event_buffer,
+                                       ray_task_event_recorder,
+                                       pool_manager,
+                                       1,
+                                       execute_task,
+                                       cancel_task);
+  JobID job_id = JobID::FromInt(1);
+  TaskID task_id = TaskID::FromRandom(job_id);
+
+  // Attempt 0 arrives first (seq 0) and blocks waiting for its dependencies.
+  TaskSpecification task_spec_attempt_0;
+  task_spec_attempt_0.GetMutableMessage().set_type(TaskType::ACTOR_TASK);
+  task_spec_attempt_0.GetMutableMessage().set_task_id(task_id.Binary());
+  task_spec_attempt_0.GetMutableMessage().set_attempt_number(0);
+  task_spec_attempt_0.GetMutableMessage().add_args()->mutable_object_ref()->set_object_id(
+      ObjectID::FromRandom().Binary());
+  EnqueueWithFetch(queue, waiter, 0, -1, MakeTaskToExecute(task_spec_attempt_0));
+
+  // Attempt 1 arrives with a later seq no, and the client has already
+  // processed up to seq 1: attempt 0 is discarded as stale while attempt 1
+  // stays queued. Attempt 1 is a retry (attempt number > 0), so it is held in
+  // the retry queue while its seq no is marked skippable.
+  TaskSpecification task_spec_attempt_1;
+  task_spec_attempt_1.GetMutableMessage().set_type(TaskType::ACTOR_TASK);
+  task_spec_attempt_1.GetMutableMessage().set_task_id(task_id.Binary());
+  task_spec_attempt_1.GetMutableMessage().set_attempt_number(1);
+  task_spec_attempt_1.GetMutableMessage().add_args()->mutable_object_ref()->set_object_id(
+      ObjectID::FromRandom().Binary());
+  EnqueueWithFetch(queue, waiter, 2, 1, MakeTaskToExecute(task_spec_attempt_1));
+
+  // ray.cancel must still find the queued attempt.
+  ASSERT_TRUE(queue.CancelTaskIfFound(task_id));
+
+  // Attempt 1's dependencies arrive; it must be rejected as canceled, not run.
+  waiter.Complete(1);
+  auto default_executor = pool_manager->GetDefaultExecutor();
+  default_executor->Join();
+
+  ASSERT_EQ(n_executed.load(), 0);
+  ASSERT_EQ(n_rejected.load(), 1);
+  {
+    absl::MutexLock lock(&queue.mu_);
+    ASSERT_TRUE(queue.pending_task_attempt_to_is_canceled.empty());
+  }
+
+  queue.Stop();
+}
+
 TEST(OrderedActorTaskExecutionQueueTest, TestWaitForObjects) {
   ObjectID obj = ObjectID::FromRandom();
   instrumented_io_context io_service;


### PR DESCRIPTION
## Description

The ordered actor queue kept one cancellation entry per task id, but two attempts of one task can be queued at once: it has a separate retry channel, and the ordering protocol lets a retry arrive with a later sequence number while the original attempt is still waiting for its dependencies. The second attempt's `emplace` was a no-op, so both shared one entry, and whichever left the queue first erased it. After that `CancelTaskIfFound` answered that the task was absent, `CancelActorTaskOnExecutor` skipped straight to `on_canceled(false, false)`, and the remaining attempt ran with no flag to check.

The map is now keyed by `TaskAttempt`. `CancelTaskIfFound` still takes a `TaskID`, because that is what the cancel RPC carries, and marks every attempt of that task, which is what the old shared entry did by construction. The unordered queue already tracks attempts of one task id explicitly, so this brings the two queues in line.

One thing the shared entry gave for free was worth keeping: an attempt arriving after the cancel inherited the mark, since `emplace` left the existing `true` in place. A per-attempt entry would have started at `false` and executed, so `EnqueueTask` now seeds the new entry from any pending attempt of the same task that is already marked. The map is `task id -> attempt number -> is_canceled`, which keeps both that seeding and cancelling every attempt of a task O(1) on a queue that can hold thousands of pending attempts. A task's entry is dropped once none of its attempts is pending, so an entry that exists always holds at least one attempt.

## Related issues

Fixes #66020

Not a duplicate: searches for `CancelTaskIfFound` and `actor task cancellation attempt` turn up no open PR on this path, and no open issue describes it. #63765 also erases from this map, but it is marked DO NOT MERGE and has not moved since 2026-07-08; if it revives, the two changes overlap textually at those erase sites.

## Additional information

The first new test builds the state the way the protocol does, with attempt 0 queued behind a dependency and attempt 1 arriving as a retry that discards attempt 0 as stale, then asserts that cancellation still finds the queued attempt and that it is rejected instead of executed. On master the first assertion fails with `Actual: false`. The second test covers the inheritance: a retry arriving after the cancel must still be rejected, which fails if the seeding is dropped and passes on master, where the shared entry provided it.

This touches the same file as #65928, in a different function, with no textual overlap.

```
bazel test --dynamic_mode=off \
  --copt=-Wno-error=deprecated-builtins \
  --host_copt=-Wno-error=deprecated-builtins \
  //src/ray/core_worker/task_execution/tests:all
```

```
//src/ray/core_worker/task_execution/tests:actor_task_execution_queue_test PASSED in 3.7s
//src/ray/core_worker/task_execution/tests:concurrency_group_manager_test PASSED in 0.5s
//src/ray/core_worker/task_execution/tests:fiber_state_test              PASSED in 1.5s
//src/ray/core_worker/task_execution/tests:normal_task_execution_queue_test PASSED in 0.5s
//src/ray/core_worker/task_execution/tests:task_receiver_test            PASSED in 1.6s
//src/ray/core_worker/task_execution/tests:thread_pool_test              PASSED in 0.6s

Executed 6 out of 6 tests: 6 tests pass.
```

`actor_task_execution_queue_test` is 16 tests, 14 of them pre-existing and unchanged. macOS 26.5 / arm64, Apple clang 21; the two extra flags work around a deprecated builtin in the pinned absl on that toolchain, not this change. `pre-commit run clang-format` and `pre-commit run cpplint` pass on all three files.

## AI assistance

AI assistance was used for this change and for reviewing it. I have read every changed line and run the commands above locally.
