### PR TITLE
[Data] Fix zero-scale decimals in ClickHouse schemas

### DIFF
--- a/python/ray/data/_internal/datasource/clickhouse_datasink.py
+++ b/python/ray/data/_internal/datasource/clickhouse_datasink.py
@@ -24,9 +24,6 @@ from ray.util.annotations import DeveloperAPI, PublicAPI
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_DECIMAL_PRECISION = 38
-DEFAULT_DECIMAL_SCALE = 10
-
 
 def _pick_best_arrow_field_for_order_by(schema: pyarrow.Schema) -> str:
     if len(schema) == 0:
@@ -47,9 +44,7 @@ def _arrow_to_clickhouse_type(field: pyarrow.Field) -> str:
     """Convert a PyArrow field to an appropriate ClickHouse column type."""
     t = field.type
     if pat.is_decimal(t):
-        precision = t.precision or DEFAULT_DECIMAL_PRECISION
-        scale = t.scale or DEFAULT_DECIMAL_SCALE
-        return f"Decimal({precision}, {scale})"
+        return f"Decimal({t.precision}, {t.scale})"
     if pat.is_boolean(t):
         return "UInt8"
     if pat.is_int8(t):

--- a/python/ray/data/tests/datasource/test_clickhouse.py
+++ b/python/ray/data/tests/datasource/test_clickhouse.py
@@ -653,6 +653,13 @@ class TestClickHouseDatasink:
             for clause in expected_clauses:
                 assert clause in create_sql
 
+    def test_generate_create_table_sql_preserves_zero_decimal_scale(self, datasink):
+        schema = pa.schema([("amount", pa.decimal128(9, 0))])
+
+        create_sql = datasink._generate_create_table_sql(schema)
+
+        assert "`amount` Decimal(9, 0)" in create_sql
+
     @pytest.mark.parametrize(
         "provided_schema,block_fields,expected_create_columns",
         [


### PR DESCRIPTION
## Description

I fixed ClickHouse schema generation treating a valid Arrow decimal scale of zero as missing. `decimal128(9, 0)` became `Decimal(9, 10)`, which ClickHouse rejects because the scale exceeds the precision.

I now use Arrow's declared precision and scale directly and added a scale-zero regression test.

## Related issues

I searched open issues and PRs for ClickHouse decimal and scale handling and found no existing fix. The related schema fix in #63582 handles column ordering, not decimal conversion.

## Tests

- `python -m pytest python/ray/data/tests/datasource/test_clickhouse.py -q`: 83 passed.
- I ran the generated DDL against ClickHouse 26.7.2.1 through chDB. The original DDL was rejected; the fixed DDL created `Decimal(9, 0)` and correctly stored `-123456789` and `123456789`.
- `pre-commit run --all-files`: passed.

I used OpenAI Codex for AI assistance; this has been manually reviewed. I reviewed every changed line, understand the change, and personally ran the tests and end-to-end check above.
