### PR TITLE
[RLlib] Skip updates if some learners don't have batches, prevent deadlocks

### DIFF
--- a/rllib/BUILD.bazel
+++ b/rllib/BUILD.bazel
@@ -2502,6 +2502,20 @@ py_test(
     deps = [":conftest"],
 )
 
+py_test(
+    name = "test_learner_group_update_plan",
+    size = "medium",
+    srcs = ["core/learner/tests/test_learner_group.py"],
+    args = ["TestLearnerGroupUpdatePlan"],
+    main = "core/learner/tests/test_learner_group.py",
+    tags = [
+        "core",
+        "exclusive",
+        "team:rllib",
+    ],
+    deps = [":conftest"],
+)
+
 # Learner
 py_test(
     name = "test_learner",

--- a/rllib/algorithms/algorithm_config.py
+++ b/rllib/algorithms/algorithm_config.py
@@ -379,6 +379,7 @@ class AlgorithmConfig(_Config):
         #  3 first, then with unlimited, and if both show the same behavior on
         #  an async algo, remove this restriction entirely.
         self.max_requests_in_flight_per_learner = 3
+        self.never_skip_update = False
 
         # `self.training()`
         self.gamma = 0.99
@@ -2305,6 +2306,7 @@ class AlgorithmConfig(_Config):
         max_requests_in_flight_per_aggregator_actor: Optional[float] = NotProvided,
         local_gpu_idx: Optional[int] = NotProvided,
         max_requests_in_flight_per_learner: Optional[int] = NotProvided,
+        never_skip_update: Optional[bool] = NotProvided,
         learner_class: Optional[Type["Learner"]] = NotProvided,
         learner_connector: Optional[
             Callable[
@@ -2363,6 +2365,18 @@ class AlgorithmConfig(_Config):
                 updates a policy has undergone on the Learner vs the EnvRunners.
                 See the `ray.rllib.utils.actor_manager.FaultTolerantActorManager` class
                 for more details.
+            never_skip_update: By default (False), a Learner skips an `update()` call
+                whose train batch is empty (no timesteps for any module; e.g. all
+                sampled episodes were lost to EnvRunner or node failures), and with
+                `num_learners > 1` all Learners first agree on that via one small
+                collective per `update()`, so that they skip together and stay in
+                sync. The same collective also makes all Learners step through the
+                same number of minibatches when `minibatch_size` is set, even if
+                their shards differ in size. Set to True to turn this off: no skip
+                logic, no per-update collective, and an empty train batch raises an
+                error instead. Only for setups that guarantee non-empty and equally
+                sized batches on every Learner and want to save the (small)
+                per-update overhead.
             learner_class: The `Learner` class to use for (distributed) updating of the
                 RLModule.
             learner_connector: A callable taking an env observation space and an env
@@ -2418,6 +2432,8 @@ class AlgorithmConfig(_Config):
             self.local_gpu_idx = local_gpu_idx
         if max_requests_in_flight_per_learner is not NotProvided:
             self.max_requests_in_flight_per_learner = max_requests_in_flight_per_learner
+        if never_skip_update is not NotProvided:
+            self.never_skip_update = never_skip_update
         if learner_class is not NotProvided:
             self._learner_class = learner_class
         if learner_connector is not NotProvided:

--- a/rllib/core/learner/differentiable_learner.py
+++ b/rllib/core/learner/differentiable_learner.py
@@ -31,6 +31,7 @@ from ray.rllib.utils.checkpoints import Checkpointable
 from ray.rllib.utils.metrics import (
     DATASET_NUM_ITERS_TRAINED,
     DATASET_NUM_ITERS_TRAINED_LIFETIME,
+    LEARNER_UPDATE_SKIPPED_EMPTY_BATCH_LIFETIME,
     MODULE_TRAIN_BATCH_SIZE_MEAN,
     NUM_ENV_STEPS_TRAINED,
     NUM_ENV_STEPS_TRAINED_LIFETIME,
@@ -52,6 +53,7 @@ from ray.rllib.utils.typing import (
     StateDict,
     TensorType,
 )
+from ray.util.debug import log_once
 
 if TYPE_CHECKING:
     from ray.rllib.algorithms.algorithm_config import AlgorithmConfig
@@ -334,6 +336,14 @@ class DifferentiableLearner(Checkpointable):
             shuffle_batch_per_epoch=self.learner_config.shuffle_batch_per_epoch,
         )
 
+        # `None` means: skip this update. `_create_iterator_if_necessary` has already
+        # warned and counted it; the parameters are returned unchanged and there is no
+        # loss to report.
+        if batch_iter is None:
+            if not _no_metrics_reduce:
+                return params, {}, self.metrics.reduce()
+            return params, {}, {}
+
         # Perform the actual looping through the minibatches or the given data iterator.
         for iteration, tensor_minibatch in enumerate(batch_iter):
             # Check the MultiAgentBatch, whether our RLModule contains all ModuleIDs
@@ -407,7 +417,7 @@ class DifferentiableLearner(Checkpointable):
         minibatch_size: Optional[int] = None,
         shuffle_batch_per_epoch: bool = False,
         **kwargs,
-    ) -> Iterable:
+    ) -> Optional[Iterable]:
         """Provides a batch iterator."""
 
         # Data iterator provided.
@@ -458,8 +468,27 @@ class DifferentiableLearner(Checkpointable):
             for module_id in list(batch.policy_batches.keys()):
                 if not self.should_module_be_updated(module_id, batch):
                     del batch.policy_batches[module_id]
+            # Deliberately NOT `Learner`'s `_should_skip_update` + group sync: this runs
+            # inside the meta-learner's inner loop on every rank and computes gradients
+            # with `torch.autograd.grad`, which never engages DDP's all-reduce, so a
+            # lone skip is lockstep-safe and a collective here would only add a sync
+            # point per inner step.
             if not batch.policy_batches:
-                return {}
+                if log_once("differentiable_learner_empty_train_batch"):
+                    logger.warning(
+                        "The train batch of this DifferentiableLearner is empty (no "
+                        "timesteps for any module). This can happen if sampled episodes "
+                        "are lost (e.g., due to EnvRunner or node failures) or if "
+                        "`policies_to_train` excludes all modules. Skipping this inner "
+                        "update: no gradients are computed and the parameters are passed "
+                        "through unchanged."
+                    )
+                self.metrics.log_value(
+                    (ALL_MODULES, LEARNER_UPDATE_SKIPPED_EMPTY_BATCH_LIFETIME),
+                    1,
+                    reduce="lifetime_sum",
+                )
+                return None
 
             batch = self._set_slicing_by_batch_id(batch, value=True)
 

--- a/rllib/core/learner/differentiable_learner.py
+++ b/rllib/core/learner/differentiable_learner.py
@@ -336,9 +336,7 @@ class DifferentiableLearner(Checkpointable):
             shuffle_batch_per_epoch=self.learner_config.shuffle_batch_per_epoch,
         )
 
-        # `None` means: skip this update. `_create_iterator_if_necessary` has already
-        # warned and counted it; the parameters are returned unchanged and there is no
-        # loss to report.
+        # `None` means: skip this update.
         if batch_iter is None:
             if not _no_metrics_reduce:
                 return params, {}, self.metrics.reduce()

--- a/rllib/core/learner/learner.py
+++ b/rllib/core/learner/learner.py
@@ -12,6 +12,7 @@ from typing import (
     Hashable,
     Iterable,
     List,
+    NamedTuple,
     Optional,
     Sequence,
     Tuple,
@@ -54,6 +55,9 @@ from ray.rllib.utils.metrics import (
     ALL_MODULES,
     DATASET_NUM_ITERS_TRAINED,
     DATASET_NUM_ITERS_TRAINED_LIFETIME,
+    LEARNER_ENV_STEPS_DROPPED_ON_SKIP_LIFETIME,
+    LEARNER_UPDATE_SKIPPED_EMPTY_BATCH_LIFETIME,
+    LEARNER_UPDATE_SKIPPED_FOR_PEER_LIFETIME,
     MODULE_TRAIN_BATCH_SIZE_MEAN,
     NUM_ENV_STEPS_SAMPLED_LIFETIME,
     NUM_ENV_STEPS_TRAINED,
@@ -87,6 +91,7 @@ from ray.rllib.utils.typing import (
     TensorType,
 )
 from ray.util.annotations import PublicAPI
+from ray.util.debug import log_once
 from ray.util.metrics import Counter, Histogram
 
 if TYPE_CHECKING:
@@ -106,6 +111,23 @@ ENTROPY_KEY = "entropy"
 
 # Additional update keys
 LR_KEY = "learning_rate"
+
+
+class UpdatePlan(NamedTuple):
+    """How one `Learner.update()` call is to be carried out.
+
+    In a multi-Learner group every Learner must follow the same plan: they run one
+    DDP all-reduce per minibatch, so a Learner that skips while the others train, or
+    that steps a different number of times, deadlocks the group. Each Learner
+    proposes a plan from its own train batch, and `Learner._sync_update_plan` makes
+    the plans identical (see there for how they are combined).
+    """
+
+    # Do not train on this batch at all (by default: it holds no module data).
+    skip: bool
+    # Number of minibatches to step through; 0 means "as many as the data yields",
+    # which is only safe when it is the same on every Learner (no minibatching).
+    num_minibatches: int
 
 
 @PublicAPI(stability="alpha")
@@ -1105,7 +1127,20 @@ class Learner(Checkpointable):
             **kwargs,
         )
 
+        # `None` means: skip this update. `_create_iterator_if_necessary` has already
+        # warned and counted it; only the per-update bookkeeping remains.
+        if batch_iter is None:
+            self.after_gradient_based_update(timesteps=timesteps or {})
+            if not _no_metrics_reduce:
+                return self.metrics.reduce()
+            return
+
         # Perform the actual looping through the minibatches or the given data iterator.
+        # Note: `loss_per_module` and `iteration` are initialized upfront so that the
+        # code below the loop is safe even if the iterator (e.g., a data iterator
+        # over an empty dataset) does not yield a single minibatch.
+        loss_per_module = {}
+        iteration = -1
         for iteration, tensor_minibatch in enumerate(batch_iter):
             # Check the MultiAgentBatch, whether our RLModule contains all ModuleIDs
             # found in this batch. If not, throw an error.
@@ -1178,7 +1213,20 @@ class Learner(Checkpointable):
         minibatch_size: Optional[int] = None,
         shuffle_batch_per_epoch: bool = False,
         **kwargs,
-    ) -> Iterable:
+    ) -> Optional[Iterable]:
+        """Returns the minibatch iterator for `training_data`, or None to skip.
+
+        None means this `update()` call must be skipped: `_should_skip_update` said
+        so for this Learner's batch (by default: it has no module data, e.g. all
+        sampled episodes were lost or `policies_to_train` excludes every module),
+        or -- in a multi-Learner group -- for another Learner's. Overrides of
+        `update()` must check for None and return early; see the base `update()`
+        for the bookkeeping to do in that case.
+
+        In a multi-Learner group the returned iterator also yields the same number
+        of minibatches on every Learner (see `_sync_update_plan`), even if the
+        Learners' shards differ in size.
+        """
         # Data iterator provided.
         if training_data.data_iterators:
             num_iters = kwargs.pop("num_iters", None)
@@ -1208,10 +1256,91 @@ class Learner(Checkpointable):
             for module_id in list(batch.policy_batches.keys()):
                 if not self.should_module_be_updated(module_id, batch):
                     del batch.policy_batches[module_id]
-            if not batch.policy_batches:
-                return {}
-
+            # Sequence batches are sliced (and thus counted) in the sequence dimension
+            # by `MiniBatchCyclicIterator`; decide that before counting minibatches.
             batch = self._set_slicing_by_batch_id(batch, value=True)
+
+            if self.config.never_skip_update:
+                # Opt-out: no skip logic and no cross-Learner reconciliation (saves one
+                # collective per `update()` in multi-Learner setups). The user
+                # promises well-formed batches; hold them to it rather than crashing
+                # deep in the update loop or -- worse -- deadlocking the group.
+                if not batch.policy_batches:
+                    raise ValueError(
+                        "Received an empty train batch (no timesteps for any module) "
+                        "while `never_skip_update=True`. Either ensure every Learner "
+                        "always receives data (e.g. apply backpressure so Learners are "
+                        "never starved, and keep sampled episodes from being lost), or "
+                        "unset `never_skip_update` (the default) so that empty batches "
+                        "make all Learners skip the update together."
+                    )
+            else:
+                wants_to_skip = self._should_skip_update(batch)
+                # With several Learners, shards may hold different amounts of data, and
+                # the number of minibatches `MiniBatchCyclicIterator` derives from a
+                # shard would then differ per Learner -- a DDP desync just like a lone
+                # skip. Unless the caller fixed `num_total_minibatches`, each Learner
+                # proposes its own count and the group settles on one. (Without
+                # `minibatch_size` the count is `num_epochs` or 1 on every Learner.)
+                if (
+                    not num_total_minibatches
+                    and self.config.num_learners > 1
+                    and minibatch_size
+                ):
+                    num_total_minibatches = MiniBatchCyclicIterator.num_minibatches(
+                        batch, minibatch_size=minibatch_size, num_epochs=num_epochs
+                    )
+                # Make the group follow one plan: all Learners skip together (a
+                # Learner that skips alone drops out of the collective sequence and
+                # deadlocks the others) and step the same number of times.
+                plan = self._sync_update_plan(
+                    UpdatePlan(
+                        skip=wants_to_skip, num_minibatches=num_total_minibatches
+                    )
+                )
+                num_total_minibatches = plan.num_minibatches
+                if plan.skip:
+                    if log_once(
+                        "learner_skip_update"
+                        if wants_to_skip
+                        else "learner_skip_update_peer"
+                    ):
+                        logger.warning(
+                            "Skipping this update: `_should_skip_update` returned True "
+                            "for this Learner's train batch. By default this means the "
+                            "batch is empty (no timesteps for any module), e.g. because "
+                            "sampled episodes were lost (EnvRunner or node failures) or "
+                            "`policies_to_train` excludes all modules. In a "
+                            "multi-Learner setup all Learners skip together to stay in "
+                            "sync. Note that this is a symptom of a suboptimal setup: "
+                            "Ideally, you sample exactly the amount of data your "
+                            "Learners consume or - in an asynchronous setup - apply "
+                            "backpressure such that Learners are never starved."
+                            if wants_to_skip
+                            else "Skipping this update: another Learner in the group "
+                            "wants to skip (by default because its train batch is "
+                            "empty) and all Learners must take the same update steps to "
+                            "stay in sync. This Learner's own train batch is dropped."
+                        )
+                    # Diagnostics, summed across Learners when aggregated: how many
+                    # shards were actually empty vs. how many good shards were thrown
+                    # away to stay in sync -- and how much data that was.
+                    self.metrics.log_value(
+                        (
+                            ALL_MODULES,
+                            LEARNER_UPDATE_SKIPPED_EMPTY_BATCH_LIFETIME
+                            if wants_to_skip
+                            else LEARNER_UPDATE_SKIPPED_FOR_PEER_LIFETIME,
+                        ),
+                        1,
+                        reduce="lifetime_sum",
+                    )
+                    self.metrics.log_value(
+                        (ALL_MODULES, LEARNER_ENV_STEPS_DROPPED_ON_SKIP_LIFETIME),
+                        batch.env_steps(),
+                        reduce="lifetime_sum",
+                    )
+                    return None
 
             if minibatch_size:
                 batch_iter_cls = MiniBatchCyclicIterator
@@ -1233,6 +1362,53 @@ class Learner(Checkpointable):
                 num_total_minibatches=num_total_minibatches,
             )
         return batch_iter
+
+    @OverrideToImplementCustomLogic
+    def _should_skip_update(self, batch: MultiAgentBatch) -> bool:
+        """Returns whether this Learner wants to skip the current `update()` call.
+
+        Called once per `update()` with the train batch (after modules not in
+        `policies_to_train` have been removed). By default an update is skipped when
+        the batch holds no data for any module, which happens e.g. when all sampled
+        episodes were lost to EnvRunner or node failures.
+
+        Override to add conditions, based on any information available on this
+        Learner -- it need not be consistent across Learners. In a multi-Learner
+        setup RLlib reconciles the answers of all Learners so that they either all
+        skip or all train; a Learner never skips on its own (it would drop out of
+        the group's collective communication and deadlock the others). Do not skip
+        by other means (e.g. returning early from `update()`), for the same reason.
+        Not called if `config.never_skip_update` is set; an empty batch is an error
+        then.
+
+        Args:
+            batch: The train batch of this `update()` call.
+
+        Returns:
+            True to skip this update.
+        """
+        return not batch.policy_batches
+
+    def _sync_update_plan(self, plan: UpdatePlan) -> UpdatePlan:
+        """Makes this update's plan identical on every Learner of the group.
+
+        Framework plumbing, not an extension point: framework-specific Learners
+        (e.g. `TorchLearner`) implement it, everyone else overrides
+        `_should_skip_update`. Called exactly once per `update()`, on every Learner,
+        right after `_should_skip_update`; in multi-Learner setups it is a collective
+        operation and must stay one.
+
+        The plans are combined as follows: the group skips if ANY Learner wants to;
+        the number of minibatches is the average of the Learners' proposals.
+
+        Args:
+            plan: This Learner's own proposal, derived from its own train batch.
+
+        Returns:
+            The group's plan. The base implementation, for setups without
+            cross-Learner synchronization, returns `plan` unchanged.
+        """
+        return plan
 
     @OverrideToImplementCustomLogic
     @abc.abstractmethod

--- a/rllib/core/learner/learner_group.py
+++ b/rllib/core/learner/learner_group.py
@@ -379,14 +379,12 @@ class LearnerGroup(Checkpointable):
                     # If `return_state=True`, only return it from the first Learner
                     # actor.
                     return_state=(return_state and i == 0),
-                    **kw,
                     **kwargs,
                 )
-                for i, (td_shard, kw) in enumerate(
+                for i, td_shard in enumerate(
                     training_data.shard(
                         num_shards=len(self),
                         len_lookback_buffer=self.config.episode_lookback_horizon,
-                        **kwargs,
                     )
                 )
             ]

--- a/rllib/core/learner/tests/test_learner.py
+++ b/rllib/core/learner/tests/test_learner.py
@@ -336,13 +336,7 @@ class TestLearner(unittest.TestCase):
             )
 
     def test_update_empty_batch_is_skipped(self):
-        """Tests that `update()` skips the gradient step for an empty train batch.
-
-        An empty batch -- e.g. all sampled episodes lost to EnvRunner or node
-        failures, or `policies_to_train` excluding every module -- used to crash
-        `update()` with an `UnboundLocalError` on `loss_per_module`, because the
-        minibatch loop ran zero times.
-        """
+        """Tests that `update()` skips the gradient step for an empty train batch."""
         learner = BaseTestingAlgorithmConfig().build_learner(env=self.ENV)
         timesteps = {NUM_ENV_STEPS_SAMPLED_LIFETIME: 0}
 
@@ -353,10 +347,9 @@ class TestLearner(unittest.TestCase):
                 0, results.get(LEARNER_UPDATE_SKIPPED_FOR_PEER_LIFETIME, 0)
             )
             self.assertEqual(0, results[LEARNER_ENV_STEPS_DROPPED_ON_SKIP_LIFETIME])
+            self.assertTrue(learner.TOTAL_LOSS_KEY not in results[DEFAULT_MODULE_ID])
 
-        # Both ways an empty batch reaches `update()`. The Learner's metrics logger is
-        # non-root, so each `lifetime_sum` reduce returns the delta since the last one:
-        # 1 both times, not a running total of 2.
+        # Both ways an empty batch reaches `update()`.
         check_skipped(
             learner.update(
                 batch=MultiAgentBatch(policy_batches={}, env_steps=0),
@@ -375,28 +368,19 @@ class TestLearner(unittest.TestCase):
         """`_should_skip_update` defaults to "no module data"; without DDP
         (`num_learners <= 1`) the group sync has nobody to agree with and must pass
         the decision through unchanged, without communicating.
-
-        (`num_learners > 1` without a process group is not constructible: `build()`
-        wraps the module in DDP, which itself requires the group. That branch of the
-        guard is defensive only.)
         """
-        for num_learners in (0, 1):
-            config = BaseTestingAlgorithmConfig().learners(num_learners=num_learners)
-            learner = config.build_learner(env=self.ENV)
-            self.assertTrue(
-                learner._should_skip_update(
-                    MultiAgentBatch(policy_batches={}, env_steps=0)
-                )
-            )
-            reader = get_cartpole_dataset_reader(batch_size=64)
-            self.assertFalse(
-                learner._should_skip_update(reader.next().as_multi_agent())
-            )
-            for plan in (
-                UpdatePlan(skip=False, num_minibatches=0),
-                UpdatePlan(skip=True, num_minibatches=7),
-            ):
-                self.assertEqual(plan, learner._sync_update_plan(plan))
+        config = BaseTestingAlgorithmConfig().learners(num_learners=0)
+        learner = config.build_learner(env=self.ENV)
+        self.assertTrue(
+            learner._should_skip_update(MultiAgentBatch(policy_batches={}, env_steps=0))
+        )
+        reader = get_cartpole_dataset_reader(batch_size=64)
+        self.assertFalse(learner._should_skip_update(reader.next().as_multi_agent()))
+        for plan in (
+            UpdatePlan(skip=False, num_minibatches=0),
+            UpdatePlan(skip=True, num_minibatches=7),
+        ):
+            self.assertEqual(plan, learner._sync_update_plan(plan))
 
     def test_never_skip_update(self):
         """`never_skip_update=True` opts out of the skip logic entirely: no
@@ -414,8 +398,7 @@ class TestLearner(unittest.TestCase):
             # A real batch trains as usual, still without consulting the hook.
             reader = get_cartpole_dataset_reader(batch_size=512)
             batch = learner._convert_batch_type(reader.next().as_multi_agent())
-            results = learner.update(batch=batch)
-            self.assertTrue(learner.TOTAL_LOSS_KEY in results[DEFAULT_MODULE_ID])
+            learner.update(batch=batch)
             hook.assert_not_called()
 
 

--- a/rllib/core/learner/tests/test_learner.py
+++ b/rllib/core/learner/tests/test_learner.py
@@ -23,7 +23,6 @@ from ray.rllib.utils.metrics import (
     NUM_MODULE_STEPS_TRAINED_LIFETIME,
     WEIGHTS_SEQ_NO,
 )
-from ray.rllib.utils.minibatch_utils import MiniBatchCyclicIterator
 from ray.rllib.utils.numpy import convert_to_numpy
 from ray.rllib.utils.test_utils import check, get_cartpole_dataset_reader
 
@@ -339,57 +338,39 @@ class TestLearner(unittest.TestCase):
     def test_update_empty_batch_is_skipped(self):
         """Tests that `update()` skips the gradient step for an empty train batch.
 
-        An empty batch (e.g. all sampled episodes lost to EnvRunner/node failures
-        during aggregation, or `policies_to_train` excluding every module) used to
-        crash `update()` with an `UnboundLocalError` on `loss_per_module`, because
-        the minibatch loop ran zero times. It must now be skipped gracefully,
-        counted via `LEARNER_UPDATE_SKIPPED_EMPTY_BATCH_LIFETIME` (no data dropped),
-        and leave the learner able to process a real batch afterwards.
+        An empty batch -- e.g. all sampled episodes lost to EnvRunner or node
+        failures, or `policies_to_train` excluding every module -- used to crash
+        `update()` with an `UnboundLocalError` on `loss_per_module`, because the
+        minibatch loop ran zero times.
         """
-        config = BaseTestingAlgorithmConfig()
-        learner = config.build_learner(env=self.ENV)
-
+        learner = BaseTestingAlgorithmConfig().build_learner(env=self.ENV)
         timesteps = {NUM_ENV_STEPS_SAMPLED_LIFETIME: 0}
 
-        # 1) Explicit empty `MultiAgentBatch` (no timesteps for any module).
-        results = learner.update(
-            batch=MultiAgentBatch(policy_batches={}, env_steps=0), timesteps=timesteps
-        )
-        self.assertEqual(
-            1, results[ALL_MODULES][LEARNER_UPDATE_SKIPPED_EMPTY_BATCH_LIFETIME]
-        )
-        self.assertEqual(
-            0, results[ALL_MODULES].get(LEARNER_UPDATE_SKIPPED_FOR_PEER_LIFETIME, 0)
-        )
-        self.assertEqual(
-            0, results[ALL_MODULES][LEARNER_ENV_STEPS_DROPPED_ON_SKIP_LIFETIME]
-        )
+        def check_skipped(results):
+            results = results[ALL_MODULES]
+            self.assertEqual(1, results[LEARNER_UPDATE_SKIPPED_EMPTY_BATCH_LIFETIME])
+            self.assertEqual(
+                0, results.get(LEARNER_UPDATE_SKIPPED_FOR_PEER_LIFETIME, 0)
+            )
+            self.assertEqual(0, results[LEARNER_ENV_STEPS_DROPPED_ON_SKIP_LIFETIME])
 
-        # 2) Empty episode list -- the AggregatorActor "all episodes lost" path.
-        # The learner's metrics logger is non-root, so a `lifetime_sum` reduce
-        # returns the delta since the last reduce (and resets); the value is 1
-        # again, not a running total of 2.
-        results = learner.update(episodes=[], timesteps=timesteps)
-        self.assertEqual(
-            1, results[ALL_MODULES][LEARNER_UPDATE_SKIPPED_EMPTY_BATCH_LIFETIME]
+        # Both ways an empty batch reaches `update()`. The Learner's metrics logger is
+        # non-root, so each `lifetime_sum` reduce returns the delta since the last one:
+        # 1 both times, not a running total of 2.
+        check_skipped(
+            learner.update(
+                batch=MultiAgentBatch(policy_batches={}, env_steps=0),
+                timesteps=timesteps,
+            )
         )
-        self.assertEqual(
-            0, results[ALL_MODULES].get(LEARNER_UPDATE_SKIPPED_FOR_PEER_LIFETIME, 0)
-        )
-        self.assertEqual(
-            0, results[ALL_MODULES][LEARNER_ENV_STEPS_DROPPED_ON_SKIP_LIFETIME]
-        )
+        check_skipped(learner.update(episodes=[], timesteps=timesteps))
 
-        # 3) A real batch update after the skips must still train.
+        # A real batch after the skips must still train.
         reader = get_cartpole_dataset_reader(batch_size=512)
         batch = learner._convert_batch_type(reader.next().as_multi_agent())
         results = learner.update(batch=batch)
         self.assertTrue(learner.TOTAL_LOSS_KEY in results[DEFAULT_MODULE_ID])
 
-    @unittest.skipIf(
-        try_import_torch()[1] is None,
-        "torch not available",
-    )
     def test_should_skip_update_single_learner(self):
         """`_should_skip_update` defaults to "no module data"; without DDP
         (`num_learners <= 1`) the group sync has nobody to agree with and must pass
@@ -416,183 +397,6 @@ class TestLearner(unittest.TestCase):
                 UpdatePlan(skip=True, num_minibatches=7),
             ):
                 self.assertEqual(plan, learner._sync_update_plan(plan))
-
-    @unittest.skipIf(
-        try_import_torch()[1] is None,
-        "torch not available",
-    )
-    def test_update_empty_batch_multi_learner_skips_in_lockstep(self):
-        """Tests that a multi-Learner (`num_learners > 1`) group skips together.
-
-        Every Learner in a DDP group must take the same number of update steps, or
-        the all-reduces mismatch and the group deadlocks. So each Learner's
-        `_should_skip_update` verdict is reconciled group-wide (one all-reduce in
-        `_sync_update_plan`) and ALL of them skip the update --
-        including those that did receive data.
-
-        This runs on a single-process gloo group. Case 2 exercises the real
-        all-reduce (with itself); case 3 simulates a peer's "I am empty" vote by
-        patching the all-reduce result, which is the lockstep property proper. The
-        multi-rank behaviour (no hang, identical weights) requires a multi-GPU NCCL
-        setup and is validated separately.
-        """
-        import socket
-        from unittest import mock
-
-        import torch.distributed as dist
-
-        def _free_port():
-            with socket.socket() as s:
-                s.bind(("", 0))
-                return s.getsockname()[1]
-
-        dist.init_process_group(
-            backend="gloo",
-            init_method=f"tcp://127.0.0.1:{_free_port()}",
-            world_size=1,
-            rank=0,
-        )
-        try:
-            config = BaseTestingAlgorithmConfig().learners(num_learners=2)
-            learner = config.build_learner(env=self.ENV)
-            reader = get_cartpole_dataset_reader(batch_size=512)
-            timesteps = {NUM_ENV_STEPS_SAMPLED_LIFETIME: 0}
-
-            def _weights():
-                return {
-                    mid: [p.detach().clone() for p in learner.module[mid].parameters()]
-                    for mid in learner.module.keys()
-                }
-
-            def _changed(before):
-                return any(
-                    not torch.equal(b, a)
-                    for mid in before
-                    for b, a in zip(before[mid], learner.module[mid].parameters())
-                )
-
-            # 1) A real batch trains.
-            before = _weights()
-            learner.update(
-                batch=learner._convert_batch_type(reader.next().as_multi_agent())
-            )
-            self.assertTrue(_changed(before))
-
-            # 2) Own batch empty -> agreed (with itself) -> skipped: metric logged,
-            #    no optimizer step, weights untouched.
-            before = _weights()
-            results = learner.update(
-                batch=MultiAgentBatch(policy_batches={}, env_steps=0),
-                timesteps=timesteps,
-            )
-            self.assertEqual(
-                1, results[ALL_MODULES][LEARNER_UPDATE_SKIPPED_EMPTY_BATCH_LIFETIME]
-            )
-            self.assertEqual(
-                0,
-                results[ALL_MODULES].get(LEARNER_UPDATE_SKIPPED_FOR_PEER_LIFETIME, 0),
-            )
-            self.assertFalse(_changed(before))
-
-            # 3) Own batch fine, but a PEER votes empty (the all-reduce returns 1).
-            #    This Learner must skip as well, or it would step alone.
-            batch = learner._convert_batch_type(reader.next().as_multi_agent())
-            before = _weights()
-            with mock.patch.object(
-                dist, "all_reduce", side_effect=lambda t, *a, **kw: t.fill_(1)
-            ):
-                results = learner.update(batch=batch, timesteps=timesteps)
-            # Skipped for a peer, and this Learner's good data was the price.
-            self.assertEqual(
-                1, results[ALL_MODULES][LEARNER_UPDATE_SKIPPED_FOR_PEER_LIFETIME]
-            )
-            self.assertEqual(
-                0,
-                results[ALL_MODULES].get(
-                    LEARNER_UPDATE_SKIPPED_EMPTY_BATCH_LIFETIME, 0
-                ),
-            )
-            self.assertEqual(
-                batch.env_steps(),
-                results[ALL_MODULES][LEARNER_ENV_STEPS_DROPPED_ON_SKIP_LIFETIME],
-            )
-            self.assertFalse(_changed(before))
-
-            # 4) Back to normal: a real batch trains again.
-            before = _weights()
-            results = learner.update(
-                batch=learner._convert_batch_type(reader.next().as_multi_agent())
-            )
-            self.assertTrue(learner.TOTAL_LOSS_KEY in results[DEFAULT_MODULE_ID])
-            self.assertTrue(_changed(before))
-        finally:
-            try:
-                dist.destroy_process_group()
-            except Exception:
-                pass
-
-    @unittest.skipIf(
-        try_import_torch()[1] is None,
-        "torch not available",
-    )
-    def test_update_minibatch_count_is_reconciled(self):
-        """In a multi-Learner group every Learner must step through the number of
-        minibatches the group settled on, not the one its own shard implies."""
-        import socket
-        from unittest import mock
-
-        import torch.distributed as dist
-
-        def _free_port():
-            with socket.socket() as s:
-                s.bind(("", 0))
-                return s.getsockname()[1]
-
-        dist.init_process_group(
-            backend="gloo",
-            init_method=f"tcp://127.0.0.1:{_free_port()}",
-            world_size=1,
-            rank=0,
-        )
-        try:
-            config = BaseTestingAlgorithmConfig().learners(num_learners=2)
-            learner = config.build_learner(env=self.ENV)
-            reader = get_cartpole_dataset_reader(batch_size=512)
-            batch = learner._convert_batch_type(reader.next().as_multi_agent())
-
-            def num_steps(**update_kwargs):
-                with mock.patch.object(
-                    learner, "_update", wraps=learner._update
-                ) as upd:
-                    learner.update(batch=batch, **update_kwargs)
-                return upd.call_count
-
-            # Alone in its group (world_size=1): the reconciled count equals this
-            # Learner's own, ceil(rows / 128).
-            own = MiniBatchCyclicIterator.num_minibatches(
-                batch, minibatch_size=128, num_epochs=1
-            )
-            self.assertEqual(-(-batch.count // 128), own)
-            self.assertEqual(own, num_steps(minibatch_size=128, num_epochs=1))
-
-            # A peer with a larger shard: simulate the group settling on 12 by
-            # patching the all-reduce result ([num_skipping, sum_minibatches]).
-            def peer(t, *a, **kw):
-                t[0] = 0
-                t[1] = 12
-
-            with mock.patch.object(dist, "all_reduce", side_effect=peer):
-                self.assertEqual(12, num_steps(minibatch_size=128, num_epochs=1))
-
-            # An explicit caller-provided cap is respected and not overridden.
-            self.assertEqual(
-                3, num_steps(minibatch_size=128, num_epochs=1, num_total_minibatches=3)
-            )
-        finally:
-            try:
-                dist.destroy_process_group()
-            except Exception:
-                pass
 
     def test_never_skip_update(self):
         """`never_skip_update=True` opts out of the skip logic entirely: no

--- a/rllib/core/learner/tests/test_learner.py
+++ b/rllib/core/learner/tests/test_learner.py
@@ -6,19 +6,24 @@ import numpy as np
 
 import ray
 from ray.rllib.core import DEFAULT_MODULE_ID
-from ray.rllib.core.learner.learner import Learner
+from ray.rllib.core.learner.learner import Learner, UpdatePlan
 from ray.rllib.core.testing.testing_learner import BaseTestingAlgorithmConfig
 from ray.rllib.policy.sample_batch import MultiAgentBatch
 from ray.rllib.utils.framework import try_import_torch
 from ray.rllib.utils.metrics import (
     ALL_MODULES,
+    LEARNER_ENV_STEPS_DROPPED_ON_SKIP_LIFETIME,
+    LEARNER_UPDATE_SKIPPED_EMPTY_BATCH_LIFETIME,
+    LEARNER_UPDATE_SKIPPED_FOR_PEER_LIFETIME,
     MODULE_TRAIN_BATCH_SIZE_MEAN,
+    NUM_ENV_STEPS_SAMPLED_LIFETIME,
     NUM_ENV_STEPS_TRAINED,
     NUM_ENV_STEPS_TRAINED_LIFETIME,
     NUM_MODULE_STEPS_TRAINED,
     NUM_MODULE_STEPS_TRAINED_LIFETIME,
     WEIGHTS_SEQ_NO,
 )
+from ray.rllib.utils.minibatch_utils import MiniBatchCyclicIterator
 from ray.rllib.utils.numpy import convert_to_numpy
 from ray.rllib.utils.test_utils import check, get_cartpole_dataset_reader
 
@@ -330,6 +335,284 @@ class TestLearner(unittest.TestCase):
             self.assertEqual(
                 batch1.count + batch2.count, results[ALL_MODULES][NUM_ENV_STEPS_TRAINED]
             )
+
+    def test_update_empty_batch_is_skipped(self):
+        """Tests that `update()` skips the gradient step for an empty train batch.
+
+        An empty batch (e.g. all sampled episodes lost to EnvRunner/node failures
+        during aggregation, or `policies_to_train` excluding every module) used to
+        crash `update()` with an `UnboundLocalError` on `loss_per_module`, because
+        the minibatch loop ran zero times. It must now be skipped gracefully,
+        counted via `LEARNER_UPDATE_SKIPPED_EMPTY_BATCH_LIFETIME` (no data dropped),
+        and leave the learner able to process a real batch afterwards.
+        """
+        config = BaseTestingAlgorithmConfig()
+        learner = config.build_learner(env=self.ENV)
+
+        timesteps = {NUM_ENV_STEPS_SAMPLED_LIFETIME: 0}
+
+        # 1) Explicit empty `MultiAgentBatch` (no timesteps for any module).
+        results = learner.update(
+            batch=MultiAgentBatch(policy_batches={}, env_steps=0), timesteps=timesteps
+        )
+        self.assertEqual(
+            1, results[ALL_MODULES][LEARNER_UPDATE_SKIPPED_EMPTY_BATCH_LIFETIME]
+        )
+        self.assertEqual(
+            0, results[ALL_MODULES].get(LEARNER_UPDATE_SKIPPED_FOR_PEER_LIFETIME, 0)
+        )
+        self.assertEqual(
+            0, results[ALL_MODULES][LEARNER_ENV_STEPS_DROPPED_ON_SKIP_LIFETIME]
+        )
+
+        # 2) Empty episode list -- the AggregatorActor "all episodes lost" path.
+        # The learner's metrics logger is non-root, so a `lifetime_sum` reduce
+        # returns the delta since the last reduce (and resets); the value is 1
+        # again, not a running total of 2.
+        results = learner.update(episodes=[], timesteps=timesteps)
+        self.assertEqual(
+            1, results[ALL_MODULES][LEARNER_UPDATE_SKIPPED_EMPTY_BATCH_LIFETIME]
+        )
+        self.assertEqual(
+            0, results[ALL_MODULES].get(LEARNER_UPDATE_SKIPPED_FOR_PEER_LIFETIME, 0)
+        )
+        self.assertEqual(
+            0, results[ALL_MODULES][LEARNER_ENV_STEPS_DROPPED_ON_SKIP_LIFETIME]
+        )
+
+        # 3) A real batch update after the skips must still train.
+        reader = get_cartpole_dataset_reader(batch_size=512)
+        batch = learner._convert_batch_type(reader.next().as_multi_agent())
+        results = learner.update(batch=batch)
+        self.assertTrue(learner.TOTAL_LOSS_KEY in results[DEFAULT_MODULE_ID])
+
+    @unittest.skipIf(
+        try_import_torch()[1] is None,
+        "torch not available",
+    )
+    def test_should_skip_update_single_learner(self):
+        """`_should_skip_update` defaults to "no module data"; without DDP
+        (`num_learners <= 1`) the group sync has nobody to agree with and must pass
+        the decision through unchanged, without communicating.
+
+        (`num_learners > 1` without a process group is not constructible: `build()`
+        wraps the module in DDP, which itself requires the group. That branch of the
+        guard is defensive only.)
+        """
+        for num_learners in (0, 1):
+            config = BaseTestingAlgorithmConfig().learners(num_learners=num_learners)
+            learner = config.build_learner(env=self.ENV)
+            self.assertTrue(
+                learner._should_skip_update(
+                    MultiAgentBatch(policy_batches={}, env_steps=0)
+                )
+            )
+            reader = get_cartpole_dataset_reader(batch_size=64)
+            self.assertFalse(
+                learner._should_skip_update(reader.next().as_multi_agent())
+            )
+            for plan in (
+                UpdatePlan(skip=False, num_minibatches=0),
+                UpdatePlan(skip=True, num_minibatches=7),
+            ):
+                self.assertEqual(plan, learner._sync_update_plan(plan))
+
+    @unittest.skipIf(
+        try_import_torch()[1] is None,
+        "torch not available",
+    )
+    def test_update_empty_batch_multi_learner_skips_in_lockstep(self):
+        """Tests that a multi-Learner (`num_learners > 1`) group skips together.
+
+        Every Learner in a DDP group must take the same number of update steps, or
+        the all-reduces mismatch and the group deadlocks. So each Learner's
+        `_should_skip_update` verdict is reconciled group-wide (one all-reduce in
+        `_sync_update_plan`) and ALL of them skip the update --
+        including those that did receive data.
+
+        This runs on a single-process gloo group. Case 2 exercises the real
+        all-reduce (with itself); case 3 simulates a peer's "I am empty" vote by
+        patching the all-reduce result, which is the lockstep property proper. The
+        multi-rank behaviour (no hang, identical weights) requires a multi-GPU NCCL
+        setup and is validated separately.
+        """
+        import socket
+        from unittest import mock
+
+        import torch.distributed as dist
+
+        def _free_port():
+            with socket.socket() as s:
+                s.bind(("", 0))
+                return s.getsockname()[1]
+
+        dist.init_process_group(
+            backend="gloo",
+            init_method=f"tcp://127.0.0.1:{_free_port()}",
+            world_size=1,
+            rank=0,
+        )
+        try:
+            config = BaseTestingAlgorithmConfig().learners(num_learners=2)
+            learner = config.build_learner(env=self.ENV)
+            reader = get_cartpole_dataset_reader(batch_size=512)
+            timesteps = {NUM_ENV_STEPS_SAMPLED_LIFETIME: 0}
+
+            def _weights():
+                return {
+                    mid: [p.detach().clone() for p in learner.module[mid].parameters()]
+                    for mid in learner.module.keys()
+                }
+
+            def _changed(before):
+                return any(
+                    not torch.equal(b, a)
+                    for mid in before
+                    for b, a in zip(before[mid], learner.module[mid].parameters())
+                )
+
+            # 1) A real batch trains.
+            before = _weights()
+            learner.update(
+                batch=learner._convert_batch_type(reader.next().as_multi_agent())
+            )
+            self.assertTrue(_changed(before))
+
+            # 2) Own batch empty -> agreed (with itself) -> skipped: metric logged,
+            #    no optimizer step, weights untouched.
+            before = _weights()
+            results = learner.update(
+                batch=MultiAgentBatch(policy_batches={}, env_steps=0),
+                timesteps=timesteps,
+            )
+            self.assertEqual(
+                1, results[ALL_MODULES][LEARNER_UPDATE_SKIPPED_EMPTY_BATCH_LIFETIME]
+            )
+            self.assertEqual(
+                0,
+                results[ALL_MODULES].get(LEARNER_UPDATE_SKIPPED_FOR_PEER_LIFETIME, 0),
+            )
+            self.assertFalse(_changed(before))
+
+            # 3) Own batch fine, but a PEER votes empty (the all-reduce returns 1).
+            #    This Learner must skip as well, or it would step alone.
+            batch = learner._convert_batch_type(reader.next().as_multi_agent())
+            before = _weights()
+            with mock.patch.object(
+                dist, "all_reduce", side_effect=lambda t, *a, **kw: t.fill_(1)
+            ):
+                results = learner.update(batch=batch, timesteps=timesteps)
+            # Skipped for a peer, and this Learner's good data was the price.
+            self.assertEqual(
+                1, results[ALL_MODULES][LEARNER_UPDATE_SKIPPED_FOR_PEER_LIFETIME]
+            )
+            self.assertEqual(
+                0,
+                results[ALL_MODULES].get(
+                    LEARNER_UPDATE_SKIPPED_EMPTY_BATCH_LIFETIME, 0
+                ),
+            )
+            self.assertEqual(
+                batch.env_steps(),
+                results[ALL_MODULES][LEARNER_ENV_STEPS_DROPPED_ON_SKIP_LIFETIME],
+            )
+            self.assertFalse(_changed(before))
+
+            # 4) Back to normal: a real batch trains again.
+            before = _weights()
+            results = learner.update(
+                batch=learner._convert_batch_type(reader.next().as_multi_agent())
+            )
+            self.assertTrue(learner.TOTAL_LOSS_KEY in results[DEFAULT_MODULE_ID])
+            self.assertTrue(_changed(before))
+        finally:
+            try:
+                dist.destroy_process_group()
+            except Exception:
+                pass
+
+    @unittest.skipIf(
+        try_import_torch()[1] is None,
+        "torch not available",
+    )
+    def test_update_minibatch_count_is_reconciled(self):
+        """In a multi-Learner group every Learner must step through the number of
+        minibatches the group settled on, not the one its own shard implies."""
+        import socket
+        from unittest import mock
+
+        import torch.distributed as dist
+
+        def _free_port():
+            with socket.socket() as s:
+                s.bind(("", 0))
+                return s.getsockname()[1]
+
+        dist.init_process_group(
+            backend="gloo",
+            init_method=f"tcp://127.0.0.1:{_free_port()}",
+            world_size=1,
+            rank=0,
+        )
+        try:
+            config = BaseTestingAlgorithmConfig().learners(num_learners=2)
+            learner = config.build_learner(env=self.ENV)
+            reader = get_cartpole_dataset_reader(batch_size=512)
+            batch = learner._convert_batch_type(reader.next().as_multi_agent())
+
+            def num_steps(**update_kwargs):
+                with mock.patch.object(
+                    learner, "_update", wraps=learner._update
+                ) as upd:
+                    learner.update(batch=batch, **update_kwargs)
+                return upd.call_count
+
+            # Alone in its group (world_size=1): the reconciled count equals this
+            # Learner's own, ceil(rows / 128).
+            own = MiniBatchCyclicIterator.num_minibatches(
+                batch, minibatch_size=128, num_epochs=1
+            )
+            self.assertEqual(-(-batch.count // 128), own)
+            self.assertEqual(own, num_steps(minibatch_size=128, num_epochs=1))
+
+            # A peer with a larger shard: simulate the group settling on 12 by
+            # patching the all-reduce result ([num_skipping, sum_minibatches]).
+            def peer(t, *a, **kw):
+                t[0] = 0
+                t[1] = 12
+
+            with mock.patch.object(dist, "all_reduce", side_effect=peer):
+                self.assertEqual(12, num_steps(minibatch_size=128, num_epochs=1))
+
+            # An explicit caller-provided cap is respected and not overridden.
+            self.assertEqual(
+                3, num_steps(minibatch_size=128, num_epochs=1, num_total_minibatches=3)
+            )
+        finally:
+            try:
+                dist.destroy_process_group()
+            except Exception:
+                pass
+
+    def test_never_skip_update(self):
+        """`never_skip_update=True` opts out of the skip logic entirely: no
+        `_should_skip_update` call (and thus no cross-Learner agreement collective),
+        and an empty batch is a hard error instead of a skipped update."""
+        from unittest import mock
+
+        config = BaseTestingAlgorithmConfig().learners(never_skip_update=True)
+        learner = config.build_learner(env=self.ENV)
+        with mock.patch.object(
+            type(learner), "_should_skip_update", autospec=True
+        ) as hook:
+            with self.assertRaisesRegex(ValueError, "never_skip_update"):
+                learner.update(batch=MultiAgentBatch(policy_batches={}, env_steps=0))
+            # A real batch trains as usual, still without consulting the hook.
+            reader = get_cartpole_dataset_reader(batch_size=512)
+            batch = learner._convert_batch_type(reader.next().as_multi_agent())
+            results = learner.update(batch=batch)
+            self.assertTrue(learner.TOTAL_LOSS_KEY in results[DEFAULT_MODULE_ID])
+            hook.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/rllib/core/learner/tests/test_learner_group.py
+++ b/rllib/core/learner/tests/test_learner_group.py
@@ -23,8 +23,17 @@ from ray.rllib.core.testing.torch.bc_module import DiscreteBCTorchModule
 from ray.rllib.env.multi_agent_episode import MultiAgentEpisode
 from ray.rllib.env.single_agent_episode import SingleAgentEpisode
 from ray.rllib.examples.envs.classes.multi_agent import MultiAgentCartPole
-from ray.rllib.utils.metrics import ALL_MODULES, LEARNER_CONNECTOR
+from ray.rllib.policy.sample_batch import MultiAgentBatch, SampleBatch
+from ray.rllib.utils.metrics import (
+    ALL_MODULES,
+    LEARNER_CONNECTOR,
+    LEARNER_ENV_STEPS_DROPPED_ON_SKIP_LIFETIME,
+    LEARNER_UPDATE_SKIPPED_EMPTY_BATCH_LIFETIME,
+    LEARNER_UPDATE_SKIPPED_FOR_PEER_LIFETIME,
+    NUM_MODULE_STEPS_TRAINED,
+)
 from ray.rllib.utils.metrics.metrics_logger import MetricsLogger
+from ray.rllib.utils.numpy import convert_to_numpy
 from ray.rllib.utils.test_utils import check
 from ray.util.timer import _Timer
 
@@ -255,6 +264,116 @@ class TestLearnerGroupSyncUpdate(unittest.TestCase):
             # autoscale
             learner_group.shutdown()
             del learner_group
+
+
+class TestLearnerGroupUpdatePlan(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        ray.init()
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        ray.shutdown()
+
+    def test_learners_agree_on_the_update_plan(self):
+        """Tests that the Learners of a group carry out every update the same way.
+
+        Learners in a DDP group run one all-reduce per minibatch, so one of them
+        skipping an update that its peer takes, or stepping through a different
+        number of minibatches, makes their collectives mismatch. This test would
+        therefore hang rather than fail if the Learners stopped agreeing.
+        """
+        config = BaseTestingAlgorithmConfig().update_from_dict(
+            REMOTE_CONFIGS["multi-cpu-ddp"]
+        )
+        learner_group = config.build_learner_group(env=gym.make("CartPole-v1"))
+
+        def batch(num_timesteps, seed):
+            rng = np.random.default_rng(seed)
+            return MultiAgentBatch(
+                {
+                    DEFAULT_MODULE_ID: SampleBatch(
+                        {
+                            Columns.OBS: rng.standard_normal(
+                                (num_timesteps, 4), dtype=np.float32
+                            ),
+                            Columns.ACTIONS: rng.integers(0, 2, size=(num_timesteps,)),
+                        }
+                    )
+                },
+                env_steps=num_timesteps,
+            )
+
+        def weights():
+            """The module weights of each Learner in the group."""
+            return [
+                result.get()
+                for result in learner_group.foreach_learner(
+                    lambda learner: convert_to_numpy(
+                        learner.module[DEFAULT_MODULE_ID].get_state()
+                    )
+                )
+            ]
+
+        def update(**kwargs):
+            """Runs one group update; returns each Learner's results as plain values.
+
+            `LearnerGroup.update()` hands back one `Stats`-valued dict per Learner.
+            """
+            return MetricsLogger.peek_results(learner_group.update(**kwargs))
+
+        def steps_trained(results):
+            """The timesteps each Learner trained on, i.e. minibatches x their size."""
+            return [result[ALL_MODULES][NUM_MODULE_STEPS_TRAINED] for result in results]
+
+        def total(results, metric):
+            return sum(result[ALL_MODULES].get(metric, 0) for result in results)
+
+        try:
+            # One Learner's shard is empty: both skip, so neither trains, and the
+            # skip is attributed per Learner -- one had no data, the other had to
+            # drop the data it did have.
+            before = weights()
+            results = update(
+                batches=[
+                    batch(128, seed=0),
+                    MultiAgentBatch(policy_batches={}, env_steps=0),
+                ]
+            )
+            check(before, weights())
+            self.assertEqual(
+                1, total(results, LEARNER_UPDATE_SKIPPED_EMPTY_BATCH_LIFETIME)
+            )
+            self.assertEqual(
+                1, total(results, LEARNER_UPDATE_SKIPPED_FOR_PEER_LIFETIME)
+            )
+            self.assertEqual(
+                128, total(results, LEARNER_ENV_STEPS_DROPPED_ON_SKIP_LIFETIME)
+            )
+
+            # Unequal shards: both Learners still step through the same number of
+            # minibatches (the group's, not their own), and stay in sync.
+            results = update(
+                batches=[batch(256, seed=1), batch(64, seed=2)],
+                minibatch_size=32,
+                num_epochs=1,
+            )
+            # On their own the two shards would yield ceil(256/32) = 8 and
+            # ceil(64/32) = 2 minibatches; the group settles on the average, 5.
+            self.assertEqual([5 * 32, 5 * 32], steps_trained(results))
+            learner_0_weights, learner_1_weights = weights()
+            check(learner_0_weights, learner_1_weights)
+
+            # A minibatch count passed in by the caller is used by both as-is.
+            results = update(
+                batches=[batch(256, seed=3), batch(64, seed=4)],
+                minibatch_size=32,
+                num_epochs=1,
+                num_total_minibatches=3,
+            )
+            self.assertEqual([3 * 32, 3 * 32], steps_trained(results))
+        finally:
+            learner_group.shutdown()
 
 
 class TestLearnerGroupCheckpointRestore(unittest.TestCase):

--- a/rllib/core/learner/tests/test_learner_group.py
+++ b/rllib/core/learner/tests/test_learner_group.py
@@ -129,6 +129,27 @@ FAKE_MA_EPISODES_WO_P1 = [
 ]
 FAKE_MA_EPISODES_WO_P1[0].to_numpy()
 
+# What an AggregatorActor hands to one Learner: a ready-made train batch. The batch
+# whose EnvRunners were all lost carries no data for any module.
+NO_DATA = MultiAgentBatch(policy_batches={}, env_steps=0)
+
+
+def fake_batch(num_timesteps, seed):
+    rng = np.random.default_rng(seed)
+    return MultiAgentBatch(
+        {
+            DEFAULT_MODULE_ID: SampleBatch(
+                {
+                    Columns.OBS: rng.standard_normal(
+                        (num_timesteps, 4), dtype=np.float32
+                    ),
+                    Columns.ACTIONS: rng.integers(0, 2, size=(num_timesteps,)),
+                }
+            )
+        },
+        env_steps=num_timesteps,
+    )
+
 
 class TestLearnerGroupSyncUpdate(unittest.TestCase):
     @classmethod
@@ -288,22 +309,6 @@ class TestLearnerGroupUpdatePlan(unittest.TestCase):
         )
         learner_group = config.build_learner_group(env=gym.make("CartPole-v1"))
 
-        def batch(num_timesteps, seed):
-            rng = np.random.default_rng(seed)
-            return MultiAgentBatch(
-                {
-                    DEFAULT_MODULE_ID: SampleBatch(
-                        {
-                            Columns.OBS: rng.standard_normal(
-                                (num_timesteps, 4), dtype=np.float32
-                            ),
-                            Columns.ACTIONS: rng.integers(0, 2, size=(num_timesteps,)),
-                        }
-                    )
-                },
-                env_steps=num_timesteps,
-            )
-
         def weights():
             """The module weights of each Learner in the group."""
             return [
@@ -315,63 +320,55 @@ class TestLearnerGroupUpdatePlan(unittest.TestCase):
                 )
             ]
 
-        def update(**kwargs):
-            """Runs one group update; returns each Learner's results as plain values.
-
-            `LearnerGroup.update()` hands back one `Stats`-valued dict per Learner.
-            """
-            return MetricsLogger.peek_results(learner_group.update(**kwargs))
-
-        def steps_trained(results):
-            """The timesteps each Learner trained on, i.e. minibatches x their size."""
-            return [result[ALL_MODULES][NUM_MODULE_STEPS_TRAINED] for result in results]
-
-        def total(results, metric):
-            return sum(result[ALL_MODULES].get(metric, 0) for result in results)
-
         try:
-            # One Learner's shard is empty: both skip, so neither trains, and the
-            # skip is attributed per Learner -- one had no data, the other had to
-            # drop the data it did have.
+            # The EnvRunners feeding the second Learner were lost, so it is handed a
+            # batch without any data while its peer has a full one. Both must skip:
+            # nobody trains, and each Learner reports why it skipped.
             before = weights()
-            results = update(
-                batches=[
-                    batch(128, seed=0),
-                    MultiAgentBatch(policy_batches={}, env_steps=0),
-                ]
+            with_data, starved = MetricsLogger.peek_results(
+                learner_group.update(batches=[fake_batch(128, seed=0), NO_DATA])
             )
             check(before, weights())
             self.assertEqual(
-                1, total(results, LEARNER_UPDATE_SKIPPED_EMPTY_BATCH_LIFETIME)
+                1, starved[ALL_MODULES][LEARNER_UPDATE_SKIPPED_EMPTY_BATCH_LIFETIME]
             )
             self.assertEqual(
-                1, total(results, LEARNER_UPDATE_SKIPPED_FOR_PEER_LIFETIME)
+                1, with_data[ALL_MODULES][LEARNER_UPDATE_SKIPPED_FOR_PEER_LIFETIME]
             )
             self.assertEqual(
-                128, total(results, LEARNER_ENV_STEPS_DROPPED_ON_SKIP_LIFETIME)
+                128, with_data[ALL_MODULES][LEARNER_ENV_STEPS_DROPPED_ON_SKIP_LIFETIME]
             )
 
-            # Unequal shards: both Learners still step through the same number of
-            # minibatches (the group's, not their own), and stay in sync.
-            results = update(
-                batches=[batch(256, seed=1), batch(64, seed=2)],
-                minibatch_size=32,
-                num_epochs=1,
+            # Both Learners have data, but unequal amounts of it. On their own they
+            # would step through ceil(256/32) = 8 and ceil(64/32) = 2 minibatches;
+            # the group settles on the average, 5, and stays in sync.
+            results = MetricsLogger.peek_results(
+                learner_group.update(
+                    batches=[fake_batch(256, seed=1), fake_batch(64, seed=2)],
+                    minibatch_size=32,
+                    num_epochs=1,
+                )
             )
-            # On their own the two shards would yield ceil(256/32) = 8 and
-            # ceil(64/32) = 2 minibatches; the group settles on the average, 5.
-            self.assertEqual([5 * 32, 5 * 32], steps_trained(results))
+            self.assertEqual(
+                [5 * 32, 5 * 32],
+                [result[ALL_MODULES][NUM_MODULE_STEPS_TRAINED] for result in results],
+            )
             learner_0_weights, learner_1_weights = weights()
             check(learner_0_weights, learner_1_weights)
 
             # A minibatch count passed in by the caller is used by both as-is.
-            results = update(
-                batches=[batch(256, seed=3), batch(64, seed=4)],
-                minibatch_size=32,
-                num_epochs=1,
-                num_total_minibatches=3,
+            results = MetricsLogger.peek_results(
+                learner_group.update(
+                    batches=[fake_batch(256, seed=3), fake_batch(64, seed=4)],
+                    minibatch_size=32,
+                    num_epochs=1,
+                    num_total_minibatches=3,
+                )
             )
-            self.assertEqual([3 * 32, 3 * 32], steps_trained(results))
+            self.assertEqual(
+                [3 * 32, 3 * 32],
+                [result[ALL_MODULES][NUM_MODULE_STEPS_TRAINED] for result in results],
+            )
         finally:
             learner_group.shutdown()
 

--- a/rllib/core/learner/torch/torch_differentiable_learner.py
+++ b/rllib/core/learner/torch/torch_differentiable_learner.py
@@ -20,7 +20,7 @@ from ray.rllib.utils.metrics import (
 from ray.rllib.utils.torch_utils import convert_to_torch_tensor
 from ray.rllib.utils.typing import DeviceType, ModuleID, NamedParamDict, TensorType
 
-logger = logging.getLogger("__name__")
+logger = logging.getLogger(__name__)
 
 torch, nn = try_import_torch()
 
@@ -329,7 +329,7 @@ class TorchDifferentiableLearner(DifferentiableLearner):
         This method is specific to TorchDifferentiableLearner. Before running super() it will
         initialize the device properly based on `self.config`, so that `_make_module()`
         can place the created module on the correct device. After running super() it
-        wraps the module in a TorchDDPRLModule if `config.num_learners > 0`.
+        wraps the module in a TorchDDPRLModule if `config.num_learners > 1`.
         Note, in inherited classes it is advisable to call the parent's `build()`
         after setting up all variables because `configure_optimizer_for_module` is
         called in this `Learner.build()`.

--- a/rllib/core/learner/torch/torch_learner.py
+++ b/rllib/core/learner/torch/torch_learner.py
@@ -533,22 +533,12 @@ class TorchLearner(Learner):
 
     @override(Learner)
     def _sync_update_plan(self, plan: UpdatePlan) -> UpdatePlan:
-        # Without DDP there is no group to agree with (same condition
-        # `_make_modules_ddp_if_necessary` wraps on); without an initialized process
-        # group there is nothing to agree over (a Learner built with
-        # `num_learners > 1` but driven directly, as in unit tests).
         if (
             self.config.num_learners <= 1
             or not torch.distributed.is_available()
             or not torch.distributed.is_initialized()
         ):
             return plan
-        # One SUM all-reduce per `update()` carrying the whole plan, on the
-        # device/backend DDP uses (NCCL needs a CUDA tensor). It blocks until every
-        # Learner arrives, but DDP already keeps the group in lockstep per minibatch,
-        # so this only moves where a fast Learner waits -- from inside its first
-        # backward to just before its first forward -- and adds the collective's own
-        # latency.
         summed = torch.tensor(
             [int(plan.skip), plan.num_minibatches],
             dtype=torch.int64,

--- a/rllib/core/learner/torch/torch_learner.py
+++ b/rllib/core/learner/torch/torch_learner.py
@@ -17,7 +17,7 @@ from ray.rllib.algorithms.algorithm_config import (
     TorchCompileWhatToCompile,
 )
 from ray.rllib.core.columns import Columns
-from ray.rllib.core.learner.learner import LR_KEY, Learner
+from ray.rllib.core.learner.learner import LR_KEY, Learner, UpdatePlan
 from ray.rllib.core.rl_module.multi_rl_module import (
     MultiRLModule,
     MultiRLModuleSpec,
@@ -530,6 +530,39 @@ class TorchLearner(Learner):
             return self._uncompiled_update(batch)
         else:
             return self._possibly_compiled_update(batch)
+
+    @override(Learner)
+    def _sync_update_plan(self, plan: UpdatePlan) -> UpdatePlan:
+        # Without DDP there is no group to agree with (same condition
+        # `_make_modules_ddp_if_necessary` wraps on); without an initialized process
+        # group there is nothing to agree over (a Learner built with
+        # `num_learners > 1` but driven directly, as in unit tests).
+        if (
+            self.config.num_learners <= 1
+            or not torch.distributed.is_available()
+            or not torch.distributed.is_initialized()
+        ):
+            return plan
+        # One SUM all-reduce per `update()` carrying the whole plan, on the
+        # device/backend DDP uses (NCCL needs a CUDA tensor). It blocks until every
+        # Learner arrives, but DDP already keeps the group in lockstep per minibatch,
+        # so this only moves where a fast Learner waits -- from inside its first
+        # backward to just before its first forward -- and adds the collective's own
+        # latency.
+        summed = torch.tensor(
+            [int(plan.skip), plan.num_minibatches],
+            dtype=torch.int64,
+            device=self._device,
+        )
+        torch.distributed.all_reduce(summed)
+        num_skipping, total_minibatches = summed.tolist()
+        # Skip if anyone wants to. Steps: the average proposal. Every non-empty
+        # Learner proposes at least 1 when minibatching, so the floor is >= 1 then;
+        # without minibatching all propose 0, and 0 ("uncapped") is the right answer.
+        return UpdatePlan(
+            skip=num_skipping > 0,
+            num_minibatches=total_minibatches // torch.distributed.get_world_size(),
+        )
 
     @OverrideToImplementCustomLogic
     def _make_modules_ddp_if_necessary(self) -> None:

--- a/rllib/core/learner/torch/torch_meta_learner.py
+++ b/rllib/core/learner/torch/torch_meta_learner.py
@@ -161,9 +161,7 @@ class TorchMetaLearner(TorchLearner):
             **kwargs,
         )
 
-        # `None` means: skip this update. The inherited `_create_iterator_if_necessary`
-        # has agreed with the other Learners of the group, warned and counted it; only
-        # the per-update bookkeeping remains.
+        # `None` means: skip this update.
         if batch_iter is None:
             self.after_gradient_based_update(timesteps=timesteps or {})
             if not _no_metrics_reduce:

--- a/rllib/core/learner/torch/torch_meta_learner.py
+++ b/rllib/core/learner/torch/torch_meta_learner.py
@@ -34,7 +34,7 @@ from ray.rllib.utils.typing import (
     TensorType,
 )
 
-logger = logging.getLogger("__name__")
+logger = logging.getLogger(__name__)
 
 torch, nn = try_import_torch()
 
@@ -160,6 +160,15 @@ class TorchMetaLearner(TorchLearner):
             shuffle_batch_per_epoch=shuffle_batch_per_epoch,
             **kwargs,
         )
+
+        # `None` means: skip this update. The inherited `_create_iterator_if_necessary`
+        # has agreed with the other Learners of the group, warned and counted it; only
+        # the per-update bookkeeping remains.
+        if batch_iter is None:
+            self.after_gradient_based_update(timesteps=timesteps or {})
+            if not _no_metrics_reduce:
+                return self.metrics.reduce()
+            return
 
         # If no training data for `DifferentiableLearner`s have been passed in, cycle
         # over the main training_data for each `DifferentiableLearner`.

--- a/rllib/core/learner/training_data.py
+++ b/rllib/core/learner/training_data.py
@@ -1,11 +1,9 @@
 import dataclasses
-from collections import defaultdict
 from typing import List, Optional
 
 import tree  # pip install dm_tree
 
 import ray
-from ray.rllib.env.multi_agent_episode import MultiAgentEpisode
 from ray.rllib.policy.sample_batch import MultiAgentBatch
 from ray.rllib.utils.minibatch_utils import (
     ShardBatchIterator,
@@ -73,19 +71,8 @@ class TrainingData:
         # List of episodes -> Split into n equally sized shards (based on the lengths
         # of the episodes).
         elif self.episodes is not None:
-            num_total_minibatches = 0
-            if "minibatch_size" in kwargs and num_shards > 1:
-                num_total_minibatches = self._compute_num_total_minibatches(
-                    self.episodes,
-                    num_shards,
-                    kwargs["minibatch_size"],
-                    kwargs.get("num_epochs", 1),
-                )
             return [
-                (
-                    TrainingData(episodes=e),
-                    {"num_total_minibatches": num_total_minibatches},
-                )
+                (TrainingData(episodes=e), {})
                 for e in ShardEpisodesIterator(
                     self.episodes,
                     num_shards=num_shards,
@@ -138,22 +125,3 @@ class TrainingData:
                         )
             self.episodes = episodes
             self.episodes_refs = None
-
-    @staticmethod
-    def _compute_num_total_minibatches(
-        episodes,
-        num_shards,
-        minibatch_size,
-        num_epochs,
-    ):
-        # Count total number of timesteps per module ID.
-        if isinstance(episodes[0], MultiAgentEpisode):
-            per_mod_ts = defaultdict(int)
-            for ma_episode in episodes:
-                for sa_episode in ma_episode.agent_episodes.values():
-                    per_mod_ts[sa_episode.module_id] += len(sa_episode)
-            max_ts = max(per_mod_ts.values())
-        else:
-            max_ts = sum(map(len, episodes))
-
-        return int((num_epochs * max_ts) / (num_shards * minibatch_size))

--- a/rllib/core/learner/training_data.py
+++ b/rllib/core/learner/training_data.py
@@ -47,24 +47,24 @@ class TrainingData:
         self,
         num_shards: int,
         len_lookback_buffer: Optional[int] = None,
-        **kwargs,
-    ):
+    ) -> List["TrainingData"]:
+        """Splits this training data into `num_shards` shards, one per Learner."""
         # Single batch -> Split into n smaller batches.
         if self.batch is not None:
             return [
-                (TrainingData(batch=b), {})
+                TrainingData(batch=b)
                 for b in ShardBatchIterator(self.batch, num_shards=num_shards)
             ]
 
         # TODO (sven): Do we need a more sohpisticated shard mechanism for this case?
         elif self.batches is not None:
             assert num_shards == len(self.batches)
-            return [(TrainingData(batch=b), {}) for b in self.batches]
+            return [TrainingData(batch=b) for b in self.batches]
 
         # List of batch refs.
         elif self.batch_refs is not None:
             return [
-                (TrainingData(batch_refs=b), {})
+                TrainingData(batch_refs=b)
                 for b in ShardObjectRefIterator(self.batch_refs, num_shards=num_shards)
             ]
 
@@ -72,7 +72,7 @@ class TrainingData:
         # of the episodes).
         elif self.episodes is not None:
             return [
-                (TrainingData(episodes=e), {})
+                TrainingData(episodes=e)
                 for e in ShardEpisodesIterator(
                     self.episodes,
                     num_shards=num_shards,
@@ -82,15 +82,13 @@ class TrainingData:
         # List of episodes refs.
         elif self.episodes_refs is not None:
             return [
-                (TrainingData(episodes_refs=e), {})
+                TrainingData(episodes_refs=e)
                 for e in ShardObjectRefIterator(self.episodes_refs, num_shards)
             ]
         # List of data iterators.
         else:
             assert self.data_iterators and len(self.data_iterators) == num_shards
-            return [
-                (TrainingData(data_iterators=[di]), {}) for di in self.data_iterators
-            ]
+            return [TrainingData(data_iterators=[di]) for di in self.data_iterators]
 
     def solve_refs(self):
         # Batch references.

--- a/rllib/utils/metrics/__init__.py
+++ b/rllib/utils/metrics/__init__.py
@@ -120,6 +120,13 @@ MODULE_SAMPLE_BATCH_SIZE_MEAN = "module_sample_batch_size_mean"
 MODULE_TRAIN_BATCH_SIZE_MEAN = "module_train_batch_size_mean"
 LEARNER_CONNECTOR_SUM_EPISODES_LENGTH_IN = "learner_connector_sum_episodes_length_in"
 LEARNER_CONNECTOR_SUM_EPISODES_LENGTH_OUT = "learner_connector_sum_episodes_length_out"
+LEARNER_UPDATE_SKIPPED_EMPTY_BATCH_LIFETIME = (
+    "learner_update_skipped_empty_batch_lifetime"
+)
+LEARNER_UPDATE_SKIPPED_FOR_PEER_LIFETIME = "learner_update_skipped_for_peer_lifetime"
+LEARNER_ENV_STEPS_DROPPED_ON_SKIP_LIFETIME = (
+    "learner_env_steps_dropped_on_skip_lifetime"
+)
 
 # Backward compatibility: Replace with num_env_steps_... or num_agent_steps_...
 STEPS_TRAINED_THIS_ITER_COUNTER = "num_steps_trained_this_iter"

--- a/rllib/utils/minibatch_utils.py
+++ b/rllib/utils/minibatch_utils.py
@@ -33,12 +33,11 @@ class MiniBatchIteratorBase:
                 batch into per epoch. The train batch is generated from the given
                 `episodes` through the Learner connector pipeline.
             num_total_minibatches: The total number of minibatches to loop through
-                (over all `num_epochs` epochs). It's only required to set this to != 0
-                in multi-agent + multi-GPU situations, in which the MultiAgentEpisodes
-                themselves are roughly sharded equally, however, they might contain
-                SingleAgentEpisodes with very lopsided length distributions. Thus,
-                without this fixed, pre-computed value, one Learner might go through a
-                different number of minibatche passes than others causing a deadlock.
+                (over all `num_epochs` epochs). 0 (the default) means: as many as it
+                takes to cover every module's data `num_epochs` times, see
+                `MiniBatchCyclicIterator.num_minibatches`. Multi-Learner setups agree
+                on one value and pass it explicitly, so that Learners holding
+                differently sized shards still step the same number of times.
         """
         pass
 
@@ -48,9 +47,10 @@ class MiniBatchCyclicIterator(MiniBatchIteratorBase):
     """This implements a simple multi-agent minibatch iterator.
 
     This iterator will split the input multi-agent batch into minibatches where the
-    size of batch for each module_id (aka policy_id) is equal to minibatch_size. If the
-    input batch is smaller than minibatch_size, then the iterator will cycle through
-    the batch until it has covered `num_epochs` epochs.
+    size of batch for each module_id is equal to minibatch_size,
+    cycling through the batch as needed. It yields exactly `num_total_minibatches`
+    minibatches; when that is not given, it yields as many as it takes to cover
+    every module's data `num_epochs` times.
     """
 
     def __init__(
@@ -72,39 +72,73 @@ class MiniBatchCyclicIterator(MiniBatchIteratorBase):
 
         self._batch = batch
         self._minibatch_size = minibatch_size
-        self._num_epochs = num_epochs
         self._shuffle_batch_per_epoch = shuffle_batch_per_epoch
 
         # mapping from module_id to the start index of the batch
         self._start = {mid: 0 for mid in batch.policy_batches.keys()}
-        # mapping from module_id to the number of epochs covered for each module_id
-        self._num_covered_epochs = {mid: 0 for mid in batch.policy_batches.keys()}
 
         self._minibatch_count = 0
-        self._num_total_minibatches = num_total_minibatches
+        self._num_total_minibatches = num_total_minibatches or self.num_minibatches(
+            batch, minibatch_size=minibatch_size, num_epochs=num_epochs
+        )
+
+    @classmethod
+    def num_minibatches(
+        cls, batch: MultiAgentBatch, *, minibatch_size: int, num_epochs: int
+    ) -> int:
+        """Returns how many minibatches cover every module's data `num_epochs` times.
+
+        Each minibatch consumes `minibatch_size` rows per module (for batches sliced
+        in the sequence dimension: the corresponding number of sequences), so the
+        module with the most data governs: ceil(num_epochs * n / step), maxed over
+        the modules. Returns 0 for a batch without any module.
+        """
+        return max(
+            (
+                math.ceil(num_epochs * n / step)
+                for n, step in (
+                    cls._len_and_step(module_batch, minibatch_size)
+                    for module_batch in batch.policy_batches.values()
+                )
+            ),
+            default=0,
+        )
+
+    @staticmethod
+    def _len_and_step(module_batch: SampleBatch, minibatch_size: int):
+        """Returns `module_batch`'s length and the amount one minibatch consumes of it.
+
+        Both are in the unit the batch is sliced in: timesteps, or -- for batches
+        flagged to be sliced in the sequence dimension B -- sequences, in which case a
+        minibatch of `minibatch_size` timesteps corresponds to proportionally many
+        sequences.
+        """
+        if module_batch._slice_seq_lens_in_B:
+            assert module_batch.get(SampleBatch.SEQ_LENS) is not None, (
+                "MiniBatchCyclicIterator requires SampleBatch.SEQ_LENS"
+                "to be present in the batch for slicing a batch in the batch "
+                "dimension B."
+            )
+            n = len(module_batch[SampleBatch.SEQ_LENS])
+            step = int(n * (minibatch_size / len(module_batch)))
+            if step <= 0:
+                raise ValueError(
+                    f"`minibatch_size` ({minibatch_size}) is smaller than the average "
+                    f"sequence length ({len(module_batch) / n:.1f}), so a minibatch "
+                    "would hold less than one sequence. Increase `minibatch_size`."
+                )
+            return n, step
+        return len(module_batch), minibatch_size
 
     def __iter__(self):
-        while (
-            # Make sure each item in the total batch gets at least iterated over
-            # `self._num_epochs` times.
-            (
-                self._num_total_minibatches == 0
-                and min(self._num_covered_epochs.values()) < self._num_epochs
-            )
-            # Make sure we reach at least the given minimum number of mini-batches.
-            or (
-                self._num_total_minibatches > 0
-                and self._minibatch_count < self._num_total_minibatches
-            )
-        ):
+        while self._minibatch_count < self._num_total_minibatches:
             minibatch = {}
             for module_id, module_batch in self._batch.policy_batches.items():
 
                 if len(module_batch) == 0:
                     raise ValueError(
-                        f"The batch for module_id {module_id} is empty! "
-                        "This will create an infinite loop because we need to cover "
-                        "the same number of samples for each module_id."
+                        f"The batch for module_id {module_id} is empty! Minibatches "
+                        "need `minibatch_size` samples from every module_id."
                     )
                 s = self._start[module_id]  # start
 
@@ -117,28 +151,18 @@ class MiniBatchCyclicIterator(MiniBatchIteratorBase):
                 #  these setups require sequencing, BUT their batches are not yet time-
                 #  ranked (this is done only in their loss functions via the
                 #  `make_time_major` utility).
-                n_steps = self._minibatch_size
+                # One rule for how much a minibatch consumes (timesteps, or sequences
+                # for batches sliced in the sequence dimension B); `_len_and_step` also
+                # checks that SEQ_LENS is present in that case.
+                _, n_steps = self._len_and_step(module_batch, self._minibatch_size)
 
                 samples_to_concat = []
 
-                # get_len is a function that returns the length of a batch
-                # if we are not slicing the batch in the batch dimension B, then
-                # the length of the batch is simply the length of the batch
-                # o.w the length of the batch is the length list of seq_lens.
+                # Length of a (sub-)batch in the unit we slice in.
                 if module_batch._slice_seq_lens_in_B:
-                    assert module_batch.get(SampleBatch.SEQ_LENS) is not None, (
-                        "MiniBatchCyclicIterator requires SampleBatch.SEQ_LENS"
-                        "to be present in the batch for slicing a batch in the batch "
-                        "dimension B."
-                    )
 
                     def get_len(b):
                         return len(b[SampleBatch.SEQ_LENS])
-
-                    n_steps = int(
-                        get_len(module_batch)
-                        * (self._minibatch_size / len(module_batch))
-                    )
 
                 else:
 
@@ -153,7 +177,6 @@ class MiniBatchCyclicIterator(MiniBatchIteratorBase):
                     assert len_sample > 0, "Length of a sample must be > 0!"
                     n_steps -= len_sample
                     s = 0
-                    self._num_covered_epochs[module_id] += 1
                     # Shuffle the individual single-agent batch, if required.
                     # This should happen once per minibatch iteration in order to make
                     # each iteration go through a different set of minibatches.

--- a/rllib/utils/tests/test_minibatch_utils.py
+++ b/rllib/utils/tests/test_minibatch_utils.py
@@ -126,6 +126,72 @@ class TestMinibatchUtils(unittest.TestCase):
                     check(iteration_counter, expected_iteration_counter)
                 print(f"iteration_counter: {iteration_counter}")
 
+    def test_minibatch_cyclic_iterator_num_minibatches(self):
+        """The iterator terminates purely by count. Without an explicit count it
+        derives the one that covers every module's data `num_epochs` times:
+        ceil(num_epochs * rows / minibatch_size), governed by the largest module.
+        The expected values below are independent of that formula."""
+
+        def mab(**rows_per_module):
+            return MultiAgentBatch(
+                {
+                    mid: SampleBatch({"obs": np.zeros((n, 2), dtype=np.float32)})
+                    for mid, n in rows_per_module.items()
+                },
+                env_steps=max(rows_per_module.values()),
+            )
+
+        cases = [  # (rows per module, minibatch_size, num_epochs, expected count)
+            (dict(p0=512), 128, 1, 4),
+            (dict(p0=96), 16, 2, 12),
+            (dict(p0=32), 16, 2, 4),
+            (dict(p0=100), 32, 3, 10),  # not a multiple -> ceil
+            (dict(p0=32), 128, 1, 1),  # batch smaller than a minibatch -> 1
+            (dict(p0=128, p1=64), 32, 2, 8),  # the largest module governs
+        ]
+        for rows, minibatch_size, num_epochs, expected in cases:
+            batch = mab(**rows)
+            self.assertEqual(
+                expected,
+                MiniBatchCyclicIterator.num_minibatches(
+                    batch, minibatch_size=minibatch_size, num_epochs=num_epochs
+                ),
+                (rows, minibatch_size, num_epochs),
+            )
+            minibatches = list(
+                MiniBatchCyclicIterator(
+                    batch,
+                    num_epochs=num_epochs,
+                    minibatch_size=minibatch_size,
+                    shuffle_batch_per_epoch=False,
+                )
+            )
+            self.assertEqual(expected, len(minibatches), (rows, minibatch_size))
+            # Every minibatch is full, and the total covers the largest module at
+            # least `num_epochs` times but not a whole extra minibatch more.
+            for minibatch in minibatches:
+                for mid in rows:
+                    self.assertEqual(minibatch_size, len(minibatch[mid]))
+            n_max = max(rows.values())
+            self.assertGreaterEqual(expected * minibatch_size, num_epochs * n_max)
+            self.assertLess((expected - 1) * minibatch_size, num_epochs * n_max)
+
+        # An explicit count wins over the derived one.
+        self.assertEqual(
+            3,
+            len(
+                list(
+                    MiniBatchCyclicIterator(
+                        mab(p0=512),
+                        num_epochs=1,
+                        minibatch_size=128,
+                        shuffle_batch_per_epoch=False,
+                        num_total_minibatches=3,
+                    )
+                )
+            ),
+        )
+
     def test_shard_episodes_iterator(self):
         class DummyEpisode:
             def __init__(self, length):


### PR DESCRIPTION
## Description

With learners, we can arrive in situations where a) we have multiple learners and b) not enough data is produced to feed all learners at a given DDP step. Today, this creates an empty batch with an unbound loss_per_module.

The naive solution is to skip empty batches but that creates deadlocks in torch DDP as workers wait for each other's steps.
I looked into different solutions of how to solve this, such as having blueprint of valid batches to step with if an empty batch arrives but this solution is messy in practice as each learner needs to have the correct bluebrint at all times (even before the first valid training batch arrives).

This PR proposes as solution where, prior to a DDP step, all learners agree that they have data available and how often they will step on any available minibatches.

## Known limitation: differing module sets across Learners

The agreement added here is per Learner, not per module. Each submodule of a `MultiRLModule` is wrapped in its own `TorchDDPRLModule` (`TorchLearner._make_modules_ddp_if_necessary`), so every module has its own all-reduce, and `MultiRLModule._forward_train` only forwards the modules that are present in the batch it is given.

If two Learners receive batches with different sets of module IDs — for example in multi-agent setups where an agent does not appear in every shard of the sampled episodes — the Learner that is missing a module never runs that module's backward pass, while its peers wait on that module's all-reduce, and the group deadlocks. `_should_skip_update` cannot express this case: it is a single boolean per Learner.

This is pre-existing behaviour that this PR neither introduces nor makes worse; it was confirmed on two CPU-DDP Learners fed `{p0, p1}` and `{p0}` respectively.

A follow-up can close it: `self.module.keys()` is identical on every Learner, so the Learners can agree on a per-module bitmask (AND'ed across the group) and train the intersection, filtering the batch to it. The all-or-nothing skip in this PR then becomes the special case of an empty intersection.
