### PR TITLE
[serve] Deflake test_direct_ingress backpressure request deadlines

### DIFF
--- a/python/ray/serve/tests/test_direct_ingress.py
+++ b/python/ray/serve/tests/test_direct_ingress.py
@@ -1340,9 +1340,14 @@ def test_port_recovery_on_controller_restart(_skip_if_ff_not_enabled, serve_inst
     wait_for_condition(validate_port_recovery)
 
 
+# These tests deliberately queue up to 1000 requests behind `max_ongoing_requests`,
+# so a request's deadline must cover the whole queue drain, not one request's service.
+BACKPRESSURE_REQUEST_TIMEOUT_S = 60
+
+
 class TestDirectIngressBackpressure:
     def _do_http_request(self, url: str) -> bool:
-        r = httpx.get(url, timeout=10)
+        r = httpx.get(url, timeout=BACKPRESSURE_REQUEST_TIMEOUT_S)
         if r.status_code == 200:
             return True
         elif r.status_code == 503:
@@ -1354,7 +1359,10 @@ class TestDirectIngressBackpressure:
         channel = grpc.insecure_channel(url)
         stub = serve_pb2_grpc.UserDefinedServiceStub(channel)
         try:
-            stub.Method1(serve_pb2.UserDefinedMessage(), timeout=20)
+            stub.Method1(
+                serve_pb2.UserDefinedMessage(),
+                timeout=BACKPRESSURE_REQUEST_TIMEOUT_S,
+            )
             return True
         except grpc.RpcError as e:
             if e.code() == grpc.StatusCode.RESOURCE_EXHAUSTED:


### PR DESCRIPTION
TestDirectIngressBackpressure gave every request a fixed client deadline sized for one request's service time, while the tests deliberately queue up to 1000 requests behind max_ongoing_requests. The deadline therefore has to cover the whole queue drain, which scales with the number of queued requests.

Measured per-request latency against the 10s deadline _do_http_request used (replica access logs, 4-core box, passing runs):

  test_backpressure_queued_requests    max 9161-9539ms   92-95% of budget
  test_drop_after_max_queued_requests  max 7589-7903ms   76-79% of budget
  test_mixed_http_grpc_backpressure    max 2359-2566ms   24-26% of budget

The p50 of test_backpressure_queued_requests is ~6.9s, so this is not a tail effect: the whole distribution sits just under the deadline, and a slightly slower run pushes it over. The request then raises httpx.ReadTimeout, which f.result() re-raises at the assert, so it presents as a backpressure assertion failure rather than a timeout.

_do_grpc_request already used 20s and its leg never failed; both helpers now share one constant, removing that unexplained asymmetry. Deliberately short deadlines elsewhere in the class are left alone.

Isolated soak of TestDirectIngressBackpressure: 2 failures in 4 runs before, 10/10 passed after change.