### PR TITLE
[Serve] Reconnect HAProxy long polling after controller replacement

### DIFF
--- a/python/ray/serve/_private/haproxy.py
+++ b/python/ray/serve/_private/haproxy.py
@@ -1773,6 +1773,9 @@ class HAProxyManager(ProxyActorInterface):
             },
             call_in_event_loop=self.event_loop,
             client_id=f"{type(self).__name__}:{ray.get_runtime_context().get_actor_id()}",
+            host_actor_resolver=functools.partial(
+                ray.get_actor, SERVE_CONTROLLER_NAME, namespace=SERVE_NAMESPACE
+            ),
         )
 
         is_head = self._node_id == get_head_node_id()
@@ -1846,6 +1849,15 @@ class HAProxyManager(ProxyActorInterface):
         This method should be called before the actor is killed to ensure
         the HAProxy subprocess is properly terminated.
         """
+        self.long_poll_client.stop()
+        self._update_pending = False
+        if self._coalesce_task is not None and not self._coalesce_task.done():
+            self._coalesce_task.cancel()
+            try:
+                await self._coalesce_task
+            except asyncio.CancelledError:
+                pass
+
         try:
             logger.info(
                 f"Shutting down HAProxyManager on node {self._node_id}.",

--- a/python/ray/serve/_private/long_poll.py
+++ b/python/ray/serve/_private/long_poll.py
@@ -123,8 +123,9 @@ class LongPollClient:
           disables itself.
         host_actor_resolver: optional synchronous callback that looks up a
           replacement host after an actor error. It runs off the event loop
-          and should raise ValueError while the host is unavailable. The owner
-          must call stop() when it no longer wants to receive updates.
+          and should raise ValueError while the host is unavailable or
+          GetTimeoutError when lookup times out. The owner must call stop()
+          when it no longer wants to receive updates.
     """
 
     def __init__(
@@ -201,7 +202,7 @@ class LongPollClient:
                     # ray.get_actor can block. Keep discovery off the client's
                     # event loop, with only one lookup in flight at a time.
                     host_actor = await self.event_loop.run_in_executor(None, resolver)
-                except ValueError:
+                except (ValueError, ray.exceptions.GetTimeoutError):
                     continue
                 except Exception:
                     logger.exception(

--- a/python/ray/serve/_private/long_poll.py
+++ b/python/ray/serve/_private/long_poll.py
@@ -53,6 +53,8 @@ LISTEN_FOR_CHANGE_REQUEST_TIMEOUT_S = (
     float(os.environ.get("LISTEN_FOR_CHANGE_REQUEST_TIMEOUT_S_UPPER_BOUND", "60")),
 )
 
+LONG_POLL_HOST_RETRY_DELAY_S = 1.0
+
 
 class LongPollNamespace(Enum):
     def __repr__(self):
@@ -119,6 +121,10 @@ class LongPollClient:
           to post the callback into.
         client_id: identifier reported back to the host if this client
           disables itself.
+        host_actor_resolver: optional synchronous callback that looks up a
+          replacement host after an actor error. It runs off the event loop
+          and should raise ValueError while the host is unavailable. The owner
+          must call stop() when it no longer wants to receive updates.
     """
 
     def __init__(
@@ -127,6 +133,7 @@ class LongPollClient:
         key_listeners: Dict[KeyType, UpdateStateCallable],
         call_in_event_loop: AbstractEventLoop,
         client_id: str,
+        host_actor_resolver: Optional[Callable[[], Any]] = None,
     ) -> None:
         # We used to allow this to be optional, but due to Ray Client issue
         # we now enforce all long poll client to post callback to event loop
@@ -137,6 +144,8 @@ class LongPollClient:
         self.key_listeners = key_listeners
         self.event_loop = call_in_event_loop
         self.client_id = client_id
+        self._host_actor_resolver = host_actor_resolver
+        self._reconnect_task: Optional[asyncio.Task] = None
         # The initial snapshot id for each key is < 0,
         # but real snapshot keys in the long poll host are always >= 0,
         # so this will always trigger an initial update.
@@ -164,8 +173,56 @@ class LongPollClient:
         )
 
     def stop(self) -> None:
-        """Stop the long poll client after the next RPC returns."""
+        """Stop callbacks and recovery; an in-flight RPC may still finish."""
         self.is_running = False
+        if not self.event_loop.is_closed():
+            self.event_loop.call_soon_threadsafe(self._cancel_reconnect)
+
+    def _cancel_reconnect(self) -> None:
+        if self._reconnect_task is not None:
+            self._reconnect_task.cancel()
+
+    def _schedule_reconnect(self) -> None:
+        if self.is_running and (
+            self._reconnect_task is None or self._reconnect_task.done()
+        ):
+            self._reconnect_task = self.event_loop.create_task(self._reconnect())
+
+    async def _reconnect(self) -> None:
+        resolver = self._host_actor_resolver
+        assert resolver is not None
+        try:
+            while self.is_running:
+                # Bound retries even if discovery still returns the dead handle.
+                await asyncio.sleep(
+                    random.uniform(0.5, 1.5) * LONG_POLL_HOST_RETRY_DELAY_S
+                )
+                try:
+                    # ray.get_actor can block. Keep discovery off the client's
+                    # event loop, with only one lookup in flight at a time.
+                    host_actor = await self.event_loop.run_in_executor(None, resolver)
+                except ValueError:
+                    continue
+                except Exception:
+                    logger.exception(
+                        "LongPollClient %r could not resolve its host. Shutting down.",
+                        self.client_id,
+                    )
+                    self.is_running = False
+                    return
+
+                # Cancelling the task cannot stop an already-running executor
+                # call. A stopped client must never accept its late result.
+                if not self.is_running:
+                    return
+                self.host_actor = host_actor
+                # Versions belong to the host incarnation, not its stable name.
+                # Include listeners added while discovery was in flight.
+                self.snapshot_ids = dict.fromkeys(self.key_listeners, -1)
+                self._poll_next()
+                return
+        finally:
+            self._reconnect_task = None
 
     def add_key_listeners(
         self, key_listeners: Dict[KeyType, UpdateStateCallable]
@@ -249,7 +306,17 @@ class LongPollClient:
                 )
 
     def _process_update(self, updates: Dict[str, UpdatedObject]):
+        if not self.is_running:
+            return
+
         if isinstance(updates, (ray.exceptions.RayActorError)):
+            if self._host_actor_resolver is not None:
+                logger.warning(
+                    "LongPollClient %r lost its host; resolving a replacement.",
+                    self.client_id,
+                )
+                self._schedule_to_event_loop(self._schedule_reconnect)
+                return
             # This can happen during shutdown where the controller is
             # intentionally killed, the client should just gracefully
             # exit.
@@ -309,6 +376,8 @@ class LongPollClient:
             # Bind the parameters because closures are late-binding.
             # https://docs.python-guide.org/writing/gotchas/#late-binding-closures # noqa: E501
             def chained(callback=callback, arg=update.object_snapshot):
+                if not self.is_running:
+                    return
                 callback(arg)
                 self._on_callback_completed(trigger_at=len(updates))
 

--- a/python/ray/serve/tests/BUILD.bazel
+++ b/python/ray/serve/tests/BUILD.bazel
@@ -70,6 +70,7 @@ py_test_module_list(
         "test_http_cancellation.py",
         "test_kv_store.py",
         "test_long_poll.py",
+        "test_long_poll_reconnect.py",
         "test_persistence.py",
         "test_replica_request_context.py",
         "test_serve_with_tracing.py",

--- a/python/ray/serve/tests/test_long_poll_reconnect.py
+++ b/python/ray/serve/tests/test_long_poll_reconnect.py
@@ -1,0 +1,476 @@
+"""Real-actor regression tests for optional LongPollClient host replacement.
+
+These tests need no Serve deployment, HAProxy process, or external service. The
+host fixture embeds the real LongPollHost; only its published versions and data
+are controlled so that cross-incarnation version collisions are deterministic.
+"""
+
+import asyncio
+import threading
+import time
+import uuid
+
+import pytest
+import pytest_asyncio
+
+import ray
+import ray.serve._private.long_poll as long_poll_module
+from ray.serve._private.long_poll import LongPollClient, LongPollHost
+
+WAIT_TIMEOUT_S = 30
+
+
+async def wait_until(predicate, timeout=WAIT_TIMEOUT_S):
+    deadline = asyncio.get_running_loop().time() + timeout
+    while not predicate():
+        if asyncio.get_running_loop().time() >= deadline:
+            raise AssertionError("Condition did not become true before the deadline")
+        await asyncio.sleep(0.01)
+
+
+async def actor_result(ref):
+    return await asyncio.wait_for(ref, timeout=WAIT_TIMEOUT_S)
+
+
+@ray.remote(num_cpus=0)
+class ReconnectHost:
+    def __init__(self, values, snapshot_id=None):
+        self.incarnation = uuid.uuid4().hex
+        self.host = LongPollHost(listen_for_change_request_timeout_s=(0.05, 0.1))
+        self.requests = []
+        self.active = 0
+        self.max_active = 0
+        self.publish(values, snapshot_id)
+
+    def publish(self, values, snapshot_id=None):
+        self.host.notify_changed(values)
+        if snapshot_id is not None:
+            for key in values:
+                self.host.snapshot_ids[key] = snapshot_id
+
+    async def listen_for_change(self, snapshot_ids):
+        self.requests.append(dict(snapshot_ids))
+        self.active += 1
+        self.max_active = max(self.max_active, self.active)
+        try:
+            return await self.host.listen_for_change(snapshot_ids)
+        finally:
+            self.active -= 1
+
+    def stats(self):
+        return {
+            "incarnation": self.incarnation,
+            "requests": self.requests,
+            "active": self.active,
+            "max_active": self.max_active,
+            "snapshot_ids": self.host.snapshot_ids,
+        }
+
+    def notify_long_poll_client_disabled(self, client_id, reason):
+        self.host.notify_client_disabled(client_id, reason)
+
+
+@pytest.fixture(scope="module")
+def reconnect_ray():
+    # When run alone, own a small local runtime. Never shut down a runtime owned
+    # by another fixture when this module is included in a larger test command.
+    owns_runtime = not ray.is_initialized()
+    if owns_runtime:
+        ray.init(address="local", num_cpus=2, include_dashboard=False)
+    yield
+    if owns_runtime:
+        ray.shutdown()
+
+
+class Hosts:
+    def __init__(self):
+        self.namespace = f"long-poll-reconnect-{uuid.uuid4().hex}"
+        self.actors = []
+        self.clients = []
+        self.releases = []
+
+    async def create(self, name, values, snapshot_id=7, max_restarts=0):
+        actor = ReconnectHost.options(
+            name=name,
+            namespace=self.namespace,
+            max_restarts=max_restarts,
+            max_task_retries=-1 if max_restarts else 0,
+        ).remote(values, snapshot_id)
+        self.actors.append(actor)
+        await actor_result(actor.stats.remote())
+        return actor
+
+    def resolver(self, name):
+        return lambda: ray.get_actor(name, namespace=self.namespace)
+
+    def client(self, actor, listeners, resolver=None):
+        kwargs = {} if resolver is None else {"host_actor_resolver": resolver}
+        client = LongPollClient(
+            actor,
+            listeners,
+            call_in_event_loop=asyncio.get_running_loop(),
+            client_id=f"test-reconnect-{uuid.uuid4().hex}",
+            **kwargs,
+        )
+        self.clients.append(client)
+        return client
+
+    async def retire(self, actor, name):
+        await asyncio.to_thread(ray.kill, actor, no_restart=True)
+
+        def absent():
+            try:
+                ray.get_actor(name, namespace=self.namespace)
+            except ValueError:
+                return True
+            return False
+
+        deadline = asyncio.get_running_loop().time() + WAIT_TIMEOUT_S
+        while not await asyncio.to_thread(absent):
+            assert asyncio.get_running_loop().time() < deadline, "Name still occupied"
+            await asyncio.sleep(0.01)
+
+    def blocking_resolver(self, name):
+        entered = threading.Event()
+        release = threading.Event()
+        finished = threading.Event()
+        calls = []
+        self.releases.append(release)
+
+        def resolve():
+            calls.append(time.monotonic())
+            entered.set()
+            try:
+                if not release.wait(WAIT_TIMEOUT_S):
+                    raise RuntimeError("Test did not release the blocked resolver")
+                return ray.get_actor(name, namespace=self.namespace)
+            finally:
+                finished.set()
+
+        return resolve, entered, release, finished, calls
+
+    async def close(self):
+        for client in self.clients:
+            client.stop()
+        for release in self.releases:
+            release.set()
+        # Let event-loop cancellation and late Ray completions see stopped state
+        # before the fixture's loop is closed.
+        await asyncio.sleep(0.05)
+        for actor in self.actors:
+            try:
+                await asyncio.to_thread(ray.kill, actor, no_restart=True)
+            except ray.exceptions.RayError:
+                pass
+        await asyncio.sleep(0.05)
+
+
+@pytest_asyncio.fixture
+async def hosts(reconnect_ray, monkeypatch):
+    monkeypatch.setattr(long_poll_module, "LONG_POLL_HOST_RETRY_DELAY_S", 0.05)
+    hosts = Hosts()
+    try:
+        yield hosts
+    finally:
+        await hosts.close()
+
+
+@pytest.mark.asyncio
+async def test_named_replacement_with_equal_snapshot_id(hosts):
+    old = await hosts.create("controller", {"state": "old"})
+    received = []
+    client = hosts.client(old, {"state": received.append}, hosts.resolver("controller"))
+    await wait_until(lambda: received == ["old"])
+
+    await hosts.retire(old, "controller")
+    new = await hosts.create("controller", {"state": "new"})
+    assert old._actor_id != new._actor_id
+    await wait_until(lambda: received == ["old", "new"])
+
+    stats = await actor_result(new.stats.remote())
+    assert stats["requests"][0] == {"state": -1}
+    assert stats["max_active"] == 1
+    assert client.host_actor._actor_id == new._actor_id
+    assert client.is_running
+
+
+@pytest.mark.asyncio
+async def test_named_host_becomes_available_after_several_lookups(hosts):
+    old = await hosts.create("controller", {"state": "old"})
+    received = []
+    calls = []
+
+    def resolve():
+        calls.append(time.monotonic())
+        return ray.get_actor("controller", namespace=hosts.namespace)
+
+    client = hosts.client(old, {"state": received.append}, resolve)
+    await wait_until(lambda: received == ["old"])
+    await hosts.retire(old, "controller")
+    await wait_until(lambda: len(calls) >= 3)
+    assert received == ["old"]
+    assert client.is_running
+    # A zero-delay retry loop would violate this very loose lower bound. The
+    # configured minimum is 25ms; no upper latency/SLA is asserted.
+    assert all(b - a >= 0.01 for a, b in zip(calls, calls[1:]))
+
+    await hosts.create("controller", {"state": "new"})
+    await wait_until(lambda: received == ["old", "new"])
+
+
+@pytest.mark.asyncio
+async def test_same_actor_id_restart_preserves_existing_ray_retry_behavior(hosts):
+    actor = await hosts.create(
+        "controller", {"state": "old"}, snapshot_id=None, max_restarts=1
+    )
+    before = await actor_result(actor.stats.remote())
+    received = []
+    resolver_calls = []
+
+    def unexpected_resolver():
+        resolver_calls.append(True)
+        return actor
+
+    client = hosts.client(actor, {"state": received.append}, unexpected_resolver)
+    await wait_until(lambda: received == ["old"])
+    original_id = actor._actor_id
+    await asyncio.to_thread(ray.kill, actor, no_restart=False)
+    deadline = asyncio.get_running_loop().time() + WAIT_TIMEOUT_S
+    while True:
+        after = await actor_result(actor.stats.remote())
+        if after["incarnation"] != before["incarnation"]:
+            break
+        assert asyncio.get_running_loop().time() < deadline, "Actor did not restart"
+        await asyncio.sleep(0.01)
+    assert after["incarnation"] != before["incarnation"]
+    assert actor._actor_id == original_id
+    await actor_result(
+        actor.publish.remote(
+            {"state": "restarted"}, before["snapshot_ids"]["state"] + 1
+        )
+    )
+    await wait_until(lambda: received[-1] == "restarted")
+    assert resolver_calls == []
+    assert client.is_running
+
+
+@pytest.mark.asyncio
+async def test_default_client_stops_without_resolving_replacement(hosts):
+    old = await hosts.create("controller", {"state": "old"})
+    received = []
+    client = hosts.client(old, {"state": received.append})
+    await wait_until(lambda: received == ["old"])
+    await hosts.retire(old, "controller")
+    await wait_until(lambda: not client.is_running)
+    new = await hosts.create("controller", {"state": "new"})
+    await asyncio.sleep(0.2)
+    assert received == ["old"]
+    assert (await actor_result(new.stats.remote()))["requests"] == []
+
+
+@pytest.mark.asyncio
+async def test_one_client_survives_repeated_named_replacements(hosts):
+    actor = await hosts.create("controller", {"state": 0})
+    received = []
+    client = hosts.client(
+        actor, {"state": received.append}, hosts.resolver("controller")
+    )
+    await wait_until(lambda: received == [0])
+    actor_ids = [actor._actor_id]
+    for value in (1, 2, 3):
+        await hosts.retire(actor, "controller")
+        actor = await hosts.create("controller", {"state": value})
+        actor_ids.append(actor._actor_id)
+        await wait_until(lambda: received == list(range(value + 1)))
+        stats = await actor_result(actor.stats.remote())
+        assert stats["requests"][0] == {"state": -1}
+        assert stats["max_active"] == 1
+    assert len(set(actor_ids)) == 4
+    assert client.is_running
+
+
+@pytest.mark.asyncio
+async def test_listener_added_while_lookup_is_in_flight(hosts):
+    old = await hosts.create("controller", {"first": "old"})
+    first, second = [], []
+    resolve, entered, release, finished, calls = hosts.blocking_resolver("controller")
+    client = hosts.client(old, {"first": first.append}, resolve)
+    await wait_until(lambda: first == ["old"])
+    await hosts.retire(old, "controller")
+    await wait_until(entered.is_set)
+    new = await hosts.create("controller", {"first": "new", "second": "added"})
+    client.add_key_listeners({"second": second.append})
+    await wait_until(lambda: "second" in client.key_listeners)
+    release.set()
+    await wait_until(lambda: first == ["old", "new"] and second == ["added"])
+    assert finished.is_set()
+    assert len(calls) == 1
+    assert (await actor_result(new.stats.remote()))["requests"][0] == {
+        "first": -1,
+        "second": -1,
+    }
+
+
+@pytest.mark.asyncio
+async def test_explicit_empty_snapshot_differs_from_unknown_key(hosts):
+    old = await hosts.create("controller", {"routes": ["old"], "later": ["cached"]})
+    routes, later = [], []
+    hosts.client(
+        old,
+        {"routes": routes.append, "later": later.append},
+        hosts.resolver("controller"),
+    )
+    await wait_until(lambda: routes == [["old"]] and later == [["cached"]])
+    await hosts.retire(old, "controller")
+    new = await hosts.create("controller", {"routes": []})
+    await wait_until(lambda: routes == [["old"], []])
+    # Several real host timeouts must not invent a deletion for the unknown key.
+    await asyncio.sleep(0.3)
+    assert later == [["cached"]]
+    assert len((await actor_result(new.stats.remote()))["requests"]) >= 2
+    await actor_result(new.publish.remote({"later": []}, 7))
+    await wait_until(lambda: later == [["cached"], []])
+
+
+@pytest.mark.asyncio
+async def test_stop_cancels_pending_retry_before_lookup(hosts, monkeypatch):
+    # A long delay makes this a cancellation test, not a race against actor
+    # startup latency. Prompt task termination is the decisive oracle.
+    monkeypatch.setattr(long_poll_module, "LONG_POLL_HOST_RETRY_DELAY_S", 60.0)
+    old = await hosts.create("controller", {"state": "old"})
+    received, calls = [], []
+
+    def resolve():
+        calls.append(True)
+        return ray.get_actor("controller", namespace=hosts.namespace)
+
+    client = hosts.client(old, {"state": received.append}, resolve)
+    await wait_until(lambda: received == ["old"])
+    await hosts.retire(old, "controller")
+    await wait_until(lambda: client._reconnect_task is not None)
+    retry_task = client._reconnect_task
+    await asyncio.sleep(0)
+    client.stop()
+    await wait_until(retry_task.done)
+    assert retry_task.cancelled() or retry_task.exception() is None
+    new = await hosts.create("controller", {"state": "new"})
+    await asyncio.sleep(0.1)
+    assert calls == []
+    assert not client.is_running
+    assert received == ["old"]
+    assert (await actor_result(new.stats.remote()))["requests"] == []
+
+
+@pytest.mark.asyncio
+async def test_stop_discards_blocked_executor_result_and_loop_keeps_running(hosts):
+    old = await hosts.create("controller", {"state": "old"})
+    received = []
+    resolve, entered, release, finished, calls = hosts.blocking_resolver("controller")
+    client = hosts.client(old, {"state": received.append}, resolve)
+    await wait_until(lambda: received == ["old"])
+    await hosts.retire(old, "controller")
+    await wait_until(entered.is_set)
+
+    heartbeat = []
+
+    async def tick():
+        for _ in range(5):
+            await asyncio.sleep(0.01)
+            heartbeat.append(True)
+
+    await asyncio.wait_for(tick(), timeout=2)
+    assert len(heartbeat) == 5
+    assert not finished.is_set()
+    assert len(calls) == 1
+    client.stop()
+    new = await hosts.create("controller", {"state": "new"})
+    release.set()
+    await wait_until(finished.is_set)
+    await asyncio.sleep(0.2)
+    assert not client.is_running
+    assert client.host_actor._actor_id == old._actor_id
+    assert received == ["old"]
+    assert len(calls) == 1
+    assert (await actor_result(new.stats.remote()))["requests"] == []
+
+
+@pytest.mark.asyncio
+async def test_unexpected_resolver_error_is_terminal(hosts):
+    old = await hosts.create("controller", {"state": "old"})
+    received, calls = [], []
+
+    def resolve():
+        calls.append(True)
+        raise RuntimeError("Resolver configuration is invalid")
+
+    client = hosts.client(old, {"state": received.append}, resolve)
+    await wait_until(lambda: received == ["old"])
+    await hosts.retire(old, "controller")
+    await wait_until(lambda: not client.is_running)
+    await asyncio.sleep(0.2)
+    assert calls == [True]
+    assert received == ["old"]
+
+
+@pytest.mark.asyncio
+async def test_resolver_may_briefly_return_the_dead_handle(hosts):
+    old = await hosts.create("controller", {"state": "old"})
+    received, calls = [], []
+
+    def resolve():
+        calls.append(time.monotonic())
+        if len(calls) == 1:
+            return old
+        return ray.get_actor("controller", namespace=hosts.namespace)
+
+    hosts.client(old, {"state": received.append}, resolve)
+    await wait_until(lambda: received == ["old"])
+    await hosts.retire(old, "controller")
+    await hosts.create("controller", {"state": "new"})
+    await wait_until(lambda: received == ["old", "new"])
+    assert len(calls) >= 2
+    assert calls[1] - calls[0] >= 0.01
+
+
+@pytest.mark.asyncio
+async def test_stop_during_real_poll_discards_later_update(hosts):
+    actor = await hosts.create("controller", {"state": "old"})
+    received = []
+    client = hosts.client(
+        actor, {"state": received.append}, hosts.resolver("controller")
+    )
+    await wait_until(lambda: received == ["old"])
+    client.stop()
+    await actor_result(actor.publish.remote({"state": "after-stop"}))
+    await asyncio.sleep(0.2)
+    assert received == ["old"]
+    assert not client.is_running
+
+
+@pytest.mark.asyncio
+async def test_listener_stop_discards_already_queued_callbacks(hosts, monkeypatch):
+    actor = await hosts.create("controller", {"first": 1, "second": 2})
+    received = []
+
+    def first(value):
+        received.append(value)
+        client.stop()
+
+    client = hosts.client(actor, {"first": first, "second": received.append})
+    schedule_callback = client._schedule_to_event_loop
+    queued_callbacks = []
+    # Let the actual host RPC finish, but hold its callback deliveries until
+    # both have arrived. This removes the race between the completion thread
+    # scheduling the second callback and the event loop executing the first.
+    monkeypatch.setattr(client, "_schedule_to_event_loop", queued_callbacks.append)
+    await wait_until(lambda: len(queued_callbacks) == 2)
+    assert received == []
+    monkeypatch.setattr(client, "_schedule_to_event_loop", schedule_callback)
+    for callback in queued_callbacks:
+        schedule_callback(callback)
+    # No yield occurred while enqueuing: both callbacks precede the first stop.
+    assert len(queued_callbacks) == 2
+    assert received == []
+    await wait_until(lambda: not client.is_running)
+    await asyncio.sleep(0.1)
+    assert received == [1]

--- a/python/ray/serve/tests/test_long_poll_reconnect.py
+++ b/python/ray/serve/tests/test_long_poll_reconnect.py
@@ -395,13 +395,14 @@ async def test_stop_discards_blocked_executor_result_and_loop_keeps_running(host
 
 
 @pytest.mark.asyncio
-async def test_unexpected_resolver_error_is_terminal(hosts):
+@pytest.mark.parametrize("error_type", [RuntimeError, ray.exceptions.RaySystemError])
+async def test_unexpected_resolver_error_is_terminal(hosts, error_type):
     old = await hosts.create("controller", {"state": "old"})
     received, calls = [], []
 
     def resolve():
         calls.append(True)
-        raise RuntimeError("Resolver configuration is invalid")
+        raise error_type("Resolver configuration is invalid")
 
     client = hosts.client(old, {"state": received.append}, resolve)
     await wait_until(lambda: received == ["old"])
@@ -474,3 +475,38 @@ async def test_listener_stop_discards_already_queued_callbacks(hosts, monkeypatc
     await wait_until(lambda: not client.is_running)
     await asyncio.sleep(0.1)
     assert received == [1]
+
+
+@pytest.mark.asyncio
+async def test_named_lookup_timeouts_are_retried(hosts):
+    old = await hosts.create("controller", {"state": "old"})
+    received, calls = [], []
+    timed_out = threading.Event()
+
+    def resolve():
+        calls.append(True)
+        if len(calls) <= 2:
+            # ActorManager maps a timed-out GCS lookup to GetTimeoutError.
+            # Inject that known result; this is not a live GCS outage test.
+            timed_out.set()
+            raise ray.exceptions.GetTimeoutError("Named actor lookup timed out")
+        return ray.get_actor("controller", namespace=hosts.namespace)
+
+    client = hosts.client(old, {"state": received.append}, resolve)
+    await wait_until(lambda: received == ["old"])
+    await hosts.retire(old, "controller")
+    await wait_until(timed_out.is_set)
+    new = await hosts.create("controller", {"state": "new"})
+    await wait_until(lambda: received == ["old", "new"] or not client.is_running)
+
+    assert client.is_running
+    assert received == ["old", "new"]
+    assert len(calls) >= 3
+    assert client.host_actor._actor_id == new._actor_id
+    assert (await actor_result(new.stats.remote()))["requests"][0] == {"state": -1}
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main(["-v", "-s", __file__]))

--- a/python/ray/serve/tests/unit/test_haproxy_manager_shutdown.py
+++ b/python/ray/serve/tests/unit/test_haproxy_manager_shutdown.py
@@ -1,0 +1,95 @@
+"""HAProxyManager shutdown ordering without Ray actors or subprocesses."""
+
+import asyncio
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from ray.serve._private.haproxy import HAProxyManager
+
+
+@pytest.mark.asyncio
+async def test_shutdown_stops_subscription_and_awaits_coalesced_update():
+    # Exercise the actual actor implementation's shutdown method. Construction
+    # starts external services, so supply only its shutdown dependencies here.
+    manager_class = HAProxyManager.__ray_metadata__.modified_class
+    manager = manager_class.__new__(manager_class)
+    manager._node_id = "shutdown-test-node"
+    manager._update_pending = True
+    events = []
+    started = asyncio.Event()
+    cancellation_observed = asyncio.Event()
+    finish_cleanup = asyncio.Event()
+
+    async def pending_update():
+        started.set()
+        try:
+            await asyncio.Event().wait()
+        finally:
+            events.append("update-cancelled")
+            cancellation_observed.set()
+            # Cancellation itself is insufficient: shutdown must await this
+            # cleanup before stopping the process the update could still use.
+            await finish_cleanup.wait()
+            events.append("update-finished")
+
+    manager._coalesce_task = asyncio.create_task(pending_update())
+    manager.long_poll_client = Mock(spec=["stop"])
+    manager.long_poll_client.stop.side_effect = lambda: events.append(
+        "subscription-stopped"
+    )
+
+    async def stop_process():
+        assert manager._coalesce_task.done()
+        assert manager._coalesce_task.cancelled()
+        events.append("haproxy-stopped")
+
+    manager._haproxy = Mock(spec=["stop"])
+    manager._haproxy.stop = AsyncMock(side_effect=stop_process)
+    metrics_collector = Mock(spec=["close"])
+    metrics_collector.close.side_effect = lambda: events.append("metrics-closed")
+    manager._metrics_collector = metrics_collector
+    tasks = [manager._coalesce_task]
+
+    try:
+        await asyncio.wait_for(started.wait(), timeout=5)
+        shutdown_task = asyncio.create_task(manager.shutdown())
+        cancellation_waiter = asyncio.create_task(cancellation_observed.wait())
+        tasks.extend([shutdown_task, cancellation_waiter])
+        done, _ = await asyncio.wait(
+            [shutdown_task, cancellation_waiter],
+            timeout=5,
+            return_when=asyncio.FIRST_COMPLETED,
+        )
+        if shutdown_task in done:
+            # Surface a process-stop ordering assertion directly rather than
+            # obscuring it behind a timeout waiting for missing cancellation.
+            await shutdown_task
+            pytest.fail("Shutdown finished before update cleanup was released")
+        assert cancellation_waiter in done, "Pending update was not cancelled"
+        manager.long_poll_client.stop.assert_called_once_with()
+        assert manager._update_pending is False
+        assert events == ["subscription-stopped", "update-cancelled"]
+        assert not manager._coalesce_task.done()
+        assert not shutdown_task.done()
+        manager._haproxy.stop.assert_not_awaited()
+
+        finish_cleanup.set()
+        await asyncio.wait_for(shutdown_task, timeout=5)
+        assert manager._coalesce_task.cancelled()
+        manager._haproxy.stop.assert_awaited_once_with()
+        metrics_collector.close.assert_called_once_with()
+        assert manager._metrics_collector is None
+        assert events == [
+            "subscription-stopped",
+            "update-cancelled",
+            "update-finished",
+            "haproxy-stopped",
+            "metrics-closed",
+        ]
+    finally:
+        finish_cleanup.set()
+        for task in tasks:
+            if not task.done():
+                task.cancel()
+        await asyncio.gather(*tasks, return_exceptions=True)

--- a/python/ray/serve/tests/unit/test_haproxy_manager_shutdown.py
+++ b/python/ray/serve/tests/unit/test_haproxy_manager_shutdown.py
@@ -93,3 +93,9 @@ async def test_shutdown_stops_subscription_and_awaits_coalesced_update():
             if not task.done():
                 task.cancel()
         await asyncio.gather(*tasks, return_exceptions=True)
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main(["-v", "-s", __file__]))


### PR DESCRIPTION
## Description

When the Serve controller is replaced with a different actor ID, a surviving `HAProxyManager` can retain a terminal `LongPollClient` subscription to the old controller. Existing routes keep serving, but a newly deployed route can return the catch-all application's body even though its own deployment is healthy.

This adds an optional synchronous `host_actor_resolver` to `LongPollClient`. On actor failure, opted-in clients resolve a replacement off the event loop, retry unavailable names with jitter, and invalidate snapshot versions before resubscribing. Resetting versions matters because different controller incarnations can publish the same snapshot ID. Clients without a resolver retain their existing behavior.

Only `HAProxyManager` opts in, using the controller's stable name and namespace. Its shutdown stops the subscription and cancels/awaits a pending coalesced configuration update before stopping HAProxy. Regressions cover replacement/version collisions, repeated and delayed replacement, same-ID restarts, listener changes during discovery, resolver errors, and stop races including already-queued callbacks.

## Related issues

Related to #63784. This addresses HAProxy subscription recovery, not every controller-replacement failure mode.

The existing #63785 addresses checkpoint compatibility and diagnostics; this change adds opt-in discovery and subscription recovery. I rechecked the existing work and explained this distinction [in the issue before submission](https://github.com/ray-project/ray/issues/63784#issuecomment-5611518583).

## Additional information

Validation used source and native Ray pinned to `80142bad1d1db176f19c7e3aff6b6448631e66c2`. [Linux CI and raw artifacts](https://github.com/thantiklermcirony/empirical-architecture/actions/runs/34425598056) contain the paired HTTP reproduction, commands, imported-source/native hashes, actor identities, JUnit, and lint results. The tested patch SHA-256 is `eee705a017b381dbcf78bfcdcd6a6c1d507941a6cc4595bf2f76e81e561fad3c`.

- **Real HAProxy HTTP reproduction:** one controller replacement per condition, retaining the original manager within each run. Over a 30-second observation window, all 60 baseline probes returned the wrong catch-all body and all 60 candidate probes returned the new-route body. Both returned HTTP 200; the new deployment was independently checked through its handle. These are repeated probes of one failover per condition, not 60 independent failovers.
- **Linux/Python 3.12:** 30 passed, zero skipped: 13 new actor regressions, all 16 existing `test_long_poll.py` cases, and one HAProxy shutdown unit. Applicable upstream formatting, lint, type, and build-file hooks passed without changing the candidate.
- **Human local validation on Windows/Python 3.12:** I reviewed every changed line and ran `Review_Ray_Candidate.ps1`: all 14 new tests passed. The helper first verifies the native commit and both modified module hashes, then runs the 13 actor regressions and shutdown unit. This is separate from the agent-run Linux validation.
- **Published commit:** [the Linux submission workflow](https://github.com/thantiklermcirony/ray/actions/runs/34427825241) installed the upstream pre-commit hook and ran it automatically during `git commit -s`. All applicable hooks passed. The committed diff was checked byte-for-byte against the reviewed and tested patch before publishing.

The Linux test groups were run separately with this exact command pattern (`TEST_FILE` and `RESULT_XML` identify each group's file and JUnit output):

```bash
python -c "import ray, pytest; assert ray.__commit__ == '80142bad1d1db176f19c7e3aff6b6448631e66c2'; raise SystemExit(pytest.main())" \
  -q --import-mode=importlib --timeout=90 --timeout-method=thread \
  -o asyncio_mode=auto -o asyncio_default_fixture_loop_scope=function \
  --junitxml="$RESULT_XML" "$TEST_FILE"
```

The three `TEST_FILE` values were `python/ray/serve/tests/test_long_poll_reconnect.py`, `python/ray/serve/tests/test_long_poll.py`, and `python/ray/serve/tests/unit/test_haproxy_manager_shutdown.py`. The paired reproduction and these groups are orchestrated by:

```bash
python research/ray-campaign/run_validation.py \
  --source-root /absolute/path/to/pinned-ray-checkout \
  --evidence-dir /absolute/path/to/new-evidence-directory
```

That harness lives in the linked evidence repository; [setup and reproduction instructions](https://github.com/thantiklermcirony/empirical-architecture/blob/fa6ea1612709b859509339231af75c61799d37cc/research/ray-campaign/VALIDATION_WORKFLOW.md) describe the matching native wheel and actual upstream fixtures. The Linux command deliberately imports the verified native package before pytest collection.

Scope limits: this validates single-node CPU HTTP recovery, not multi-node/EKS, gRPC, GPU workloads, autoscaling, all Serve client lifetimes, or recovery latency. Sampling starts after the new deployment is healthy. Unknown keys do not become synthetic deletion events. Stopping a client discards a late resolver result but cannot forcibly interrupt a synchronous lookup already running in an executor.

Both HTTP runs logged a 30-second controller shutdown warning during teardown, then returned from Serve/Ray shutdown without forced supervisor cleanup. The existing LongPoll test group required scoped cleanup of two tagged processes. No inspectable tagged processes remained; three same-user process environments were inaccessible. These limitations are preserved in the artifacts.

AI assistance was used for investigation, implementation, tests, and this description. The human review and local test confirmation above are provided in accordance with `AGENTS.md`.