### PR TITLE
[Data] Make OOM warning messages easier to read

### DIFF
--- a/release/ray_release/command_runner/_anyscale_job_wrapper.py
+++ b/release/ray_release/command_runner/_anyscale_job_wrapper.py
@@ -323,6 +323,19 @@ def _metric_unavailable(check_name: str, metrics: dict, key: str) -> bool:
     return False
 
 
+def _summarize_metric_series(series_list: list[PrometheusSeries]) -> str:
+    """Summarize each series by its latest value, omitting raw samples."""
+    summaries = []
+    for series in series_list:
+        labels = series.get("metric", {})
+        values = series.get("values", [])
+        name = labels.get("Name", "unknown")
+        metric_type = labels.get("Type", "unknown")
+        final_value = values[-1][1] if values else "unknown"
+        summaries.append(f"  - {name} ({metric_type}): {final_value}")
+    return "\n".join(summaries)
+
+
 def run_oom_check():
     metrics = _load_metrics_for_check("OOM check", "RAYTEST_FAIL_ON_WORKER_OOM")
     if metrics is None:
@@ -335,7 +348,9 @@ def run_oom_check():
         worker_oom_kills = _filter_idle_worker_kills(metrics["worker_oom_kills"])
         if worker_oom_kills:
             logger.error(
-                f"Test failed: OOM worker kills detected. Details: {worker_oom_kills}"
+                "Test failed: OOM worker kills detected. "
+                "Latest cumulative counter values by metric:\n"
+                f"{_summarize_metric_series(worker_oom_kills)}"
             )
             return_code = 1
 
@@ -345,7 +360,8 @@ def run_oom_check():
         logger.error(
             "Test failed: Unexpected worker failures detected "
             "(potential kernel OOM kills or SIGKILLs not captured by Ray's memory monitor). "
-            f"Details: {metrics['unexpected_worker_failures']}"
+            "Latest cumulative counter values by metric:\n"
+            f"{_summarize_metric_series(metrics['unexpected_worker_failures'])}"
         )
         return_code = 1
     return return_code

--- a/release/ray_release/tests/test_anyscale_job_wrapper.py
+++ b/release/ray_release/tests/test_anyscale_job_wrapper.py
@@ -11,6 +11,7 @@ from ray_release.command_runner._anyscale_job_wrapper import (
     main,
     run_bash_command,
     run_obj_store_util_check,
+    run_oom_check,
     run_spilling_check,
 )
 
@@ -235,6 +236,73 @@ def test_run_spilling_check_non_dict_json(tmpdir, payload):
         json.dump(payload, f)
     with patch.dict(os.environ, {"METRICS_OUTPUT_JSON": metrics_path}):
         assert run_spilling_check() == 1
+
+
+_PROM_TASK_OOM_SAMPLE = {
+    "metric": {
+        "Name": "ReadFiles",
+        "Type": "MemoryManager.TaskEviction.Total",
+    },
+    "values": [[1786542912, "1"], [1786544112, "4"]],
+}
+_PROM_IDLE_WORKER_OOM_SAMPLE = {
+    "metric": {
+        "Name": "idle",
+        "Type": "MemoryManager.IdleWorkerEviction.Total",
+    },
+    "values": [[1786542912, "10"]],
+}
+_PROM_UNEXPECTED_WORKER_FAILURE_SAMPLE = {
+    "metric": {
+        "Name": "MapWorker(MapBatches(ExtractImageFeatures)).__init__",
+        "Type": "Raylet.UnexpectedActorFailure.Total",
+    },
+    "values": [[1786542267, "1"], [1786544217, "1"]],
+}
+
+
+def test_run_oom_check_ignores_idle_worker_kills(tmpdir, caplog):
+    metrics_path = str(tmpdir / "metrics.json")
+    with open(metrics_path, "w") as f:
+        json.dump(
+            {
+                "worker_oom_kills": [_PROM_IDLE_WORKER_OOM_SAMPLE],
+                "unexpected_worker_failures": [],
+            },
+            f,
+        )
+
+    with patch.dict(os.environ, {"METRICS_OUTPUT_JSON": metrics_path}):
+        assert run_oom_check() == 0
+    assert caplog.records == []
+
+
+def test_run_oom_check_summarizes_metric_series(tmpdir, caplog):
+    metrics_path = str(tmpdir / "metrics.json")
+    with open(metrics_path, "w") as f:
+        json.dump(
+            {
+                "worker_oom_kills": [
+                    _PROM_TASK_OOM_SAMPLE,
+                    _PROM_IDLE_WORKER_OOM_SAMPLE,
+                ],
+                "unexpected_worker_failures": [_PROM_UNEXPECTED_WORKER_FAILURE_SAMPLE],
+            },
+            f,
+        )
+
+    with patch.dict(os.environ, {"METRICS_OUTPUT_JSON": metrics_path}):
+        assert run_oom_check() == 1
+    assert [record.getMessage() for record in caplog.records] == [
+        "Test failed: OOM worker kills detected. "
+        "Latest cumulative counter values by metric:\n"
+        "  - ReadFiles (MemoryManager.TaskEviction.Total): 4",
+        "Test failed: Unexpected worker failures detected "
+        "(potential kernel OOM kills or SIGKILLs not captured by Ray's memory monitor). "
+        "Latest cumulative counter values by metric:\n"
+        "  - MapWorker(MapBatches(ExtractImageFeatures)).__init__ "
+        "(Raylet.UnexpectedActorFailure.Total): 1",
+    ]
 
 
 class TestRunObjStoreUtilCheck:


### PR DESCRIPTION
## Description

Ray Data release tests currently include the complete Prometheus timestamp/value series when reporting OOM worker kills and unexpected worker failures. Long-running tests can produce hundreds of repeated samples, making the actionable metric name, type, and count difficult to find.

This change summarizes each matching Prometheus series as one line containing its name, type, and latest cumulative counter value. It preserves the existing failure behavior and idle-worker eviction filtering while omitting the raw timestamped samples.

Tests cover both OOM warning types, selecting the latest value, and ignoring idle-worker evictions.

## Related issues
None

## Additional information

### Before:

```
[2026-08-12T14:17:23Z] [ERROR 2026-08-12 07:17:04,118] anyscale_job_wrapper.py: 322  Test failed: OOM worker kills detected. Details: [{'metric': {'Name': 'ReadFiles', 'Type': 'MemoryManager.TaskEviction.Total'}, 'values': [[1786542912, '1'], [1786542927, '1'], [1786542942, '1'], [1786542957, '1'], [1786542972, '1'], [1786542987, '1'], [1786543002, '1'], [1786543017, '1'], [1786543032, '1'], [1786543047, '1'], [1786543062, '1'], [1786543077, '1'], [1786543092, '1'], [1786543107, '1'], [1786543122, '1'], [1786543137, '1'], [1786543152, '1'], [1786543167, '1'], [1786543182, '1'], [1786543197, '1'], [1786543212, '1'], [1786543227, '1'], [1786543242, '1'], [1786543257, '1'], [1786543272, '1'], [1786543287, '1'], [1786543302, '1'], [1786543317, '1'], [1786543332, '1'], [1786543347, '1'], [1786543362, '1'], [1786543377, '1'], [1786543392, '1'], [1786543407, '1'], [1786543422, '1'], [1786543437, '1'], [1786543452, '1'], [1786543467, '1'], [1786543482, '1'], [1786543497, '1'], [1786543512, '1'], [1786543527, '1'], [1786543542, '1'], [1786543557, '1'], [1786543572, '1'], [1786543587, '2'], [1786543602, '2'], [1786543617, '2'], [1786543632, '2'], [1786543647, '2'], [1786543662, '2'], [1786543677, '2'], [1786543692, '2'], [1786543707, '2'], [1786543722, '2'], [1786543737, '2'], [1786543752, '2'], [1786543767, '2'], [1786543782, '2'], [1786543797, '2'], [1786543812, '2'], [1786543827, '2'], [1786543842, '2'], [1786543857, '2'], [1786543872, '2'], [1786543887, '2'], [1786543902, '2'], [1786543917, '2'], [1786543932, '2'], [1786543947, '3'], [1786543962, '3'], [1786543977, '3'], [1786543992, '3'], [1786544007, '3'], [1786544022, '3'], [1786544037, '3'], [1786544052, '3'], [1786544067, '3'], [1786544082, '3'], [1786544097, '3'], [1786544112, '4'], [1786544127, '4'], [1786544142, '4'], [1786544157, '4'], [1786544172, '4'], [1786544187, '4'], [1786544202, '4'], [1786544217, '4']]}]
```

### After

```
[2026-08-12T14:17:23Z] [ERROR 2026-08-12 07:17:04,118] _anyscale_job_wrapper.py: 350  Test failed: OOM worker kills detected. Latest cumulative counter values by metric:
  - ReadFiles (MemoryManager.TaskEviction.Total): 4
```