### PR TITLE
[Data] Fix hash shuffle after workers scale to zero

### DIFF
--- a/python/ray/data/_internal/execution/operators/hash_shuffle.py
+++ b/python/ray/data/_internal/execution/operators/hash_shuffle.py
@@ -479,11 +479,13 @@ def _derive_max_shuffle_aggregators(
     # As such we establish that the max number of shuffle
     # aggregators (workers):
     #
-    #   - Should not exceed total # of CPUs (to fully utilize cluster resources
-    #   while avoiding thrashing these due to over-allocation)
+    #   - Should request at least one aggregator so a cluster with no workers
+    #     can scale up
+    #   - Otherwise should not exceed total # of CPUs (to fully utilize cluster
+    #     resources while avoiding thrashing these due to over-allocation)
     #   - Should be capped at fixed size (128 by default)
     return min(
-        math.ceil(total_cluster_resources.cpu),
+        max(1, math.ceil(total_cluster_resources.cpu)),
         data_context.max_hash_shuffle_aggregators
         or DEFAULT_MAX_HASH_SHUFFLE_AGGREGATORS,
     )

--- a/python/ray/data/tests/test_groupby_e2e.py
+++ b/python/ray/data/tests/test_groupby_e2e.py
@@ -1,6 +1,7 @@
 import itertools
 import random
 import time
+from concurrent.futures import ThreadPoolExecutor
 from typing import Iterator, Optional
 
 import numpy as np
@@ -10,6 +11,8 @@ import pytest
 from packaging.version import parse as parse_version
 
 import ray
+from ray._common.test_utils import wait_for_condition
+from ray.autoscaler.v2.sdk import get_cluster_status
 from ray.data._internal.arrow_ops.transform_pyarrow import (
     MIN_PYARROW_VERSION_TYPE_PROMOTION,
     combine_chunks,
@@ -114,6 +117,52 @@ def test_map_groups_with_gpus(
     )
 
     assert rows == [{"id": 0}]
+
+
+def test_map_groups_on_cluster_without_workers(ray_start_cluster, restore_data_context):
+    ray.shutdown()
+    cluster = ray_start_cluster
+    cluster.add_node(
+        num_cpus=0,
+        include_dashboard=False,
+        object_store_memory=128 * 1024 * 1024,
+    )
+    ray.init(address=cluster.address)
+    ray.data.DataContext.get_current().shuffle_strategy = ShuffleStrategy.HASH_SHUFFLE
+
+    rows = [
+        {"key": "a", "value": 1},
+        {"key": "b", "value": 2},
+        {"key": "a", "value": 3},
+    ]
+    ds = (
+        ray.data.from_items(rows)
+        .groupby("key")
+        .map_groups(lambda group: group, batch_format="pyarrow")
+    )
+
+    def has_cpu_demand():
+        demands = get_cluster_status(cluster.address).resource_demands
+        return any(
+            bundle.count > 0 and bundle.bundle.get("CPU", 0) > 0
+            for demand in demands.ray_task_actor_demand
+            for bundle in demand.bundles_by_count
+        )
+
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        result = executor.submit(ds.materialize)
+        try:
+            wait_for_condition(lambda: result.done() or has_cpu_demand(), timeout=30)
+            if result.done():
+                # Surface planning failures rather than timing out waiting for demand.
+                result.result()
+            assert has_cpu_demand()
+            cluster.add_node(num_cpus=2, object_store_memory=128 * 1024 * 1024)
+            materialized = result.result(timeout=60)
+            assert sorted(materialized.take_all(), key=lambda row: row["value"]) == rows
+        finally:
+            # Unblock the executor if the shuffle is still waiting for resources.
+            ray.shutdown()
 
 
 def test_groupby_with_column_expression_udf(

--- a/python/ray/data/tests/test_groupby_e2e.py
+++ b/python/ray/data/tests/test_groupby_e2e.py
@@ -1,7 +1,6 @@
 import itertools
 import random
 import time
-from concurrent.futures import ThreadPoolExecutor
 from typing import Iterator, Optional
 
 import numpy as np
@@ -11,8 +10,6 @@ import pytest
 from packaging.version import parse as parse_version
 
 import ray
-from ray._common.test_utils import wait_for_condition
-from ray.autoscaler.v2.sdk import get_cluster_status
 from ray.data._internal.arrow_ops.transform_pyarrow import (
     MIN_PYARROW_VERSION_TYPE_PROMOTION,
     combine_chunks,
@@ -117,52 +114,6 @@ def test_map_groups_with_gpus(
     )
 
     assert rows == [{"id": 0}]
-
-
-def test_map_groups_on_cluster_without_workers(ray_start_cluster, restore_data_context):
-    ray.shutdown()
-    cluster = ray_start_cluster
-    cluster.add_node(
-        num_cpus=0,
-        include_dashboard=False,
-        object_store_memory=128 * 1024 * 1024,
-    )
-    ray.init(address=cluster.address)
-    ray.data.DataContext.get_current().shuffle_strategy = ShuffleStrategy.HASH_SHUFFLE
-
-    rows = [
-        {"key": "a", "value": 1},
-        {"key": "b", "value": 2},
-        {"key": "a", "value": 3},
-    ]
-    ds = (
-        ray.data.from_items(rows)
-        .groupby("key")
-        .map_groups(lambda group: group, batch_format="pyarrow")
-    )
-
-    def has_cpu_demand():
-        demands = get_cluster_status(cluster.address).resource_demands
-        return any(
-            bundle.count > 0 and bundle.bundle.get("CPU", 0) > 0
-            for demand in demands.ray_task_actor_demand
-            for bundle in demand.bundles_by_count
-        )
-
-    with ThreadPoolExecutor(max_workers=1) as executor:
-        result = executor.submit(ds.materialize)
-        try:
-            wait_for_condition(lambda: result.done() or has_cpu_demand(), timeout=30)
-            if result.done():
-                # Surface planning failures rather than timing out waiting for demand.
-                result.result()
-            assert has_cpu_demand()
-            cluster.add_node(num_cpus=2, object_store_memory=128 * 1024 * 1024)
-            materialized = result.result(timeout=60)
-            assert sorted(materialized.take_all(), key=lambda row: row["value"]) == rows
-        finally:
-            # Unblock the executor if the shuffle is still waiting for resources.
-            ray.shutdown()
 
 
 def test_groupby_with_column_expression_udf(

--- a/python/ray/data/tests/test_hash_shuffle.py
+++ b/python/ray/data/tests/test_hash_shuffle.py
@@ -13,7 +13,10 @@ from ray.data._internal.execution.interfaces import (
     RefBundle,
 )
 from ray.data._internal.execution.operators.hash_aggregate import HashAggregateOperator
-from ray.data._internal.execution.operators.hash_shuffle import HashShuffleOperator
+from ray.data._internal.execution.operators.hash_shuffle import (
+    HashShuffleOperator,
+    _derive_max_shuffle_aggregators,
+)
 from ray.data._internal.execution.operators.join import JoinOperator
 from ray.data._internal.logical.interfaces import LogicalOperator
 from ray.data._internal.logical.operators import JoinType
@@ -21,6 +24,28 @@ from ray.data._internal.planner.exchange.sort_task_spec import SortKey
 from ray.data._internal.util import GiB, MiB
 from ray.data.aggregate import AggregateFnV2, Count, Sum
 from ray.data.block import BlockAccessor, BlockMetadata
+from ray.data.context import DEFAULT_MAX_HASH_SHUFFLE_AGGREGATORS
+
+
+@pytest.mark.parametrize(
+    "num_cpus,max_aggregators,expected",
+    [
+        (0, None, 1),
+        (0, 4, 1),
+        (2.5, 4, 3),
+        (8, 4, 4),
+        (
+            2 * DEFAULT_MAX_HASH_SHUFFLE_AGGREGATORS,
+            None,
+            DEFAULT_MAX_HASH_SHUFFLE_AGGREGATORS,
+        ),
+    ],
+)
+def test_derive_max_shuffle_aggregators(num_cpus, max_aggregators, expected):
+    ctx = DataContext(max_hash_shuffle_aggregators=max_aggregators)
+    resources = ExecutionResources(cpu=num_cpus)
+
+    assert _derive_max_shuffle_aggregators(resources, ctx) == expected
 
 
 def _create_aggregator_pool_for_test(op, estimated_dataset_bytes: Optional[int]):


### PR DESCRIPTION
## Description

Hash shuffle derives zero aggregators when only a CPU-less head remains and the configured maximum cluster resources are unavailable. Actor memory sizing then divides by zero.

I keep at least one aggregator so the operation can request workers. The existing CPU-based and configured caps are unchanged for positive capacity.

## Related issues

Fixes #66028. I checked the issue and open shuffle PRs and found no existing fix for it.

## Tests

Per review, I replaced the cluster-startup end-to-end regression with `test_derive_max_shuffle_aggregators` in `test_hash_shuffle.py`. It covers zero CPUs with default and explicit caps, fractional CPU rounding, and default and configured aggregator limits. The production fix is unchanged.

```sh
python -m pytest -q python/ray/data/tests/test_hash_shuffle.py --tb=short --show-capture=no
```

42 passed, using Python 3.12, the repository's NumPy/pandas/PyArrow and pytest pins, and the documented Python-only development setup with official Ray nightly binaries.

The two zero-CPU cases fail with 0 instead of 1 when I load the upstream pre-fix helper into memory. All five replacement unit-test cases pass with the fix.

```sh
pre-commit run --files \
  python/ray/data/tests/test_hash_shuffle.py \
  python/ray/data/tests/test_groupby_e2e.py
```

All applicable hooks passed.

I used OpenAI Codex to help prepare the implementation, tests, and review response.
