### PR TITLE
[Data] Add logical memory usage chart

### DIFF
--- a/python/ray/dashboard/modules/data/data_head.py
+++ b/python/ray/dashboard/modules/data/data_head.py
@@ -46,6 +46,7 @@ DATASET_METRICS = {
     "ray_data_current_bytes": (PrometheusQuery.VALUE, PrometheusQuery.MAX),
     "ray_data_cpu_usage_cores": (PrometheusQuery.VALUE, PrometheusQuery.MAX),
     "ray_data_gpu_usage_cores": (PrometheusQuery.VALUE, PrometheusQuery.MAX),
+    "ray_data_memory_usage_bytes": (PrometheusQuery.VALUE, PrometheusQuery.MAX),
 }
 
 

--- a/python/ray/dashboard/modules/data/tests/test_data_head.py
+++ b/python/ray/dashboard/modules/data/tests/test_data_head.py
@@ -23,6 +23,7 @@ DATA_SCHEMA = [
     "ray_data_current_bytes",
     "ray_data_cpu_usage_cores",
     "ray_data_gpu_usage_cores",
+    "ray_data_memory_usage_bytes",
 ]
 
 RESPONSE_SCHEMA = [

--- a/python/ray/dashboard/modules/metrics/dashboards/data_dashboard_panels.py
+++ b/python/ray/dashboard/modules/metrics/dashboards/data_dashboard_panels.py
@@ -103,6 +103,21 @@ GPU_USAGE_PANEL = Panel(
     stack=False,
 )
 
+MEMORY_USAGE_PANEL = Panel(
+    id=92,
+    title="Logical Slots Being Used (Memory)",
+    description="Current amount of logical heap memory in bytes allocated to running tasks per dataset operator. This tracks logical resource allocation, not actual physical memory usage.",
+    unit="bytes",
+    targets=[
+        Target(
+            expr='sum(ray_data_memory_usage_bytes{{{global_filters}, operator=~"$Operator"}}) by (dataset, operator)',
+            legend="Memory Usage: {{dataset}}, {{operator}}",
+        )
+    ],
+    fill=0,
+    stack=False,
+)
+
 BYTES_OUTPUT_PER_SECOND_PANEL = Panel(
     id=7,
     title="Bytes Output / Second",
@@ -1510,6 +1525,7 @@ DATA_GRAFANA_ROWS = [
         panels=[
             CPU_USAGE_PANEL,
             GPU_USAGE_PANEL,
+            MEMORY_USAGE_PANEL,
             CPU_BUDGET_PANEL,
             GPU_BUDGET_PANEL,
             MEMORY_BUDGET_PANEL,

--- a/python/ray/data/_internal/execution/interfaces/op_runtime_metrics.py
+++ b/python/ray/data/_internal/execution/interfaces/op_runtime_metrics.py
@@ -612,6 +612,7 @@ class OpRuntimeMetrics(metaclass=OpRuntimesMetricsMeta):
             [
                 ("cpu_usage", resource_usage.cpu or 0),
                 ("gpu_usage", resource_usage.gpu or 0),
+                ("memory_usage", resource_usage.memory or 0),
             ]
         )
         result.extend(self._extra_metrics.items())

--- a/python/ray/data/_internal/stats.py
+++ b/python/ray/data/_internal/stats.py
@@ -431,6 +431,11 @@ class _StatsActor:
             description="GPUs allocated to dataset operators",
             tag_keys=op_tags_keys,
         )
+        self.memory_usage_bytes = Gauge(
+            "data_memory_usage_bytes",
+            description="Heap memory allocated to dataset operators",
+            tag_keys=op_tags_keys,
+        )
         self.output_bytes = Gauge(
             "data_output_bytes",
             description="Bytes outputted by dataset operators",
@@ -768,6 +773,7 @@ class _StatsActor:
             self.output_rows.set(stats.get("row_outputs_taken", 0), tags)
             self.cpu_usage_cores.set(stats.get("cpu_usage", 0), tags)
             self.gpu_usage_cores.set(stats.get("gpu_usage", 0), tags)
+            self.memory_usage_bytes.set(stats.get("memory_usage", 0), tags)
             for field_name, prom_metric in self.execution_metrics_inputs.items():
                 _record(prom_metric, stats.get(field_name, 0), tags)
             for field_name, prom_metric in self.execution_metrics_outputs.items():

--- a/python/ray/data/tests/test_stats.py
+++ b/python/ray/data/tests/test_stats.py
@@ -426,6 +426,7 @@ def gen_expected_metrics(
             "'obj_store_mem_used': A",
             "'cpu_usage': Z",
             "'gpu_usage': Z",
+            "'memory_usage': Z",
         ]
     else:
         metrics = [
@@ -515,6 +516,7 @@ def gen_expected_metrics(
             "'obj_store_mem_used': A",
             "'cpu_usage': Z",
             "'gpu_usage': Z",
+            "'memory_usage': Z",
         ]
     if extra_metrics:
         metrics.extend(extra_metrics)
@@ -992,6 +994,7 @@ def test_dataset__repr__(ray_start_regular_shared, restore_data_context):
         "      obj_store_mem_used: A,\n"
         "      cpu_usage: Z,\n"
         "      gpu_usage: Z,\n"
+        "      memory_usage: Z,\n"
         "      ray_remote_args: {'num_cpus': N, 'scheduling_strategy': 'SPREAD'},\n"
         "   },\n"
         "   operators_stats=[\n"
@@ -1156,6 +1159,7 @@ def test_dataset__repr__(ray_start_regular_shared, restore_data_context):
         "      obj_store_mem_used: A,\n"
         "      cpu_usage: Z,\n"
         "      gpu_usage: Z,\n"
+        "      memory_usage: Z,\n"
         "      ray_remote_args: {'num_cpus': N, 'scheduling_strategy': 'SPREAD'},\n"
         "   },\n"
         "   operators_stats=[\n"
@@ -1273,6 +1277,7 @@ def test_dataset__repr__(ray_start_regular_shared, restore_data_context):
         "            obj_store_mem_used: A,\n"
         "            cpu_usage: Z,\n"
         "            gpu_usage: Z,\n"
+        "            memory_usage: Z,\n"
         "            ray_remote_args: {'num_cpus': N, 'scheduling_strategy': 'SPREAD'},\n"  # noqa: E501
         "         },\n"
         "         operators_stats=[\n"


### PR DESCRIPTION
## Description

Ray Data exposes logical CPU and GPU usage in the Data dashboard, but it does not expose the logical heap memory reserved by running operator tasks. Now that memory is a first-class scheduling resource, users need the same visibility for memory when diagnosing resource allocation and operator concurrency.

## Related issues
None

## Additional information

<img width="2880" height="1556" alt="image" src="https://github.com/user-attachments/assets/fc9eee4e-dc27-4fb9-bbb5-84587e4c9462" />

