### PR TITLE
[Data] Fix KeyError in CSE projection on schema-less empty blocks

### DIFF
--- a/python/ray/data/_internal/planner/plan_expression/expression_evaluator.py
+++ b/python/ray/data/_internal/planner/plan_expression/expression_evaluator.py
@@ -924,6 +924,15 @@ def eval_projection(
     temporary columns on a working block. Visible projection expressions are
     then evaluated against that working block.
     """
+    block_accessor = BlockAccessor.for_block(block)
+
+    # Skip projection only for schema-less empty blocks. Evaluating the CSE
+    # common expressions against such a block would raise a KeyError (there
+    # are no columns to resolve against), so short-circuit before the CSE
+    # branch, mirroring the guard in ``_eval_projection_without_cse``.
+    if block_accessor.num_rows() == 0 and len(block_accessor.column_names()) == 0:
+        return block
+
     if not common_sub_exprs:
         return _eval_projection_without_cse(projection_exprs, block)
 

--- a/python/ray/data/tests/unit/test_expression_evaluator.py
+++ b/python/ray/data/tests/unit/test_expression_evaluator.py
@@ -423,6 +423,24 @@ def test_eval_projection_with_common_sub_exprs_pandas():
     assert out["y"].tolist() == [4, 6, 8]
 
 
+def test_eval_projection_with_common_sub_exprs_schema_less_empty_block():
+    """CSE projection must pass a schema-less empty block through unchanged
+    instead of raising a KeyError while evaluating the common subexpressions."""
+    block = pa.table({})
+    common = (col("a") + 1).alias(f"{CSE_TEMP_COLUMN_PREFIX}test_0")
+    projection = [
+        (
+            col(f"{CSE_TEMP_COLUMN_PREFIX}test_0")
+            + col(f"{CSE_TEMP_COLUMN_PREFIX}test_0")
+        ).alias("y")
+    ]
+
+    out = eval_projection(projection, block, common_sub_exprs=[common])
+
+    assert out.num_rows == 0
+    assert out.num_columns == 0
+
+
 if __name__ == "__main__":
     import sys
 


### PR DESCRIPTION
## Why this change

`eval_projection` raises a `KeyError` when it receives a schema-less empty block (zero rows, zero columns) and common subexpressions are present. The `CommonSubExprElimination` rule runs unconditionally in the optimizer's post-optimize phase, so any projection with duplicated subexpressions takes the CSE branch. That branch evaluates the common subexpressions against the input block before checking for schema-less empty blocks, producing:

```
KeyError: 'Field "a" does not exist in schema'
```

Operators emit schema-less empty blocks for empty partitions whenever the input schema is unknown (for example, a hash aggregate downstream of an opaque `map_batches`), so the crash is reachable from plain Ray Data pipelines.

The non-CSE path (`_eval_projection_without_cse`) already short-circuits schema-less empty blocks. This change applies the same guard at the top of `eval_projection`, before the CSE branch, so both paths behave consistently.

## Related issue

Closes #66045

## Tests

- `pytest python/ray/data/tests/unit/test_expression_evaluator.py` -> 38 passed (added `test_eval_projection_with_common_sub_exprs_schema_less_empty_block`)
- The reproduction script from the issue now returns `(0, 0)` as expected.

## Not duplicating

No existing PR references #66045, and no open PR touches the CSE branch of `eval_projection`.
