### PR TITLE
[Serve][Docs] Define an application checkpoint contract for async inference

### DIFF
--- a/doc/source/serve/asynchronous-inference.md
+++ b/doc/source/serve/asynchronous-inference.md
@@ -226,7 +226,60 @@ In this example:
 
 ## Concurrency and reliability
 
- Manage concurrency by setting `max_ongoing_requests` on the consumer deployment; this caps how many tasks each replica can process simultaneously. For at-least-once delivery, adapters should acknowledge a task only after the handler completes successfully. Failed tasks are retried up to `max_retries`; once exhausted, they are routed to the failed-task DLQ when configured. The default Celery adapter acknowledges on success, providing at-least-once processing.
+Manage concurrency by setting `max_ongoing_requests` on the consumer deployment; this caps how many tasks each replica can process simultaneously. The default Celery adapter enables late acknowledgement and requeueing on worker loss. Delivery and redelivery behavior still depend on the broker and its configuration; handlers must tolerate duplicate execution.
+
+By default, the Celery adapter uses `max_retries` for retries of application exceptions. After those retries are exhausted, it routes the failed task to the configured DLQ. Broker redelivery after a process dies can occur without advancing this application retry count. If a job needs a limit across worker losses or re-enqueueing, track admitted attempts or a deadline in application-owned durable state.
+
+(serve-async-inference-checkpoints)=
+### Application-owned checkpoints and progress
+
+The task consumer API doesn't provide durable checkpoints, resumable progress, or a transaction spanning application state and queue acknowledgement. `get_task_status_sync(task_id)` reads the adapter's task result; it isn't a checkpoint for partially completed inference. For a workload that can resume between pages, video segments, or batches, define an application contract before choosing storage.
+
+Keep these identities and state separate:
+
+| Field | Contract |
+| --- | --- |
+| `job_id` | Stable logical job ID, passed in the task payload and reused when submission is retried or a task is re-enqueued. Use it to key application progress and results. |
+| Request fingerprint | Immutable input revision, model/pipeline version, and relevant parameters. Reject reuse of a `job_id` with different inputs; a mutable URL alone isn't an input revision. |
+| `task_id` | Adapter/transport task identity, useful for status and diagnostics. A retry may retain it, and re-enqueueing may create another ID for the same logical job. |
+| `attempt_id` and fencing token | A fresh execution identity and a monotonically increasing token issued by an atomic job claim. Every checkpoint and result commit must validate that this attempt still owns the job. |
+| Committed checkpoint | Immutable checkpoint reference plus the next unit to process, updated atomically. The checkpoint must recover the entire committed prefix `[0, next_unit)`, directly or through a manifest of earlier outputs. Progress describes committed work and must not move backwards. |
+| Committed result | Immutable result reference published with the terminal state. A completed job returns this reference on redelivery without recomputing it. |
+
+Implement the handler around four transitions:
+
+1. **Claim or return the existing result.** Validate the fingerprint. If the job is complete, return its committed result. Otherwise, acquire an application-owned lease and a new fencing token atomically. A duplicate delivery must not take over a live lease. An expired lease permits takeover even if the old worker is still running.
+2. **Resume committed work.** Load the saved checkpoint and begin at its next unit. Write each checkpoint artifact to durable storage before conditionally publishing its reference and progress under the current token. Retrying the same commit must be idempotent. Local variables and emitted progress events aren't recovery state.
+3. **Publish completion before returning.** Write the final result durably, then conditionally commit its reference and terminal state under the current token. Only then return from the handler, allowing the adapter to complete and acknowledge the task. Don't acknowledge while result publication is still pending. If publication times out, read back the committed state before retrying the same operation.
+4. **Fence late writers.** After takeover, reject the old attempt's checkpoint and result commits. Checking ownership only when the handler starts is insufficient. Poll progress by `job_id` from committed application state, including the terminal result reference, rather than combining counters from different attempts.
+
+The storage implementation must make ownership checks and their associated writes atomic. For object storage, write immutable artifacts first and conditionally publish their references through a transactional record; losing attempts can leave unreferenced artifacts for later cleanup. A checkpoint protocol doesn't make arbitrary external effects exactly once: use idempotency keys or an appropriate transaction for those effects, and expect computation since the last checkpoint to repeat.
+
+Retain the job record, its terminal result and fencing generation, and referenced artifacts throughout the retry/redelivery horizon. Don't delete and recreate job state or reuse a `job_id` while an old attempt can still write or a task can be redelivered: doing so resets fencing and result deduplication.
+
+These failure traces define the recovery behavior:
+
+| Failure window | Expected recovery |
+| --- | --- |
+| Checkpoint committed, worker lost before completion | A replacement attempt gets a new token, loads that checkpoint, and resumes at the next uncommitted unit. |
+| Result committed, worker lost before acknowledgement | A redelivered task finds the terminal record and returns the same result, even if its transport `task_id` differs. |
+| Two attempts overlap after a lease takeover | The old token cannot publish either progress or a result. Only the new owner can commit; completed state remains immutable. |
+
+The following record types make the distinction explicit:
+
+```{literalinclude} doc_code/async_inference_checkpoint_contract.py
+:language: python
+:start-after: __records_begin__
+:end-before: __records_end__
+```
+
+Download the {download}`executable contract model <doc_code/async_inference_checkpoint_contract.py>` to run the three traces with the Python standard library:
+
+```bash
+python doc/source/serve/doc_code/async_inference_checkpoint_contract.py -v
+```
+
+The model executes serial interleavings with an in-memory record standing in for committed state. Each claim assumes lease admission has already succeeded. It tests the contract, including fingerprint conflicts, monotonic progress, and stale writers; it doesn't implement leases, durable storage, inference, or broker integration. Validate those properties separately against the storage and adapter you deploy.
 
 (serve-async-inference-autoscaling)=
 ## Autoscaling
@@ -301,4 +354,3 @@ Recommendations:
 :::{note}
 The APIs in this guide reflect the alpha interfaces in `ray.serve.schema` and `ray.serve.task_consumer`.
 :::
-

--- a/doc/source/serve/asynchronous-inference.md
+++ b/doc/source/serve/asynchronous-inference.md
@@ -226,46 +226,16 @@ In this example:
 
 ## Concurrency and reliability
 
-Manage concurrency by setting `max_ongoing_requests` on the consumer deployment; this caps how many tasks each replica can process simultaneously. The default Celery adapter enables late acknowledgement and requeueing on worker loss. Delivery and redelivery behavior still depend on the broker and its configuration; handlers must tolerate duplicate execution.
+Set `max_ongoing_requests` on the consumer deployment to cap how many tasks each replica processes simultaneously. The default Celery adapter uses late acknowledgement and requeues tasks on worker loss. Delivery behavior depends on the broker and its configuration. Write handlers that tolerate duplicate execution.
 
 By default, the Celery adapter uses `max_retries` for retries of application exceptions. After those retries are exhausted, it routes the failed task to the configured DLQ. Broker redelivery after a process dies can occur without advancing this application retry count. If a job needs a limit across worker losses or re-enqueueing, track admitted attempts or a deadline in application-owned durable state.
 
 (serve-async-inference-checkpoints)=
-### Application-owned checkpoints and progress
+### Resume work from checkpoints
 
-The task consumer API doesn't provide durable checkpoints, resumable progress, or a transaction spanning application state and queue acknowledgement. `get_task_status_sync(task_id)` reads the adapter's task result; it isn't a checkpoint for partially completed inference. For a workload that can resume between pages, video segments, or batches, define an application contract before choosing storage.
+To resume inference between pages, video segments, or batches, store checkpoints in your application. The task consumer API doesn't provide durable checkpoints or resumable progress. `get_task_status_sync(task_id)` reads the adapter's task status and result. It doesn't restore partially completed inference.
 
-Keep these identities and state separate:
-
-| Field | Contract |
-| --- | --- |
-| `job_id` | Stable logical job ID, passed in the task payload and reused when submission is retried or a task is re-enqueued. Use it to key application progress and results. |
-| Request fingerprint | Immutable input revision, model/pipeline version, and relevant parameters. Reject reuse of a `job_id` with different inputs; a mutable URL alone isn't an input revision. |
-| `task_id` | Adapter/transport task identity, useful for status and diagnostics. A retry may retain it, and re-enqueueing may create another ID for the same logical job. |
-| `attempt_id` and fencing token | A fresh execution identity and a monotonically increasing token issued by an atomic job claim. Every checkpoint and result commit must validate that this attempt still owns the job. |
-| Committed checkpoint | Immutable checkpoint reference plus the next unit to process, updated atomically. The checkpoint must recover the entire committed prefix `[0, next_unit)`, directly or through a manifest of earlier outputs. Progress describes committed work and must not move backwards. |
-| Committed result | Immutable result reference published with the terminal state. A completed job returns this reference on redelivery without recomputing it. |
-
-Implement the handler around four transitions:
-
-1. **Claim or return the existing result.** Validate the fingerprint. If the job is complete, return its committed result. Otherwise, acquire an application-owned lease and a new fencing token atomically. A duplicate delivery must not take over a live lease. An expired lease permits takeover even if the old worker is still running.
-2. **Resume committed work.** Load the saved checkpoint and begin at its next unit. Write each checkpoint artifact to durable storage before conditionally publishing its reference and progress under the current token. Retrying the same commit must be idempotent. Local variables and emitted progress events aren't recovery state.
-3. **Publish completion before returning.** Write the final result durably, then conditionally commit its reference and terminal state under the current token. Only then return from the handler, allowing the adapter to complete and acknowledge the task. Don't acknowledge while result publication is still pending. If publication times out, read back the committed state before retrying the same operation.
-4. **Fence late writers.** After takeover, reject the old attempt's checkpoint and result commits. Checking ownership only when the handler starts is insufficient. Poll progress by `job_id` from committed application state, including the terminal result reference, rather than combining counters from different attempts.
-
-The storage implementation must make ownership checks and their associated writes atomic. For object storage, write immutable artifacts first and conditionally publish their references through a transactional record; losing attempts can leave unreferenced artifacts for later cleanup. A checkpoint protocol doesn't make arbitrary external effects exactly once: use idempotency keys or an appropriate transaction for those effects, and expect computation since the last checkpoint to repeat.
-
-Retain the job record, its terminal result and fencing generation, and referenced artifacts throughout the retry/redelivery horizon. Don't delete and recreate job state or reuse a `job_id` while an old attempt can still write or a task can be redelivered: doing so resets fencing and result deduplication.
-
-These failure traces define the recovery behavior:
-
-| Failure window | Expected recovery |
-| --- | --- |
-| Checkpoint committed, worker lost before completion | A replacement attempt gets a new token, loads that checkpoint, and resumes at the next uncommitted unit. |
-| Result committed, worker lost before acknowledgement | A redelivered task finds the terminal record and returns the same result, even if its transport `task_id` differs. |
-| Two attempts overlap after a lease takeover | The old token cannot publish either progress or a result. Only the new owner can commit; completed state remains immutable. |
-
-The following record types make the distinction explicit:
+The following example separates task delivery, execution attempts, and committed job state:
 
 ```{literalinclude} doc_code/async_inference_checkpoint_contract.py
 :language: python
@@ -273,13 +243,44 @@ The following record types make the distinction explicit:
 :end-before: __records_end__
 ```
 
-Download the {download}`executable contract model <doc_code/async_inference_checkpoint_contract.py>` to run the three traces with the Python standard library:
+Use these fields to identify work and recover committed state:
+
+| Field | Contract |
+| --- | --- |
+| `job_id` | Stable application job ID. Pass it in the task payload and reuse it across submission retries and re-enqueueing. |
+| `fingerprint` | Immutable input revision, model and pipeline versions, and relevant parameters. A mutable URL alone doesn't identify an input revision. |
+| `task_id` | Adapter task ID for status and diagnostics. Retries may retain it, while re-enqueueing may create a different ID for the same job. |
+| `attempt_id`, `fence` | Fresh execution ID and a monotonically increasing token that identifies the job's owner. |
+| `checkpoint_ref`, `next_unit` | Immutable checkpoint reference and the next unit to process. Progress counts committed work. |
+| `result_ref` | Immutable result reference. Its presence marks the job complete. |
+
+Implement three transitions in the handler:
+
+1. Claim the job or return its result. Reject a mismatched fingerprint before checking for completion. If the job is complete, return `result_ref` without recomputing it. Otherwise, atomically acquire an application-owned lease and fencing token for a fresh `attempt_id`. Duplicate deliveries must not take over a live lease. After expiry, another attempt can take over even if the old worker still runs.
+1. Resume from the committed checkpoint. Restore all completed units `[0, next_unit)` from the checkpoint or its manifest, then process the next unit. Write each checkpoint artifact durably before atomically committing its reference and progress. Reject backwards progress. Make retries of the same commit idempotent.
+1. Publish the result before returning. Write the final artifact durably, then atomically commit `result_ref` and the terminal state. Only then return from the handler so the adapter can acknowledge the task. If publication times out, read back the record before retrying. The task API doesn't provide a transaction spanning this record and queue acknowledgement.
+
+For every checkpoint and result commit, atomically check the attempt's ownership token with the write. An old attempt must not overwrite state after takeover. With object storage, publish immutable artifact references through a transactional record and clean up unreferenced artifacts later. Poll committed application state by `job_id` instead of combining progress events from different attempts.
+
+Retain the job record, fencing generation, and referenced artifacts for as long as attempts can write or tasks can be redelivered. Deleting and recreating state or reusing a `job_id` during that period resets fencing and result deduplication. Checkpointing doesn't make external effects exactly once. Use idempotency keys or a transaction for those effects, and expect computation since the last checkpoint to repeat.
+
+Verify these three failure cases:
+
+| Failure window | Expected recovery |
+| --- | --- |
+| A worker dies after committing a checkpoint | The replacement loads that checkpoint and resumes at the next uncommitted unit with a new token. |
+| A worker dies after committing the result but before acknowledgement | The redelivered task returns the same result, even if its `task_id` differs. |
+| An old attempt keeps running after lease takeover | Its token cannot publish checkpoints or results. Only the new owner can commit, and completed state stays immutable. |
+
+Download the {download}`checkpoint example <doc_code/async_inference_checkpoint_contract.py>` and run its tests with the Python standard library. From the Ray repository root, run:
 
 ```bash
 python doc/source/serve/doc_code/async_inference_checkpoint_contract.py -v
 ```
 
-The model executes serial interleavings with an in-memory record standing in for committed state. Each claim assumes lease admission has already succeeded. It tests the contract, including fingerprint conflicts, monotonic progress, and stale writers; it doesn't implement leases, durable storage, inference, or broker integration. Validate those properties separately against the storage and adapter you deploy.
+:::{note}
+The example models atomic storage transitions with in-memory records. Each claim assumes lease admission has succeeded. Tests interleave attempts to check recovery, identity, and commit rules. They don't implement leases, durable storage, inference, or a broker. Test those components separately with your storage and adapter.
+:::
 
 (serve-async-inference-autoscaling)=
 ## Autoscaling

--- a/doc/source/serve/doc_code/async_inference_checkpoint_contract.py
+++ b/doc/source/serve/doc_code/async_inference_checkpoint_contract.py
@@ -1,0 +1,181 @@
+"""Executable application-state contract, not a checkpoint storage implementation.
+
+Run with Python alone. Each method models one atomic storage transition, and
+claim() assumes lease admission has succeeded. The tests interleave attempts;
+they do not start workers, write durable artifacts, or exercise a broker.
+"""
+
+import unittest
+from dataclasses import dataclass, replace
+from typing import Dict, Optional, Tuple
+
+
+# __records_begin__
+@dataclass(frozen=True)
+class Delivery:
+    job_id: str
+    fingerprint: str
+    total_units: int
+    task_id: str  # Transport identity, not the key for progress or results.
+
+
+@dataclass(frozen=True)
+class Attempt:
+    job_id: str
+    attempt_id: str
+    fence: int
+
+
+@dataclass(frozen=True)
+class JobRecord:
+    fingerprint: str
+    total_units: int
+    fence: int = 0
+    attempt_id: Optional[str] = None
+    next_unit: int = 0
+    checkpoint_ref: Optional[str] = None
+    result_ref: Optional[str] = None
+
+
+# __records_end__
+class StaleAttempt(RuntimeError):
+    """A newer attempt owns the job."""
+
+
+class ApplicationStateModel:
+    """Serial model of atomic, conditional writes to an application job record."""
+
+    def __init__(self):
+        self.records: Dict[str, JobRecord] = {}
+
+    def claim(
+        self, delivery: Delivery, attempt_id: str
+    ) -> Tuple[Optional[Attempt], JobRecord]:
+        """Model an admitted lease acquisition or takeover, not lease expiry."""
+        if delivery.total_units <= 0:
+            raise ValueError("Expected at least one work unit")
+        record = self.records.get(
+            delivery.job_id, JobRecord(delivery.fingerprint, delivery.total_units)
+        )
+        if (record.fingerprint, record.total_units) != (
+            delivery.fingerprint,
+            delivery.total_units,
+        ):
+            raise ValueError("job_id already belongs to a different request")
+        if record.result_ref is not None:
+            return None, record
+        if not attempt_id or attempt_id == record.attempt_id:
+            raise ValueError("Use a fresh attempt_id for each execution")
+        record = replace(record, attempt_id=attempt_id, fence=record.fence + 1)
+        self.records[delivery.job_id] = record
+        return Attempt(delivery.job_id, attempt_id, record.fence), record
+
+    def _owned_record(self, attempt: Attempt) -> JobRecord:
+        record = self.records[attempt.job_id]
+        if (record.attempt_id, record.fence) != (attempt.attempt_id, attempt.fence):
+            raise StaleAttempt("Checkpoint and result writes require the current token")
+        return record
+
+    def checkpoint(
+        self, attempt: Attempt, next_unit: int, checkpoint_ref: str
+    ) -> JobRecord:
+        """Publish a reference to an already durable, immutable checkpoint."""
+        record = self._owned_record(attempt)
+        if record.result_ref is not None:
+            raise ValueError("A completed job cannot accept checkpoints")
+        if (
+            not checkpoint_ref
+            or not record.next_unit <= next_unit <= record.total_units
+        ):
+            raise ValueError(
+                "Committed progress must not move backwards or exceed work"
+            )
+        if next_unit == record.next_unit:
+            if checkpoint_ref != record.checkpoint_ref:
+                raise ValueError("Cannot replace an already committed checkpoint")
+            return record
+        record = replace(record, next_unit=next_unit, checkpoint_ref=checkpoint_ref)
+        self.records[attempt.job_id] = record
+        return record
+
+    def finish(self, attempt: Attempt, result_ref: str) -> JobRecord:
+        """Publish an already durable result before the handler returns."""
+        record = self._owned_record(attempt)
+        if not result_ref or record.next_unit != record.total_units:
+            raise ValueError("Complete the work before publishing a result")
+        if record.result_ref is not None and record.result_ref != result_ref:
+            raise ValueError("A committed result cannot be replaced")
+        record = replace(record, result_ref=result_ref)
+        self.records[attempt.job_id] = record
+        return record
+
+
+class FailureContractTests(unittest.TestCase):
+    def setUp(self):
+        self.store = ApplicationStateModel()
+        self.delivery = Delivery("job-1", "input-v1/model-v1/pipeline-v1", 3, "task-1")
+
+    def test_checkpoint_then_worker_loss(self):
+        first, _ = self.store.claim(self.delivery, "attempt-a")
+        saved = self.store.checkpoint(first, 1, "checkpoints/unit-1")
+
+        # The worker is lost. A replacement claims after the old lease expires.
+        second, resumed = self.store.claim(self.delivery, "attempt-b")
+        self.assertGreater(second.fence, first.fence)
+        self.assertEqual(resumed.checkpoint_ref, saved.checkpoint_ref)
+        remaining_work = list(range(resumed.next_unit, resumed.total_units))
+        self.assertEqual(remaining_work, [1, 2])  # Unit 0 is already committed.
+        for unit in remaining_work:
+            self.store.checkpoint(second, unit + 1, f"checkpoints/unit-{unit + 1}")
+        self.assertEqual(self.store.finish(second, "results/final").next_unit, 3)
+
+    def test_result_commit_then_redelivery_before_acknowledgement(self):
+        first, _ = self.store.claim(self.delivery, "attempt-a")
+        self.store.checkpoint(first, 3, "checkpoints/unit-3")
+        committed = self.store.finish(first, "results/final")
+
+        # The result is visible, but the worker dies before the broker sees an ack.
+        for task_id in ("task-1", "task-reenqueued"):
+            attempt, result = self.store.claim(
+                replace(self.delivery, task_id=task_id), "attempt-redelivered"
+            )
+            self.assertIsNone(attempt)  # Return the result; do not run inference.
+            self.assertEqual(result, committed)
+
+        with self.assertRaisesRegex(ValueError, "different request"):
+            self.store.claim(
+                replace(self.delivery, fingerprint="input-v2/model-v1/pipeline-v1"),
+                "attempt-other-input",
+            )
+        self.assertEqual(self.store.records[self.delivery.job_id], committed)
+
+    def test_overlapping_attempts_fence_checkpoints_and_results(self):
+        old, _ = self.store.claim(self.delivery, "attempt-a")
+        self.store.checkpoint(old, 1, "checkpoints/unit-1")
+        # A pauses beyond its lease; B takes over while A may still compute.
+        current, claimed = self.store.claim(self.delivery, "attempt-b")
+        with self.assertRaises(StaleAttempt):
+            self.store.checkpoint(old, 3, "checkpoints/late-a")
+        self.assertEqual(self.store.records[self.delivery.job_id], claimed)
+
+        with self.assertRaisesRegex(ValueError, "backwards"):
+            self.store.checkpoint(current, 0, "checkpoints/older")
+        with self.assertRaisesRegex(ValueError, "already committed"):
+            self.store.checkpoint(current, 1, "checkpoints/conflicting")
+        self.assertEqual(
+            self.store.checkpoint(current, 1, "checkpoints/unit-1"), claimed
+        )
+
+        self.store.checkpoint(current, 3, "checkpoints/unit-3")
+        with self.assertRaises(StaleAttempt):
+            self.store.finish(old, "results/late-a")
+        committed = self.store.finish(current, "results/current-b")
+        with self.assertRaisesRegex(ValueError, "cannot be replaced"):
+            self.store.finish(current, "results/conflicting-b")
+        with self.assertRaisesRegex(ValueError, "completed job"):
+            self.store.checkpoint(current, 3, "checkpoints/after-result")
+        self.assertEqual(self.store.records[self.delivery.job_id], committed)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/doc/source/serve/doc_code/async_inference_checkpoint_contract.py
+++ b/doc/source/serve/doc_code/async_inference_checkpoint_contract.py
@@ -6,11 +6,12 @@ they do not start workers, write durable artifacts, or exercise a broker.
 """
 
 import unittest
+
+# __records_begin__
 from dataclasses import dataclass, replace
 from typing import Dict, Optional, Tuple
 
 
-# __records_begin__
 @dataclass(frozen=True)
 class Delivery:
     job_id: str
@@ -33,7 +34,7 @@ class JobRecord:
     fence: int = 0
     attempt_id: Optional[str] = None
     next_unit: int = 0
-    checkpoint_ref: Optional[str] = None
+    checkpoint_ref: Optional[str] = None  # Restores the prefix [0, next_unit).
     result_ref: Optional[str] = None
 
 
@@ -57,9 +58,9 @@ class ApplicationStateModel:
         record = self.records.get(
             delivery.job_id, JobRecord(delivery.fingerprint, delivery.total_units)
         )
-        if (record.fingerprint, record.total_units) != (
-            delivery.fingerprint,
-            delivery.total_units,
+        if (
+            record.fingerprint != delivery.fingerprint
+            or record.total_units != delivery.total_units
         ):
             raise ValueError("job_id already belongs to a different request")
         if record.result_ref is not None:
@@ -72,7 +73,7 @@ class ApplicationStateModel:
 
     def _owned_record(self, attempt: Attempt) -> JobRecord:
         record = self.records[attempt.job_id]
-        if (record.attempt_id, record.fence) != (attempt.attempt_id, attempt.fence):
+        if record.attempt_id != attempt.attempt_id or record.fence != attempt.fence:
             raise StaleAttempt("Checkpoint and result writes require the current token")
         return record
 
@@ -83,10 +84,9 @@ class ApplicationStateModel:
         record = self._owned_record(attempt)
         if record.result_ref is not None:
             raise ValueError("A completed job cannot accept checkpoints")
-        if (
-            not checkpoint_ref
-            or not record.next_unit <= next_unit <= record.total_units
-        ):
+        if not checkpoint_ref:
+            raise ValueError("Expected a checkpoint reference")
+        if not record.next_unit <= next_unit <= record.total_units:
             raise ValueError(
                 "Committed progress must not move backwards or exceed work"
             )
@@ -101,7 +101,9 @@ class ApplicationStateModel:
     def finish(self, attempt: Attempt, result_ref: str) -> JobRecord:
         """Publish an already durable result before the handler returns."""
         record = self._owned_record(attempt)
-        if not result_ref or record.next_unit != record.total_units:
+        if not result_ref:
+            raise ValueError("Expected a result reference")
+        if record.next_unit != record.total_units:
             raise ValueError("Complete the work before publishing a result")
         if record.result_ref is not None and record.result_ref != result_ref:
             raise ValueError("A committed result cannot be replaced")
@@ -113,67 +115,94 @@ class ApplicationStateModel:
 class FailureContractTests(unittest.TestCase):
     def setUp(self):
         self.store = ApplicationStateModel()
-        self.delivery = Delivery("job-1", "input-v1/model-v1/pipeline-v1", 3, "task-1")
+        self.delivery = Delivery(
+            job_id="job-1",
+            fingerprint="input-v1/model-v1/pipeline-v1",
+            total_units=3,
+            task_id="task-1",
+        )
 
     def test_checkpoint_then_worker_loss(self):
         first, _ = self.store.claim(self.delivery, "attempt-a")
-        saved = self.store.checkpoint(first, 1, "checkpoints/unit-1")
+        saved = self.store.checkpoint(first, 1, "checkpoints/prefix-1")
 
-        # The worker is lost. A replacement claims after the old lease expires.
+        # Replace the lost worker after its lease expires.
         second, resumed = self.store.claim(self.delivery, "attempt-b")
         self.assertGreater(second.fence, first.fence)
         self.assertEqual(resumed.checkpoint_ref, saved.checkpoint_ref)
         remaining_work = list(range(resumed.next_unit, resumed.total_units))
         self.assertEqual(remaining_work, [1, 2])  # Unit 0 is already committed.
         for unit in remaining_work:
-            self.store.checkpoint(second, unit + 1, f"checkpoints/unit-{unit + 1}")
+            self.store.checkpoint(second, unit + 1, f"checkpoints/prefix-{unit + 1}")
         self.assertEqual(self.store.finish(second, "results/final").next_unit, 3)
 
     def test_result_commit_then_redelivery_before_acknowledgement(self):
         first, _ = self.store.claim(self.delivery, "attempt-a")
-        self.store.checkpoint(first, 3, "checkpoints/unit-3")
+        self.store.checkpoint(first, 3, "checkpoints/prefix-3")
         committed = self.store.finish(first, "results/final")
 
-        # The result is visible, but the worker dies before the broker sees an ack.
+        # Redeliver after publication, before the broker sees an acknowledgement.
         for task_id in ("task-1", "task-reenqueued"):
-            attempt, result = self.store.claim(
-                replace(self.delivery, task_id=task_id), "attempt-redelivered"
-            )
-            self.assertIsNone(attempt)  # Return the result; do not run inference.
-            self.assertEqual(result, committed)
-
-        with self.assertRaisesRegex(ValueError, "different request"):
-            self.store.claim(
-                replace(self.delivery, fingerprint="input-v2/model-v1/pipeline-v1"),
-                "attempt-other-input",
-            )
-        self.assertEqual(self.store.records[self.delivery.job_id], committed)
+            with self.subTest(task_id=task_id):
+                attempt, result = self.store.claim(
+                    replace(self.delivery, task_id=task_id), "attempt-redelivered"
+                )
+                self.assertIsNone(attempt)  # Return the result without inference.
+                self.assertEqual(result, committed)
 
     def test_overlapping_attempts_fence_checkpoints_and_results(self):
         old, _ = self.store.claim(self.delivery, "attempt-a")
-        self.store.checkpoint(old, 1, "checkpoints/unit-1")
-        # A pauses beyond its lease; B takes over while A may still compute.
+        self.store.checkpoint(old, 1, "checkpoints/prefix-1")
+        # Admit B after A's lease expires, while A may still compute.
         current, claimed = self.store.claim(self.delivery, "attempt-b")
         with self.assertRaises(StaleAttempt):
             self.store.checkpoint(old, 3, "checkpoints/late-a")
         self.assertEqual(self.store.records[self.delivery.job_id], claimed)
 
-        with self.assertRaisesRegex(ValueError, "backwards"):
-            self.store.checkpoint(current, 0, "checkpoints/older")
-        with self.assertRaisesRegex(ValueError, "already committed"):
-            self.store.checkpoint(current, 1, "checkpoints/conflicting")
-        self.assertEqual(
-            self.store.checkpoint(current, 1, "checkpoints/unit-1"), claimed
-        )
-
-        self.store.checkpoint(current, 3, "checkpoints/unit-3")
+        self.store.checkpoint(current, 3, "checkpoints/prefix-3")
         with self.assertRaises(StaleAttempt):
             self.store.finish(old, "results/late-a")
-        committed = self.store.finish(current, "results/current-b")
+        result = self.store.finish(current, "results/current-b")
+        self.assertEqual(result.result_ref, "results/current-b")
+
+    def test_request_identity_is_checked_before_returning_a_result(self):
+        attempt, _ = self.store.claim(self.delivery, "attempt-a")
+        self.store.checkpoint(attempt, 3, "checkpoints/prefix-3")
+        committed = self.store.finish(attempt, "results/final")
+        for field, value in (("fingerprint", "input-v2"), ("total_units", 4)):
+            with self.subTest(field=field):
+                with self.assertRaisesRegex(ValueError, "different request"):
+                    self.store.claim(
+                        replace(self.delivery, **{field: value}), "attempt-b"
+                    )
+                self.assertEqual(self.store.records[self.delivery.job_id], committed)
+
+    def test_checkpoint_commits_are_monotonic_and_idempotent(self):
+        attempt, _ = self.store.claim(self.delivery, "attempt-a")
+        saved = self.store.checkpoint(attempt, 1, "checkpoints/prefix-1")
+        self.assertEqual(
+            self.store.checkpoint(attempt, 1, "checkpoints/prefix-1"), saved
+        )
+        for next_unit, ref in (
+            (0, "older"),
+            (4, "beyond-end"),
+            (1, "conflict"),
+            (2, ""),
+        ):
+            with self.subTest(next_unit=next_unit, checkpoint_ref=ref):
+                with self.assertRaises(ValueError):
+                    self.store.checkpoint(attempt, next_unit, ref)
+                self.assertEqual(self.store.records[self.delivery.job_id], saved)
+
+    def test_completed_job_is_immutable(self):
+        attempt, _ = self.store.claim(self.delivery, "attempt-a")
+        self.store.checkpoint(attempt, 3, "checkpoints/prefix-3")
+        committed = self.store.finish(attempt, "results/final")
+        self.assertEqual(self.store.finish(attempt, "results/final"), committed)
         with self.assertRaisesRegex(ValueError, "cannot be replaced"):
-            self.store.finish(current, "results/conflicting-b")
+            self.store.finish(attempt, "results/conflicting")
         with self.assertRaisesRegex(ValueError, "completed job"):
-            self.store.checkpoint(current, 3, "checkpoints/after-result")
+            self.store.checkpoint(attempt, 3, "checkpoints/after-result")
         self.assertEqual(self.store.records[self.delivery.job_id], committed)
 
 


### PR DESCRIPTION
## Description

Long-running asynchronous inference jobs can be delivered again after worker loss, but the guide currently doesn't explain how to recover partially completed application work or distinguish transport status from committed progress.

Document an application-owned checkpoint contract with stable job/input identity, fenced attempts, atomic checkpoint/result publication, retention requirements, and publish-before-return ordering. A self-contained record snippet introduces the state, followed by three recovery transitions. An executable standard-library model exercises recovery after a checkpoint, redelivery after result publication, and overlapping attempts after takeover, with focused checks for identity, progress, and immutable results. The existing Serve doc-code Bazel glob includes the example.

## Related issues

Motivated by the [checkpointing and progress discussion](https://discuss.ray.io/t/maturity-and-plans-of-asynchronous-inference/23600/9).

Checked open PRs for `"23600" in:body`, `serve "checkpoint" in:title`, and `serve "progress" in:title`: no matching PRs on 2026-09-10. Reviewed [Taskiq #61053](https://github.com/ray-project/ray/pull/61053); it implements the task processor adapter, while this contribution documents application state and recovery behavior.

## Additional information

AI assistance was used to draft, implement, test, and review this change.

Validation against master `35ec02d3`:

- `python doc/source/serve/doc_code/async_inference_checkpoint_contract.py -v` — 6 tests passed (Python 3.12).
- `black --check doc/source/serve/doc_code/async_inference_checkpoint_contract.py` — passed with Black 22.10.0.
- `ruff check --no-cache --select I,F,E doc/source/serve/doc_code/async_inference_checkpoint_contract.py` — passed with Ruff 0.8.4.
- The record snippet extracted between the `literalinclude` markers executes independently with its displayed imports.
- `pre-commit run --files doc/source/serve/asynchronous-inference.md doc/source/serve/doc_code/async_inference_checkpoint_contract.py` — exited successfully; repository configuration excludes these documentation paths, so hooks skipped them. Black and Ruff were run separately above.
- `git diff --check` — passed.
- Isolated Sphinx/MyST HTML build of the changed section with `-W --keep-going` — passed without warnings, including the literalinclude and downloadable example. The full Ray documentation build and Bazel test suite were not run.

The example is a serial model of atomic application-state transitions. Durable storage, lease admission, inference, and broker integration are deployment responsibilities described by the contract, and are not implemented or exercised by this model.
