### PR TITLE
[Serve] Validate TLS when the certificate field is omitted

### DIFF
--- a/python/ray/serve/config.py
+++ b/python/ray/serve/config.py
@@ -890,7 +890,7 @@ class HTTPOptions(BaseModel):
     request_timeout_s: Optional[float] = None
     keep_alive_timeout_s: int = DEFAULT_UVICORN_KEEP_ALIVE_TIMEOUT_S
     ssl_keyfile: Optional[str] = None
-    ssl_certfile: Optional[str] = None
+    ssl_certfile: Optional[str] = Field(default=None, validate_default=True)
     ssl_keyfile_password: Optional[str] = None
     ssl_ca_certs: Optional[str] = None
 

--- a/python/ray/serve/schema.py
+++ b/python/ray/serve/schema.py
@@ -1052,6 +1052,7 @@ class HTTPOptionsSchema(BaseModel):
     )
     ssl_certfile: Optional[str] = Field(
         default=None,
+        validate_default=True,
         description="Path to the SSL certificate file for HTTPS. If provided with "
         "ssl_keyfile, the HTTP server will use HTTPS. Cannot be updated once Serve "
         "has started.",

--- a/python/ray/serve/tests/unit/test_http_options.py
+++ b/python/ray/serve/tests/unit/test_http_options.py
@@ -1,0 +1,48 @@
+import sys
+
+import pytest
+from pydantic import ValidationError
+
+from ray.serve.config import HTTPOptions
+from ray.serve.schema import HTTPOptionsSchema, ServeDeploySchema
+
+
+@pytest.mark.parametrize("options_type", [HTTPOptions, HTTPOptionsSchema])
+@pytest.mark.parametrize(
+    "tls_options",
+    [
+        {"ssl_keyfile": "key.pem"},
+        {"ssl_keyfile": "key.pem", "ssl_certfile": None},
+        {"ssl_certfile": "cert.pem"},
+        {"ssl_certfile": "cert.pem", "ssl_keyfile": None},
+    ],
+)
+def test_http_options_reject_incomplete_tls(options_type, tls_options):
+    with pytest.raises(ValidationError, match="Both ssl_keyfile and ssl_certfile"):
+        options_type(**tls_options)
+
+
+@pytest.mark.parametrize("options_type", [HTTPOptions, HTTPOptionsSchema])
+@pytest.mark.parametrize(
+    "tls_options",
+    [
+        {},
+        {"ssl_keyfile": None},
+        {"ssl_keyfile": None, "ssl_certfile": None},
+        {"ssl_keyfile": "key.pem", "ssl_certfile": "cert.pem"},
+    ],
+)
+def test_http_options_accept_complete_or_disabled_tls(options_type, tls_options):
+    options = options_type(**tls_options)
+    assert options.ssl_keyfile == tls_options.get("ssl_keyfile")
+    assert options.ssl_certfile == tls_options.get("ssl_certfile")
+    assert options.model_fields_set == set(tls_options)
+
+
+def test_serve_deploy_schema_rejects_incomplete_tls():
+    with pytest.raises(ValidationError, match="Both ssl_keyfile and ssl_certfile"):
+        ServeDeploySchema(applications=[], http_options={"ssl_keyfile": "key.pem"})
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-v", "-s", __file__]))


### PR DESCRIPTION
## Description

`HTTPOptions(ssl_keyfile="key.pem")` and the equivalent Serve config currently pass validation when `ssl_certfile` is omitted. The existing pair validator only runs when the certificate field is explicitly present. A key-only config can therefore reach proxy startup without enabling TLS.

Validate the certificate default in both `HTTPOptions` and `HTTPOptionsSchema`, so the existing validator rejects incomplete pairs consistently. Both omitted, both `None`, and complete pairs remain valid. This change covers config construction and preserves the existing validation error location.

## Related issues

Found while reviewing Serve config validation. Searched open PRs for `ssl_keyfile` and TLS validation; no PR covers omitted-field validation. #65699 concerns changing TLS options after startup, a separate path.

## Additional information

Validation:

- `pytest -q --confcutdir=python/ray/serve/tests/unit python/ray/serve/tests/unit/test_http_options.py`: 17 passed; the baseline had 3 failures. Coverage includes both models and nested `ServeDeploySchema` input.
- `pre-commit run --files python/ray/serve/config.py python/ray/serve/schema.py python/ray/serve/tests/unit/test_http_options.py`: all applicable hooks passed.
- `git diff --check`: passed.

AI assistance was used to investigate, implement, and review this change. Local Python checks loaded the affected modules from this checkout into a Ray 2.58.0 virtual environment; no Ray native build was produced. Unit tests retain `tests/unit/conftest.py` and exclude the parent cluster-integration fixtures. Full Ray integration CI was not run locally. Commits include DCO sign-off.
