### PR TITLE
[Serve] Isolate Celery dead-letter signals by adapter

### DIFF
--- a/python/ray/serve/task_processor.py
+++ b/python/ray/serve/task_processor.py
@@ -132,10 +132,17 @@ class CeleryTaskProcessorAdapter(TaskProcessorAdapter):
             )
 
         if self._config.failed_task_queue_name:
-            task_failure.connect(self._handle_task_failure)
+            # Celery identifies bound receivers by function, not by instance.
+            task_failure.connect(
+                self._handle_task_failure,
+                dispatch_uid=f"ray_serve_task_failure_{id(self)}",
+            )
 
         if self._config.unprocessable_task_queue_name:
-            task_unknown.connect(self._handle_unknown_task)
+            task_unknown.connect(
+                self._handle_unknown_task,
+                dispatch_uid=f"ray_serve_task_unknown_{id(self)}",
+            )
 
     def register_task_handle(self, func, name=None):
         # Celery does not support async task handlers
@@ -264,7 +271,7 @@ class CeleryTaskProcessorAdapter(TaskProcessorAdapter):
         kwargs: Any = None,
         einfo: Any = None,
         **kw,
-    ):
+    ) -> None:
         """Handle task failures and route them to appropriate dead letter queues.
 
         This method is called when a task fails after all retry attempts have been
@@ -278,6 +285,9 @@ class CeleryTaskProcessorAdapter(TaskProcessorAdapter):
             einfo: Exception info object containing exception details and traceback
             **kw: Additional keyword arguments passed by Celery
         """
+        if getattr(sender, "app", None) is not self._app:
+            return
+
         logger.info(
             f"Task failure detected for task_id: {task_id}, einfo: {str(einfo)}"
         )
@@ -309,7 +319,7 @@ class CeleryTaskProcessorAdapter(TaskProcessorAdapter):
         message: Any = None,
         exc: Any = None,
         **kwargs,
-    ):
+    ) -> None:
         """Handle unknown or unregistered tasks received by Celery.
 
         This method is called when Celery receives a task that it doesn't recognize
@@ -317,13 +327,16 @@ class CeleryTaskProcessorAdapter(TaskProcessorAdapter):
         are moved to the unprocessable task queue if configured.
 
         Args:
-            sender: The Celery app or worker that detected the unknown task
+            sender: The Celery consumer that detected the unknown task
             name: Name of the unknown task
             id: Task ID of the unknown task
             message: The raw message received for the unknown task
             exc: The exception raised when trying to process the unknown task
             **kwargs: Additional context information from Celery
         """
+        if getattr(sender, "app", None) is not self._app:
+            return
+
         logger.info(
             f"Unknown task detected by Celery. Name: {name}, ID: {id}, Exc: {str(exc)}"
         )

--- a/python/ray/serve/tests/unit/test_celery_task_processor.py
+++ b/python/ray/serve/tests/unit/test_celery_task_processor.py
@@ -1,0 +1,113 @@
+import gc
+import sys
+import uuid
+import weakref
+from unittest.mock import Mock
+
+import pytest
+from celery import Celery, signals
+from celery.utils.dispatch import Signal
+
+from ray.serve import task_processor
+from ray.serve.schema import CeleryAdapterConfig, TaskProcessorConfig
+
+
+@pytest.fixture
+def create_adapter(monkeypatch, request):
+    for signal_name in ("task_failure", "task_unknown"):
+        signal = Signal(name=signal_name)
+        monkeypatch.setattr(signals, signal_name, signal)
+        monkeypatch.setattr(task_processor, signal_name, signal)
+
+    def create():
+        queue = f"test_queue_{uuid.uuid4().hex}"
+        adapter = task_processor.CeleryTaskProcessorAdapter(
+            TaskProcessorConfig(
+                queue_name=queue,
+                failed_task_queue_name=f"{queue}_failed",
+                unprocessable_task_queue_name=f"{queue}_unknown",
+                adapter_config=CeleryAdapterConfig(
+                    broker_url="memory://", backend_url="cache+memory://"
+                ),
+            )
+        )
+        adapter.initialize()
+        monkeypatch.setattr(adapter._app, "send_task", Mock())
+        request.addfinalizer(adapter._app.close)
+        return adapter
+
+    return create
+
+
+def fail_task(app):
+    @app.task(name=f"{app.main}.failure", lazy=False, shared=False)
+    def fail():
+        raise ValueError("Expected task failure")
+
+    result = fail.apply(throw=False)
+    assert result.status == "FAILURE"
+    return result.id
+
+
+@pytest.mark.parametrize("owner_index", [0, 1])
+def test_task_failure_routes_only_to_owning_adapter(create_adapter, owner_index):
+    adapters = [create_adapter(), create_adapter()]
+    owner = adapters[owner_index]
+    task_id = fail_task(owner._app)
+
+    owner._app.send_task.assert_called_once()
+    sent = owner._app.send_task.call_args.kwargs
+    assert sent["queue"] == owner._config.failed_task_queue_name
+    assert sent["args"][0] == task_id
+    adapters[1 - owner_index]._app.send_task.assert_not_called()
+
+
+@pytest.mark.parametrize("owner_index", [0, 1])
+def test_unknown_task_routes_only_to_owning_adapter(create_adapter, owner_index):
+    adapters = [create_adapter(), create_adapter()]
+    owner = adapters[owner_index]
+    signals.task_unknown.send(
+        sender=Mock(app=owner._app),
+        name="missing_task",
+        id="unknown-task-id",
+        message="Unregistered task",
+        exc=LookupError("missing_task"),
+    )
+
+    owner._app.send_task.assert_called_once()
+    sent = owner._app.send_task.call_args.kwargs
+    assert sent["queue"] == owner._config.unprocessable_task_queue_name
+    assert sent["args"][:2] == ["missing_task", "unknown-task-id"]
+    adapters[1 - owner_index]._app.send_task.assert_not_called()
+
+
+def test_unrelated_celery_app_does_not_use_adapter_dead_letter_queues(create_adapter):
+    adapters = [create_adapter(), create_adapter()]
+    with Celery("unrelated", broker="memory://", backend="cache+memory://") as app:
+        fail_task(app)
+        signals.task_unknown.send(
+            sender=Mock(app=app), name="unrelated_task", id="unrelated-task-id"
+        )
+
+    for adapter in adapters:
+        adapter._app.send_task.assert_not_called()
+
+
+def test_signal_receivers_do_not_keep_adapter_alive(create_adapter):
+    first = create_adapter()
+    second = create_adapter()
+    first_reference = weakref.ref(first)
+    del first
+    gc.collect()
+    assert first_reference() is None
+
+    fail_task(second._app)
+    second._app.send_task.assert_called_once()
+    assert (
+        second._app.send_task.call_args.kwargs["queue"]
+        == second._config.failed_task_queue_name
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-v", "-s", __file__]))


### PR DESCRIPTION
## Description

When two `CeleryTaskProcessorAdapter` instances share a process, Celery deduplicates their bound signal receivers by function. Only the first adapter is registered for task failure and unknown-task events. Its handler can then publish another application's task to the wrong dead-letter queue.

Give each adapter a separate signal registration and accept events only from its own Celery application. Receivers remain weak references. Tests exercise failures from real eager Celery tasks, unknown-task signals, unrelated apps, and collection of an unused adapter.

## Related issues

Found while reviewing the Celery adapter. Searched open PRs for `Celery`, `task_failure`, and dead-letter handling; no matching fix was found. The Taskiq adapter work in #61053 does not change this Celery signal path.

## Additional information

Validation:

- `pytest -q --confcutdir=python/ray/serve/tests/unit python/ray/serve/tests/unit/test_celery_task_processor.py`: 6 passed; the baseline had 4 failures. Uses Celery 5.6.3 with its in-memory broker/backend; no external broker or worker process is required.
- `pre-commit run --files python/ray/serve/task_processor.py python/ray/serve/tests/unit/test_celery_task_processor.py`: all applicable hooks passed.
- `git diff --check`: passed.

AI assistance was used to investigate, implement, and review this change. Local Python checks loaded the affected modules from this checkout into a Ray 2.58.0 virtual environment; no Ray native build was produced. Unit tests retain `tests/unit/conftest.py` and exclude the parent cluster-integration fixtures. Full Ray integration CI was not run locally. Commits include DCO sign-off.
