### PR TITLE
[Serve] Reload logging when additional standard attributes change

### DIFF
--- a/python/ray/serve/schema.py
+++ b/python/ray/serve/schema.py
@@ -214,6 +214,7 @@ class LoggingConfig(BaseModel):
                 + str(self.log_level)
                 + str(self.logs_dir)
                 + str(self.enable_access_log)
+                + str(sorted(self.additional_log_standard_attrs))
             ).encode("utf-8")
         )
 

--- a/python/ray/serve/tests/unit/test_controller.py
+++ b/python/ray/serve/tests/unit/test_controller.py
@@ -1,9 +1,12 @@
 from copy import deepcopy
+from types import SimpleNamespace
+from unittest.mock import Mock
 
 import pytest
 
 from ray.serve._private.common import TargetCapacityDirection
 from ray.serve._private.controller import (
+    ServeController,
     applications_match,
     calculate_target_capacity_direction,
 )
@@ -11,13 +14,45 @@ from ray.serve._private.controller_health_metrics_tracker import (
     _HEALTH_METRICS_HISTORY_SIZE,
     ControllerHealthMetricsTracker,
 )
+from ray.serve._private.long_poll import LongPollNamespace
 from ray.serve.schema import (
     ControllerHealthMetrics,
     DurationStats,
     HTTPOptionsSchema,
+    LoggingConfig,
     ServeApplicationSchema,
     ServeDeploySchema,
 )
+
+
+def test_reconfigure_global_logging_additional_attrs(monkeypatch):
+    initial = LoggingConfig(encoding="JSON", additional_log_standard_attrs=["name"])
+    updated = LoggingConfig(encoding="JSON", additional_log_standard_attrs=["process"])
+    controller = SimpleNamespace(
+        global_logging_config=initial,
+        kv_store=Mock(),
+        long_poll_host=Mock(),
+    )
+    configure_logger = Mock()
+    monkeypatch.setattr(
+        "ray.serve._private.controller.configure_component_logger", configure_logger
+    )
+
+    ServeController.reconfigure_global_logging_config(controller, updated)
+
+    assert controller.global_logging_config is updated
+    controller.kv_store.put.assert_called_once()
+    controller.long_poll_host.notify_changed.assert_called_once_with(
+        {LongPollNamespace.GLOBAL_LOGGING_CONFIG: updated}
+    )
+    configure_logger.assert_called_once()
+    assert configure_logger.call_args.kwargs["logging_config"] is updated
+
+    # Reapplying the same fields must not publish another update.
+    ServeController.reconfigure_global_logging_config(controller, updated)
+    controller.kv_store.put.assert_called_once()
+    controller.long_poll_host.notify_changed.assert_called_once()
+    configure_logger.assert_called_once()
 
 
 def create_app_config(name: str) -> ServeApplicationSchema:

--- a/python/ray/serve/tests/unit/test_schema.py
+++ b/python/ray/serve/tests/unit/test_schema.py
@@ -1136,6 +1136,26 @@ class TestLoggingConfig:
         )
         assert schema.additional_log_standard_attrs == ["name"]
 
+    @pytest.mark.parametrize(
+        "initial_attrs,updated_attrs",
+        [([], ["name"]), (["name"], ["process"]), (["name"], [])],
+    )
+    def test_additional_log_standard_attrs_affect_equality(
+        self, initial_attrs, updated_attrs
+    ):
+        initial = LoggingConfig(additional_log_standard_attrs=initial_attrs)
+        updated = LoggingConfig(additional_log_standard_attrs=updated_attrs)
+
+        assert initial != updated
+
+    def test_additional_log_standard_attrs_order_does_not_affect_equality(self):
+        initial = LoggingConfig(additional_log_standard_attrs=["name", "process"])
+        reordered = LoggingConfig(
+            additional_log_standard_attrs=["process", "name", "process"]
+        )
+
+        assert initial == reordered
+
 
 # This function is defined globally to be accessible via import path
 def global_f():


### PR DESCRIPTION
## Description

Changing only `additional_log_standard_attrs` currently compares equal to the previous `LoggingConfig`. The controller returns early, so the updated fields are not checkpointed or propagated to loggers.

Include the normalized attributes in config equality. Sorting preserves equality for reordered or duplicated attributes. Regression tests cover adding, replacing, and removing fields, plus the controller's persistence, long-poll notification, logger update, and repeated-config no-op.

## Related issues

Found while reviewing Serve logging reconfiguration. Searched open PRs for `additional_log_standard_attrs` and logging configuration equality; no matching fix was found. #59504 adds a separate flush-timeout setting and does not account for additional standard attributes.

## Additional information

Validation:

- `pytest -q --confcutdir=python/ray/serve/tests/unit python/ray/serve/tests/unit/test_schema.py python/ray/serve/tests/unit/test_controller.py`: 192 passed. Four new regressions failed before the fix.
- `pre-commit run --files python/ray/serve/schema.py python/ray/serve/tests/unit/test_schema.py python/ray/serve/tests/unit/test_controller.py`: all applicable hooks passed.
- `git diff --check`: passed.

AI assistance was used to investigate, implement, and review this change. Local Python checks loaded the affected modules from this checkout into a Ray 2.58.0 virtual environment; no Ray native build was produced. Unit tests retain `tests/unit/conftest.py` and exclude the parent cluster-integration fixtures. Full Ray integration CI was not run locally. Commits include DCO sign-off.
