### PR TITLE
[Serve][Docs] Preserve fallback ranks in the custom router example

### DIFF
--- a/doc/source/serve/advanced-guides/custom-request-router.md
+++ b/doc/source/serve/advanced-guides/custom-request-router.md
@@ -66,8 +66,8 @@ Ray Serve provides utility mixins that can be used to extend the functionality o
 
 
 (throughput-aware-request-router)=
-## Define a complex throughput-aware request router
-A fully featured request router can be more complex and should take into account the multiplexed model, locality, the request queue length on each replica, and using custom statistics like throughput  to decide which replica to route the request to. The following class defines a throughput-aware request router that routes requests to the replica with these factors in mind. Add the following code into the `custom_request_router.py` file:
+## Define a throughput-aware request router
+The following router first prefers replicas that have the requested model loaded, then those with the fewest loaded models. Within each model rank, it prefers replicas on the same node, in the same availability zone, and elsewhere, in that order. It breaks ties using increasing reported throughput. Add this class to `custom_request_router.py`:
 
 ```{literalinclude} ../doc_code/custom_request_router.py
 :start-after: __begin_define_throughput_aware_request_router__
@@ -75,7 +75,9 @@ A fully featured request router can be more complex and should take into account
 :language: python
 ```
 
-This request router inherits from [`RequestRouter`](../api/doc/ray.serve.request_router.RequestRouter.rst), as well as [`FIFOMixin`](../api/doc/ray.serve.request_router.FIFOMixin.rst) for FIFO request routing, [`LocalityMixin`](../api/doc/ray.serve.request_router.LocalityMixin.rst) for locality-aware request routing, and [`MultiplexMixin`](../api/doc/ray.serve.request_router.MultiplexMixin.rst) for multiplexed model support. It implements [`choose_replicas`](../api/doc/ray.serve.request_router.RequestRouter.choose_replicas.rst) to take the highest ranked replicas from [`rank_replicas_via_multiplex`](../api/doc/ray.serve.request_router.MultiplexMixin.rank_replicas_via_multiplex.rst) and [`rank_replicas_via_locality`](../api/doc/ray.serve.request_router.LocalityMixin.rank_replicas_via_locality.rst) and uses the [`select_available_replicas`](../api/doc/ray.serve.request_router.RequestRouter.select_available_replicas.rst) helper to filter out replicas that have reached their maximum request queue length. Finally, it takes the replicas with the minimum throughput and returns the top one.
+The router keeps every rank returned by the multiplexing and locality helpers. The first rank can be empty when no replica has loaded a model or no replica shares the router's node. Keeping the remaining ranks provides a fallback to other replicas.
+
+`select_available_replicas` skips replicas whose cached queue length has reached `max_ongoing_requests`. The router returns each remaining replica in its own rank so the base router tries them in throughput order. If a preferred replica rejects the request, lower-ranked replicas remain available as fallbacks. This policy returns all fallback ranks in one call and sets `routing_context.should_backoff` to `True` for the next retry. If every replica is at capacity, it returns an empty list and the base router retries with backoff.
 
 (deploy-app-with-throughput-aware-request-router)=
 ## Deploy an app with the throughput-aware request router

--- a/doc/source/serve/doc_code/custom_request_router.py
+++ b/doc/source/serve/doc_code/custom_request_router.py
@@ -48,7 +48,6 @@ from ray.serve.request_router import (
     RunningReplica,
 )
 from typing import (
-    Dict,
     List,
     Optional,
 )
@@ -62,62 +61,115 @@ class ThroughputAwareRequestRouter(
         candidate_replicas: List[RunningReplica],
         pending_request: Optional[PendingRequest] = None,
     ) -> List[List[RunningReplica]]:
-        """
-        This method chooses the best replica for the request based on
-        multiplexed, locality, and custom throughput stats. The algorithm
-        works as follows:
-
-        1. Populate top_ranked_replicas based on available replicas based on
-          multiplex_id
-        2. Populate and override top_ranked_replicas info based on locality
-         information of replicas (we want to prefer replicas that are in the
-          same vicinity to this deployment)
-        3. Select the replica with minimum throughput.
-        """
-
-        # Dictionary to hold the top-ranked replicas
-        top_ranked_replicas: Dict[ReplicaID, RunningReplica] = {}
-        # Take the best set of replicas for the multiplexed model
+        """Rank by model affinity, then locality, then reported throughput."""
+        if pending_request is not None:
+            # All fallback ranks are returned together, so back off after this pass.
+            pending_request.routing_context.should_backoff = True
+        model_ranks = [candidate_replicas]
         if (
             pending_request is not None
             and pending_request.metadata.multiplexed_model_id
         ):
-            ranked_replicas_multiplex: List[RunningReplica] = (
-                self.rank_replicas_via_multiplex(
-                    replicas=candidate_replicas,
-                    multiplexed_model_id=pending_request.metadata.multiplexed_model_id,
-                )
-            )[0]
-
-            # Filter out replicas that are not available (queue length exceed max ongoing request)
-            ranked_replicas_multiplex = self.select_available_replicas(
-                candidates=ranked_replicas_multiplex
+            model_ranks = self.rank_replicas_via_multiplex(
+                replicas=candidate_replicas,
+                multiplexed_model_id=pending_request.metadata.multiplexed_model_id,
             )
 
-            for replica in ranked_replicas_multiplex:
-                top_ranked_replicas[replica.replica_id] = replica
-
-        # Take the best set of replicas in terms of locality
-        ranked_replicas_locality: List[
-            RunningReplica
-        ] = self.rank_replicas_via_locality(replicas=candidate_replicas)[0]
-
-        # Filter out replicas that are not available (queue length exceed max ongoing request)
-        ranked_replicas_locality = self.select_available_replicas(
-            candidates=ranked_replicas_locality
-        )
-
-        for replica in ranked_replicas_locality:
-            top_ranked_replicas[replica.replica_id] = replica
-
-        print("ThroughputAwareRequestRouter routing request")
-
-        # Take the replica with minimum throughput.
-        min_throughput_replicas = min(
-            [replica for replica in top_ranked_replicas.values()],
-            key=lambda r: r.routing_stats.get("throughput", 0),
-        )
-        return [[min_throughput_replicas]]
+        ranked_replicas = []
+        for model_rank in model_ranks:
+            for locality_rank in self.rank_replicas_via_locality(model_rank):
+                available = self.select_available_replicas(candidates=locality_rank)
+                by_throughput = sorted(
+                    available,
+                    key=lambda replica: replica.routing_stats.get("throughput", 0),
+                )
+                # Return singleton ranks so throughput determines the attempt order.
+                ranked_replicas.extend([[replica] for replica in by_throughput])
+        return ranked_replicas
 
 
 # __end_define_throughput_aware_request_router__
+
+
+if __name__ == "__main__":
+    import asyncio
+    from types import SimpleNamespace
+    from unittest.mock import AsyncMock
+
+    from ray.serve._private.common import (
+        DeploymentHandleSource,
+        DeploymentID,
+        RequestMetadata,
+    )
+
+    deployment_id = DeploymentID("routing-example")
+
+    def replica(name, *, node="local", zone="zone-1", models=(), throughput=0):
+        return SimpleNamespace(
+            replica_id=ReplicaID(unique_id=name, deployment_id=deployment_id),
+            node_id=node,
+            availability_zone=zone,
+            multiplexed_model_ids=list(models),
+            max_ongoing_requests=1,
+            routing_stats={"throughput": throughput},
+        )
+
+    async def check(replicas, expected, *, model_id="", full=()):
+        router = ThroughputAwareRequestRouter(
+            deployment_id=deployment_id,
+            handle_source=DeploymentHandleSource.REPLICA,
+            self_node_id="local",
+            self_availability_zone="zone-1",
+            get_curr_time_s=lambda: 0.0,
+        )
+        # Populate the real mixins and queue cache without starting replica actors.
+        router._replicas = {item.replica_id: item for item in replicas}
+        router._replicas_list = replicas
+        router._update_colocated_replica_ids_with_replicas(replicas)
+        router._update_multiplexed_model_ids_with_replicas(replicas)
+        for item in replicas:
+            router._replica_queue_len_cache.update(
+                item.replica_id, int(item.replica_id.unique_id in full)
+            )
+        request = PendingRequest(
+            args=[],
+            kwargs={},
+            metadata=RequestMetadata(
+                request_id="example-request",
+                internal_request_id="example-request",
+                multiplexed_model_id=model_id,
+            ),
+        )
+        ranks = await router.choose_replicas(replicas, request)
+        assert [[item.replica_id.unique_id for item in rank] for rank in ranks] == [
+            [name] for name in expected
+        ]
+        if replicas and not expected:
+            # Check the flag first so a regression cannot spin the generator forever.
+            assert request.routing_context.should_backoff
+            router._backoff = AsyncMock(side_effect=RuntimeError("backoff reached"))
+            try:
+                await anext(router._choose_replicas_with_backoff(request))
+            except RuntimeError as error:
+                assert str(error) == "backoff reached"
+            else:
+                raise AssertionError("Expected the full replicas to trigger backoff")
+            router._backoff.assert_awaited_once_with(0)
+
+    async def test_routing():
+        local = replica("local")
+        remote = replica("remote", node="remote", zone="zone-2")
+        await check([remote], ["remote"])
+        await check([local, remote], ["remote"], full=("local",))
+        await check([local, remote], [], full=("local", "remote"))
+        await check([], [])
+
+        cached = replica("cached", node="remote", models=("model-a",), throughput=10)
+        await check([local, cached], ["cached", "local"], model_id="model-a")
+        await check([local, cached], ["local", "cached"], model_id="new-model")
+
+        slow = replica("slow", node="remote", throughput=10)
+        fast = replica("fast", node="remote", throughput=1)
+        await check([slow, fast], ["fast", "slow"])
+
+    asyncio.run(test_routing())


### PR DESCRIPTION
## Description

The throughput-aware router example takes only the first locality and model ranks. With only remote replicas, that rank can be empty and `min()` raises. A full preferred replica can also hide usable fallback replicas. The example additionally leaves `should_backoff` false, allowing an all-busy routing pass to spin without yielding.

Keep each model/locality rank, order available replicas by reported throughput, and return singleton ranks so the base router preserves that order. Mark a completed pass for backoff. The guide explains the priority and fallback behavior.

## Related issues

Found by running the custom-request-router example. Searched open PRs for `ThroughputAwareRequestRouter`, custom router fallback, and this guide; no matching fix was found. This changes the documented router policy, not Serve's core routing algorithm.

## Additional information

Validation with Ray 2.58.0 in an isolated virtual environment:

- `python doc/source/serve/doc_code/custom_request_router.py`: passed seven ranking cases plus an all-busy regression that exercises the base router's backoff generator. Cases include remote-only replicas, a full local replica, all-full and empty candidates, model affinity/fallback, and throughput ordering.
- Ran the documented throughput deployment with the changed router on a private local Ray cluster: 12 of 12 requests completed. The cluster was shut down afterward.
- Black 22.10.0, Ruff 0.8.4, and `git diff --check`: passed.
- `pre-commit run --files doc/source/serve/doc_code/custom_request_router.py doc/source/serve/advanced-guides/custom-request-router.md`: completed; repository configuration excludes these `doc/source` files from its hooks.
- A focused Sphinx HTML build of the changed section with `-W --keep-going` passed. The full Ray documentation build was not run locally.

AI assistance was used to investigate, implement, and review this change. Independent review found the missing backoff flag; the regression now covers it. The example was tested against the released Ray runtime, not a local native build. Commits include DCO sign-off.
