### PR TITLE
[Serve][Docs] Make the composed application builder example runnable

### DIFF
--- a/doc/source/serve/advanced-guides/app-builder-guide.md
+++ b/doc/source/serve/advanced-guides/app-builder-guide.md
@@ -125,10 +125,24 @@ applications:
 
 ### Configuring multiple composed deployments
 
-You can use the arguments passed to an application builder to configure multiple deployments in a single application. For example a model composition application might take weights to two different models as follows:
+Pass arguments from one builder to multiple deployments in the same application. This example configures an adder and a multiplier independently. The ingress adds `increment` to the request's value, then multiplies the result by `multiplier`:
 
 ```{literalinclude} ../doc_code/app_builder.py
 :start-after: __begin_composed_builder__
 :end-before: __end_composed_builder__
 :language: python
 ```
+
+Save the example in `hello.py` and pass both arguments to the builder:
+
+```bash
+serve run hello:composed_app_builder increment=1 multiplier=2
+```
+
+Send a request from another terminal:
+
+```bash
+curl 'http://localhost:8000/?value=5'
+```
+
+The response is `12`, calculated as `(5 + 1) * 2`. Changing the builder arguments to `increment=3 multiplier=4` produces `32` for the same request without modifying the deployment code.

--- a/doc/source/serve/doc_code/app_builder.py
+++ b/doc/source/serve/doc_code/app_builder.py
@@ -65,21 +65,64 @@ resp = requests.get("http://localhost:8000")
 assert resp.text == "Hello baz"
 
 # __begin_composed_builder__
+# hello.py
 from pydantic import BaseModel
+from starlette.requests import Request
 
+from ray import serve
 from ray.serve import Application
+from ray.serve.handle import DeploymentHandle
 
 
 class ComposedArgs(BaseModel):
-    model1_uri: str
-    model2_uri: str
+    increment: int
+    multiplier: int
+
+
+@serve.deployment
+class Adder:
+    def __init__(self, increment: int):
+        self._increment = increment
+
+    def __call__(self, value: int) -> int:
+        return value + self._increment
+
+
+@serve.deployment
+class Multiplier:
+    def __init__(self, multiplier: int):
+        self._multiplier = multiplier
+
+    def __call__(self, value: int) -> int:
+        return value * self._multiplier
+
+
+@serve.deployment
+class IngressDeployment:
+    def __init__(self, adder: DeploymentHandle, multiplier: DeploymentHandle):
+        self._adder = adder
+        self._multiplier = multiplier
+
+    async def __call__(self, request: Request) -> int:
+        value = int(request.query_params["value"])
+        added = await self._adder.remote(value)
+        return await self._multiplier.remote(added)
 
 
 def composed_app_builder(args: ComposedArgs) -> Application:
     return IngressDeployment.bind(
-        Model1.bind(args.model1_uri),
-        Model2.bind(args.model2_uri),
+        Adder.bind(args.increment),
+        Multiplier.bind(args.multiplier),
     )
 
 
 # __end_composed_builder__
+
+for args, expected in [
+    (ComposedArgs(increment=1, multiplier=2), 12),
+    (ComposedArgs(increment=3, multiplier=4), 32),
+]:
+    serve.run(composed_app_builder(args))
+    response = requests.get("http://localhost:8000", params={"value": 5}, timeout=30)
+    response.raise_for_status()
+    assert response.json() == expected


### PR DESCRIPTION
## Description

The composed application builder example references undefined `IngressDeployment`, `Model1`, and `Model2`, so calling the builder raises `NameError`. The executable documentation script never calls that builder and misses the failure.

Make the example self-contained with an adder, a multiplier, and an ingress that composes their deployment handles. Typed builder arguments configure both downstream deployments. Add launch/request commands and run the composition with two argument sets in the existing executable script, verifying that the same input produces 12 and 32.

## Related issues

Found by executing the composed-builder example. Searched open PRs for `composed_app_builder`, `app_builder.py`, and the application builder guide; no matching fix was found. This repairs the guide's example without changing the Serve builder API.

## Additional information

Validation with Ray 2.58.0 in an isolated virtual environment:

- Executed the complete `doc/source/serve/doc_code/app_builder.py` script on a private local Ray cluster, redirecting its HTTP requests to test port 18084: all four HTTP assertions passed (`Hello bar`, `Hello baz`, `12`, and `32`). The cluster was shut down afterward.
- Black 22.10.0, Ruff 0.8.4, and `git diff --check`: passed.
- `pre-commit run --files doc/source/serve/doc_code/app_builder.py doc/source/serve/advanced-guides/app-builder-guide.md`: completed; repository configuration excludes these `doc/source` files from its hooks.
- A focused Sphinx HTML build of the changed section with `-W --keep-going` passed. The full Ray documentation build was not run locally.

AI assistance was used to investigate, implement, and review this change. An independent review checked the standalone snippet and argument propagation through the deployment graph. Tests used the released Ray runtime, not a local native build. Commits include DCO sign-off.
