### PR TITLE
[Data] DSv2 Reorg [1/6]: Complete the DataSourceV2 contract for non-Parquet datasources

### DIFF
--- a/python/ray/data/_internal/datasource_v2/datasource_v2.py
+++ b/python/ray/data/_internal/datasource_v2/datasource_v2.py
@@ -72,19 +72,15 @@ class DataSourceV2(ABC, Generic[InputSplit]):
     """Abstract base class for V2 datasources.
 
     The framework touches a datasource in exactly one place,
-    ``ray.data.read_api._read_datasource_v2``: it builds the
-    ``ListFiles -> ReadFiles`` logical plan from the datasource and then drops
-    it. Every attribute that function reads is declared here, so a subclass
-    that implements the abstract members works end to end. The abstract
-    members are :attr:`paths`, :attr:`filesystem`, :meth:`_get_file_indexer`,
-    :attr:`schema_needs_file_sample`, :meth:`infer_schema` and
-    :meth:`create_scanner`; everything else has a working default.
+    ``ray.data.read_api._read_datasource_v2``, which builds the
+    ``ListFiles -> ReadFiles`` plan and then drops it. Every attribute that
+    function reads is declared here, so implementing the abstract members is
+    enough to work end to end.
 
-    The framework is file-based today -- ``_read_datasource_v2`` always builds
-    a ``ListFiles`` op -- which is why ``paths``, ``filesystem`` and
-    ``_get_file_indexer`` live on this base class. When a non-file source (a
-    database scan, say) is added they move down into a ``FileDataSourceV2``
-    subclass and ``_read_datasource_v2`` branches on which one it received.
+    That function always builds a ``ListFiles`` op, which is why ``paths``,
+    ``filesystem`` and ``_get_file_indexer`` live here. A future non-file
+    source (a database scan, say) moves them into a ``FileDataSourceV2``
+    subclass.
 
     Example::
 
@@ -142,31 +138,27 @@ class DataSourceV2(ABC, Generic[InputSplit]):
     @property
     @abstractmethod
     def paths(self) -> List[str]:
-        """Listing inputs. Each becomes the input of one ``ListFiles`` task and
-        is handed to :meth:`_get_file_indexer`'s ``list_files`` unread: the
-        framework never interprets them. File sources return the root files or
-        directories to walk; a catalog- or engine-backed source, whose indexer
-        already knows what to read, returns one identifier label. Must be
-        non-empty: with no paths ``ListFiles`` schedules no task and the read
-        is silently empty.
+        """Listing inputs, one ``ListFiles`` task each, passed to the indexer
+        unread -- the framework never interprets them.
 
-        Also recorded as ``ListFiles.source_paths`` for lineage tracking.
+        File sources return the roots to walk. A catalog- or engine-backed
+        source, whose indexer already knows what to read, returns a single
+        identifier label. Must be non-empty, or ``ListFiles`` schedules no task
+        and the read is silently empty.
         """
         ...
 
     @property
     @abstractmethod
     def filesystem(self) -> Optional["FileSystem"]:
-        """PyArrow filesystem the indexer and scanner should read through, or
-        ``None`` when they do their own IO.
+        """PyArrow filesystem the indexer and scanner read through, or ``None``
+        when they do their own IO.
 
-        The framework only forwards it -- to ``ListFiles``, to
-        ``sample_files`` and to :meth:`create_scanner` -- and never dereferences
-        it, so whether ``None`` is acceptable is decided by the components the
-        datasource itself returns. ``NonSamplingFileIndexer`` and
-        ``FooterFileIndexer`` require one; resolve it in ``__init__`` (see
-        ``_resolve_paths_and_filesystem``). A source read through its own
-        library (PyIceberg's ``FileIO``, Lance, hudi-rs) returns ``None``.
+        The framework only forwards it and never dereferences it, so whether
+        ``None`` is acceptable is up to the components this datasource returns.
+        The stock indexers require one -- resolve it in ``__init__``, see
+        ``_resolve_paths_and_filesystem``. A source read through its own library
+        (PyIceberg, Lance, hudi-rs) returns ``None``.
         """
         ...
 
@@ -189,12 +181,10 @@ class DataSourceV2(ABC, Generic[InputSplit]):
         """Indexer that ``ListFiles`` runs to turn :attr:`paths` into
         ``FileManifest`` blocks.
 
-        Abstract rather than defaulted: the framework hands the result straight
-        to ``ListFiles`` and to schema sampling, neither of which accepts
-        ``None``, and a silent default would commit a new format to whole-file
-        chunking without anyone choosing it. Formats without usable file
-        metadata return ``NonSamplingFileIndexer``; Parquet returns
-        ``FooterFileIndexer``.
+        Abstract rather than defaulted, because a default would commit a new
+        format to whole-file chunking without anyone choosing it. Formats
+        without usable file metadata return ``NonSamplingFileIndexer``; Parquet
+        returns ``FooterFileIndexer``.
         """
         ...
 

--- a/python/ray/data/_internal/datasource_v2/datasource_v2.py
+++ b/python/ray/data/_internal/datasource_v2/datasource_v2.py
@@ -21,7 +21,10 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Generic,
+    List,
+    Literal,
     Optional,
+    Union,
 )
 
 import pyarrow as pa
@@ -40,6 +43,7 @@ if TYPE_CHECKING:
         InMemorySizeEstimator,
     )
     from ray.data._internal.datasource_v2.scanners.scanner import Scanner
+    from ray.data.datasource.file_based_datasource import FileShuffleConfig
 
 
 @DeveloperAPI
@@ -67,19 +71,24 @@ class DatasourceCategory(Enum):
 class DataSourceV2(ABC, Generic[InputSplit]):
     """Abstract base class for V2 datasources.
 
-    DataSourceV2 is the entry point for reading data from a source. It provides:
-    1. File listing (for file-based sources) - via _get_file_indexer()
-    2. Schema inference
-    3. Size estimation
-    4. Scanner creation
+    The framework touches a datasource in exactly one place,
+    ``ray.data.read_api._read_datasource_v2``: it builds the
+    ``ListFiles -> ReadFiles`` logical plan from the datasource and then drops
+    it. Every attribute that function reads is declared here, so a subclass
+    that implements the abstract members works end to end. The abstract
+    members are :attr:`paths`, :attr:`filesystem`, :meth:`_get_file_indexer`,
+    :attr:`schema_needs_file_sample`, :meth:`infer_schema` and
+    :meth:`create_scanner`; everything else has a working default.
 
-    Subclasses should implement the abstract methods and can optionally
-    override _get_file_indexer(), get_size_estimator(), and optionally
-    get_file_partitioner() for file-based sources.
+    The framework is file-based today -- ``_read_datasource_v2`` always builds
+    a ``ListFiles`` op -- which is why ``paths``, ``filesystem`` and
+    ``_get_file_indexer`` live on this base class. When a non-file source (a
+    database scan, say) is added they move down into a ``FileDataSourceV2``
+    subclass and ``_read_datasource_v2`` branches on which one it received.
 
     Example::
 
-        datasource = ParquetDatasourceV2()
+        datasource = ParquetDatasourceV2(paths)
         indexer = datasource._get_file_indexer()
         # List files with optional sampling
         for manifest in indexer.list_files(paths, filesystem=fs):
@@ -130,15 +139,64 @@ class DataSourceV2(ABC, Generic[InputSplit]):
         """
         return self._supports_distributed_reads
 
-    def _get_file_indexer(self) -> Optional[FileIndexer]:
-        """Return FileIndexer component if applicable.
+    @property
+    @abstractmethod
+    def paths(self) -> List[str]:
+        """Listing inputs. Each becomes the input of one ``ListFiles`` task and
+        is handed to :meth:`_get_file_indexer`'s ``list_files`` unread: the
+        framework never interprets them. File sources return the root files or
+        directories to walk; a catalog- or engine-backed source, whose indexer
+        already knows what to read, returns one identifier label. Must be
+        non-empty: with no paths ``ListFiles`` schedules no task and the read
+        is silently empty.
 
-        Override this for file-based datasources to provide file discovery.
+        Also recorded as ``ListFiles.source_paths`` for lineage tracking.
+        """
+        ...
 
-        Returns:
-            FileIndexer instance, or None for non-file-based sources.
+    @property
+    @abstractmethod
+    def filesystem(self) -> Optional["FileSystem"]:
+        """PyArrow filesystem the indexer and scanner should read through, or
+        ``None`` when they do their own IO.
+
+        The framework only forwards it -- to ``ListFiles``, to
+        ``sample_files`` and to :meth:`create_scanner` -- and never dereferences
+        it, so whether ``None`` is acceptable is decided by the components the
+        datasource itself returns. ``NonSamplingFileIndexer`` and
+        ``FooterFileIndexer`` require one; resolve it in ``__init__`` (see
+        ``_resolve_paths_and_filesystem``). A source read through its own
+        library (PyIceberg's ``FileIO``, Lance, hudi-rs) returns ``None``.
+        """
+        ...
+
+    @property
+    def file_extensions(self) -> Optional[List[str]]:
+        """File extensions to keep while listing; ``None`` keeps every file."""
+        return None
+
+    @property
+    def shuffle(self) -> Optional[Union[Literal["files"], "FileShuffleConfig"]]:
+        """File-level shuffle the user asked for; ``None`` means no shuffle.
+
+        ``"files"`` shuffles with a seed drawn per execution; a
+        :class:`FileShuffleConfig` pins the seed.
         """
         return None
+
+    @abstractmethod
+    def _get_file_indexer(self) -> FileIndexer:
+        """Indexer that ``ListFiles`` runs to turn :attr:`paths` into
+        ``FileManifest`` blocks.
+
+        Abstract rather than defaulted: the framework hands the result straight
+        to ``ListFiles`` and to schema sampling, neither of which accepts
+        ``None``, and a silent default would commit a new format to whole-file
+        chunking without anyone choosing it. Formats without usable file
+        metadata return ``NonSamplingFileIndexer``; Parquet returns
+        ``FooterFileIndexer``.
+        """
+        ...
 
     def get_file_partitioner(self, **kwargs) -> Optional["FilePartitioner"]:
         """Partitioner that groups this source's listing rows into read units.

--- a/python/ray/data/_internal/datasource_v2/listing/file_indexer.py
+++ b/python/ray/data/_internal/datasource_v2/listing/file_indexer.py
@@ -252,7 +252,7 @@ class NonSamplingFileIndexer(FileIndexer):
         self,
         paths: "BlockColumn",
         *,
-        filesystem: "FileSystem",
+        filesystem: Optional["FileSystem"],
         pruners: Optional[List[FilePruner]] = None,
         preserve_order: bool = False,
         predicate: Optional["Expr"] = None,
@@ -280,7 +280,7 @@ class NonSamplingFileIndexer(FileIndexer):
         self,
         paths: "BlockColumn",
         *,
-        filesystem: "FileSystem",
+        filesystem: Optional["FileSystem"],
         pruners: Optional[List[FilePruner]] = None,
         preserve_order: bool = False,
         shuffle_config: Optional["FileShuffleConfig"] = None,
@@ -436,7 +436,7 @@ class NonSamplingFileIndexer(FileIndexer):
         self,
         paths: "BlockColumn",
         *,
-        filesystem: "FileSystem",
+        filesystem: Optional["FileSystem"],
         pruners: Optional[List[FilePruner]] = None,
         preserve_order: bool = False,
     ) -> Iterable[FileInfo]:
@@ -451,6 +451,13 @@ class NonSamplingFileIndexer(FileIndexer):
         partition filters) are applied here, so both listing paths share one
         filtering point.
         """
+        if filesystem is None:
+            raise ValueError(
+                f"{type(self).__name__} lists files through a PyArrow filesystem, "
+                "but the datasource returned `filesystem=None`. Resolve one in the "
+                "datasource's `__init__` (see `_resolve_paths_and_filesystem`) or "
+                "return an indexer that does its own IO."
+            )
         pruners = pruners or []
         file_info_iterator = self._get_file_info_iterator(
             paths, filesystem, preserve_order

--- a/python/ray/data/_internal/datasource_v2/listing/file_indexer.py
+++ b/python/ray/data/_internal/datasource_v2/listing/file_indexer.py
@@ -34,10 +34,8 @@ class FileIndexer(ABC):
     """Turns root paths into ``FileManifest`` blocks inside ``ListFiles`` tasks.
 
     Chosen by ``DataSourceV2._get_file_indexer``. How an implementation splits a
-    file into manifest rows (whole file, byte ranges, row groups) is its own
-    business and not part of this interface: see ``NonSamplingFileIndexer``'s
-    ``file_chunker`` for the generic path and ``FooterFileIndexer`` for the
-    Parquet one.
+    file into manifest rows is deliberately its own business, not part of this
+    interface.
     """
 
     def as_whole_file_indexer(self) -> Optional["FileIndexer"]:
@@ -218,7 +216,6 @@ class NonSamplingFileIndexer(FileIndexer):
         """The chunker ``list_files`` applies to each listed file.
 
         Specific to this indexer -- its ``list_files`` is the only consumer.
-        Exposed so tests can check which strategy an indexer was built with.
         """
         return self._file_chunker
 

--- a/python/ray/data/_internal/datasource_v2/listing/file_indexer.py
+++ b/python/ray/data/_internal/datasource_v2/listing/file_indexer.py
@@ -31,11 +31,14 @@ logger = logging.getLogger(__name__)
 
 
 class FileIndexer(ABC):
-    @property
-    @abstractmethod
-    def file_chunker(self) -> FileChunker:
-        """The file chunker that this indexer uses."""
-        ...
+    """Turns root paths into ``FileManifest`` blocks inside ``ListFiles`` tasks.
+
+    Chosen by ``DataSourceV2._get_file_indexer``. How an implementation splits a
+    file into manifest rows (whole file, byte ranges, row groups) is its own
+    business and not part of this interface: see ``NonSamplingFileIndexer``'s
+    ``file_chunker`` for the generic path and ``FooterFileIndexer`` for the
+    Parquet one.
+    """
 
     def as_whole_file_indexer(self) -> Optional["FileIndexer"]:
         """An equivalent indexer that emits each file exactly once, or ``None``.
@@ -56,7 +59,7 @@ class FileIndexer(ABC):
         self,
         paths: "BlockColumn",
         *,
-        filesystem: "FileSystem",
+        filesystem: Optional["FileSystem"],
         pruners: Optional[List[FilePruner]] = None,
         preserve_order: bool = False,
         predicate: Optional["Expr"] = None,
@@ -69,7 +72,9 @@ class FileIndexer(ABC):
 
         Args:
             paths: A column of paths pointing to files or directories.
-            filesystem: A PyArrow filesystem object.
+            filesystem: PyArrow filesystem to list through, or ``None`` for an
+                indexer that does its own IO (the framework forwards
+                ``DataSourceV2.filesystem`` unchanged).
             pruners: A list of file pruners to apply.
             preserve_order: Whether to preserve order in file listing.
             predicate: Pushed-down row filter. Indexers that read file
@@ -96,7 +101,7 @@ class FileIndexer(ABC):
         self,
         paths: "BlockColumn",
         *,
-        filesystem: "FileSystem",
+        filesystem: Optional["FileSystem"],
         pruners: Optional[List[FilePruner]] = None,
         preserve_order: bool = False,
     ) -> Iterable["FileInfo"]:
@@ -210,10 +215,10 @@ class NonSamplingFileIndexer(FileIndexer):
 
     @property
     def file_chunker(self) -> FileChunker:
-        """The file chunker that this indexer uses.
+        """The chunker ``list_files`` applies to each listed file.
 
-        Exposed primarily for tests and shuffle-aware planning code that needs
-        to introspect or override the chunking strategy.
+        Specific to this indexer -- its ``list_files`` is the only consumer.
+        Exposed so tests can check which strategy an indexer was built with.
         """
         return self._file_chunker
 

--- a/python/ray/data/_internal/datasource_v2/listing/file_pruners.py
+++ b/python/ray/data/_internal/datasource_v2/listing/file_pruners.py
@@ -52,12 +52,12 @@ class PartitionPredicatePruner(FilePruner):
     Backs ``ds.filter(expr=...)`` on a partition column, once the optimizer has
     pushed that expression onto the scanner -- not something a caller
     constructs. Unlike :class:`PartitionPruner`, it duplicates pruning the
-    reader also performs (``ArrowFileScanner.prune_manifest``), so the two must
-    drop exactly the same files: a pushed-down limit stops listing early, and
-    every row listing counted towards it has to belong to a file the reader
+    reader also performs (``ArrowFileScanner.prune_input_split``), so the two
+    must drop exactly the same files: a pushed-down limit stops listing early,
+    and every row listing counted towards it has to belong to a file the reader
     keeps. Sharing
     :meth:`PathPartitionParser.evaluate_predicate_on_partition` with
-    ``prune_manifest`` is what holds that equality.
+    ``prune_input_split`` is what holds that equality.
 
     The two are therefore not interchangeable. A ``PathPartitionFilter`` is an
     opaque callable carrying no such obligation, and expressing a pushed-down

--- a/python/ray/data/_internal/datasource_v2/listing/footer_file_indexer.py
+++ b/python/ray/data/_internal/datasource_v2/listing/footer_file_indexer.py
@@ -156,7 +156,7 @@ class FooterFileIndexer(NonSamplingFileIndexer):
         self,
         paths: "BlockColumn",
         *,
-        filesystem: "FileSystem",
+        filesystem: Optional["FileSystem"],
         pruners: Optional[List["FilePruner"]] = None,
         preserve_order: bool = False,
         predicate: Optional["Expr"] = None,

--- a/python/ray/data/_internal/datasource_v2/listing/listing_utils.py
+++ b/python/ray/data/_internal/datasource_v2/listing/listing_utils.py
@@ -62,7 +62,7 @@ def list_files_for_each_block(
     _: TaskContext,
     *,
     indexer: "FileIndexer",
-    filesystem: "FileSystem",
+    filesystem: Optional["FileSystem"],
     file_extensions: Optional[List[str]] = None,
     partition_filter: Optional["PathPartitionFilter"] = None,
     partition_pruner: Optional[FilePruner] = None,
@@ -112,7 +112,7 @@ def list_files_for_each_block(
 def sample_files(
     indexer: "FileIndexer",
     paths: List[str],
-    filesystem: "FileSystem",
+    filesystem: Optional["FileSystem"],
     pruners: Optional[List[FilePruner]] = None,
     max_files: int = 16,
 ) -> FileManifest:

--- a/python/ray/data/_internal/datasource_v2/parquet_datasource_v2.py
+++ b/python/ray/data/_internal/datasource_v2/parquet_datasource_v2.py
@@ -138,7 +138,7 @@ class ParquetDatasourceV2(DataSourceV2[FileManifest]):
         return self._paths
 
     @property
-    def filesystem(self) -> Optional["FileSystem"]:
+    def filesystem(self) -> "FileSystem":
         return self._filesystem
 
     @property

--- a/python/ray/data/_internal/datasource_v2/scanners/arrow_file_scanner.py
+++ b/python/ray/data/_internal/datasource_v2/scanners/arrow_file_scanner.py
@@ -201,41 +201,39 @@ class ArrowFileScanner(
     @override
     def pushed_partition_pruner(self) -> Optional["FilePruner"]:
         if self.partition_predicate is None or self.partitioning is None:
-            # No spec, no partition values -- same guard as ``prune_manifest``.
+            # No spec, no partition values -- same guard as ``prune_input_split``.
             return None
         return PartitionPredicatePruner(self.partitioning, self.partition_predicate)
 
     @override
-    def prune_manifest(self, manifest: FileManifest) -> FileManifest:
-        """Filter manifest to only files matching ``self.partition_predicate``.
+    def prune_input_split(self, input_split: FileManifest) -> FileManifest:
+        """Keep only the files matching ``self.partition_predicate``.
 
-        Called by :func:`plan_read_files_op.do_read` for every incoming
-        manifest block. No-op when either the predicate or the
-        partitioning spec is absent. Uses
-        :class:`PathPartitionParser` to parse partition values from
-        each file path and evaluate the predicate.
+        No-op when either the predicate or the partitioning spec is absent.
+        Partition values are parsed out of each file path by
+        :class:`PathPartitionParser`.
         """
         if self.partition_predicate is None or self.partitioning is None:
-            return manifest
+            return input_split
 
         parser = PathPartitionParser(self.partitioning)
         keep_indices = []
 
-        for i, path in enumerate(manifest.paths):
+        for i, path in enumerate(input_split.paths):
             if parser.evaluate_predicate_on_partition(path, self.partition_predicate):
                 keep_indices.append(i)
 
-        if len(keep_indices) == len(manifest):
-            return manifest
+        if len(keep_indices) == len(input_split):
+            return input_split
 
-        pruned_count = len(manifest) - len(keep_indices)
+        pruned_count = len(input_split) - len(keep_indices)
         logger.debug(
             "Partition pruning removed %d of %d files",
             pruned_count,
-            len(manifest),
+            len(input_split),
         )
 
-        block = manifest.as_block()
+        block = input_split.as_block()
         # An untyped empty list infers null indices: ArrowNotImplementedError.
         pruned_block = block.take(pa.array(keep_indices, type=pa.int64()))
         return FileManifest(pruned_block)

--- a/python/ray/data/_internal/datasource_v2/scanners/file_scanner.py
+++ b/python/ray/data/_internal/datasource_v2/scanners/file_scanner.py
@@ -34,14 +34,3 @@ class FileScanner(Scanner[FileManifest]):
 
     def __post_init__(self) -> None:
         _validate_shuffle_arg(self.shuffle)
-
-    def prune_manifest(self, manifest: FileManifest) -> FileManifest:
-        """Return a filtered view of ``manifest``.
-
-        Default: identity. Subclasses that support file-level predicate
-        pruning (e.g. :class:`ArrowFileScanner`'s ``partition_predicate``)
-        override this to drop rows whose partition values fail the
-        predicate. Invoked per-block from
-        :func:`plan_read_files_op.do_read`.
-        """
-        return manifest

--- a/python/ray/data/_internal/datasource_v2/scanners/scanner.py
+++ b/python/ray/data/_internal/datasource_v2/scanners/scanner.py
@@ -20,6 +20,8 @@ class Scanner(ABC, Generic[InputSplit]):
     The Scanner is responsible for:
     1. Determining the output schema after all projections
     2. Creating Reader instances configured with all pushdowns
+    3. Optionally dropping parts of an input split it knows it will not read
+       (:meth:`prune_manifest`)
 
     Splitting the input into parallel work units used to live here as a
     ``plan()`` method. That responsibility now belongs to the listing-side
@@ -55,6 +57,17 @@ class Scanner(ABC, Generic[InputSplit]):
         both must agree.
         """
         return False
+
+    def prune_manifest(self, input_split: InputSplit) -> InputSplit:
+        """Drop the parts of ``input_split`` this scan is known not to read.
+
+        Called by ``plan_read_files_op.do_read`` on every incoming split before
+        ``create_reader().read()``. Default: return it unchanged. A scanner with
+        a pushed-down file-level predicate (``ArrowFileScanner`` and its
+        ``partition_predicate``) overrides this to drop files whose partition
+        values fail it.
+        """
+        return input_split
 
     @abstractmethod
     def create_reader(self) -> Reader[InputSplit]:

--- a/python/ray/data/_internal/datasource_v2/scanners/scanner.py
+++ b/python/ray/data/_internal/datasource_v2/scanners/scanner.py
@@ -21,7 +21,7 @@ class Scanner(ABC, Generic[InputSplit]):
     1. Determining the output schema after all projections
     2. Creating Reader instances configured with all pushdowns
     3. Optionally dropping parts of an input split it knows it will not read
-       (:meth:`prune_manifest`)
+       (:meth:`prune_input_split`)
 
     Splitting the input into parallel work units used to live here as a
     ``plan()`` method. That responsibility now belongs to the listing-side
@@ -58,16 +58,15 @@ class Scanner(ABC, Generic[InputSplit]):
         """
         return False
 
-    def prune_manifest(self, manifest: InputSplit) -> InputSplit:
-        """Drop the parts of ``manifest`` this scan is known not to read.
+    def prune_input_split(self, input_split: InputSplit) -> InputSplit:
+        """Drop the parts of ``input_split`` this scan is known not to read.
 
-        Called by ``plan_read_files_op.do_read`` on every incoming split before
-        ``create_reader().read()``. Default: return it unchanged. A scanner with
-        a pushed-down file-level predicate (``ArrowFileScanner`` and its
-        ``partition_predicate``) overrides this to drop files whose partition
-        values fail it.
+        Called per split by ``plan_read_files_op.do_read`` before
+        ``create_reader().read()``. Default: return it unchanged.
+        ``ArrowFileScanner`` overrides it to drop files whose partition values
+        fail a pushed-down predicate.
         """
-        return manifest
+        return input_split
 
     @abstractmethod
     def create_reader(self) -> Reader[InputSplit]:

--- a/python/ray/data/_internal/datasource_v2/scanners/scanner.py
+++ b/python/ray/data/_internal/datasource_v2/scanners/scanner.py
@@ -58,8 +58,8 @@ class Scanner(ABC, Generic[InputSplit]):
         """
         return False
 
-    def prune_manifest(self, input_split: InputSplit) -> InputSplit:
-        """Drop the parts of ``input_split`` this scan is known not to read.
+    def prune_manifest(self, manifest: InputSplit) -> InputSplit:
+        """Drop the parts of ``manifest`` this scan is known not to read.
 
         Called by ``plan_read_files_op.do_read`` on every incoming split before
         ``create_reader().read()``. Default: return it unchanged. A scanner with
@@ -67,7 +67,7 @@ class Scanner(ABC, Generic[InputSplit]):
         ``partition_predicate``) overrides this to drop files whose partition
         values fail it.
         """
-        return input_split
+        return manifest
 
     @abstractmethod
     def create_reader(self) -> Reader[InputSplit]:

--- a/python/ray/data/_internal/logical/operators/read_operator.py
+++ b/python/ray/data/_internal/logical/operators/read_operator.py
@@ -453,7 +453,7 @@ class ListFiles(LogicalOperator, SourceOperator):
 
     paths: List[str]
     file_indexer: "FileIndexer"
-    filesystem: "FileSystem"
+    filesystem: Optional["FileSystem"]
     # Original user-supplied paths. Lineage-tracking pins this to the
     # caller's intent rather than the resolved absolute paths.
     source_paths: List[str]
@@ -465,13 +465,14 @@ class ListFiles(LogicalOperator, SourceOperator):
     shuffle_config_factory: Callable[[], Optional["FileShuffleConfig"]] = field(
         default=lambda: None
     )
-    # Pushed-down read constraints, populated by the optimizer rules
-    # (``predicate_pushdown`` / ``projection_pushdown`` / ``limit_pushdown``).
-    # A ``StreamingFileChunker`` (e.g. the Parquet footer chunker) uses them to
-    # prune row groups, size only projected columns, and stop listing early;
-    # the per-file listing path ignores them. Whether footer-based chunking runs
-    # is decided by the indexer's chunker type, not a flag here -- this op stays
-    # format-agnostic.
+    # Pushed-down read constraints, filled in by ``DeriveListFilesPushdown``
+    # from the scanner's accepted pushdowns after the logical rules have run.
+    # They are forwarded to ``FileIndexer.list_files``: a metadata-aware indexer
+    # (``FooterFileIndexer``, which reads Parquet footers on an actor pool) uses
+    # them to drop row groups, size only projected columns and stop listing
+    # early; the generic ``NonSamplingFileIndexer`` ignores them. Which happens
+    # is decided by the indexer the datasource chose, not by a flag here -- this
+    # op stays format-agnostic.
     predicate: Optional[Expr] = None
     projected_columns: Optional[List[str]] = None
     limit: Optional[int] = None

--- a/python/ray/data/_internal/logical/operators/read_operator.py
+++ b/python/ray/data/_internal/logical/operators/read_operator.py
@@ -466,13 +466,11 @@ class ListFiles(LogicalOperator, SourceOperator):
         default=lambda: None
     )
     # Pushed-down read constraints, filled in by ``DeriveListFilesPushdown``
-    # from the scanner's accepted pushdowns after the logical rules have run.
-    # They are forwarded to ``FileIndexer.list_files``: a metadata-aware indexer
-    # (``FooterFileIndexer``, which reads Parquet footers on an actor pool) uses
-    # them to drop row groups, size only projected columns and stop listing
-    # early; the generic ``NonSamplingFileIndexer`` ignores them. Which happens
-    # is decided by the indexer the datasource chose, not by a flag here -- this
-    # op stays format-agnostic.
+    # from the scanner's accepted pushdowns and forwarded to
+    # ``FileIndexer.list_files``. ``FooterFileIndexer`` uses them to drop row
+    # groups, size only projected columns and stop listing early;
+    # ``NonSamplingFileIndexer`` ignores them. Which one runs is the
+    # datasource's choice of indexer, not a flag here.
     predicate: Optional[Expr] = None
     projected_columns: Optional[List[str]] = None
     limit: Optional[int] = None

--- a/python/ray/data/_internal/planner/plan_read_files_op.py
+++ b/python/ray/data/_internal/planner/plan_read_files_op.py
@@ -58,12 +58,10 @@ def plan_read_files_op(
 
     def do_read(blocks: Iterable[Block], _: TaskContext) -> Iterable[Block]:
         reader = scanner.create_reader()
-        # File-level predicate pruning (partition predicates pushed down onto
-        # the scanner) runs per incoming manifest block. ``Scanner.prune_manifest``
-        # is an identity by default; ``ArrowFileScanner`` overrides it to
-        # evaluate ``partition_predicate``.
+        # ``prune_input_split`` is an identity by default; ``ArrowFileScanner``
+        # overrides it to drop files failing a pushed-down partition predicate.
         for block in blocks:
-            manifest = scanner.prune_manifest(FileManifest(block))
+            manifest = scanner.prune_input_split(FileManifest(block))
             if len(manifest) == 0:
                 continue
             for table in reader.read(manifest):

--- a/python/ray/data/_internal/planner/plan_read_files_op.py
+++ b/python/ray/data/_internal/planner/plan_read_files_op.py
@@ -24,7 +24,6 @@ import logging
 from typing import Iterable, List
 
 from ray.data._internal.datasource_v2.listing.file_manifest import FileManifest
-from ray.data._internal.datasource_v2.scanners.file_scanner import FileScanner
 from ray.data._internal.execution.interfaces import PhysicalOperator
 from ray.data._internal.execution.interfaces.task_context import TaskContext
 from ray.data._internal.execution.operators.map_operator import MapOperator
@@ -59,15 +58,12 @@ def plan_read_files_op(
 
     def do_read(blocks: Iterable[Block], _: TaskContext) -> Iterable[Block]:
         reader = scanner.create_reader()
-        # File-level predicate pruning (partition predicates pushed down
-        # onto the scanner) runs per incoming manifest block. Only
-        # ``FileScanner`` subclasses expose ``prune_manifest``; the base
-        # implementation is an identity no-op, and ``ArrowFileScanner``
-        # overrides it to evaluate ``partition_predicate``.
+        # File-level predicate pruning (partition predicates pushed down onto
+        # the scanner) runs per incoming manifest block. ``Scanner.prune_manifest``
+        # is an identity by default; ``ArrowFileScanner`` overrides it to
+        # evaluate ``partition_predicate``.
         for block in blocks:
-            manifest = FileManifest(block)
-            if isinstance(scanner, FileScanner):
-                manifest = scanner.prune_manifest(manifest)
+            manifest = scanner.prune_manifest(FileManifest(block))
             if len(manifest) == 0:
                 continue
             for table in reader.read(manifest):

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -525,9 +525,8 @@ def _read_datasource_v2(
     file — no caching layer needed.
 
     This function is the whole framework <-> datasource contract: every
-    attribute it reads off ``datasource`` is declared on ``DataSourceV2``, and
-    the datasource object is not referenced after it returns (``ReadFiles``
-    keeps only ``datasource.name``).
+    attribute it reads is declared on ``DataSourceV2``, and the object is not
+    referenced after it returns (``ReadFiles`` keeps only ``datasource.name``).
     """
     import time
 

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -143,6 +143,7 @@ if TYPE_CHECKING:
     from pyiceberg.expressions import BooleanExpression
     from tensorflow_metadata.proto.v0 import schema_pb2
 
+    from ray.data._internal.datasource_v2.datasource_v2 import DataSourceV2
     from ray.data.catalog import Catalog
 
 T = TypeVar("T")
@@ -489,7 +490,7 @@ def _resolve_read_remote_args(
 
 @wrap_auto_init
 def _read_datasource_v2(
-    datasource,
+    datasource: "DataSourceV2",
     *,
     parallelism: int = -1,
     num_cpus: Optional[float] = None,
@@ -522,6 +523,11 @@ def _read_datasource_v2(
 
     Schema inference happens once on the driver by sampling the first
     file — no caching layer needed.
+
+    This function is the whole framework <-> datasource contract: every
+    attribute it reads off ``datasource`` is declared on ``DataSourceV2``, and
+    the datasource object is not referenced after it returns (``ReadFiles``
+    keeps only ``datasource.name``).
     """
     import time
 
@@ -629,7 +635,7 @@ def _read_datasource_v2(
 
     # NOTE: We're using shuffle config factory to fix the seed at the planning
     #       time, rather than at the composition time (for backward-compatibility)
-    shuffle = getattr(datasource, "shuffle", None)
+    shuffle = datasource.shuffle
 
     def _shuffle_config_factory() -> Optional[FileShuffleConfig]:
         return (

--- a/python/ray/data/tests/unit/datasource_v2/test_arrow_file_scanner.py
+++ b/python/ray/data/tests/unit/datasource_v2/test_arrow_file_scanner.py
@@ -1,4 +1,4 @@
-"""Unit tests for :meth:`ArrowFileScanner.prune_manifest`."""
+"""Unit tests for :meth:`ArrowFileScanner.prune_input_split`."""
 import pyarrow as pa
 import pytest
 
@@ -13,7 +13,7 @@ from ray.data.datasource.partitioning import Partitioning, PartitionStyle
 from ray.data.expressions import col
 
 
-def test_prune_manifest_matching_no_file():
+def test_prune_input_split_matching_no_file():
     """Pruning away every file is an ordinary outcome, not an error."""
     manifest = FileManifest(
         pa.table(
@@ -30,7 +30,7 @@ def test_prune_manifest_matching_no_file():
         partition_predicate=col("year") == "2029",
     )
 
-    assert len(scanner.prune_manifest(manifest)) == 0
+    assert len(scanner.prune_input_split(manifest)) == 0
 
 
 if __name__ == "__main__":

--- a/python/ray/data/tests/unit/datasource_v2/test_file_indexer.py
+++ b/python/ray/data/tests/unit/datasource_v2/test_file_indexer.py
@@ -581,6 +581,15 @@ class TestFooterIndexerFileShuffle:
         assert len(batches) > 1
 
 
+def test_list_file_infos_rejects_missing_filesystem():
+    # The FileIndexer base accepts ``filesystem=None`` for indexers that do
+    # their own IO; this one cannot, and must say so instead of failing on a
+    # ``None`` attribute deep inside path expansion.
+    indexer = NonSamplingFileIndexer(ignore_missing_paths=False)
+    with pytest.raises(ValueError, match="NonSamplingFileIndexer.*filesystem=None"):
+        list(indexer.list_file_infos(pa.array(["a.csv"]), filesystem=None))
+
+
 if __name__ == "__main__":
     import sys
 


### PR DESCRIPTION
## Description

Second PR of the DSv2 Reorg series (`[0/6]` … `[6/6]`), stacked on #66244
(`[0/6]`); the diff shows both until that one merges.

`_read_datasource_v2` in `read_api.py` reads four attributes and calls one
method that `DataSourceV2` never declared. Parquet defines them all, so it
worked; any other datasource that implemented only the abstract methods failed
with `AttributeError` inside the read code. After this PR, implementing the
abstract members of `DataSourceV2` is enough for a new datasource to work end
to end, and a missing one is reported at construction. No behavior change for
Parquet.

```mermaid
flowchart LR
  R[read_api._read_datasource_v2] -->|reads paths, filesystem, file_extensions, shuffle; calls _get_file_indexer| D[DataSourceV2 base class]
  D -->|abstract: paths, filesystem, _get_file_indexer| S[new datasource subclass]
  D -->|default None: file_extensions, shuffle| S
```

### Changes

1. Declare everything the read code uses on `DataSourceV2`: `paths`,
   `filesystem`, `_get_file_indexer` abstract; `file_extensions`, `shuffle`
   default `None`.
2. `filesystem` may be `None`, for sources that read through their own
   library (PyIceberg, Lance, hudi-rs).
3. `FileScanner.prune_manifest` → `Scanner.prune_input_split`, so partition
   pruning runs for every scanner, not only `FileScanner` subclasses.
4. `FileIndexer` docstring updated for the per-file listing contract left
   after #66244.

## Additional information

Not a duplicate: no open PR changes the `DataSourceV2` base class. #65887 and
#65888 also touch `file_indexer.py` / `listing_utils.py`, so expect small merge
conflicts there.

Tests run locally from this branch (macOS, `~/ray/.venv`), from `python/ray/data`:

```
pytest -q tests/unit/datasource_v2                     # 119 passed
pytest -q tests/datasource/test_read_parquet_v2.py     # 37 passed
pytest -q tests/datasource/test_parquet.py             # 246 passed, 13 skipped, 34 errors
```

The 34 errors are moto `s3_fs` fixture setup errors (`moto_server` not on
PATH), identical on master. `ruff`, `black` and `pydoclint` at the pre-commit
pins are clean; `pyrefly` reports the same pre-existing errors as the base
commit.

Written with Claude Code; I reviewed every changed line and ran the tests above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
