### PR TITLE
[cherry-pick][2.59.0][ci] Pin the uv installer version in release and CI image builds (#66068)

### DIFF
--- a/.buildkite/release-automation/forge_arm64.Dockerfile
+++ b/.buildkite/release-automation/forge_arm64.Dockerfile
@@ -28,7 +28,7 @@ chmod +x /usr/local/bin/bazelisk
 ln -s /usr/local/bin/bazelisk /usr/local/bin/bazel
 
 # Install uv
-curl -fsSL https://astral.sh/uv/install.sh | env UV_UNMANAGED_INSTALL="/usr/local/bin" sh
+curl -fsSL https://astral.sh/uv/0.11.33/install.sh | env UV_UNMANAGED_INSTALL="/usr/local/bin" sh
 
 mkdir -p /usr/local/python
 # Install Python using uv

--- a/.buildkite/release-automation/forge_x86_64.Dockerfile
+++ b/.buildkite/release-automation/forge_x86_64.Dockerfile
@@ -33,7 +33,7 @@ chmod +x /usr/local/bin/bazelisk
 ln -s /usr/local/bin/bazelisk /usr/local/bin/bazel
 
 # Install uv
-curl -fsSL https://astral.sh/uv/install.sh | env UV_UNMANAGED_INSTALL="/usr/local/bin" sh
+curl -fsSL https://astral.sh/uv/0.11.33/install.sh | env UV_UNMANAGED_INSTALL="/usr/local/bin" sh
 
 mkdir -p /usr/local/python
 # Install Python using uv

--- a/.buildkite/release/custom-image-build-and-test-init.sh
+++ b/.buildkite/release/custom-image-build-and-test-init.sh
@@ -41,7 +41,7 @@ chmod +x /tmp/bazel
 echo "--- Install uv"
 
 UV_PYTHON_VERSION=3.10
-curl -LsSf https://astral.sh/uv/install.sh | sh
+curl -LsSf https://astral.sh/uv/0.11.33/install.sh | sh
 UV_BIN="${HOME}/.local/bin/uv"
 "${UV_BIN}" python install "${UV_PYTHON_VERSION}"
 UV_PYTHON_BIN="$("${UV_BIN}" python find --no-project "${UV_PYTHON_VERSION}")"

--- a/ci/docker/base.gpu.Dockerfile
+++ b/ci/docker/base.gpu.Dockerfile
@@ -64,7 +64,7 @@ apt-get install -y docker-ce-cli
 
 echo "build --remote_cache=${BUILDKITE_BAZEL_CACHE_URL}" >> /root/.bazelrc
 
-curl -fsSL https://astral.sh/uv/install.sh | env UV_UNMANAGED_INSTALL="/usr/local/bin" sh
+curl -fsSL https://astral.sh/uv/0.11.33/install.sh | env UV_UNMANAGED_INSTALL="/usr/local/bin" sh
 
 EOF
 

--- a/ci/docker/forge.Dockerfile
+++ b/ci/docker/forge.Dockerfile
@@ -78,7 +78,7 @@ apt-get install -y \
   google-cloud-cli
 
 # Install uv
-curl -fsSL https://astral.sh/uv/install.sh | env UV_UNMANAGED_INSTALL="/usr/local/bin" sh
+curl -fsSL https://astral.sh/uv/0.11.33/install.sh | env UV_UNMANAGED_INSTALL="/usr/local/bin" sh
 
 mkdir -p /usr/local/python
 # Install Python using uv

--- a/docker/base-deps/Dockerfile
+++ b/docker/base-deps/Dockerfile
@@ -109,7 +109,7 @@ $HOME/anaconda3/bin/conda install -y libgcc-ng python=$PYTHON_VERSION "libffi>=3
 $HOME/anaconda3/bin/conda clean -y --all
 
 # Install uv
-wget -qO- https://astral.sh/uv/install.sh | sudo -E env UV_UNMANAGED_INSTALL="/usr/local/bin" sh
+wget -qO- https://astral.sh/uv/0.11.33/install.sh | sudo -E env UV_UNMANAGED_INSTALL="/usr/local/bin" sh
 
 # Set up Conda as system Python
 export PATH=$HOME/anaconda3/bin:$PATH

--- a/docker/base-slim/Dockerfile
+++ b/docker/base-slim/Dockerfile
@@ -43,7 +43,7 @@ usermod -aG sudo ray
 echo 'ray ALL=NOPASSWD: ALL' >> /etc/sudoers
 
 # Install uv
-curl -sSL -o- https://astral.sh/uv/install.sh | env UV_UNMANAGED_INSTALL="/usr/local/bin" sh
+curl -sSL -o- https://astral.sh/uv/0.11.33/install.sh | env UV_UNMANAGED_INSTALL="/usr/local/bin" sh
 
 # Determine the architecture of the host
 if [[ "${HOSTTYPE}" =~ ^x86_64 ]]; then


### PR DESCRIPTION
## Description

Cherry-pick of #66068 onto `releases/2.59.0`. Applied cleanly, no conflicts, identical 7-file diff.

Seven image builds fetched `https://astral.sh/uv/install.sh`, which always resolves to the latest uv release, so the uv version baked into an image was whatever happened to be current on the day it was built. On a release branch that matters more than on master: a 2.59.0 patch image rebuilt weeks after the cut would pick up a different uv than the original.

Pinned to **0.11.33**:

| File | Builds |
|---|---|
| `docker/base-deps/Dockerfile` | release image chain root |
| `docker/base-slim/Dockerfile` | slim image |
| `ci/docker/forge.Dockerfile` | CI forge |
| `ci/docker/base.gpu.Dockerfile` | CI GPU base |
| `.buildkite/release-automation/forge_x86_64.Dockerfile` | release-automation forge |
| `.buildkite/release-automation/forge_arm64.Dockerfile` | release-automation forge |
| `.buildkite/release/custom-image-build-and-test-init.sh` | release custom-image build |

`git grep astral.sh/uv/install.sh` returns nothing on this branch.

## Related issues

Cherry-pick of #66068.

## Additional information

**No behaviour change is expected.** Both release images use uv only as `uv pip install --system --no-cache-dir --no-deps --index-strategy unsafe-best-match -r <depset>.lock` — installing an already-resolved lock with `--no-deps`, so no resolver behaviour is in play.

**Why an exact patch version:** astral publishes no series aliases. `https://astral.sh/uv/0.11/install.sh` 301-redirects to a 404, so a pin has to name a full version. 0.11.33 is the newest in the 0.11 series.

Already-pinned call sites (`manylinux.Dockerfile` 0.8.17, `ci/ray_ci/windows/build_base.sh` 0.9.22, the dependabot workflow and `WORKSPACE` 0.9.26, `uv==0.8.9` in requirements) are deliberately untouched here, matching the master PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)