### PR TITLE
[serve] Deflake test_standalone_3 convergence waits

### DIFF
--- a/python/ray/serve/tests/test_standalone_3.py
+++ b/python/ray/serve/tests/test_standalone_3.py
@@ -218,9 +218,11 @@ def test_shutdown_remote(start_and_shutdown_ray_cli_function, tmp_path):
         return True
 
     def check_proxy_gone() -> bool:
+        # Deliberately not httpx.RequestError: that also covers timeouts, and a request
+        # that timed out means something is still listening.
         try:
             resp = httpx.get("http://localhost:8000/f")
-        except httpx.ConnectError:
+        except (httpx.NetworkError, httpx.RemoteProtocolError):
             return True
         raise AssertionError(f"Proxy still serving: {resp.status_code}")
 

--- a/python/ray/serve/tests/test_standalone_3.py
+++ b/python/ray/serve/tests/test_standalone_3.py
@@ -26,6 +26,13 @@ from ray.serve.schema import ProxyStatus, ServeInstanceDetails
 from ray.tests.conftest import call_ray_stop_only  # noqa: F401
 from ray.util.state import list_actors
 
+# Multi-node convergence here (autoscaler node churn, cluster-wide actor teardown)
+# routinely outlasts wait_for_condition's 10s default on the slowest CI platforms.
+WAIT_TIMEOUT_S = 60
+# Deliberately-held requests must outlive the waits above, so httpx's 5s default
+# read timeout cannot be left in place.
+HTTP_TIMEOUT_S = 2 * WAIT_TIMEOUT_S
+
 
 @pytest.fixture
 def shutdown_ray():
@@ -86,20 +93,32 @@ def test_long_poll_timeout_with_max_ongoing_requests(ray_instance):
     # `max_ongoing_requests=1`.
     serve.run(f.bind())
 
+    def check_route_served() -> bool:
+        resp = httpx.get("http://localhost:8000/-/routes")
+        assert resp.status_code == 200, resp.status_code
+        assert "/" in resp.json(), resp.text
+        return True
+
+    # serve.run returns on RUNNING, but proxies learn routes over long poll: a request
+    # sent before the route lands 404s instead of reaching a replica.
+    wait_for_condition(check_route_served, timeout=WAIT_TIMEOUT_S)
+
     @ray.remote
     def do_req():
-        return httpx.get("http://localhost:8000").text
+        return httpx.get("http://localhost:8000", timeout=HTTP_TIMEOUT_S).text
 
     # The request should be hanging waiting on the `SignalActor`.
     first_ref = do_req.remote()
 
     def check_request_started(num_expected_requests: int) -> bool:
-        with pytest.raises(TimeoutError):
-            ray.get(first_ref, timeout=0.1)
+        ready, _ = ray.wait([first_ref], timeout=0.1)
+        assert not ready, f"Request returned instead of hanging: {ray.get(first_ref)!r}"
         assert ray.get(counter_actor.get.remote()) == num_expected_requests
         return True
 
-    wait_for_condition(check_request_started, timeout=5, num_expected_requests=1)
+    wait_for_condition(
+        check_request_started, timeout=WAIT_TIMEOUT_S, num_expected_requests=1
+    )
 
     # Now issue 10 more requests and wait for significantly longer than the long poll
     # timeout. They should all be queued in the handle due to `max_ongoing_requests`
@@ -194,13 +213,23 @@ def test_shutdown_remote(start_and_shutdown_ray_cli_function, tmp_path):
 
     shutdown_file.write_text(shutdown_serve_script)
 
+    def check_f_serving() -> bool:
+        assert httpx.get("http://localhost:8000/f").text == "got f"
+        return True
+
+    def check_proxy_gone() -> bool:
+        try:
+            resp = httpx.get("http://localhost:8000/f")
+        except httpx.ConnectError:
+            return True
+        raise AssertionError(f"Proxy still serving: {resp.status_code}")
+
     # Ensure Serve can be restarted and shutdown with for loop
     for _ in range(2):
         subprocess.check_output([sys.executable, str(deploy_file)])
-        assert httpx.get("http://localhost:8000/f").text == "got f"
+        wait_for_condition(check_f_serving, timeout=WAIT_TIMEOUT_S)
         subprocess.check_output([sys.executable, str(shutdown_file)])
-        with pytest.raises(httpx.ConnectError):
-            httpx.get("http://localhost:8000/f")
+        wait_for_condition(check_proxy_gone, timeout=WAIT_TIMEOUT_S)
 
 
 def test_handle_early_detect_failure(shutdown_ray):
@@ -218,8 +247,13 @@ def test_handle_early_detect_failure(shutdown_ray):
             return os.getpid()
 
         handle = serve.run(f.bind())
-        responses = [handle.remote() for _ in range(10)]
-        assert len({r.result() for r in responses}) == 2
+
+        def check_both_replicas_serving() -> bool:
+            responses = [handle.remote() for _ in range(10)]
+            assert len({r.result() for r in responses}) == 2
+            return True
+
+        wait_for_condition(check_both_replicas_serving, timeout=WAIT_TIMEOUT_S)
 
         client = _get_global_client()
         # Kill the controller so that the replicas membership won't be updated
@@ -287,7 +321,9 @@ def test_autoscaler_shutdown_node_http_everynode(
         **expected_proxy_actors(num_proxy_nodes=2),
         "ServeReplica:app_f:A": 2,
     }
-    wait_for_condition(lambda: alive_actor_counts() == expected_actors)
+    wait_for_condition(
+        lambda: alive_actor_counts() == expected_actors, timeout=WAIT_TIMEOUT_S
+    )
     assert len(ray.nodes()) == 2
 
     # Stop all deployment replicas.
@@ -295,7 +331,9 @@ def test_autoscaler_shutdown_node_http_everynode(
 
     # The worker node and its proxy exit, leaving only the head-node proxy.
     expected_actors = {"ServeController": 1, **expected_proxy_actors(num_proxy_nodes=1)}
-    wait_for_condition(lambda: alive_actor_counts() == expected_actors)
+    wait_for_condition(
+        lambda: alive_actor_counts() == expected_actors, timeout=WAIT_TIMEOUT_S
+    )
 
     client = _get_global_client()
 
@@ -305,7 +343,7 @@ def test_autoscaler_shutdown_node_http_everynode(
         )
         return len(serve_details.proxies)
 
-    wait_for_condition(lambda: serve_details_proxy_count() == 1)
+    wait_for_condition(lambda: serve_details_proxy_count() == 1, timeout=WAIT_TIMEOUT_S)
 
     serve_details = ServeInstanceDetails(
         **ray.get(client._controller.get_serve_instance_details.remote())
@@ -314,7 +352,8 @@ def test_autoscaler_shutdown_node_http_everynode(
 
     # Only head node should exist now.
     wait_for_condition(
-        lambda: len(list(filter(lambda n: n["Alive"], ray.nodes()))) == 1
+        lambda: len(list(filter(lambda n: n["Alive"], ray.nodes()))) == 1,
+        timeout=WAIT_TIMEOUT_S,
     )
 
     # Clean up serve.
@@ -365,7 +404,9 @@ def test_controller_shutdown_gracefully(
         **expected_proxy_actors(num_proxy_nodes=2),
         f"ServeReplica:{SERVE_DEFAULT_APP_NAME}:HelloModel": 2,
     }
-    wait_for_condition(lambda: alive_actor_counts() == expected_actors)
+    wait_for_condition(
+        lambda: alive_actor_counts() == expected_actors, timeout=WAIT_TIMEOUT_S
+    )
     assert len(ray.nodes()) == 2
 
     # Call `graceful_shutdown()` on the controller, so it will start shutdown.
@@ -381,6 +422,7 @@ def test_controller_shutdown_gracefully(
     # Ensure the all resources are shutdown.
     wait_for_condition(
         lambda: len(list_actors(filters=[("STATE", "=", "ALIVE")])) == 0,
+        timeout=WAIT_TIMEOUT_S,
     )
 
     # Clean up serve.
@@ -428,7 +470,9 @@ def test_client_shutdown_gracefully_when_timeout(
         **expected_proxy_actors(num_proxy_nodes=2),
         f"ServeReplica:{SERVE_DEFAULT_APP_NAME}:HelloModel": 2,
     }
-    wait_for_condition(lambda: alive_actor_counts() == expected_actors)
+    wait_for_condition(
+        lambda: alive_actor_counts() == expected_actors, timeout=WAIT_TIMEOUT_S
+    )
     assert len(ray.nodes()) == 2
 
     # Ensure client times out if the controller does not shutdown within timeout.
@@ -443,6 +487,7 @@ def test_client_shutdown_gracefully_when_timeout(
     # Ensure the all resources are shutdown gracefully.
     wait_for_condition(
         lambda: len(list_actors(filters=[("STATE", "=", "ALIVE")])) == 0,
+        timeout=WAIT_TIMEOUT_S,
     )
 
     # Clean up serve.
@@ -474,6 +519,7 @@ def test_serve_shut_down_without_duplicated_logs(
     # Ensure the all resources are shutdown gracefully.
     wait_for_condition(
         lambda: len(list_actors(filters=[("STATE", "=", "ALIVE")])) == 0,
+        timeout=WAIT_TIMEOUT_S,
     )
 
     all_serve_logs = ""


### PR DESCRIPTION
Every fragile assertion in this file checks state that converges asynchronously after the call that triggered it, with either no retry budget or the bare 10s wait_for_condition default.

- test_long_poll_timeout_with_max_ongoing_requests sent its held request before the proxy had the route (serve.run returns on RUNNING, proxies learn the route table over long poll, so the request 404s and completes instead of hanging), and the check that followed was built out of pytest.raises inside a wait_for_condition predicate. Failed derives from BaseException, so wait_for_condition's `except Exception` cannot retry it and the 5s budget collapsed to a single attempt.
- The request that same test deliberately holds open carried httpx's 5s default read timeout, so the client cancelled it out from under the test.
- test_shutdown_remote probed HTTP immediately after the deploy and the shutdown subprocesses exited, with no retries at all.
- test_handle_early_detect_failure required one batch of 10 requests to reach both replicas, but the handle also learns its second replica over long poll.
- Nine wait_for_condition calls guarding autoscaler node churn and cluster-wide actor teardown ran on the bare 10s default; the tightest measured 2.7x headroom on an idle 4-core Linux box.
