### PR TITLE
[Java] Update httpcore5 to 5.4.3

### DIFF
--- a/ci/build/bundled_dependency_versions_test.py
+++ b/ci/build/bundled_dependency_versions_test.py
@@ -44,3 +44,14 @@ def test_ray_dist_jar_uses_fixed_log4j_version():
         "log4j-core": "2.25.4",
         "log4j-slf4j-impl": "2.25.4",
     }
+
+
+def test_ray_dist_jar_uses_patched_httpcore5_version():
+    java_deps = (REPO_ROOT / "java" / "dependencies.bzl").read_text()
+    match = re.search(
+        r"org\.apache\.httpcomponents\.core5:httpcore5:([0-9][^\"\s]*)",
+        java_deps,
+    )
+
+    assert match is not None
+    assert match.group(1) == "5.4.3"

--- a/java/dependencies.bzl
+++ b/java/dependencies.bzl
@@ -28,7 +28,7 @@ def gen_java_deps():
             "com.lmax:disruptor:3.3.4",
             "net.java.dev.jna:jna:5.8.0",
             "org.apache.httpcomponents.client5:httpclient5:5.0.3",
-            "org.apache.httpcomponents.core5:httpcore5:5.0.2",
+            "org.apache.httpcomponents.core5:httpcore5:5.4.3",
             "org.apache.httpcomponents.client5:httpclient5-fluent:5.0.3",
             maven.artifact(
                 group = "org.testng",


### PR DESCRIPTION
## Description

Updates the bundled Maven dependency `org.apache.httpcomponents.core5:httpcore5` from 5.0.2 to 5.4.3 to address CVE-2026-54399.

Adds a regression test that checks the pinned version so the patched dependency is not accidentally downgraded.

Duplicate check: searched open PRs for `66013` and `httpcore5 5.4.3`; no related PRs were found.

## Related issues

Fixes #66013

## Testing

- `.venv/bin/python -m pytest -q ci/build/bundled_dependency_versions_test.py` — 3 passed
- `.venv/bin/pre-commit run --files java/dependencies.bzl ci/build/bundled_dependency_versions_test.py` — passed
- `npx --yes @bazel/bazelisk@latest build @maven//:org_apache_httpcomponents_core5_httpcore5` — passed and resolved httpcore5 5.4.3
- `npx --yes @bazel/bazelisk@latest build --jobs=4 //java:io_ray_ray_serve` — passed

## Additional information

AI assistance was used to implement and validate this change. The submitter reviewed and understands the submitted changes.