### PR TITLE
[Core] Add opt-in log monitor stdout/stderr tee

### DIFF
--- a/doc/source/ray-observability/user-guides/configure-logging.md
+++ b/doc/source/ray-observability/user-guides/configure-logging.md
@@ -64,6 +64,11 @@ System logs may include information about your applications. For example, ``runt
 - ``runtime_env_setup-ray_client_server_[port].log``: Logs from installing {ref}`Runtime Environments <runtime-environments>` for a job when connecting with {ref}`Ray Client <ray-client-ref>`.
 - ``runtime_env_setup-[job_id].log``: Logs from installing {ref}`runtime environments <runtime-environments>` for a Task, Actor, or Job. This file is only present if you install a runtime environment.
 
+To keep log monitor output visible in container stdout and stderr while also
+writing it to ``log_monitor.out`` and ``log_monitor.err``, set
+``RAY_LOG_MONITOR_TEE_STDOUT=1`` on each Ray node before starting Ray. The
+default is ``0``, which redirects the output only to the log files.
+
 
 (log-redirection-to-driver)=
 ## Redirecting Worker logs to the Driver

--- a/python/ray/_private/log_monitor.py
+++ b/python/ray/_private/log_monitor.py
@@ -613,6 +613,8 @@ if __name__ == "__main__":
         args.stderr_filepath,
         logging_rotation_bytes,
         logging_rotation_backup_count,
+        tee_to_stdout=ray_constants.LOG_MONITOR_TEE_STDOUT,
+        tee_to_stderr=ray_constants.LOG_MONITOR_TEE_STDOUT,
     )
 
     gcs_client = GcsClient(address=args.gcs_address)

--- a/python/ray/_private/logging_utils.py
+++ b/python/ray/_private/logging_utils.py
@@ -9,14 +9,19 @@ def redirect_stdout_stderr_if_needed(
     stderr_filepath: str,
     rotation_bytes: int,
     rotation_backup_count: int,
+    *,
+    tee_to_stdout: bool = False,
+    tee_to_stderr: bool = False,
 ):
-    """This function sets up redirection for stdout and stderr if needed, based on the given rotation parameters.
+    """Set up stdout and stderr redirection.
 
     params:
     stdout_filepath: the filepath stdout will be redirected to; if empty, stdout will not be redirected.
     stderr_filepath: the filepath stderr will be redirected to; if empty, stderr will not be redirected.
     rotation_bytes: number of bytes which triggers file rotation.
     rotation_backup_count: the max size of rotation files.
+    tee_to_stdout: whether redirected stdout is also written to the original stdout.
+    tee_to_stderr: whether redirected stderr is also written to the original stderr.
     """
 
     # Setup redirection for stdout and stderr.
@@ -25,7 +30,7 @@ def redirect_stdout_stderr_if_needed(
             stdout_filepath,
             rotation_bytes,
             rotation_backup_count,
-            False,  # tee_to_stdout
+            tee_to_stdout,
             False,  # tee_to_stderr
         )
     if stderr_filepath:
@@ -34,7 +39,7 @@ def redirect_stdout_stderr_if_needed(
             rotation_bytes,
             rotation_backup_count,
             False,  # tee_to_stdout
-            False,  # tee_to_stderr
+            tee_to_stderr,
         )
 
     # Setup python system stdout/stderr.

--- a/python/ray/_private/ray_constants.py
+++ b/python/ray/_private/ray_constants.py
@@ -495,6 +495,10 @@ LOG_MONITOR_NUM_LINES_TO_READ = int(
     os.environ.get("RAY_LOG_MONITOR_NUM_LINES_TO_READ", "1000")
 )
 
+# Whether log monitor stdout and stderr should also be emitted to their original
+# streams after being redirected to files.
+LOG_MONITOR_TEE_STDOUT = env_bool("RAY_LOG_MONITOR_TEE_STDOUT", False)
+
 # Autoscaler events are denoted by the ":event_summary:" magic token.
 LOG_PREFIX_EVENT_SUMMARY = ":event_summary:"
 # Cluster-level info events are denoted by the ":info_message:" magic token. These may

--- a/python/ray/_private/services.py
+++ b/python/ray/_private/services.py
@@ -1215,8 +1215,19 @@ def start_log_monitor(
         )
         command.append(f"--logging-format={logging_format}")
 
-    stdout_file = subprocess.DEVNULL if stdout_filepath else None
-    stderr_file = subprocess.DEVNULL if stderr_filepath else None
+    # StreamRedirector can only tee to the streams inherited by the log monitor.
+    # Preserve them when teeing is enabled instead of attaching the child to
+    # DEVNULL before redirection is configured.
+    stdout_file = (
+        subprocess.DEVNULL
+        if stdout_filepath and not ray_constants.LOG_MONITOR_TEE_STDOUT
+        else None
+    )
+    stderr_file = (
+        subprocess.DEVNULL
+        if stderr_filepath and not ray_constants.LOG_MONITOR_TEE_STDOUT
+        else None
+    )
 
     process_info = start_ray_process(
         command,

--- a/python/ray/tests/test_logging.py
+++ b/python/ray/tests/test_logging.py
@@ -20,7 +20,7 @@ from ray._common.test_utils import (
     run_string_as_driver,
     wait_for_condition,
 )
-from ray._private import ray_constants
+from ray._private import logging_utils, ray_constants
 from ray._private.log_monitor import (
     LOG_NAME_UPDATE_INTERVAL_S,
     RAY_LOG_MONITOR_MANY_FILES_THRESHOLD,
@@ -56,6 +56,34 @@ from ray.autoscaler._private.cli_logger import cli_logger
 def set_logging_config(monkeypatch, max_bytes, backup_count):
     monkeypatch.setenv("RAY_ROTATION_MAX_BYTES", str(max_bytes))
     monkeypatch.setenv("RAY_ROTATION_BACKUP_COUNT", str(backup_count))
+
+
+@pytest.mark.parametrize("tee_enabled", [False, True])
+def test_redirect_stdout_stderr_tee_options(tee_enabled):
+    with (
+        patch.object(logging_utils, "sys") as mock_sys,
+        patch.object(logging_utils, "open_log"),
+        patch.object(
+            logging_utils.StreamRedirector, "redirect_stdout"
+        ) as redirect_stdout,
+        patch.object(
+            logging_utils.StreamRedirector, "redirect_stderr"
+        ) as redirect_stderr,
+    ):
+        mock_sys.stdout.fileno.return_value = 1
+        mock_sys.stderr.fileno.return_value = 2
+
+        logging_utils.redirect_stdout_stderr_if_needed(
+            "stdout.log",
+            "stderr.log",
+            100,
+            3,
+            tee_to_stdout=tee_enabled,
+            tee_to_stderr=tee_enabled,
+        )
+
+    redirect_stdout.assert_called_once_with("stdout.log", 100, 3, tee_enabled, False)
+    redirect_stderr.assert_called_once_with("stderr.log", 100, 3, False, tee_enabled)
 
 
 def test_reopen_changed_inode_seeks_on_non_empty_file(tmp_path):

--- a/python/ray/tests/test_logging.py
+++ b/python/ray/tests/test_logging.py
@@ -20,7 +20,7 @@ from ray._common.test_utils import (
     run_string_as_driver,
     wait_for_condition,
 )
-from ray._private import logging_utils, ray_constants
+from ray._private import logging_utils, ray_constants, services
 from ray._private.log_monitor import (
     LOG_NAME_UPDATE_INTERVAL_S,
     RAY_LOG_MONITOR_MANY_FILES_THRESHOLD,
@@ -84,6 +84,28 @@ def test_redirect_stdout_stderr_tee_options(tee_enabled):
 
     redirect_stdout.assert_called_once_with("stdout.log", 100, 3, tee_enabled, False)
     redirect_stderr.assert_called_once_with("stderr.log", 100, 3, False, tee_enabled)
+
+
+@pytest.mark.parametrize(
+    ("tee_enabled", "expected_stream"),
+    [(False, subprocess.DEVNULL), (True, None)],
+)
+def test_start_log_monitor_preserves_streams_for_tee(tee_enabled, expected_stream):
+    with (
+        patch.object(ray_constants, "LOG_MONITOR_TEE_STDOUT", tee_enabled),
+        patch.object(services, "start_ray_process") as start_ray_process,
+    ):
+        services.start_log_monitor(
+            "session",
+            "logs",
+            "gcs-address",
+            "node-address",
+            stdout_filepath="stdout.log",
+            stderr_filepath="stderr.log",
+        )
+
+    assert start_ray_process.call_args.kwargs["stdout_file"] == expected_stream
+    assert start_ray_process.call_args.kwargs["stderr_file"] == expected_stream
 
 
 def test_reopen_changed_inode_seeks_on_non_empty_file(tmp_path):


### PR DESCRIPTION
## Description

Adds the opt-in `RAY_LOG_MONITOR_TEE_STDOUT=1` setting so the log monitor continues writing `log_monitor.out` and `log_monitor.err` while also emitting output to the original container streams.

The shared redirection helper gains keyword-only tee options with backward-compatible `False` defaults. The log monitor enables stdout-to-stdout and stderr-to-stderr teeing, preserving stream identity without changing dashboard, autoscaler, or runtime-environment callers. Documentation and focused tests are included.

Duplicate check: searched open PRs for `66054` and `log monitor tee stdout`; no related PRs were found.

## Related issues

Fixes #66054

## Testing

- File-scoped Ray pre-commit hooks — passed
- Python bytecode compilation for the changed Python files — passed
- Focused behavior harness for disabled and enabled tee options — passed
- The standalone Bazel `test_logging` invocation could not collect tests in this partial checkout because the Ray extension module was not built; CI should execute the added test in the built-Ray environment

## Additional information

AI assistance was used to implement and validate this change. The submitter reviewed and understands every submitted change.