### PR TITLE
[Data] iter_batches(local_shuffle_buffer_size=...) yields short batches mid-stream, breaking DDP step parity

### DIFF
--- a/python/ray/data/_internal/batcher.py
+++ b/python/ray/data/_internal/batcher.py
@@ -340,6 +340,7 @@ class ShufflingBatcher(BatcherInterface):
         if self._num_uncompacted_rows() > 0 and (
             self._done_adding
             or self._num_compacted_rows() <= self._min_rows_to_yield_batch
+            or self._num_compacted_rows() < self._batch_size
         ):
             if self._shuffle_buffer is not None and self._batch_head < len(
                 self._shuffled_indices

--- a/python/ray/data/tests/test_batcher.py
+++ b/python/ray/data/tests/test_batcher.py
@@ -385,6 +385,42 @@ def test_no_partial_batch_mid_stream():
     assert total == 35
 
 
+def test_no_partial_batch_when_uncompacted_rows_available():
+    """Rows waiting in the builder must be merged instead of yielding a short batch.
+
+    Regression test: `has_batch()` gates on the total number of unyielded rows, but
+    `next_batch()` used to only recompact once the compacted buffer fell to
+    `_min_rows_to_yield_batch`. When the compacted buffer held more than that but
+    fewer than `batch_size` rows, it was sliced on its own and yielded a short batch
+    mid-stream, even though more rows were already waiting in the builder.
+
+    With ``batch_size=8`` and blocks of ``[30, 10]``, the 30-row block drains to a
+    remainder of 6, which must be merged with the 10 pending rows rather than emitted
+    as a batch of 6.
+    """
+    batch_size = 8
+    batcher = ShufflingBatcher(
+        batch_size=batch_size,
+        shuffle_buffer_min_size=batch_size,
+        shuffle_seed=0,
+    )
+
+    sizes = []
+    for block_size in (30, 10):
+        batcher.add(gen_block(block_size))
+        while batcher.has_batch():
+            sizes.append(len(batcher.next_batch()))
+    batcher.done_adding()
+    while batcher.has_batch() or batcher.has_any():
+        sizes.append(len(batcher.next_batch()))
+
+    short_mid_stream = [size for size in sizes[:-1] if size != batch_size]
+    assert not short_mid_stream, f"expected only the last batch to be short: {sizes}"
+    assert sum(sizes) == 40
+    # 40 rows in batches of 8 is 5 batches, whatever the blocking.
+    assert sizes == [batch_size] * 5
+
+
 if __name__ == "__main__":
     import sys
 


### PR DESCRIPTION
## Description

With `local_shuffle_buffer_size` set, `iter_batches` emits batches shorter than `batch_size`
mid-stream, not only as the final batch as documented: 40 rows in blocks of `[30, 10]` with
`batch_size=8` yields `[8, 8, 8, 6, 8, 2]` instead of `[8, 8, 8, 8, 8]`. It costs roughly one
extra short batch per block boundary.

This deadlocks DDP training. `streaming_split(equal=True)` equalizes rows per worker but not
blocks, so ranks get different batch counts, run a different number of steps, and hang in the
epoch-end all-reduce with no error and no traceback. `drop_last=True` does not help, because the
short batches are not at the end.

`next_batch()` now compacts the shuffle buffer whenever it cannot serve a full batch and rows are
still waiting, so short batches occur only at the end of the stream and the batch count is exactly
`ceil(rows / batch_size)` regardless of blocking.

## Related issues

Fixes https://github.com/ray-project/ray/issues/66085

## Additional information

AI assistance was used to implement and validate this change. The submitter reviewed and understands every submitted change.
