### PR TITLE
[Data][PreProc][1/4] Add exact TopKUnique aggregation

### DIFF
--- a/doc/source/data/api/aggregate.rst
+++ b/doc/source/data/api/aggregate.rst
@@ -32,3 +32,4 @@ compute aggregations.
     ZeroPercentage
     ApproximateQuantile
     ApproximateTopK
+    TopKUnique

--- a/python/ray/data/aggregate.py
+++ b/python/ray/data/aggregate.py
@@ -1,4 +1,5 @@
 import abc
+import collections
 import enum
 import math
 import pickle
@@ -1848,6 +1849,9 @@ class ApproximateTopK(AggregateFnV2):
         Computes the approximate top k items in a column by using a datasketches frequent_strings_sketch.
         https://datasketches.apache.org/docs/Frequency/FrequentItemsOverview.html
 
+        For an exact variant that returns a plain list of values (at the cost of
+        keeping all distinct values in the accumulator), see :class:`TopKUnique`.
+
         Guarantees:
             - Any item with true frequency > N / (2^log_capacity) is guaranteed to appear in the results
             - Reported counts may have an error of at most ± N / (2^log_capacity).
@@ -1941,3 +1945,167 @@ class ApproximateTopK(AggregateFnV2):
             {column: pickle.loads(bytes.fromhex(item[0])), "count": int(item[1])}
             for item in frequent_items[: self.k]
         ]
+
+
+@PublicAPI
+class TopKUnique(AggregateFnV2[Dict[str, List], List[Any]]):
+    """Defines an exact top-k-by-frequency unique aggregation.
+
+    Counts value frequencies globally (summed across all blocks) and returns the
+    ``k`` most frequent values. The ranking is global: a value that is only
+    moderately frequent in every individual block but frequent overall is
+    correctly preferred over a value that is frequent in a single block.
+
+    Unlike :class:`ApproximateTopK`, the result is exact, no third-party
+    dependency is required, and the output is a plain list of values (like
+    :class:`Unique`) rather than value/count records.
+
+    Ties are broken deterministically: values with equal counts are ordered by
+    value, falling back to their string representation when values aren't
+    comparable with each other.
+
+    Example:
+
+        .. testcode::
+
+            import ray
+            from ray.data.aggregate import TopKUnique
+
+            ds = ray.data.from_items([
+                {"word": "apple"}, {"word": "banana"}, {"word": "apple"},
+                {"word": "cherry"}, {"word": "apple"}, {"word": "banana"}
+            ])
+
+            result = ds.aggregate(TopKUnique(on="word", k=2))
+            # result: {'topk_unique(word)': ['apple', 'banana']}
+
+    Args:
+        on: The name of the column to aggregate.
+        k: The number of most frequent values to return.
+        ignore_nulls: Whether to ignore null values when counting. If ``False``
+            (the default, matching :class:`Unique`), nulls are counted like any
+            other value and ``None`` can appear in the result.
+        alias_name: Optional name for the resulting column. Defaults to
+            ``"topk_unique({on})"``.
+        encode_lists: If ``True``, list-type column elements are flattened so
+            that each list element is counted individually. If ``False``, entire
+            lists are treated as single values (converted to tuples for
+            hashability). Note that this is a top-level flatten (not a recursive
+            flatten) operation.
+    """
+
+    def __init__(
+        self,
+        on: str,
+        k: int,
+        ignore_nulls: bool = False,
+        alias_name: Optional[str] = None,
+        encode_lists: bool = False,
+    ):
+        if k <= 0:
+            raise ValueError(f"`k` must be a positive integer (got {k})")
+
+        self._k = k
+        self._encode_lists = bool(encode_lists)
+
+        super().__init__(
+            alias_name if alias_name else f"topk_unique({str(on)})",
+            on=on,
+            ignore_nulls=ignore_nulls,
+            zero_factory=lambda: {"values": [], "counts": []},
+        )
+
+    def aggregate_block(self, block: Block) -> Dict[str, List]:
+        accessor = BlockColumnAccessor.for_column(block[self._target_col_name])
+
+        if self._encode_lists and accessor.is_composed_of_lists():
+            accessor = BlockColumnAccessor.for_column(accessor.flatten())
+
+        if accessor.is_composed_of_lists():
+            # Whole lists are treated as single values. There's no vectorized
+            # `value_counts` kernel for list types, so count in Python over
+            # tuples (mirroring how `Unique` makes whole-list values hashable).
+            counter = collections.Counter(
+                None if value is None else tuple(value)
+                for value in accessor.to_pylist()
+            )
+            value_counts = {
+                "values": list(counter.keys()),
+                "counts": list(counter.values()),
+            }
+        else:
+            value_counts = accessor.value_counts() or {"values": [], "counts": []}
+
+        values: List[Any] = []
+        counts: List[int] = []
+        # Null accounting differs by block type: a pandas column drops nulls
+        # from `value_counts` entirely, while an Arrow column reports them as
+        # entries (None for nulls, NaN as a float value). Strip null-ish
+        # entries here and re-add one canonical `None` entry below, so both
+        # block types produce the same accumulator.
+        null_count_from_entries = 0
+        for value, count in zip(value_counts["values"], value_counts["counts"]):
+            if is_null(value):
+                null_count_from_entries += count
+                continue
+            # Convert lists to tuples for hashability in `combine`, mirroring
+            # how `Unique` treats whole-list values.
+            values.append(tuple(value) if isinstance(value, list) else value)
+            counts.append(count)
+
+        if not self._ignore_nulls:
+            # Whichever accounting is complete for this block type wins: the
+            # Arrow entries above cover both None and NaN, while the count
+            # delta covers everything a pandas `value_counts` dropped.
+            total = accessor.count(ignore_nulls=False) or 0
+            non_null = accessor.count(ignore_nulls=True) or 0
+            null_count = max(null_count_from_entries, total - non_null)
+            if null_count > 0:
+                values.append(None)
+                counts.append(null_count)
+
+        return {"values": values, "counts": counts}
+
+    def combine(
+        self,
+        current_accumulator: Dict[str, List],
+        new_accumulator: Dict[str, List],
+    ) -> Dict[str, List]:
+        values = [self._normalize_value(v) for v in current_accumulator["values"]]
+        counts = list(current_accumulator["counts"])
+
+        value_to_index = {v: i for i, v in enumerate(values)}
+
+        for v_new, c_new in zip(new_accumulator["values"], new_accumulator["counts"]):
+            v_new = self._normalize_value(v_new)
+            if v_new in value_to_index:
+                counts[value_to_index[v_new]] += c_new
+            else:
+                value_to_index[v_new] = len(values)
+                values.append(v_new)
+                counts.append(c_new)
+
+        return {"values": values, "counts": counts}
+
+    def finalize(self, accumulator: Dict[str, List]) -> List[Any]:
+        pairs = list(zip(accumulator["values"], accumulator["counts"]))
+        try:
+            pairs.sort(key=lambda pair: (-pair[1], pair[0]))
+        except TypeError:
+            # Values aren't mutually comparable (e.g. mixed types, or None
+            # among them) - fall back to their string representation for a
+            # deterministic tie-break.
+            pairs.sort(key=lambda pair: (-pair[1], str(pair[0])))
+        return [value for value, _ in pairs[: self._k]]
+
+    @staticmethod
+    def _normalize_value(value: Any) -> Any:
+        # Partial accumulators round-trip through Arrow between combine steps,
+        # which turns tuples back into lists - re-canonicalize so lookups in
+        # `combine` stay consistent. NaN objects are likewise canonicalized
+        # since distinct float('nan') instances hash differently.
+        if isinstance(value, list):
+            return tuple(value)
+        if isinstance(value, float) and np.isnan(value):
+            return np.nan
+        return value

--- a/python/ray/data/tests/test_aggregations.py
+++ b/python/ray/data/tests/test_aggregations.py
@@ -8,6 +8,7 @@ from ray.data.aggregate import (
     ApproximateQuantile,
     ApproximateTopK,
     MissingValuePercentage,
+    TopKUnique,
     Unique,
     ZeroPercentage,
 )
@@ -557,6 +558,140 @@ class TestUnique:
         answer = ["a", "b", "c"]
 
         assert Counter(result["unique(id)"]) == Counter(answer)
+
+
+class TestTopKUnique:
+    """Test cases for TopKUnique aggregation."""
+
+    def test_topk_unique_basic(self, ray_start_regular_shared_2_cpus):
+        """Test basic exact top-k by global frequency."""
+        data = [
+            *[{"word": "apple"} for _ in range(5)],
+            *[{"word": "banana"} for _ in range(3)],
+            *[{"word": "cherry"} for _ in range(2)],
+        ]
+        ds = ray.data.from_items(data)
+        result = ds.aggregate(TopKUnique(on="word", k=2))
+        assert result["topk_unique(word)"] == ["apple", "banana"]
+
+    def test_topk_unique_global_ranking_across_blocks(
+        self, ray_start_regular_shared_2_cpus
+    ):
+        """A value that never wins within any single block must still win globally.
+
+        With per-block top-1 semantics, "c" (3+3+3=9 occurrences, never a block
+        winner) would be dropped in favor of per-block winners "a" (4) and
+        "b" (4+2=6). Exact global counting must return "c".
+        """
+        data = [
+            # Block 1: a wins locally.
+            *[{"v": "a"} for _ in range(4)],
+            *[{"v": "c"} for _ in range(3)],
+            # Block 2: b wins locally.
+            *[{"v": "b"} for _ in range(4)],
+            *[{"v": "c"} for _ in range(3)],
+            # Block 3: b wins locally.
+            *[{"v": "b"} for _ in range(2)],
+            *[{"v": "c"} for _ in range(3)],
+        ]
+        ds = ray.data.from_items(data, override_num_blocks=3)
+        result = ds.aggregate(TopKUnique(on="v", k=1))
+        assert result["topk_unique(v)"] == ["c"]
+
+    def test_topk_unique_deterministic_tiebreak(self, ray_start_regular_shared_2_cpus):
+        """Equal counts are broken by value order, deterministically."""
+        data = [
+            *[{"v": "zebra"} for _ in range(2)],
+            *[{"v": "apple"} for _ in range(2)],
+            *[{"v": "mango"} for _ in range(2)],
+        ]
+        ds = ray.data.from_items(data, override_num_blocks=2)
+        result = ds.aggregate(TopKUnique(on="v", k=2))
+        assert result["topk_unique(v)"] == ["apple", "mango"]
+
+    def test_topk_unique_custom_alias(self, ray_start_regular_shared_2_cpus):
+        """Test custom alias name."""
+        data = [{"item": "x"}, {"item": "x"}, {"item": "y"}]
+        ds = ray.data.from_items(data)
+        result = ds.aggregate(TopKUnique(on="item", k=1, alias_name="top_items"))
+        assert result["top_items"] == ["x"]
+
+    def test_topk_unique_groupby(self, ray_start_regular_shared_2_cpus):
+        """Test top-k per group."""
+        data = [
+            *[{"category": "A", "item": "apple"} for _ in range(5)],
+            *[{"category": "A", "item": "banana"} for _ in range(3)],
+            *[{"category": "B", "item": "cherry"} for _ in range(4)],
+            *[{"category": "B", "item": "date"} for _ in range(2)],
+        ]
+        ds = ray.data.from_items(data)
+        result = ds.groupby("category").aggregate(TopKUnique(on="item", k=1)).take_all()
+
+        result_by_category = {
+            row["category"]: row["topk_unique(item)"] for row in result
+        }
+        assert result_by_category["A"] == ["apple"]
+        assert result_by_category["B"] == ["cherry"]
+
+    def test_topk_unique_fewer_items_than_k(self, ray_start_regular_shared_2_cpus):
+        """Fewer distinct values than k returns all of them."""
+        data = [{"id": "a"}, {"id": "b"}]
+        ds = ray.data.from_items(data)
+        result = ds.aggregate(TopKUnique(on="id", k=5))
+        assert sorted(result["topk_unique(id)"]) == ["a", "b"]
+
+    def test_topk_unique_counts_nulls_by_default(self, ray_start_regular_shared_2_cpus):
+        """With ignore_nulls=False (default), nulls compete for top-k slots."""
+        data = [
+            *[{"v": None} for _ in range(5)],
+            *[{"v": "a"} for _ in range(3)],
+            *[{"v": "b"} for _ in range(1)],
+        ]
+        ds = ray.data.from_items(data, override_num_blocks=2)
+        result = ds.aggregate(TopKUnique(on="v", k=2))
+        assert result["topk_unique(v)"] == [None, "a"]
+
+    def test_topk_unique_ignore_nulls(self, ray_start_regular_shared_2_cpus):
+        """With ignore_nulls=True, nulls are excluded from counting."""
+        data = [
+            *[{"v": None} for _ in range(5)],
+            *[{"v": "a"} for _ in range(3)],
+            *[{"v": "b"} for _ in range(1)],
+        ]
+        ds = ray.data.from_items(data, override_num_blocks=2)
+        result = ds.aggregate(TopKUnique(on="v", k=2, ignore_nulls=True))
+        assert result["topk_unique(v)"] == ["a", "b"]
+
+    def test_topk_unique_encode_lists(self, ray_start_regular_shared_2_cpus):
+        """With encode_lists=True, list elements are counted individually."""
+        data = [
+            {"tokens": ["a", "b", "a"]},
+            {"tokens": ["a", "c"]},
+            {"tokens": ["b"]},
+        ]
+        ds = ray.data.from_items(data)
+        result = ds.aggregate(
+            TopKUnique(on="tokens", k=2, ignore_nulls=True, encode_lists=True)
+        )
+        assert result["topk_unique(tokens)"] == ["a", "b"]
+
+    def test_topk_unique_whole_lists_as_values(self, ray_start_regular_shared_2_cpus):
+        """With encode_lists=False, whole lists are counted as single values."""
+        data = [
+            {"tokens": ["a", "b"]},
+            {"tokens": ["a", "b"]},
+            {"tokens": ["c"]},
+        ]
+        ds = ray.data.from_items(data, override_num_blocks=2)
+        result = ds.aggregate(TopKUnique(on="tokens", k=1, ignore_nulls=True))
+        # Values are counted as tuples internally (for hashability), but the
+        # result round-trips through Arrow, which represents them as lists.
+        assert [list(v) for v in result["topk_unique(tokens)"]] == [["a", "b"]]
+
+    def test_topk_unique_invalid_k(self, ray_start_regular_shared_2_cpus):
+        """k must be positive."""
+        with pytest.raises(ValueError, match="`k` must be a positive integer"):
+            TopKUnique(on="v", k=0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Why are these changes needed?

Adds `TopKUnique`, an exact top-k-by-global-frequency aggregation, alongside the
existing aggregations in `python/ray/data/aggregate.py`.

Frequencies are counted per block, merged globally, and only then ranked, so a
value that is moderately frequent in every block but frequent overall is
correctly preferred over a per-block winner (the same global semantics the
encoder preprocessors already guarantee via
`test_one_hot_encoder_max_categories_global_sum_across_partitions`). Ties are
broken deterministically by value, falling back to the string representation
for non-comparable types.

Relationship to `ApproximateTopK`: that aggregation is approximate, works on a
`datasketches` frequent-strings sketch (extra dependency), and returns
value/count records. `TopKUnique` is exact, has no third-party dependency, and
returns a plain list of values (like `Unique`) — at the cost of keeping all
distinct values in the accumulator. The two docstrings cross-reference each
other.

Motivation: this is groundwork for fitting encoder preprocessors
(`OneHotEncoder`/`MultiHotEncoder` with `max_categories`) via distributed
aggregation instead of a driver-side counter merge (follow-up PR), but it is
independently useful as a public aggregation.

## Related issue number

N/A. Duplicate-work check: searched open PRs/issues for top-k aggregation work;
the only adjacent open PR is #66012 (GPU preprocessor transforms), which does
not overlap.

## Checks

- [x] I've signed off every commit (DCO).
- [x] I've run pre-commit hooks (`pre-commit run --files ...`) — all hooks pass.
- [x] Testing:
  - `pytest python/ray/data/tests/test_aggregations.py` — 47 passed (11 new
    `TestTopKUnique` cases: global ranking across blocks, deterministic
    tie-breaks, alias, groupby, k > distinct count, null counting with
    `ignore_nulls=False`/`True`, list flattening, whole-list values, invalid k).
  - Run locally on macOS / Python 3.12 against a source build.
- [x] Docs: added `TopKUnique` to `doc/source/data/api/aggregate.rst`.

AI assistance was used to draft this change (Claude Code); every line has been
reviewed by the submitter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)