### PR TITLE
[Data][PreProc][2/4] Fit encoders and SimpleImputer via distributed aggregation

### DIFF
--- a/doc/source/data/api/aggregate.rst
+++ b/doc/source/data/api/aggregate.rst
@@ -32,3 +32,4 @@ compute aggregations.
     ZeroPercentage
     ApproximateQuantile
     ApproximateTopK
+    TopKUnique

--- a/python/ray/data/aggregate.py
+++ b/python/ray/data/aggregate.py
@@ -1,4 +1,5 @@
 import abc
+import collections
 import enum
 import math
 import pickle
@@ -1848,6 +1849,9 @@ class ApproximateTopK(AggregateFnV2):
         Computes the approximate top k items in a column by using a datasketches frequent_strings_sketch.
         https://datasketches.apache.org/docs/Frequency/FrequentItemsOverview.html
 
+        For an exact variant that returns a plain list of values (at the cost of
+        keeping all distinct values in the accumulator), see :class:`TopKUnique`.
+
         Guarantees:
             - Any item with true frequency > N / (2^log_capacity) is guaranteed to appear in the results
             - Reported counts may have an error of at most ± N / (2^log_capacity).
@@ -1941,3 +1945,167 @@ class ApproximateTopK(AggregateFnV2):
             {column: pickle.loads(bytes.fromhex(item[0])), "count": int(item[1])}
             for item in frequent_items[: self.k]
         ]
+
+
+@PublicAPI
+class TopKUnique(AggregateFnV2[Dict[str, List], List[Any]]):
+    """Defines an exact top-k-by-frequency unique aggregation.
+
+    Counts value frequencies globally (summed across all blocks) and returns the
+    ``k`` most frequent values. The ranking is global: a value that is only
+    moderately frequent in every individual block but frequent overall is
+    correctly preferred over a value that is frequent in a single block.
+
+    Unlike :class:`ApproximateTopK`, the result is exact, no third-party
+    dependency is required, and the output is a plain list of values (like
+    :class:`Unique`) rather than value/count records.
+
+    Ties are broken deterministically: values with equal counts are ordered by
+    value, falling back to their string representation when values aren't
+    comparable with each other.
+
+    Example:
+
+        .. testcode::
+
+            import ray
+            from ray.data.aggregate import TopKUnique
+
+            ds = ray.data.from_items([
+                {"word": "apple"}, {"word": "banana"}, {"word": "apple"},
+                {"word": "cherry"}, {"word": "apple"}, {"word": "banana"}
+            ])
+
+            result = ds.aggregate(TopKUnique(on="word", k=2))
+            # result: {'topk_unique(word)': ['apple', 'banana']}
+
+    Args:
+        on: The name of the column to aggregate.
+        k: The number of most frequent values to return.
+        ignore_nulls: Whether to ignore null values when counting. If ``False``
+            (the default, matching :class:`Unique`), nulls are counted like any
+            other value and ``None`` can appear in the result.
+        alias_name: Optional name for the resulting column. Defaults to
+            ``"topk_unique({on})"``.
+        encode_lists: If ``True``, list-type column elements are flattened so
+            that each list element is counted individually. If ``False``, entire
+            lists are treated as single values (converted to tuples for
+            hashability). Note that this is a top-level flatten (not a recursive
+            flatten) operation.
+    """
+
+    def __init__(
+        self,
+        on: str,
+        k: int,
+        ignore_nulls: bool = False,
+        alias_name: Optional[str] = None,
+        encode_lists: bool = False,
+    ):
+        if k <= 0:
+            raise ValueError(f"`k` must be a positive integer (got {k})")
+
+        self._k = k
+        self._encode_lists = bool(encode_lists)
+
+        super().__init__(
+            alias_name if alias_name else f"topk_unique({str(on)})",
+            on=on,
+            ignore_nulls=ignore_nulls,
+            zero_factory=lambda: {"values": [], "counts": []},
+        )
+
+    def aggregate_block(self, block: Block) -> Dict[str, List]:
+        accessor = BlockColumnAccessor.for_column(block[self._target_col_name])
+
+        if self._encode_lists and accessor.is_composed_of_lists():
+            accessor = BlockColumnAccessor.for_column(accessor.flatten())
+
+        if accessor.is_composed_of_lists():
+            # Whole lists are treated as single values. There's no vectorized
+            # `value_counts` kernel for list types, so count in Python over
+            # tuples (mirroring how `Unique` makes whole-list values hashable).
+            counter = collections.Counter(
+                None if value is None else tuple(value)
+                for value in accessor.to_pylist()
+            )
+            value_counts = {
+                "values": list(counter.keys()),
+                "counts": list(counter.values()),
+            }
+        else:
+            value_counts = accessor.value_counts() or {"values": [], "counts": []}
+
+        values: List[Any] = []
+        counts: List[int] = []
+        # Null accounting differs by block type: a pandas column drops nulls
+        # from `value_counts` entirely, while an Arrow column reports them as
+        # entries (None for nulls, NaN as a float value). Strip null-ish
+        # entries here and re-add one canonical `None` entry below, so both
+        # block types produce the same accumulator.
+        null_count_from_entries = 0
+        for value, count in zip(value_counts["values"], value_counts["counts"]):
+            if is_null(value):
+                null_count_from_entries += count
+                continue
+            # Convert lists to tuples for hashability in `combine`, mirroring
+            # how `Unique` treats whole-list values.
+            values.append(tuple(value) if isinstance(value, list) else value)
+            counts.append(count)
+
+        if not self._ignore_nulls:
+            # Whichever accounting is complete for this block type wins: the
+            # Arrow entries above cover both None and NaN, while the count
+            # delta covers everything a pandas `value_counts` dropped.
+            total = accessor.count(ignore_nulls=False) or 0
+            non_null = accessor.count(ignore_nulls=True) or 0
+            null_count = max(null_count_from_entries, total - non_null)
+            if null_count > 0:
+                values.append(None)
+                counts.append(null_count)
+
+        return {"values": values, "counts": counts}
+
+    def combine(
+        self,
+        current_accumulator: Dict[str, List],
+        new_accumulator: Dict[str, List],
+    ) -> Dict[str, List]:
+        values = [self._normalize_value(v) for v in current_accumulator["values"]]
+        counts = list(current_accumulator["counts"])
+
+        value_to_index = {v: i for i, v in enumerate(values)}
+
+        for v_new, c_new in zip(new_accumulator["values"], new_accumulator["counts"]):
+            v_new = self._normalize_value(v_new)
+            if v_new in value_to_index:
+                counts[value_to_index[v_new]] += c_new
+            else:
+                value_to_index[v_new] = len(values)
+                values.append(v_new)
+                counts.append(c_new)
+
+        return {"values": values, "counts": counts}
+
+    def finalize(self, accumulator: Dict[str, List]) -> List[Any]:
+        pairs = list(zip(accumulator["values"], accumulator["counts"]))
+        try:
+            pairs.sort(key=lambda pair: (-pair[1], pair[0]))
+        except TypeError:
+            # Values aren't mutually comparable (e.g. mixed types, or None
+            # among them) - fall back to their string representation for a
+            # deterministic tie-break.
+            pairs.sort(key=lambda pair: (-pair[1], str(pair[0])))
+        return [value for value, _ in pairs[: self._k]]
+
+    @staticmethod
+    def _normalize_value(value: Any) -> Any:
+        # Partial accumulators round-trip through Arrow between combine steps,
+        # which turns tuples back into lists - re-canonicalize so lookups in
+        # `combine` stay consistent. NaN objects are likewise canonicalized
+        # since distinct float('nan') instances hash differently.
+        if isinstance(value, list):
+            return tuple(value)
+        if isinstance(value, float) and np.isnan(value):
+            return np.nan
+        return value

--- a/python/ray/data/preprocessors/encoder.py
+++ b/python/ray/data/preprocessors/encoder.py
@@ -21,6 +21,7 @@ import pyarrow as pa
 import pyarrow.compute as pc
 
 from ray.data._internal.util import is_null
+from ray.data.aggregate import TopKUnique, Unique
 from ray.data.block import BlockAccessor
 from ray.data.datatype import DataType
 from ray.data.preprocessor import (
@@ -185,16 +186,16 @@ class OrdinalEncoder(SerializablePreprocessorBase):
         return self._output_columns
 
     def _fit(self, dataset: "Dataset") -> Preprocessor:
-        self._stat_computation_plan.add_callable_stat(
-            stat_fn=lambda key_gen: compute_unique_value_indices(
-                dataset=dataset,
-                columns=self._columns,
-                encode_lists=self._encode_lists,
-                key_gen=key_gen,
+        self._stat_computation_plan.add_aggregator(
+            aggregator_fn=lambda col: Unique(
+                on=col,
+                ignore_nulls=False,
+                encode_lists=(
+                    Unique.ListEncodingMode.FLATTEN if self._encode_lists else None
+                ),
+                alias_name=f"unique_values({col})",
             ),
             post_process_fn=unique_post_fn(),
-            stat_key_fn=lambda col: f"unique({col})",
-            post_key_fn=lambda col: f"unique_values({col})",
             columns=self._columns,
         )
         return self
@@ -459,17 +460,25 @@ class OneHotEncoder(SerializablePreprocessorBase):
         return self._output_columns
 
     def _fit(self, dataset: "Dataset") -> Preprocessor:
-        self._stat_computation_plan.add_callable_stat(
-            stat_fn=lambda key_gen: compute_unique_value_indices(
-                dataset=dataset,
-                columns=self._columns,
-                encode_lists=False,
-                key_gen=key_gen,
-                max_categories=self._max_categories,
+        _validate_max_categories(self._max_categories, self._columns)
+        self._stat_computation_plan.add_aggregator(
+            aggregator_fn=lambda col: (
+                TopKUnique(
+                    on=col,
+                    k=self._max_categories[col],
+                    ignore_nulls=False,
+                    encode_lists=False,
+                    alias_name=f"unique_values({col})",
+                )
+                if col in self._max_categories
+                else Unique(
+                    on=col,
+                    ignore_nulls=False,
+                    encode_lists=None,
+                    alias_name=f"unique_values({col})",
+                )
             ),
             post_process_fn=unique_post_fn(),
-            stat_key_fn=lambda col: f"unique({col})",
-            post_key_fn=lambda col: f"unique_values({col})",
             columns=self._columns,
         )
         return self
@@ -736,17 +745,25 @@ class MultiHotEncoder(SerializablePreprocessorBase):
         return self._output_columns
 
     def _fit(self, dataset: "Dataset") -> Preprocessor:
-        self._stat_computation_plan.add_callable_stat(
-            stat_fn=lambda key_gen: compute_unique_value_indices(
-                dataset=dataset,
-                columns=self._columns,
-                encode_lists=True,
-                key_gen=key_gen,
-                max_categories=self._max_categories,
+        _validate_max_categories(self._max_categories, self._columns)
+        self._stat_computation_plan.add_aggregator(
+            aggregator_fn=lambda col: (
+                TopKUnique(
+                    on=col,
+                    k=self._max_categories[col],
+                    ignore_nulls=False,
+                    encode_lists=True,
+                    alias_name=f"unique_values({col})",
+                )
+                if col in self._max_categories
+                else Unique(
+                    on=col,
+                    ignore_nulls=False,
+                    encode_lists=Unique.ListEncodingMode.FLATTEN,
+                    alias_name=f"unique_values({col})",
+                )
             ),
             post_process_fn=unique_post_fn(),
-            stat_key_fn=lambda col: f"unique({col})",
-            post_key_fn=lambda col: f"unique_values({col})",
             columns=self._columns,
         )
         return self
@@ -890,15 +907,14 @@ class LabelEncoder(SerializablePreprocessorBase):
         return self._output_column
 
     def _fit(self, dataset: "Dataset") -> Preprocessor:
-        self._stat_computation_plan.add_callable_stat(
-            stat_fn=lambda key_gen: compute_unique_value_indices(
-                dataset=dataset,
-                columns=[self._label_column],
-                key_gen=key_gen,
+        self._stat_computation_plan.add_aggregator(
+            aggregator_fn=lambda col: Unique(
+                on=col,
+                ignore_nulls=False,
+                encode_lists=Unique.ListEncodingMode.FLATTEN,
+                alias_name=f"unique_values({col})",
             ),
             post_process_fn=unique_post_fn(),
-            stat_key_fn=lambda col: f"unique({col})",
-            post_key_fn=lambda col: f"unique_values({col})",
             columns=[self._label_column],
         )
         return self
@@ -1094,18 +1110,17 @@ class Categorizer(SerializablePreprocessorBase):
         def callback(unique_indices: Dict[str, Dict]) -> pd.CategoricalDtype:
             return pd.CategoricalDtype(unique_indices.keys())
 
-        self._stat_computation_plan.add_callable_stat(
-            stat_fn=lambda key_gen: compute_unique_value_indices(
-                dataset=dataset,
-                columns=columns_to_get,
-                key_gen=key_gen,
+        self._stat_computation_plan.add_aggregator(
+            aggregator_fn=lambda col: Unique(
+                on=col,
+                ignore_nulls=False,
+                encode_lists=Unique.ListEncodingMode.FLATTEN,
+                alias_name=col,
             ),
             post_process_fn=make_post_processor(
                 base_fn=unique_post_fn(drop_na_values=True),
                 callbacks=[callback],
             ),
-            stat_key_fn=lambda col: f"unique({col})",
-            post_key_fn=lambda col: col,
             columns=columns_to_get,
         )
 
@@ -1169,6 +1184,21 @@ class Categorizer(SerializablePreprocessorBase):
         )
 
 
+def _validate_max_categories(
+    max_categories: Optional[Dict[str, int]], columns: List[str]
+) -> None:
+    """Validate that every ``max_categories`` key is one of ``columns``."""
+    if not max_categories:
+        return
+    columns_set = set(columns)
+    for column in max_categories:
+        if column not in columns_set:
+            raise ValueError(
+                f"You set `max_categories` for {column}, which is not present in "
+                f"{columns}."
+            )
+
+
 def compute_unique_value_indices(
     *,
     dataset: "Dataset",
@@ -1178,6 +1208,12 @@ def compute_unique_value_indices(
     max_categories: Optional[Dict[str, int]] = None,
 ):
     """Compute the set of unique values for each column across the full dataset.
+
+    .. note::
+        This helper is no longer used by the built-in encoders, which now fit
+        via distributed aggregations (:class:`~ray.data.aggregate.Unique` /
+        :class:`~ray.data.aggregate.TopKUnique`). It is kept for backwards
+        compatibility and may be removed in a future release.
 
     Counts value frequencies globally (summed across all partitions) and then,
     if ``max_categories`` is specified for a column, selects only the top-k most

--- a/python/ray/data/preprocessors/imputer.py
+++ b/python/ray/data/preprocessors/imputer.py
@@ -7,7 +7,7 @@ import numpy as np
 import pandas as pd
 from pandas.api.types import is_categorical_dtype
 
-from ray.data.aggregate import Mean
+from ray.data.aggregate import Mean, ValueCounter
 from ray.data.preprocessor import SerializablePreprocessorBase
 from ray.data.preprocessors.utils import _Computed, _PublicField, migrate_private_fields
 from ray.data.preprocessors.version_support import (
@@ -165,13 +165,11 @@ class SimpleImputer(SerializablePreprocessorBase):
                 aggregator_fn=Mean, columns=self._columns
             )
         elif self._strategy == "most_frequent":
-            self._stat_computation_plan.add_callable_stat(
-                stat_fn=lambda key_gen: _get_most_frequent_values(
-                    dataset=dataset,
-                    columns=self._columns,
-                    key_gen=key_gen,
+            self._stat_computation_plan.add_aggregator(
+                aggregator_fn=lambda col: ValueCounter(
+                    on=col, alias_name=f"most_frequent({col})"
                 ),
-                stat_key_fn=lambda col: f"most_frequent({col})",
+                post_process_fn=_most_frequent_from_value_counts,
                 columns=self._columns,
             )
 
@@ -272,11 +270,52 @@ class SimpleImputer(SerializablePreprocessorBase):
         )
 
 
+def _most_frequent_from_value_counts(
+    value_counts: Optional[Dict[str, List]],
+) -> Optional[Union[str, Number]]:
+    """Pick the most frequent non-null value from a ``ValueCounter`` result.
+
+    A column with no observed (non-null) values has no most frequent value, so
+    report None. ``_transform_pandas`` turns that into the same "Column x has
+    no fill value" error the ``"mean"`` strategy already raises. Null entries
+    are skipped explicitly: an Arrow-backed column reports nulls as
+    ``value_counts`` entries, and imputing a missing value with "null" would
+    defeat the purpose.
+
+    Ties are broken deterministically: among equally frequent values, the
+    smallest one wins (falling back to the string representation when values
+    aren't comparable).
+    """
+    if not value_counts or not value_counts.get("values"):
+        return None
+
+    pairs = [
+        (value, count)
+        for value, count in zip(value_counts["values"], value_counts["counts"])
+        if not (value is None or (isinstance(value, float) and np.isnan(value)))
+    ]
+    if not pairs:
+        return None
+
+    try:
+        return min(pairs, key=lambda pair: (-pair[1], pair[0]))[0]
+    except TypeError:
+        return min(pairs, key=lambda pair: (-pair[1], str(pair[0])))[0]
+
+
 def _get_most_frequent_values(
     dataset: "Dataset",
     columns: List[str],
     key_gen: Callable[[str], str],
 ) -> Dict[str, Union[str, Number]]:
+    """Legacy driver-side counter merge.
+
+    .. note::
+        No longer used by ``SimpleImputer``, which now fits via the distributed
+        :class:`~ray.data.aggregate.ValueCounter` aggregation. Kept for
+        backwards compatibility and may be removed in a future release.
+    """
+
     def get_pd_value_counts(df: pd.DataFrame) -> Dict[str, List[Counter]]:
         return {col: [Counter(df[col].value_counts().to_dict())] for col in columns}
 

--- a/python/ray/data/tests/preprocessors/test_encoder.py
+++ b/python/ray/data/tests/preprocessors/test_encoder.py
@@ -1671,6 +1671,32 @@ class TestEncoderSerialization:
         assert exc_info.value.preprocessor_type == "NonExistentEncoder"
 
 
+def test_encoders_fit_via_aggregation():
+    """Encoder fits register plan aggregators, not driver-side callable stats.
+
+    This is what allows a `Dataset.aggregate()`-based fit (one distributed
+    query per preprocessor, batchable with others) instead of the legacy
+    `compute_unique_value_indices` map_batches + driver-side counter merge.
+    """
+    df = pd.DataFrame({"A": ["a", "b", "a"], "B": [["x"], ["y"], ["x", "y"]]})
+    ds = ray.data.from_pandas(df)
+
+    encoders = [
+        OrdinalEncoder(["A"]),
+        OneHotEncoder(["A"], max_categories={"A": 1}),
+        MultiHotEncoder(["B"]),
+        LabelEncoder("A"),
+        Categorizer(["A"]),
+    ]
+    for encoder in encoders:
+        encoder.fit(ds)
+        assert not encoder._stat_computation_plan.has_custom_stat_fn(), (
+            f"{type(encoder).__name__} should fit via aggregators, "
+            "not callable stats"
+        )
+        assert encoder.has_stats(), f"{type(encoder).__name__} should have stats"
+
+
 if __name__ == "__main__":
     import sys
 

--- a/python/ray/data/tests/preprocessors/test_imputer.py
+++ b/python/ray/data/tests/preprocessors/test_imputer.py
@@ -623,6 +623,39 @@ class TestSimpleImputerSerialization:
         assert np.isnan(deserialized.stats_["mean(col)"])
 
 
+def test_most_frequent_fits_via_aggregation():
+    """most_frequent registers a plan aggregator, not a callable stat."""
+    ds = ray.data.from_items([{"A": "a"}, {"A": "a"}, {"A": "b"}])
+    imputer = SimpleImputer(["A"], strategy="most_frequent")
+    imputer.fit(ds)
+    assert not imputer._stat_computation_plan.has_custom_stat_fn()
+    assert imputer.stats_ == {"most_frequent(A)": "a"}
+
+
+def test_most_frequent_never_imputes_null():
+    """Nulls never win the frequency contest, even when most common.
+
+    An Arrow-backed column reports nulls as `value_counts` entries, so without
+    filtering, a mostly-null column would be "imputed" with null.
+    """
+    ds = ray.data.from_items(
+        [{"A": None}, {"A": None}, {"A": None}, {"A": "a"}, {"A": "a"}, {"A": "b"}]
+    )
+    imputer = SimpleImputer(["A"], strategy="most_frequent")
+    imputer.fit(ds)
+    assert imputer.stats_ == {"most_frequent(A)": "a"}
+
+
+def test_most_frequent_deterministic_tiebreak():
+    """Among equally frequent values, the smallest wins."""
+    ds = ray.data.from_items(
+        [{"A": "zebra"}, {"A": "apple"}, {"A": "zebra"}, {"A": "apple"}]
+    )
+    imputer = SimpleImputer(["A"], strategy="most_frequent")
+    imputer.fit(ds)
+    assert imputer.stats_ == {"most_frequent(A)": "apple"}
+
+
 if __name__ == "__main__":
     import sys
 

--- a/python/ray/data/tests/test_aggregations.py
+++ b/python/ray/data/tests/test_aggregations.py
@@ -8,6 +8,7 @@ from ray.data.aggregate import (
     ApproximateQuantile,
     ApproximateTopK,
     MissingValuePercentage,
+    TopKUnique,
     Unique,
     ZeroPercentage,
 )
@@ -557,6 +558,140 @@ class TestUnique:
         answer = ["a", "b", "c"]
 
         assert Counter(result["unique(id)"]) == Counter(answer)
+
+
+class TestTopKUnique:
+    """Test cases for TopKUnique aggregation."""
+
+    def test_topk_unique_basic(self, ray_start_regular_shared_2_cpus):
+        """Test basic exact top-k by global frequency."""
+        data = [
+            *[{"word": "apple"} for _ in range(5)],
+            *[{"word": "banana"} for _ in range(3)],
+            *[{"word": "cherry"} for _ in range(2)],
+        ]
+        ds = ray.data.from_items(data)
+        result = ds.aggregate(TopKUnique(on="word", k=2))
+        assert result["topk_unique(word)"] == ["apple", "banana"]
+
+    def test_topk_unique_global_ranking_across_blocks(
+        self, ray_start_regular_shared_2_cpus
+    ):
+        """A value that never wins within any single block must still win globally.
+
+        With per-block top-1 semantics, "c" (3+3+3=9 occurrences, never a block
+        winner) would be dropped in favor of per-block winners "a" (4) and
+        "b" (4+2=6). Exact global counting must return "c".
+        """
+        data = [
+            # Block 1: a wins locally.
+            *[{"v": "a"} for _ in range(4)],
+            *[{"v": "c"} for _ in range(3)],
+            # Block 2: b wins locally.
+            *[{"v": "b"} for _ in range(4)],
+            *[{"v": "c"} for _ in range(3)],
+            # Block 3: b wins locally.
+            *[{"v": "b"} for _ in range(2)],
+            *[{"v": "c"} for _ in range(3)],
+        ]
+        ds = ray.data.from_items(data, override_num_blocks=3)
+        result = ds.aggregate(TopKUnique(on="v", k=1))
+        assert result["topk_unique(v)"] == ["c"]
+
+    def test_topk_unique_deterministic_tiebreak(self, ray_start_regular_shared_2_cpus):
+        """Equal counts are broken by value order, deterministically."""
+        data = [
+            *[{"v": "zebra"} for _ in range(2)],
+            *[{"v": "apple"} for _ in range(2)],
+            *[{"v": "mango"} for _ in range(2)],
+        ]
+        ds = ray.data.from_items(data, override_num_blocks=2)
+        result = ds.aggregate(TopKUnique(on="v", k=2))
+        assert result["topk_unique(v)"] == ["apple", "mango"]
+
+    def test_topk_unique_custom_alias(self, ray_start_regular_shared_2_cpus):
+        """Test custom alias name."""
+        data = [{"item": "x"}, {"item": "x"}, {"item": "y"}]
+        ds = ray.data.from_items(data)
+        result = ds.aggregate(TopKUnique(on="item", k=1, alias_name="top_items"))
+        assert result["top_items"] == ["x"]
+
+    def test_topk_unique_groupby(self, ray_start_regular_shared_2_cpus):
+        """Test top-k per group."""
+        data = [
+            *[{"category": "A", "item": "apple"} for _ in range(5)],
+            *[{"category": "A", "item": "banana"} for _ in range(3)],
+            *[{"category": "B", "item": "cherry"} for _ in range(4)],
+            *[{"category": "B", "item": "date"} for _ in range(2)],
+        ]
+        ds = ray.data.from_items(data)
+        result = ds.groupby("category").aggregate(TopKUnique(on="item", k=1)).take_all()
+
+        result_by_category = {
+            row["category"]: row["topk_unique(item)"] for row in result
+        }
+        assert result_by_category["A"] == ["apple"]
+        assert result_by_category["B"] == ["cherry"]
+
+    def test_topk_unique_fewer_items_than_k(self, ray_start_regular_shared_2_cpus):
+        """Fewer distinct values than k returns all of them."""
+        data = [{"id": "a"}, {"id": "b"}]
+        ds = ray.data.from_items(data)
+        result = ds.aggregate(TopKUnique(on="id", k=5))
+        assert sorted(result["topk_unique(id)"]) == ["a", "b"]
+
+    def test_topk_unique_counts_nulls_by_default(self, ray_start_regular_shared_2_cpus):
+        """With ignore_nulls=False (default), nulls compete for top-k slots."""
+        data = [
+            *[{"v": None} for _ in range(5)],
+            *[{"v": "a"} for _ in range(3)],
+            *[{"v": "b"} for _ in range(1)],
+        ]
+        ds = ray.data.from_items(data, override_num_blocks=2)
+        result = ds.aggregate(TopKUnique(on="v", k=2))
+        assert result["topk_unique(v)"] == [None, "a"]
+
+    def test_topk_unique_ignore_nulls(self, ray_start_regular_shared_2_cpus):
+        """With ignore_nulls=True, nulls are excluded from counting."""
+        data = [
+            *[{"v": None} for _ in range(5)],
+            *[{"v": "a"} for _ in range(3)],
+            *[{"v": "b"} for _ in range(1)],
+        ]
+        ds = ray.data.from_items(data, override_num_blocks=2)
+        result = ds.aggregate(TopKUnique(on="v", k=2, ignore_nulls=True))
+        assert result["topk_unique(v)"] == ["a", "b"]
+
+    def test_topk_unique_encode_lists(self, ray_start_regular_shared_2_cpus):
+        """With encode_lists=True, list elements are counted individually."""
+        data = [
+            {"tokens": ["a", "b", "a"]},
+            {"tokens": ["a", "c"]},
+            {"tokens": ["b"]},
+        ]
+        ds = ray.data.from_items(data)
+        result = ds.aggregate(
+            TopKUnique(on="tokens", k=2, ignore_nulls=True, encode_lists=True)
+        )
+        assert result["topk_unique(tokens)"] == ["a", "b"]
+
+    def test_topk_unique_whole_lists_as_values(self, ray_start_regular_shared_2_cpus):
+        """With encode_lists=False, whole lists are counted as single values."""
+        data = [
+            {"tokens": ["a", "b"]},
+            {"tokens": ["a", "b"]},
+            {"tokens": ["c"]},
+        ]
+        ds = ray.data.from_items(data, override_num_blocks=2)
+        result = ds.aggregate(TopKUnique(on="tokens", k=1, ignore_nulls=True))
+        # Values are counted as tuples internally (for hashability), but the
+        # result round-trips through Arrow, which represents them as lists.
+        assert [list(v) for v in result["topk_unique(tokens)"]] == [["a", "b"]]
+
+    def test_topk_unique_invalid_k(self, ray_start_regular_shared_2_cpus):
+        """k must be positive."""
+        with pytest.raises(ValueError, match="`k` must be a positive integer"):
+            TopKUnique(on="v", k=0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Why are these changes needed?

Encoder preprocessors (`OrdinalEncoder`, `OneHotEncoder`, `MultiHotEncoder`,
`LabelEncoder`, `Categorizer`) currently fit through
`compute_unique_value_indices`: a `map_batches` that emits per-block value
counters, followed by a loop **on the driver** that merges them into global
counts. `SimpleImputer(strategy="most_frequent")` has the same shape via
`_get_most_frequent_values`. That driver-side merge is a scalability
bottleneck, and because it is registered as a *callable stat*, it can never be
batched with other statistics into a single `Dataset.aggregate()` query.

This PR moves those fits onto the stat computation plan as real distributed
aggregations:

- The five encoders register `Unique` (or `TopKUnique` when `max_categories`
  is set) with the same `unique_values({col})` alias the transform code reads.
- `SimpleImputer("most_frequent")` registers the existing `ValueCounter`
  aggregation plus an argmax post-processing step that skips nulls (an
  Arrow-backed column reports nulls as `value_counts` entries — imputing a
  missing value with null would defeat the purpose) and breaks frequency ties
  deterministically by picking the smallest value.

Behavior is preserved: `stats_` key names, the "contains null values …
consider imputing" errors, list-column encoding (flatten vs whole-list), and
global cross-partition top-k semantics for `max_categories` are all unchanged,
which the existing suites verify. Each fit is now a single
`Dataset.aggregate()` query per preprocessor with no driver-side merge.

The legacy helpers `compute_unique_value_indices` and
`_get_most_frequent_values` are kept (marked as no longer used by built-ins)
for backwards compatibility.

One behavior note for reviewers: fitting an encoder with `encode_lists=False`
on a list-typed Arrow column now goes through `Unique`, which uses polars for
list-column uniqueness — the same dependency any `Unique` aggregation on a
list column has today.

## Related issue number

N/A. Not a duplicate: searched open PRs/issues for encoder/imputer fit work;
no overlap found (#66012 covers GPU transforms, not fitting).

Depends on the [`TopKUnique` PR](https://github.com/ray-project/ray/pull/66087) (stacked; will rebase once it lands).

## Checks

- [x] I've signed off every commit (DCO).
- [x] I've run pre-commit hooks — all hooks pass.
- [x] Testing (macOS / Python 3.12, source build):
  - `pytest python/ray/data/tests/preprocessors/test_encoder.py
    python/ray/data/tests/preprocessors/test_imputer.py` — the set of
    pass/fail results is **byte-identical** to clean master on the same
    machine (the pre-existing local failures are pandas-3.0.5 environment
    quirks, unrelated; verified by diffing failure lists against a master
    baseline).
  - `pytest python/ray/data/tests/preprocessors/test_preprocessors_arrow_backed.py`
    — 97 passed, 3 skipped (fully green; clean baseline is also green).
  - New tests: encoders/imputer assert they register plan aggregators (no
    callable stats); most_frequent never imputes null; deterministic
    tie-break.

AI assistance was used to draft this change (Claude Code); every line has been
reviewed by the submitter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)