### PR TITLE
[docs][kuberay] Add a Modal SDK sandbox deployment example

### DIFF
--- a/doc/source/cluster/kubernetes/configs/ray-sandbox-sdk.yaml
+++ b/doc/source/cluster/kubernetes/configs/ray-sandbox-sdk.yaml
@@ -1,0 +1,108 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ray-sandbox-sdk
+---
+apiVersion: ray.io/v1
+kind: RayCluster
+metadata:
+  name: sandbox-sdk
+  namespace: ray-sandbox-sdk
+spec:
+  rayVersion: '2.58.0'
+  headGroupSpec:
+    rayStartParams:
+      num-cpus: '0'
+      dashboard-host: '0.0.0.0'
+      object-store-memory: '134217728'
+    template:
+      spec:
+        shareProcessNamespace: true
+        containers:
+        - name: ray-head
+          image: ray-sandbox-sdk:dev
+          imagePullPolicy: IfNotPresent
+          resources:
+            requests:
+              cpu: '1'
+              memory: 2Gi
+            limits:
+              cpu: '2'
+              memory: 2Gi
+          volumeMounts:
+          - name: ray-session
+            mountPath: /tmp/ray
+        - name: facade
+          image: ray-sandbox-sdk:dev
+          imagePullPolicy: IfNotPresent
+          command: [python, -m, ray.experimental.sandbox.http.grpc_facade]
+          args:
+          - --host=0.0.0.0
+          - --port=50051
+          - --advertise-url=http://127.0.0.1:50051
+          env:
+          - name: RAY_ADDRESS
+            value: 127.0.0.1:6379
+          ports:
+          - name: grpc
+            containerPort: 50051
+          readinessProbe:
+            tcpSocket:
+              port: grpc
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          resources:
+            requests:
+              cpu: '1'
+              memory: 1Gi
+            limits:
+              cpu: '1'
+              memory: 1Gi
+          volumeMounts:
+          - name: ray-session
+            mountPath: /tmp/ray
+        volumes:
+        - name: ray-session
+          emptyDir: {}
+  workerGroupSpecs:
+  - groupName: sandbox-workers
+    replicas: 1
+    minReplicas: 1
+    maxReplicas: 1
+    rayStartParams:
+      num-cpus: '2'
+      resources: '"{\"gvisor\": 2}"'
+      object-store-memory: '134217728'
+    template:
+      spec:
+        containers:
+        - name: ray-worker
+          image: ray-sandbox-sdk:dev
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            seccompProfile:
+              type: Unconfined
+            appArmorProfile:
+              type: Unconfined
+          resources:
+            requests:
+              cpu: '2'
+              memory: 3Gi
+            limits:
+              cpu: '2'
+              memory: 3Gi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: sandbox-grpc
+  namespace: ray-sandbox-sdk
+spec:
+  type: ClusterIP
+  selector:
+    ray.io/cluster: sandbox-sdk
+    ray.io/node-type: head
+  ports:
+  - name: grpc
+    port: 50051
+    targetPort: grpc

--- a/doc/source/cluster/kubernetes/examples/ray-sandboxing.md
+++ b/doc/source/cluster/kubernetes/examples/ray-sandboxing.md
@@ -178,6 +178,147 @@ USER ray
 
 ---
 
+## (Optional) Use the Modal Python SDK
+
+The sandbox gRPC facade lets an external client use a subset of the Modal
+Sandbox API against a RayCluster. The client doesn't need Ray installed: the
+facade submits work to Ray, and the Ray workers run the sandboxes with `runsc`.
+
+:::{warning}
+This example requires the development implementation in
+[Ray PR #65839](https://github.com/ray-project/ray/pull/65839), including its
+dependency on [#65633](https://github.com/ray-project/ray/pull/65633).
+It is not available in the released Ray 2.58.0 image. The example was tested
+with facade commit `259c9a3dd654478bac4784ca01923049c7172846` and
+`modal==1.5.5`; this is not a claim of full Modal API compatibility.
+:::
+
+### Prepare the Ray image
+
+Prepare an image containing the Ray build under test, `ray[serve]`, `grpclib`,
+and `runsc`. See {ref}`building-ray` for building Ray from source, and the
+custom-image section above for installing `runsc`. Use the same Ray build in
+the head, worker, and facade containers. The worker Pods must be able to pull
+the sandbox image from Docker Hub, including its authentication and blob
+endpoints. The Ray container image and the sandbox image are separate images.
+
+Before deploying, verify your image, replacing the example image name with
+your own registry location:
+
+```bash
+export RAY_SANDBOX_IMAGE=your-registry/ray-sandbox-sdk:dev
+docker run --rm --entrypoint python "$RAY_SANDBOX_IMAGE" \
+  -c 'import ray.experimental.sandbox.http.grpc_facade'
+docker run --rm --entrypoint runsc "$RAY_SANDBOX_IMAGE" --version
+```
+
+### Deploy a persistent cluster and facade
+
+Use a persistent RayCluster for SDK clients, rather than a RayJob that can
+shut down its cluster after completion. Download
+{download}`ray-sandbox-sdk.yaml <../configs/ray-sandbox-sdk.yaml>` and replace
+the example image name in all three containers:
+
+```bash
+sed "s|ray-sandbox-sdk:dev|${RAY_SANDBOX_IMAGE}|g" ray-sandbox-sdk.yaml \
+  | kubectl apply -f -
+kubectl -n ray-sandbox-sdk wait --for=jsonpath='{.status.state}'=ready \
+  raycluster/sandbox-sdk --timeout=300s
+kubectl -n ray-sandbox-sdk wait --for=condition=Ready pod \
+  -l ray.io/cluster=sandbox-sdk,ray.io/node-type=head --timeout=300s
+```
+
+The manifest reserves the head for cluster management and gives one worker
+two logical CPUs. The facade runs as a sidecar in the head Pod, connects to
+`127.0.0.1:6379`, and shares `/tmp/ray` and the Pod's process namespace with
+the Ray head container. Native Ray drivers discover the local raylet process
+and use its sockets; pointing an ordinary standalone Pod at the GCS address
+alone isn't sufficient. The worker Pods run separately and don't share this
+process namespace.
+
+Run only one facade process per cluster because command state lives in that
+process. Restarting the facade can lose in-flight command state; replicas
+behind a load balancer aren't supported by this implementation.
+
+The facade in this example has no client authentication or TLS. Keep it on a
+trusted cluster network and use the following loopback-only port forward for
+local access. The REST service's token setting doesn't authenticate this
+gRPC endpoint. Don't expose it through a public load balancer.
+
+```bash
+kubectl -n ray-sandbox-sdk port-forward service/sandbox-grpc 50051:50051
+```
+
+Leave this command running. The facade's `--advertise-url` is the command
+router address returned to the SDK. It must be reachable **from the client**
+and route to the same facade process. The manifest uses
+`http://127.0.0.1:50051` for this port-forwarded example. For clients inside
+the cluster, set the client's `RAY_SANDBOX_GRPC_URL` and `--advertise-url` to
+`http://sandbox-grpc.ray-sandbox-sdk.svc.cluster.local:50051` instead.
+
+### Run the SDK client
+
+In another terminal, download
+{download}`ray_sandbox_sdk.py <ray_sandbox_sdk.py>`, create a virtual
+environment, and run the example:
+
+```bash
+python3 -m venv .venv-sandbox-sdk
+. .venv-sandbox-sdk/bin/activate
+python -m pip install 'modal==1.5.5'
+python ray_sandbox_sdk.py
+```
+
+The client uses `modal.Client.anonymous` to select the local facade; it doesn't
+require a Modal cloud account or token. It writes and executes a Python file,
+checks a file round trip, and terminates the sandbox in a `finally` block:
+
+```{literalinclude} ray_sandbox_sdk.py
+:language: python
+```
+
+Expected output:
+
+```text
+Hello from a Ray sandbox on KubeRay!
+File round trip succeeded.
+Sandbox terminated.
+```
+
+The first operation can wait for the image to download and extract.
+`Sandbox.create()` returning a handle doesn't mean the sandbox is ready.
+Time the first successful command when measuring readiness. The sandbox's
+`block_network=True` setting blocks the sandbox's own network access; it
+doesn't prevent the Ray worker from downloading its image.
+
+At the tested revision, use `sandbox.filesystem.write_text` and `read_text`,
+as shown above. The deprecated `sandbox.open()` path isn't implemented, and
+`filesystem.list_files()` returns a placeholder empty list. Avoid relying on
+these operations until the facade supports them.
+
+### Inspect and clean up
+
+If the client doesn't complete, inspect the facade logs and worker scheduling:
+
+```bash
+kubectl -n ray-sandbox-sdk logs -l ray.io/cluster=sandbox-sdk,ray.io/node-type=head -c facade
+kubectl -n ray-sandbox-sdk get pods
+kubectl -n ray-sandbox-sdk get events --sort-by=.lastTimestamp
+```
+
+Check image-pull errors in the worker logs, available Ray resources, and both
+the client URL and advertised router URL. The default sandbox image cache is
+`/tmp/ray/sandbox/images` inside each worker Pod. This manifest doesn't mount
+persistent storage there, so replacing a worker Pod loses its cache. A warm
+cache on one worker doesn't prewarm another worker.
+
+Stop the port forward with Ctrl+C, then remove the resources created by this
+example:
+
+```bash
+kubectl delete namespace ray-sandbox-sdk
+```
+
 ## Next steps
 
 * See {ref}`ray-core-sandboxes` for API details and custom actor patterns.

--- a/doc/source/cluster/kubernetes/examples/ray_sandbox_sdk.py
+++ b/doc/source/cluster/kubernetes/examples/ray_sandbox_sdk.py
@@ -1,0 +1,47 @@
+"""Run the Modal SDK example against a Ray Sandbox facade."""
+
+import os
+
+import modal
+
+
+def main():
+    url = os.environ.get("RAY_SANDBOX_GRPC_URL", "http://127.0.0.1:50051")
+    with modal.Client.anonymous(url) as client:
+        app = modal.App.lookup(
+            "kuberay-sandbox-example", client=client, create_if_missing=True
+        )
+        sandbox = modal.Sandbox.create(
+            app=app,
+            client=client,
+            image=modal.Image.from_registry("docker.io/library/python:3.12-slim"),
+            cpu=0.25,
+            memory=256,
+            timeout=300,
+            workdir="/workspace",
+            block_network=True,
+        )
+        try:
+            sandbox.filesystem.write_text(
+                'print("Hello from a Ray sandbox on KubeRay!")\n',
+                "/workspace/main.py",
+            )
+            process = sandbox.exec("python3", "/workspace/main.py")
+            stdout = process.stdout.read()
+            stderr = process.stderr.read()
+            process.wait()
+            print(stdout, end="")
+            if process.returncode != 0:
+                raise RuntimeError(f"Sandbox command failed: {stderr}")
+            assert stdout == "Hello from a Ray sandbox on KubeRay!\n"
+
+            sandbox.filesystem.write_text(stdout, "/workspace/result.txt")
+            assert sandbox.filesystem.read_text("/workspace/result.txt") == stdout
+            print("File round trip succeeded.")
+        finally:
+            sandbox.terminate()
+            print("Sandbox terminated.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Add a KubeRay deployment example for using the official Modal Python SDK with Ray's sandbox gRPC facade. The existing guide only demonstrates the native Ray API through a RayJob; this example provides a persistent RayCluster, a single facade sidecar, a ClusterIP Service, and a downloadable SDK client that writes a file, executes Python, checks a file round trip, and terminates the sandbox.

The facade shares the head Pod's process namespace and `/tmp/ray` so the native Ray driver can discover the local raylet and access its sockets. The guide explains the client-facing command-router address, loopback port forwarding, authentication limitations, worker-local image caches, and cleanup.

## Dependencies and duplicate-work check

**Draft: depends on #65839 and its base #65633.** The guide explicitly labels this as a development preview tested against facade commit `259c9a3dd654478bac4784ca01923049c7172846`, not a feature available in the released Ray 2.58.0 image. Revalidate and update the version prerequisites when those PRs land.

This follows Andrew Sy Kim's suggestion to extend the KubeRay sandboxing user guide. Searched open Ray PRs for `sandbox KubeRay`, `sandbox SDK`, and `sandbox documentation`, and open KubeRay PRs for `sandbox`. #65839 documents the facade in the core sandbox guide; it does not provide this KubeRay deployment manifest or downloadable SDK workflow. No competing KubeRay SDK guide PR was found. This change does not reimplement the facade or image-cache work in #65992.

## Validation

- `kubectl apply --dry-run=server -f doc/source/cluster/kubernetes/configs/ray-sandbox-sdk.yaml` — passed.
- Deployed the manifest to kind / KubeRay v1.6.2, using the previously validated Ray 2.58.0 test image containing the pinned PR sandbox package and runsc release-20260817.0. Verified both head containers become ready. Environment overrides: CPU requests reduced to 100m per container because of existing workloads; client/router port 15051 because 50051 was occupied; worker HTTPS egress through a non-caching TCP relay to Docker Hub. No local sandbox image registry was used.
- `RAY_SANDBOX_GRPC_URL=http://127.0.0.1:15051 python doc/source/cluster/kubernetes/examples/ray_sandbox_sdk.py` with official `modal==1.5.5` — passed twice, with cold and warm image caches. Both runs printed the documented output. Ray ALIVE actors and runsc containers were empty afterward.
- `black --check doc/source/cluster/kubernetes/examples/ray_sandbox_sdk.py`, `ruff check` and `ruff check --select I` on that file — passed.
- `pre-commit run --files <the three changed files>` — passed; the repository's global exclude skips this docs subtree, so the Python checks above were also run explicitly.
- Sphinx / MyST isolated render of the actual guide, download targets, and literal include with `sphinx-build -W -b html` — passed. Cross-project reference labels were stubbed in the isolated harness; the full documentation build remains unverified.
- `make -C doc rtd-build` — attempted, but the repository preflight exited with `Could not run the RtD fidelity check: no pinned versions parsed from requirements-doc.lock.txt`, before Sphinx started. In this checkout the tracked symlink is materialized as a regular file containing its target path (`../python/deplocks/docs/docbuild_depset_py3.11.lock`). This environment issue and full-build validation need resolving before marking the draft ready.
- `git diff --check` — passed.

The prerequisite custom image build itself was not rebuilt as part of this documentation validation; testing reused the pinned image from the SDK investigation. This is a deployment smoke test, not a production or scalability claim.

## AI assistance and human review

AI assistance was used to draft the documentation and example, diagnose the deployment, and run validation. This PR remains a draft pending human line-by-line review and a local rerun before requesting maintainer review, as required by AGENTS.md.
