### PR TITLE
[Data][PreProc][3/4] Deferred Chain fit with batched aggregations (off by default)

### DIFF
--- a/doc/source/data/api/aggregate.rst
+++ b/doc/source/data/api/aggregate.rst
@@ -32,3 +32,4 @@ compute aggregations.
     ZeroPercentage
     ApproximateQuantile
     ApproximateTopK
+    TopKUnique

--- a/python/ray/data/aggregate.py
+++ b/python/ray/data/aggregate.py
@@ -1,4 +1,5 @@
 import abc
+import collections
 import enum
 import math
 import pickle
@@ -1848,6 +1849,9 @@ class ApproximateTopK(AggregateFnV2):
         Computes the approximate top k items in a column by using a datasketches frequent_strings_sketch.
         https://datasketches.apache.org/docs/Frequency/FrequentItemsOverview.html
 
+        For an exact variant that returns a plain list of values (at the cost of
+        keeping all distinct values in the accumulator), see :class:`TopKUnique`.
+
         Guarantees:
             - Any item with true frequency > N / (2^log_capacity) is guaranteed to appear in the results
             - Reported counts may have an error of at most ± N / (2^log_capacity).
@@ -1941,3 +1945,167 @@ class ApproximateTopK(AggregateFnV2):
             {column: pickle.loads(bytes.fromhex(item[0])), "count": int(item[1])}
             for item in frequent_items[: self.k]
         ]
+
+
+@PublicAPI
+class TopKUnique(AggregateFnV2[Dict[str, List], List[Any]]):
+    """Defines an exact top-k-by-frequency unique aggregation.
+
+    Counts value frequencies globally (summed across all blocks) and returns the
+    ``k`` most frequent values. The ranking is global: a value that is only
+    moderately frequent in every individual block but frequent overall is
+    correctly preferred over a value that is frequent in a single block.
+
+    Unlike :class:`ApproximateTopK`, the result is exact, no third-party
+    dependency is required, and the output is a plain list of values (like
+    :class:`Unique`) rather than value/count records.
+
+    Ties are broken deterministically: values with equal counts are ordered by
+    value, falling back to their string representation when values aren't
+    comparable with each other.
+
+    Example:
+
+        .. testcode::
+
+            import ray
+            from ray.data.aggregate import TopKUnique
+
+            ds = ray.data.from_items([
+                {"word": "apple"}, {"word": "banana"}, {"word": "apple"},
+                {"word": "cherry"}, {"word": "apple"}, {"word": "banana"}
+            ])
+
+            result = ds.aggregate(TopKUnique(on="word", k=2))
+            # result: {'topk_unique(word)': ['apple', 'banana']}
+
+    Args:
+        on: The name of the column to aggregate.
+        k: The number of most frequent values to return.
+        ignore_nulls: Whether to ignore null values when counting. If ``False``
+            (the default, matching :class:`Unique`), nulls are counted like any
+            other value and ``None`` can appear in the result.
+        alias_name: Optional name for the resulting column. Defaults to
+            ``"topk_unique({on})"``.
+        encode_lists: If ``True``, list-type column elements are flattened so
+            that each list element is counted individually. If ``False``, entire
+            lists are treated as single values (converted to tuples for
+            hashability). Note that this is a top-level flatten (not a recursive
+            flatten) operation.
+    """
+
+    def __init__(
+        self,
+        on: str,
+        k: int,
+        ignore_nulls: bool = False,
+        alias_name: Optional[str] = None,
+        encode_lists: bool = False,
+    ):
+        if k <= 0:
+            raise ValueError(f"`k` must be a positive integer (got {k})")
+
+        self._k = k
+        self._encode_lists = bool(encode_lists)
+
+        super().__init__(
+            alias_name if alias_name else f"topk_unique({str(on)})",
+            on=on,
+            ignore_nulls=ignore_nulls,
+            zero_factory=lambda: {"values": [], "counts": []},
+        )
+
+    def aggregate_block(self, block: Block) -> Dict[str, List]:
+        accessor = BlockColumnAccessor.for_column(block[self._target_col_name])
+
+        if self._encode_lists and accessor.is_composed_of_lists():
+            accessor = BlockColumnAccessor.for_column(accessor.flatten())
+
+        if accessor.is_composed_of_lists():
+            # Whole lists are treated as single values. There's no vectorized
+            # `value_counts` kernel for list types, so count in Python over
+            # tuples (mirroring how `Unique` makes whole-list values hashable).
+            counter = collections.Counter(
+                None if value is None else tuple(value)
+                for value in accessor.to_pylist()
+            )
+            value_counts = {
+                "values": list(counter.keys()),
+                "counts": list(counter.values()),
+            }
+        else:
+            value_counts = accessor.value_counts() or {"values": [], "counts": []}
+
+        values: List[Any] = []
+        counts: List[int] = []
+        # Null accounting differs by block type: a pandas column drops nulls
+        # from `value_counts` entirely, while an Arrow column reports them as
+        # entries (None for nulls, NaN as a float value). Strip null-ish
+        # entries here and re-add one canonical `None` entry below, so both
+        # block types produce the same accumulator.
+        null_count_from_entries = 0
+        for value, count in zip(value_counts["values"], value_counts["counts"]):
+            if is_null(value):
+                null_count_from_entries += count
+                continue
+            # Convert lists to tuples for hashability in `combine`, mirroring
+            # how `Unique` treats whole-list values.
+            values.append(tuple(value) if isinstance(value, list) else value)
+            counts.append(count)
+
+        if not self._ignore_nulls:
+            # Whichever accounting is complete for this block type wins: the
+            # Arrow entries above cover both None and NaN, while the count
+            # delta covers everything a pandas `value_counts` dropped.
+            total = accessor.count(ignore_nulls=False) or 0
+            non_null = accessor.count(ignore_nulls=True) or 0
+            null_count = max(null_count_from_entries, total - non_null)
+            if null_count > 0:
+                values.append(None)
+                counts.append(null_count)
+
+        return {"values": values, "counts": counts}
+
+    def combine(
+        self,
+        current_accumulator: Dict[str, List],
+        new_accumulator: Dict[str, List],
+    ) -> Dict[str, List]:
+        values = [self._normalize_value(v) for v in current_accumulator["values"]]
+        counts = list(current_accumulator["counts"])
+
+        value_to_index = {v: i for i, v in enumerate(values)}
+
+        for v_new, c_new in zip(new_accumulator["values"], new_accumulator["counts"]):
+            v_new = self._normalize_value(v_new)
+            if v_new in value_to_index:
+                counts[value_to_index[v_new]] += c_new
+            else:
+                value_to_index[v_new] = len(values)
+                values.append(v_new)
+                counts.append(c_new)
+
+        return {"values": values, "counts": counts}
+
+    def finalize(self, accumulator: Dict[str, List]) -> List[Any]:
+        pairs = list(zip(accumulator["values"], accumulator["counts"]))
+        try:
+            pairs.sort(key=lambda pair: (-pair[1], pair[0]))
+        except TypeError:
+            # Values aren't mutually comparable (e.g. mixed types, or None
+            # among them) - fall back to their string representation for a
+            # deterministic tie-break.
+            pairs.sort(key=lambda pair: (-pair[1], str(pair[0])))
+        return [value for value, _ in pairs[: self._k]]
+
+    @staticmethod
+    def _normalize_value(value: Any) -> Any:
+        # Partial accumulators round-trip through Arrow between combine steps,
+        # which turns tuples back into lists - re-canonicalize so lookups in
+        # `combine` stay consistent. NaN objects are likewise canonicalized
+        # since distinct float('nan') instances hash differently.
+        if isinstance(value, list):
+            return tuple(value)
+        if isinstance(value, float) and np.isnan(value):
+            return np.nan
+        return value

--- a/python/ray/data/context.py
+++ b/python/ray/data/context.py
@@ -107,6 +107,10 @@ DEFAULT_BATCH_TO_BLOCK_ARROW_FORMAT = env_bool(
     "RAY_DATA_DEFAULT_BATCH_TO_BLOCK_ARROW_FORMAT", True
 )
 
+DEFAULT_ENABLE_AGGREGATION_BASED_PREPROCESSORS = env_bool(
+    "RAY_DATA_ENABLE_AGGREGATION_BASED_PREPROCESSORS", False
+)
+
 DEFAULT_READ_OP_MIN_NUM_BLOCKS = 200
 
 DEFAULT_USE_DATASOURCE_V2 = env_bool("RAY_DATA_USE_DATASOURCE_V2", True)
@@ -842,6 +846,13 @@ class DataContext:
             assign multi-dimensional arrays into columns or rely on numpy-only
             operations (e.g. ``%``) that Arrow-backed columns do not implement.
         batch_to_block_arrow_format: Whether to convert Pandas batches to Arrow blocks by default when calling `BlockAccessor.batch_to_block`.
+        enable_aggregation_based_preprocessors: Whether fitting a preprocessor
+            ``Chain`` defers each member's statistics computation and batches
+            independent members' aggregations into a single dataset scan at the
+            first ``transform()`` (computed over the dataset that was passed to
+            ``fit()``). When enabled, ``Chain.fit()`` returns without computing
+            member statistics; they materialize at the first ``transform()``,
+            ``transform_batch()``, or serialization. Defaults to ``False``.
         gpu_shuffle_num_actors: Number of GPU actors (ranks) for GPU shuffle. Defaults
             to total GPUs available in the cluster.
         gpu_shuffle_rmm_pool_size: RMM GPU memory pool size for each rank. ``"auto"``
@@ -1060,6 +1071,10 @@ class DataContext:
     )
 
     batch_to_block_arrow_format: bool = DEFAULT_BATCH_TO_BLOCK_ARROW_FORMAT
+
+    enable_aggregation_based_preprocessors: bool = (
+        DEFAULT_ENABLE_AGGREGATION_BASED_PREPROCESSORS
+    )
 
     _checkpoint_config: Optional[CheckpointConfig] = None
 

--- a/python/ray/data/preprocessor.py
+++ b/python/ray/data/preprocessor.py
@@ -78,6 +78,13 @@ class Preprocessor(abc.ABC):
     # Preprocessors that do not need to be fitted must override this.
     _is_fittable = True
 
+    # Whether this preprocessor's `_fit` only registers aggregations on the
+    # stat computation plan (no eager dataset scan, no callable stats), so a
+    # `Chain` may defer and batch its statistics computation. Subclasses whose
+    # `_fit` satisfies that contract should set this to True. See
+    # `DataContext.enable_aggregation_based_preprocessors`.
+    _supports_deferred_fit = False
+
     def _check_has_fitted_state(self):
         """Checks if the Preprocessor has fitted state.
 
@@ -136,6 +143,11 @@ class Preprocessor(abc.ABC):
         return fitted_ds
 
     def _fit_execute(self, dataset: "Dataset"):
+        if getattr(self, "_defer_fit_execute", False):
+            # A Chain is batching this preprocessor's statistics computation
+            # with its other members'; the registered plan is executed by the
+            # Chain instead. See `ray.data.preprocessors.chain.Chain`.
+            return self
         self.stats_ |= self._stat_computation_plan.compute(dataset)
         return self
 

--- a/python/ray/data/preprocessors/chain.py
+++ b/python/ray/data/preprocessors/chain.py
@@ -1,8 +1,11 @@
-from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple
+import logging
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 
 from ray.data.preprocessor import Preprocessor, SerializablePreprocessorBase
+from ray.data.preprocessors.dag import _AggregationNode, _build_aggregation_dag
 from ray.data.preprocessors.utils import (
     _PublicField,
+    execute_aggregate_specs,
     migrate_private_fields,
 )
 from ray.data.preprocessors.version_support import SerializablePreprocessor
@@ -12,6 +15,8 @@ if TYPE_CHECKING:
     from ray.air.data_batch_type import DataBatchType
     from ray.data.dataset import Dataset
 
+logger = logging.getLogger(__name__)
+
 
 @SerializablePreprocessor(version=1, identifier="io.ray.preprocessors.chain")
 class Chain(SerializablePreprocessorBase):
@@ -19,6 +24,14 @@ class Chain(SerializablePreprocessorBase):
 
     When you call ``fit``, each preprocessor is fit on the dataset produced by the
     preceeding preprocessor's ``fit_transform``.
+
+    When :attr:`DataContext.enable_aggregation_based_preprocessors
+    <ray.data.context.DataContext.enable_aggregation_based_preprocessors>` is
+    set and every fittable member supports it, ``fit`` instead only registers
+    each member's statistics as aggregation queries; the first ``transform()``
+    (or ``transform_batch()``, or serialization) computes them over the fit
+    dataset, batching independent members' aggregations into a single dataset
+    scan per dependency level. The fitted statistics are identical either way.
 
     Example:
         >>> import pandas as pd
@@ -75,21 +88,190 @@ class Chain(SerializablePreprocessorBase):
     def __init__(self, *preprocessors: SerializablePreprocessorBase):
         super().__init__()
         self._preprocessors = preprocessors
+        self._fit_ds: Optional["Dataset"] = None
+        self._deferred_fit = False
+        self._stats_materialized = False
 
     @property
     def preprocessors(self) -> Tuple[SerializablePreprocessorBase, ...]:
         return self._preprocessors
 
+    @property
+    def _supports_deferred_fit(self) -> bool:
+        # A chain can defer only when every fittable member can; a nested
+        # Chain recurses into its own members.
+        return all(
+            not p._is_fittable or p._supports_deferred_fit for p in self._preprocessors
+        )
+
+    def get_input_columns(self) -> List[str]:
+        columns = []
+        for p in self._preprocessors:
+            columns.extend(p.get_input_columns())
+        return columns
+
+    def get_output_columns(self) -> List[str]:
+        columns = []
+        for p in self._preprocessors:
+            columns.extend(p.get_output_columns())
+        return columns
+
+    def _uses_deferred_fit(self) -> bool:
+        from ray.data.context import DataContext
+
+        return (
+            DataContext.get_current().enable_aggregation_based_preprocessors
+            and self._supports_deferred_fit
+        )
+
     def _fit(self, ds: "Dataset") -> SerializablePreprocessorBase:
+        self._fit_ds = None
+        self._deferred_fit = False
+        self._stats_materialized = False
+
+        if self._uses_deferred_fit():
+            # Every member's `_fit` only registers aggregations, so no member
+            # needs the previous members' transformed output to fit: register
+            # everything now and defer the scans to `_materialize_deferred_stats`,
+            # which computes them level-by-level over the fit dataset.
+            for preprocessor in self._preprocessors:
+                if not preprocessor._is_fittable:
+                    continue
+                preprocessor._defer_fit_execute = True
+                try:
+                    preprocessor.fit(ds)
+                finally:
+                    preprocessor._defer_fit_execute = False
+            self._fit_ds = ds
+            self._deferred_fit = True
+            return self
+
         for preprocessor in self._preprocessors[:-1]:
             ds = preprocessor.fit_transform(ds)
         self._preprocessors[-1].fit(ds)
         return self
 
     def fit_transform(self, ds: "Dataset") -> "Dataset":
+        if self._uses_deferred_fit():
+            self.fit(ds)
+            return self.transform(ds)
+
         for preprocessor in self._preprocessors:
             ds = preprocessor.fit_transform(ds)
         return ds
+
+    def _needs_stats_materialization(self) -> bool:
+        # getattr: instances deserialized from older versions lack these fields.
+        return (
+            getattr(self, "_deferred_fit", False)
+            and not getattr(self, "_stats_materialized", False)
+            and getattr(self, "_fit_ds", None) is not None
+        )
+
+    @staticmethod
+    def _sync_nested_chain_fit_ds(preprocessor: Preprocessor, ds: "Dataset") -> None:
+        """Point a nested deferred Chain's fit dataset at the data actually
+        flowing into it at its chain position (its members were registered on
+        the outer chain's raw fit dataset)."""
+        if (
+            isinstance(preprocessor, Chain)
+            and preprocessor._needs_stats_materialization()
+        ):
+            preprocessor._fit_ds = ds
+
+    def _materialize_deferred_stats(self) -> None:
+        """Compute every member's deferred statistics over the fit dataset.
+
+        Builds a column-dependency DAG with one node per (member, aggregation)
+        pair and runs one aggregation query per dependency level: all
+        aggregations whose dependencies are complete run as a single
+        ``Dataset.aggregate()`` call, results are routed into each owning
+        member's ``stats_`` by aggregator alias, and each fully-fitted member
+        then transforms the (lazy) fit dataset so the next level aggregates
+        over transformed data - exactly what sequential fitting would have
+        produced, in as few scans as there are dependency levels.
+        """
+        ds = self._fit_ds
+
+        if any(
+            p._stat_computation_plan.has_custom_stat_fn() for p in self._preprocessors
+        ):
+            self._fallback_to_serial_execution(ds)
+            self._stats_materialized = True
+            return
+
+        all_nodes = _build_aggregation_dag(self._preprocessors)
+        pending_nodes = list(all_nodes)
+        transformed = set()
+
+        while pending_nodes:
+            ready = [node for node in pending_nodes if node.is_ready()]
+            if not ready:
+                raise RuntimeError("Circular dependency detected in aggregation DAG.")
+
+            # One aggregation query for every ready aggregation node. Nodes
+            # sharing an alias (e.g. two members needing mean of the same
+            # column) can't share one query's result columns, so run them in
+            # alias-unique batches.
+            agg_nodes = [n for n in ready if isinstance(n, _AggregationNode)]
+            while agg_nodes:
+                batch = []
+                rest = []
+                seen_aliases = set()
+                for node in agg_nodes:
+                    alias = node.agg_fn.name
+                    if alias in seen_aliases:
+                        rest.append(node)
+                    else:
+                        seen_aliases.add(alias)
+                        batch.append(node)
+
+                results = execute_aggregate_specs(ds, [node.spec for node in batch])
+                for node in batch:
+                    node.preprocessor.stats_[node.agg_fn.name] = results[
+                        node.agg_fn.name
+                    ]
+                agg_nodes = rest
+
+            for node in ready:
+                node.completed = True
+            ready_set = set(ready)
+            pending_nodes = [n for n in pending_nodes if n not in ready_set]
+
+            # Apply the transform of every member whose nodes are all complete
+            # (in chain order), so the next level aggregates over transformed
+            # data.
+            for preprocessor in self._preprocessors:
+                if preprocessor in transformed:
+                    continue
+                if all(
+                    node.completed
+                    for node in all_nodes
+                    if node.preprocessor is preprocessor
+                ):
+                    self._sync_nested_chain_fit_ds(preprocessor, ds)
+                    ds = preprocessor.transform(ds)
+                    transformed.add(preprocessor)
+
+        self._stats_materialized = True
+
+    def _fallback_to_serial_execution(self, ds: "Dataset") -> None:
+        """Fit members one by one, each on the previous members' transformed
+        output - the pre-deferral behavior. Used when a member registered a
+        custom (callable) stat, which can't run inside ``Dataset.aggregate``.
+        """
+        logger.warning(
+            "Falling back to serial statistics computation because one or "
+            "more preprocessors use custom stat functions (e.g., "
+            "add_callable_stat). Rewriting those stats as AggregateFnV2-based "
+            "aggregators (add_aggregator) would allow batching them into a "
+            "single pass over the dataset."
+        )
+        for preprocessor in self._preprocessors:
+            if preprocessor._is_fittable and not preprocessor.has_stats():
+                preprocessor._fit_execute(ds)
+            self._sync_nested_chain_fit_ds(preprocessor, ds)
+            ds = preprocessor.transform(ds)
 
     def _transform(
         self,
@@ -99,6 +281,9 @@ class Chain(SerializablePreprocessorBase):
         memory: Optional[float] = None,
         concurrency: Optional[int] = None,
     ) -> "Dataset":
+        if self._needs_stats_materialization():
+            self._materialize_deferred_stats()
+
         for preprocessor in self._preprocessors:
             ds = preprocessor.transform(
                 ds,
@@ -110,6 +295,9 @@ class Chain(SerializablePreprocessorBase):
         return ds
 
     def _transform_batch(self, df: "DataBatchType") -> "DataBatchType":
+        if self._needs_stats_materialization():
+            self._materialize_deferred_stats()
+
         for preprocessor in self._preprocessors:
             df = preprocessor.transform_batch(df)
         return df
@@ -128,6 +316,11 @@ class Chain(SerializablePreprocessorBase):
         return self._preprocessors[0]._determine_transform_to_use()
 
     def _get_serializable_fields(self) -> Dict[str, Any]:
+        # A deferred fit computes stats at the first transform; serializing a
+        # fitted-but-never-transformed chain must materialize them first (in
+        # dependency order), or the serialized members would have no stats.
+        if self._needs_stats_materialization():
+            self._materialize_deferred_stats()
         return {
             "preprocessors": self._preprocessors,
         }
@@ -135,10 +328,28 @@ class Chain(SerializablePreprocessorBase):
     def _set_serializable_fields(self, fields: Dict[str, Any], version: int):
         # required fields
         self._preprocessors = fields["preprocessors"]
+        # Serialized stats are always materialized (see
+        # `_get_serializable_fields`), so a deserialized chain never defers.
+        self._fit_ds = None
+        self._deferred_fit = False
+        self._stats_materialized = False
+
+    def __getstate__(self) -> Dict[str, Any]:
+        # Same reason as `_get_serializable_fields`: plain pickling must not
+        # lose the deferred stats.
+        if self._needs_stats_materialization():
+            self._materialize_deferred_stats()
+        state = super().__getstate__()
+        # The fit dataset is only needed to materialize stats; never pickle it.
+        state.pop("_fit_ds", None)
+        return state
 
     def __setstate__(self, state: Dict[str, Any]) -> None:
         """Handle backwards compatibility for old pickled objects."""
         super().__setstate__(state)
+        self._fit_ds = None
+        self.__dict__.setdefault("_deferred_fit", False)
+        self.__dict__.setdefault("_stats_materialized", False)
         migrate_private_fields(
             self,
             fields={

--- a/python/ray/data/preprocessors/dag.py
+++ b/python/ray/data/preprocessors/dag.py
@@ -1,0 +1,132 @@
+from typing import TYPE_CHECKING, List, Sequence, Set
+
+from ray.data.preprocessor import Preprocessor
+
+if TYPE_CHECKING:
+    from ray.data.aggregate import AggregateFnV2
+    from ray.data.preprocessors.utils import AggregateStatSpec
+
+
+class _DAGNode:
+    """Base class for nodes in the deferred-fit aggregation DAG.
+
+    Each node tracks column-level dependencies: a node depends on an earlier
+    one iff it reads any column the earlier one writes. This enables
+    topological scheduling of aggregations based on column lineage - members
+    that touch disjoint columns can have their statistics computed in the same
+    dataset scan.
+
+    Args:
+        preprocessor: The preprocessor this node belongs to.
+    """
+
+    def __init__(self, preprocessor: Preprocessor):
+        self.preprocessor: Preprocessor = preprocessor
+        self.dependencies: Set["_DAGNode"] = set()
+        self.dependents: Set["_DAGNode"] = set()
+        self.completed: bool = False
+        self.read_cols: Set[str] = set(preprocessor.get_input_columns())
+        self.write_cols: Set[str] = set(preprocessor.get_output_columns())
+
+    def is_ready(self) -> bool:
+        """Returns True if every dependency has completed."""
+        return all(dep.completed for dep in self.dependencies)
+
+    @property
+    def is_placeholder(self) -> bool:
+        return isinstance(self, _PlaceholderNode)
+
+
+class _AggregationNode(_DAGNode):
+    """Node representing a single aggregation of one preprocessor.
+
+    Args:
+        preprocessor: The preprocessor this aggregation belongs to.
+        spec: The :class:`~ray.data.preprocessors.utils.AggregateStatSpec`
+            registered on the preprocessor's stat computation plan.
+    """
+
+    def __init__(self, preprocessor: Preprocessor, spec: "AggregateStatSpec"):
+        super().__init__(preprocessor)
+        self.spec: "AggregateStatSpec" = spec
+
+    @property
+    def agg_fn(self) -> "AggregateFnV2":
+        return self.spec.stat_fn
+
+
+class _PlaceholderNode(_DAGNode):
+    """Placeholder node for members that contribute no aggregations.
+
+    Covers non-fittable preprocessors, fittable members that already have
+    stats (e.g. fitted eagerly), and fittable members whose plan registered
+    nothing. These nodes have nothing to compute, but they participate in
+    dependency tracking so that transforms are ordered correctly: a
+    placeholder completes only when its own dependencies complete, which keeps
+    any member that reads this preprocessor's output columns from aggregating
+    before this preprocessor's transform has been applied.
+    """
+
+
+def _build_aggregation_dag(
+    preprocessors: Sequence[Preprocessor],
+) -> List[_DAGNode]:
+    """Construct the aggregation DAG for a chain of preprocessors.
+
+    Each fittable member contributes one node per registered aggregation;
+    every other member contributes a placeholder node. Edges follow one rule:
+    a later node depends on an earlier one iff it reads any column the earlier
+    one writes.
+
+    Args:
+        preprocessors: The chain's members, in chain order.
+
+    Returns:
+        All nodes, in chain order (a member's aggregation nodes are adjacent).
+    """
+    all_nodes: List[_DAGNode] = []
+    nodes_per_preprocessor: List[List[_DAGNode]] = []
+
+    for preprocessor in preprocessors:
+        nodes: List[_DAGNode] = []
+        if preprocessor._is_fittable and not preprocessor.has_stats():
+            for agg_spec in preprocessor._stat_computation_plan:
+                nodes.append(_AggregationNode(preprocessor=preprocessor, spec=agg_spec))
+        if not nodes:
+            # Non-fittable, already fitted, or nothing registered on the plan
+            # (e.g. a nested Chain, which runs its own DAG when transformed).
+            nodes.append(_PlaceholderNode(preprocessor=preprocessor))
+
+        nodes_per_preprocessor.append(nodes)
+        all_nodes.extend(nodes)
+
+    # Add edges based on read/write column overlap between chain positions.
+    for i in range(len(preprocessors)):
+        for j in range(i):
+            for cur_node in nodes_per_preprocessor[i]:
+                for prev_node in nodes_per_preprocessor[j]:
+                    if cur_node.read_cols & prev_node.write_cols:
+                        cur_node.dependencies.add(prev_node)
+                        prev_node.dependents.add(cur_node)
+
+    _validate_dag_is_acyclic(all_nodes)
+    return all_nodes
+
+
+def _validate_dag_is_acyclic(nodes: List[_DAGNode]) -> None:
+    visited = set()
+    stack = set()
+
+    def visit(node: _DAGNode):
+        if node in stack:
+            raise RuntimeError("Cycle detected in aggregation DAG")
+        if node in visited:
+            return
+        stack.add(node)
+        for dep in node.dependencies:
+            visit(dep)
+        stack.remove(node)
+        visited.add(node)
+
+    for node in nodes:
+        visit(node)

--- a/python/ray/data/preprocessors/encoder.py
+++ b/python/ray/data/preprocessors/encoder.py
@@ -21,6 +21,7 @@ import pyarrow as pa
 import pyarrow.compute as pc
 
 from ray.data._internal.util import is_null
+from ray.data.aggregate import TopKUnique, Unique
 from ray.data.block import BlockAccessor
 from ray.data.datatype import DataType
 from ray.data.preprocessor import (
@@ -185,16 +186,16 @@ class OrdinalEncoder(SerializablePreprocessorBase):
         return self._output_columns
 
     def _fit(self, dataset: "Dataset") -> Preprocessor:
-        self._stat_computation_plan.add_callable_stat(
-            stat_fn=lambda key_gen: compute_unique_value_indices(
-                dataset=dataset,
-                columns=self._columns,
-                encode_lists=self._encode_lists,
-                key_gen=key_gen,
+        self._stat_computation_plan.add_aggregator(
+            aggregator_fn=lambda col: Unique(
+                on=col,
+                ignore_nulls=False,
+                encode_lists=(
+                    Unique.ListEncodingMode.FLATTEN if self._encode_lists else None
+                ),
+                alias_name=f"unique_values({col})",
             ),
             post_process_fn=unique_post_fn(),
-            stat_key_fn=lambda col: f"unique({col})",
-            post_key_fn=lambda col: f"unique_values({col})",
             columns=self._columns,
         )
         return self
@@ -459,17 +460,25 @@ class OneHotEncoder(SerializablePreprocessorBase):
         return self._output_columns
 
     def _fit(self, dataset: "Dataset") -> Preprocessor:
-        self._stat_computation_plan.add_callable_stat(
-            stat_fn=lambda key_gen: compute_unique_value_indices(
-                dataset=dataset,
-                columns=self._columns,
-                encode_lists=False,
-                key_gen=key_gen,
-                max_categories=self._max_categories,
+        _validate_max_categories(self._max_categories, self._columns)
+        self._stat_computation_plan.add_aggregator(
+            aggregator_fn=lambda col: (
+                TopKUnique(
+                    on=col,
+                    k=self._max_categories[col],
+                    ignore_nulls=False,
+                    encode_lists=False,
+                    alias_name=f"unique_values({col})",
+                )
+                if col in self._max_categories
+                else Unique(
+                    on=col,
+                    ignore_nulls=False,
+                    encode_lists=None,
+                    alias_name=f"unique_values({col})",
+                )
             ),
             post_process_fn=unique_post_fn(),
-            stat_key_fn=lambda col: f"unique({col})",
-            post_key_fn=lambda col: f"unique_values({col})",
             columns=self._columns,
         )
         return self
@@ -736,17 +745,25 @@ class MultiHotEncoder(SerializablePreprocessorBase):
         return self._output_columns
 
     def _fit(self, dataset: "Dataset") -> Preprocessor:
-        self._stat_computation_plan.add_callable_stat(
-            stat_fn=lambda key_gen: compute_unique_value_indices(
-                dataset=dataset,
-                columns=self._columns,
-                encode_lists=True,
-                key_gen=key_gen,
-                max_categories=self._max_categories,
+        _validate_max_categories(self._max_categories, self._columns)
+        self._stat_computation_plan.add_aggregator(
+            aggregator_fn=lambda col: (
+                TopKUnique(
+                    on=col,
+                    k=self._max_categories[col],
+                    ignore_nulls=False,
+                    encode_lists=True,
+                    alias_name=f"unique_values({col})",
+                )
+                if col in self._max_categories
+                else Unique(
+                    on=col,
+                    ignore_nulls=False,
+                    encode_lists=Unique.ListEncodingMode.FLATTEN,
+                    alias_name=f"unique_values({col})",
+                )
             ),
             post_process_fn=unique_post_fn(),
-            stat_key_fn=lambda col: f"unique({col})",
-            post_key_fn=lambda col: f"unique_values({col})",
             columns=self._columns,
         )
         return self
@@ -890,15 +907,14 @@ class LabelEncoder(SerializablePreprocessorBase):
         return self._output_column
 
     def _fit(self, dataset: "Dataset") -> Preprocessor:
-        self._stat_computation_plan.add_callable_stat(
-            stat_fn=lambda key_gen: compute_unique_value_indices(
-                dataset=dataset,
-                columns=[self._label_column],
-                key_gen=key_gen,
+        self._stat_computation_plan.add_aggregator(
+            aggregator_fn=lambda col: Unique(
+                on=col,
+                ignore_nulls=False,
+                encode_lists=Unique.ListEncodingMode.FLATTEN,
+                alias_name=f"unique_values({col})",
             ),
             post_process_fn=unique_post_fn(),
-            stat_key_fn=lambda col: f"unique({col})",
-            post_key_fn=lambda col: f"unique_values({col})",
             columns=[self._label_column],
         )
         return self
@@ -1094,18 +1110,17 @@ class Categorizer(SerializablePreprocessorBase):
         def callback(unique_indices: Dict[str, Dict]) -> pd.CategoricalDtype:
             return pd.CategoricalDtype(unique_indices.keys())
 
-        self._stat_computation_plan.add_callable_stat(
-            stat_fn=lambda key_gen: compute_unique_value_indices(
-                dataset=dataset,
-                columns=columns_to_get,
-                key_gen=key_gen,
+        self._stat_computation_plan.add_aggregator(
+            aggregator_fn=lambda col: Unique(
+                on=col,
+                ignore_nulls=False,
+                encode_lists=Unique.ListEncodingMode.FLATTEN,
+                alias_name=col,
             ),
             post_process_fn=make_post_processor(
                 base_fn=unique_post_fn(drop_na_values=True),
                 callbacks=[callback],
             ),
-            stat_key_fn=lambda col: f"unique({col})",
-            post_key_fn=lambda col: col,
             columns=columns_to_get,
         )
 
@@ -1169,6 +1184,21 @@ class Categorizer(SerializablePreprocessorBase):
         )
 
 
+def _validate_max_categories(
+    max_categories: Optional[Dict[str, int]], columns: List[str]
+) -> None:
+    """Validate that every ``max_categories`` key is one of ``columns``."""
+    if not max_categories:
+        return
+    columns_set = set(columns)
+    for column in max_categories:
+        if column not in columns_set:
+            raise ValueError(
+                f"You set `max_categories` for {column}, which is not present in "
+                f"{columns}."
+            )
+
+
 def compute_unique_value_indices(
     *,
     dataset: "Dataset",
@@ -1178,6 +1208,12 @@ def compute_unique_value_indices(
     max_categories: Optional[Dict[str, int]] = None,
 ):
     """Compute the set of unique values for each column across the full dataset.
+
+    .. note::
+        This helper is no longer used by the built-in encoders, which now fit
+        via distributed aggregations (:class:`~ray.data.aggregate.Unique` /
+        :class:`~ray.data.aggregate.TopKUnique`). It is kept for backwards
+        compatibility and may be removed in a future release.
 
     Counts value frequencies globally (summed across all partitions) and then,
     if ``max_categories`` is specified for a column, selects only the top-k most

--- a/python/ray/data/preprocessors/encoder.py
+++ b/python/ray/data/preprocessors/encoder.py
@@ -158,6 +158,8 @@ class OrdinalEncoder(SerializablePreprocessorBase):
             Another preprocessor that encodes categorical data.
     """
 
+    _supports_deferred_fit = True
+
     def __init__(
         self,
         columns: List[str],
@@ -431,6 +433,8 @@ class OneHotEncoder(SerializablePreprocessorBase):
             If your categories are ordered, you may want to use
             :class:`OrdinalEncoder`.
     """  # noqa: E501
+
+    _supports_deferred_fit = True
 
     def __init__(
         self,
@@ -717,6 +721,8 @@ class MultiHotEncoder(SerializablePreprocessorBase):
     [1]: https://scikit-learn.org/stable/modules/generated/sklearn.preprocessing.MultiLabelBinarizer.html
     """
 
+    _supports_deferred_fit = True
+
     def __init__(
         self,
         columns: List[str],
@@ -892,6 +898,8 @@ class LabelEncoder(SerializablePreprocessorBase):
             If you're encoding ordered features, use :class:`OrdinalEncoder` instead of
             :class:`LabelEncoder`.
     """
+
+    _supports_deferred_fit = True
 
     def __init__(self, label_column: str, *, output_column: Optional[str] = None):
         super().__init__()
@@ -1070,6 +1078,8 @@ class Categorizer(SerializablePreprocessorBase):
             will be raised.
 
     """  # noqa: E501
+
+    _supports_deferred_fit = True
 
     def __init__(
         self,

--- a/python/ray/data/preprocessors/imputer.py
+++ b/python/ray/data/preprocessors/imputer.py
@@ -110,6 +110,8 @@ class SimpleImputer(SerializablePreprocessorBase):
 
     _valid_strategies = ["mean", "most_frequent", "constant"]
 
+    _supports_deferred_fit = True
+
     def __init__(
         self,
         columns: List[str],

--- a/python/ray/data/preprocessors/imputer.py
+++ b/python/ray/data/preprocessors/imputer.py
@@ -7,7 +7,7 @@ import numpy as np
 import pandas as pd
 from pandas.api.types import is_categorical_dtype
 
-from ray.data.aggregate import Mean
+from ray.data.aggregate import Mean, ValueCounter
 from ray.data.preprocessor import SerializablePreprocessorBase
 from ray.data.preprocessors.utils import _Computed, _PublicField, migrate_private_fields
 from ray.data.preprocessors.version_support import (
@@ -165,13 +165,11 @@ class SimpleImputer(SerializablePreprocessorBase):
                 aggregator_fn=Mean, columns=self._columns
             )
         elif self._strategy == "most_frequent":
-            self._stat_computation_plan.add_callable_stat(
-                stat_fn=lambda key_gen: _get_most_frequent_values(
-                    dataset=dataset,
-                    columns=self._columns,
-                    key_gen=key_gen,
+            self._stat_computation_plan.add_aggregator(
+                aggregator_fn=lambda col: ValueCounter(
+                    on=col, alias_name=f"most_frequent({col})"
                 ),
-                stat_key_fn=lambda col: f"most_frequent({col})",
+                post_process_fn=_most_frequent_from_value_counts,
                 columns=self._columns,
             )
 
@@ -272,11 +270,52 @@ class SimpleImputer(SerializablePreprocessorBase):
         )
 
 
+def _most_frequent_from_value_counts(
+    value_counts: Optional[Dict[str, List]],
+) -> Optional[Union[str, Number]]:
+    """Pick the most frequent non-null value from a ``ValueCounter`` result.
+
+    A column with no observed (non-null) values has no most frequent value, so
+    report None. ``_transform_pandas`` turns that into the same "Column x has
+    no fill value" error the ``"mean"`` strategy already raises. Null entries
+    are skipped explicitly: an Arrow-backed column reports nulls as
+    ``value_counts`` entries, and imputing a missing value with "null" would
+    defeat the purpose.
+
+    Ties are broken deterministically: among equally frequent values, the
+    smallest one wins (falling back to the string representation when values
+    aren't comparable).
+    """
+    if not value_counts or not value_counts.get("values"):
+        return None
+
+    pairs = [
+        (value, count)
+        for value, count in zip(value_counts["values"], value_counts["counts"])
+        if not (value is None or (isinstance(value, float) and np.isnan(value)))
+    ]
+    if not pairs:
+        return None
+
+    try:
+        return min(pairs, key=lambda pair: (-pair[1], pair[0]))[0]
+    except TypeError:
+        return min(pairs, key=lambda pair: (-pair[1], str(pair[0])))[0]
+
+
 def _get_most_frequent_values(
     dataset: "Dataset",
     columns: List[str],
     key_gen: Callable[[str], str],
 ) -> Dict[str, Union[str, Number]]:
+    """Legacy driver-side counter merge.
+
+    .. note::
+        No longer used by ``SimpleImputer``, which now fits via the distributed
+        :class:`~ray.data.aggregate.ValueCounter` aggregation. Kept for
+        backwards compatibility and may be removed in a future release.
+    """
+
     def get_pd_value_counts(df: pd.DataFrame) -> Dict[str, List[Counter]]:
         return {col: [Counter(df[col].value_counts().to_dict())] for col in columns}
 

--- a/python/ray/data/preprocessors/scaler.py
+++ b/python/ray/data/preprocessors/scaler.py
@@ -92,6 +92,8 @@ class StandardScaler(SerializablePreprocessorBase):
             will be raised.
     """
 
+    _supports_deferred_fit = True
+
     def __init__(self, columns: List[str], output_columns: Optional[List[str]] = None):
         super().__init__()
         self._columns = columns

--- a/python/ray/data/preprocessors/utils.py
+++ b/python/ray/data/preprocessors/utils.py
@@ -120,6 +120,53 @@ class CallableStatSpec(BaseStatSpec):
         self.post_key_fn = post_key_fn
 
 
+def execute_aggregate_specs(
+    dataset: "Dataset", specs: List["AggregateStatSpec"]
+) -> Dict[str, Any]:
+    """Run a list of :class:`AggregateStatSpec` as one global aggregation query.
+
+    All aggregations run in a single ``dataset.groupby(None).aggregate(...)``
+    pass. A global aggregation returns exactly one row; each spec's result is
+    read from the column named by its aggregator's alias and post-processed.
+
+    Aggregator aliases must be unique within one call - each alias is one
+    result column.
+
+    Args:
+        dataset: The Ray Dataset to compute the aggregations over.
+        specs: The aggregate stat specs to run.
+
+    Returns:
+        A dict mapping each aggregator's alias name to its post-processed
+        result.
+    """
+    if not specs:
+        return {}
+
+    aggregators = [spec.stat_fn for spec in specs]
+    agg_ds = dataset.groupby(None).aggregate(*aggregators)
+    arrow_refs = agg_ds.to_arrow_refs()
+    if not arrow_refs:
+        raise ValueError("Aggregation returned no results")
+    arrow_table = ray.get(arrow_refs[0])
+
+    stats = {}
+    for spec in specs:
+        stat_key = spec.stat_fn.name
+        # Aggregation returns single row - extract the scalar value
+        # ChunkedArray[0] handles multi-chunk arrays automatically
+        agg_result = arrow_table.column(stat_key)[0]
+        # Convert to appropriate format based on batch_format
+        if spec.batch_format == BatchFormat.ARROW:
+            # Pass Arrow scalar (e.g., ListScalar) for Arrow-optimized post-processing
+            stats[stat_key] = spec.post_process_fn(agg_result)
+        else:
+            # Convert to Python for pandas-style post-processing
+            stats[stat_key] = spec.post_process_fn(agg_result.as_py())
+
+    return stats
+
+
 class StatComputationPlan:
     """
     Encapsulates a set of aggregators (AggregateFnV2) and legacy stat functions
@@ -212,27 +259,8 @@ class StatComputationPlan:
         Returns:
             A dictionary of computed statistics.
         """
-        stats = {}
         # Run batched aggregators (AggregateFnV2)
-        aggregators = self._get_aggregate_fn_list()
-        if aggregators:
-            agg_ds = dataset.groupby(None).aggregate(*aggregators)
-            arrow_refs = agg_ds.to_arrow_refs()
-            if not arrow_refs:
-                raise ValueError("Aggregation returned no results")
-            arrow_table = ray.get(arrow_refs[0])
-            for spec in self._get_aggregate_specs():
-                stat_key = spec.stat_fn.name
-                # Aggregation returns single row - extract the scalar value
-                # ChunkedArray[0] handles multi-chunk arrays automatically
-                agg_result = arrow_table.column(stat_key)[0]
-                # Convert to appropriate format based on batch_format
-                if spec.batch_format == BatchFormat.ARROW:
-                    # Pass Arrow scalar (e.g., ListScalar) for Arrow-optimized post-processing
-                    stats[stat_key] = spec.post_process_fn(agg_result)
-                else:
-                    # Convert to Python for pandas-style post-processing
-                    stats[stat_key] = spec.post_process_fn(agg_result.as_py())
+        stats = execute_aggregate_specs(dataset, self._get_aggregate_specs())
 
         # Run sequential stat functions
         for spec in self._get_custom_stat_fn_specs():

--- a/python/ray/data/tests/preprocessors/test_chain.py
+++ b/python/ray/data/tests/preprocessors/test_chain.py
@@ -237,6 +237,415 @@ def test_chain_serialization():
     assert len(result) == 2
 
 
+# ---------------------------------------------------------------------------
+# Deferred (aggregation-based) chain fitting
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def deferred_fit_enabled():
+    ctx = ray.data.DataContext.get_current()
+    original = ctx.enable_aggregation_based_preprocessors
+    ctx.enable_aggregation_based_preprocessors = True
+    yield
+    ctx.enable_aggregation_based_preprocessors = original
+
+
+@pytest.fixture
+def counted_aggregations(monkeypatch):
+    """Count the aggregation queries the chain's materialization runs."""
+    import ray.data.preprocessors.chain as chain_module
+
+    calls = []
+    original = chain_module.execute_aggregate_specs
+
+    def counting(dataset, specs):
+        calls.append(len(specs))
+        return original(dataset, specs)
+
+    monkeypatch.setattr(chain_module, "execute_aggregate_specs", counting)
+    return calls
+
+
+def _example_dataset():
+    return ray.data.from_pandas(
+        pd.DataFrame.from_dict(
+            {
+                "A": [-1, -1, 1, 1],
+                "B": [1, 1, 1, None],
+                "C": ["sunday", "monday", "tuesday", "tuesday"],
+            }
+        )
+    )
+
+
+def _example_chain():
+    # scaler writes B; imputer reads B -> the imputer's statistic must be
+    # computed over the *scaled* B, exactly as sequential fitting does.
+    imputer = SimpleImputer(["B"])
+    scaler = StandardScaler(["A", "B"])
+    encoder = LabelEncoder("C")
+    return Chain(scaler, imputer, encoder), (scaler, imputer, encoder)
+
+
+def test_deferred_fit_computes_stats_at_first_transform(deferred_fit_enabled):
+    ds = _example_dataset()
+    chain, (scaler, imputer, encoder) = _example_chain()
+
+    chain.fit(ds)
+    assert not scaler.has_stats(), "fit should defer statistics computation"
+    assert not imputer.has_stats(), "fit should defer statistics computation"
+    assert not encoder.has_stats(), "fit should defer statistics computation"
+    # The chain still reports itself as fitted; transform is allowed.
+    assert chain.fit_status() == Preprocessor.FitStatus.FITTED
+
+    out_df = chain.transform(ds).to_pandas()
+
+    assert scaler.has_stats()
+    assert imputer.has_stats()
+    assert encoder.has_stats()
+
+    # Same statistics sequential fitting produces (see test_chain above).
+    assert imputer.stats_ == {"mean(B)": 0.0}
+    assert scaler.stats_ == {
+        "mean(A)": 0.0,
+        "mean(B)": 1.0,
+        "std(A)": 1.0,
+        "std(B)": 0.0,
+    }
+    assert encoder.stats_ == {
+        "unique_values(C)": {"monday": 0, "sunday": 1, "tuesday": 2}
+    }
+
+    expected_df = pd.DataFrame.from_dict(
+        {"A": [-1.0, -1.0, 1.0, 1.0], "B": [0.0] * 4, "C": [1, 0, 2, 2]}
+    ).astype(out_df.dtypes.to_dict())
+    pd.testing.assert_frame_equal(out_df, expected_df, check_like=True)
+
+
+def test_deferred_fit_matches_eager_fit(deferred_fit_enabled):
+    ds = _example_dataset()
+
+    ctx = ray.data.DataContext.get_current()
+    ctx.enable_aggregation_based_preprocessors = False
+    eager_chain, eager_members = _example_chain()
+    eager_out = eager_chain.fit_transform(ds).to_pandas()
+
+    ctx.enable_aggregation_based_preprocessors = True
+    deferred_chain, deferred_members = _example_chain()
+    deferred_out = deferred_chain.fit_transform(ds).to_pandas()
+
+    for eager, deferred in zip(eager_members, deferred_members):
+        assert eager.stats_ == deferred.stats_, type(eager).__name__
+    pd.testing.assert_frame_equal(
+        deferred_out.sort_index(axis=1), eager_out.sort_index(axis=1)
+    )
+
+
+def test_deferred_fit_batches_independent_members(
+    deferred_fit_enabled, counted_aggregations
+):
+    """Members touching disjoint columns fit in ONE aggregation query."""
+    ds = ray.data.from_pandas(
+        pd.DataFrame({"A": [1.0, 2.0], "B": [3.0, 4.0], "C": ["x", "y"]})
+    )
+    chain = Chain(
+        StandardScaler(["A"], output_columns=["A_scaled"]),
+        StandardScaler(["B"], output_columns=["B_scaled"]),
+        LabelEncoder("C"),
+    )
+    chain.fit(ds)
+    chain.transform(ds).to_pandas()
+
+    assert len(counted_aggregations) == 1, (
+        f"independent members should share one aggregation query, "
+        f"got {counted_aggregations}"
+    )
+    # 2 aggregations per scaler (mean, std) + 1 for the encoder.
+    assert counted_aggregations[0] == 5
+
+
+def test_deferred_fit_one_scan_per_dependency_level(
+    deferred_fit_enabled, counted_aggregations
+):
+    ds = _example_dataset()
+    chain, _ = _example_chain()
+    chain.fit(ds)
+    chain.transform(ds).to_pandas()
+
+    # Level 0: scaler (mean/std of A and B) + encoder (unique of C) = 5 aggs.
+    # Level 1: imputer's mean(B) over the scaled data = 1 agg.
+    assert counted_aggregations == [5, 1]
+
+
+def test_repeated_transform_does_not_recompute(
+    deferred_fit_enabled, counted_aggregations
+):
+    ds = _example_dataset()
+    chain, _ = _example_chain()
+    chain.fit(ds)
+
+    out1 = chain.transform(ds).to_pandas()
+    queries_after_first = len(counted_aggregations)
+    out2 = chain.transform(ds).to_pandas()
+    out3 = chain.transform(ds).to_pandas()
+
+    assert (
+        len(counted_aggregations) == queries_after_first
+    ), "repeated transform must not re-run aggregations"
+    pd.testing.assert_frame_equal(out1, out2)
+    pd.testing.assert_frame_equal(out2, out3)
+
+
+def test_deferred_stats_computed_on_fit_dataset(deferred_fit_enabled):
+    """Statistics come from the dataset passed to fit(), even when a different
+    dataset is transformed first."""
+    train = ray.data.from_pandas(pd.DataFrame({"A": [0.0, 2.0]}))
+    val = ray.data.from_pandas(pd.DataFrame({"A": [100.0, 200.0]}))
+
+    scaler = StandardScaler(["A"])
+    chain = Chain(scaler)
+    chain.fit(train)
+
+    chain.transform(val).to_pandas()
+
+    assert scaler.stats_ == {"mean(A)": 1.0, "std(A)": 1.0}
+
+
+def _make_add_one(input_column: str, output_column: str) -> Preprocessor:
+    """Non-fittable preprocessor writing a new column.
+
+    Defined in a function so cloudpickle serializes the class by value; a
+    module-level test class isn't importable from Ray workers.
+    """
+
+    class _AddOne(Preprocessor):
+        _is_fittable = False
+
+        def __init__(self):
+            super().__init__()
+            self._input_column = input_column
+            self._output_column = output_column
+
+        def get_input_columns(self):
+            return [self._input_column]
+
+        def get_output_columns(self):
+            return [self._output_column]
+
+        def _transform_pandas(self, df):
+            df[self._output_column] = df[self._input_column] + 1
+            return df
+
+    return _AddOne()
+
+
+def test_fittable_member_depending_on_non_fittable_output(deferred_fit_enabled):
+    """A member reading a non-fittable member's output column must aggregate
+    only after that member's transform has been applied."""
+    ds = ray.data.from_pandas(pd.DataFrame({"A": [0.0, 2.0]}))
+
+    add_one = _make_add_one("A", "D")  # D = A + 1 -> [1.0, 3.0]
+    scaler = StandardScaler(["D"])
+    chain = Chain(add_one, scaler)
+    chain.fit(ds)
+
+    out_df = chain.transform(ds).to_pandas()
+
+    assert scaler.stats_ == {"mean(D)": 2.0, "std(D)": 1.0}
+    assert list(out_df["D"]) == [-1.0, 1.0]
+
+
+def test_unmarked_member_uses_sequential_fit(deferred_fit_enabled):
+    """A chain containing a member that doesn't support deferred fitting falls
+    back to the eager sequential path for the whole chain."""
+    from ray.data.preprocessors import MinMaxScaler
+
+    ds = ray.data.from_pandas(pd.DataFrame({"A": [0.0, 2.0], "B": [1.0, 3.0]}))
+
+    scaler = StandardScaler(["A"])
+    minmax = MinMaxScaler(["B"])
+    chain = Chain(scaler, minmax)
+    chain.fit(ds)
+
+    # Eager sequential path: stats exist right after fit.
+    assert scaler.has_stats()
+    assert minmax.has_stats()
+
+    out_df = chain.transform(ds).to_pandas()
+    assert list(out_df["B"]) == [0.0, 1.0]
+
+
+def _make_callable_stat_scaler(columns) -> StandardScaler:
+    """A StandardScaler that claims deferred-fit support but registers a
+    callable stat, to exercise the serial fallback safety valve at
+    materialization time. Defined in a function so cloudpickle serializes the
+    class by value (see `_make_add_one`)."""
+
+    class _CallableStatScaler(StandardScaler):
+        def _fit(self, dataset):
+            from ray.data.aggregate import Mean, Std
+
+            def compute(key_gen):
+                stats = dataset.aggregate(
+                    *[Mean(on=col) for col in self._columns],
+                    *[Std(on=col, ddof=0) for col in self._columns],
+                )
+                return {key_gen(col): stats for col in self._columns}
+
+            self._stat_computation_plan.add_callable_stat(
+                stat_fn=compute,
+                stat_key_fn=lambda col: f"all({col})",
+                columns=self._columns,
+            )
+            return self
+
+        def _fit_execute(self, dataset):
+            super()._fit_execute(dataset)
+            if self.stats_:
+                merged = {}
+                for col in self._columns:
+                    merged.update(self.stats_.pop(f"all({col})"))
+                self.stats_ = merged
+            return self
+
+    return _CallableStatScaler(columns)
+
+
+def test_custom_stat_member_falls_back_to_serial(deferred_fit_enabled, caplog):
+    ds = ray.data.from_pandas(pd.DataFrame({"A": [0.0, 2.0], "B": [1.0, 3.0]}))
+
+    custom = _make_callable_stat_scaler(["A"])
+    scaler = StandardScaler(["B"])
+    chain = Chain(custom, scaler)
+    chain.fit(ds)
+    assert not scaler.has_stats(), "fit still defers"
+
+    with caplog.at_level("WARNING", logger="ray.data.preprocessors.chain"):
+        out_df = chain.transform(ds).to_pandas()
+
+    assert any("Falling back to serial" in record.message for record in caplog.records)
+    assert custom.stats_ == {"mean(A)": 1.0, "std(A)": 1.0}
+    assert scaler.stats_ == {"mean(B)": 2.0, "std(B)": 1.0}
+    assert list(out_df["A"]) == [-1.0, 1.0]
+    assert list(out_df["B"]) == [-1.0, 1.0]
+
+
+def test_same_aggregation_twice_in_one_level(deferred_fit_enabled):
+    """Two members needing the same statistic on the same column can't share
+    one query's result column; both must still fit correctly."""
+    ds = ray.data.from_pandas(pd.DataFrame({"A": [0.0, 2.0]}))
+
+    scaler1 = StandardScaler(["A"], output_columns=["A1"])
+    scaler2 = StandardScaler(["A"], output_columns=["A2"])
+    chain = Chain(scaler1, scaler2)
+    chain.fit(ds)
+    out_df = chain.transform(ds).to_pandas()
+
+    assert scaler1.stats_ == {"mean(A)": 1.0, "std(A)": 1.0}
+    assert scaler2.stats_ == {"mean(A)": 1.0, "std(A)": 1.0}
+    assert list(out_df["A1"]) == [-1.0, 1.0]
+    assert list(out_df["A2"]) == [-1.0, 1.0]
+
+
+def test_nested_chain_deferred(deferred_fit_enabled):
+    """A nested chain's members fit on the data flowing into the nested chain
+    at its position in the outer chain."""
+    ds = ray.data.from_pandas(pd.DataFrame({"B": [1.0, 3.0, None]}))
+
+    imputer = SimpleImputer(["B"])  # mean(B) = 2.0
+    inner = Chain(imputer)
+    scaler = StandardScaler(["B"])  # over imputed [1, 3, 2]
+    chain = Chain(inner, scaler)
+    chain.fit(ds)
+    assert not imputer.has_stats()
+
+    chain.transform(ds).to_pandas()
+
+    assert imputer.stats_ == {"mean(B)": 2.0}
+    assert scaler.stats_ == {
+        "mean(B)": 2.0,
+        "std(B)": pytest.approx(0.8164965809),
+    }
+
+
+def test_serialization_materializes_deferred_stats(deferred_fit_enabled):
+    from ray.data.preprocessor import SerializablePreprocessorBase
+
+    ds = ray.data.from_pandas(pd.DataFrame({"A": [0.0, 2.0]}))
+
+    scaler = StandardScaler(["A"])
+    chain = Chain(scaler)
+    chain.fit(ds)
+    assert not scaler.has_stats()
+
+    serialized = chain.serialize()
+    # Serializing forced the deferred computation.
+    assert scaler.stats_ == {"mean(A)": 1.0, "std(A)": 1.0}
+
+    deserialized = SerializablePreprocessorBase.deserialize(serialized)
+    result = deserialized.transform_batch(pd.DataFrame({"A": [1.0, 3.0]}))
+    assert list(result["A"]) == [0.0, 2.0]
+
+
+def test_transform_batch_materializes_deferred_stats(deferred_fit_enabled):
+    ds = ray.data.from_pandas(pd.DataFrame({"A": [0.0, 2.0]}))
+
+    scaler = StandardScaler(["A"])
+    chain = Chain(scaler)
+    chain.fit(ds)
+    assert not scaler.has_stats()
+
+    result = chain.transform_batch(pd.DataFrame({"A": [1.0, 3.0]}))
+    assert scaler.stats_ == {"mean(A)": 1.0, "std(A)": 1.0}
+    assert list(result["A"]) == [0.0, 2.0]
+
+
+def test_flag_off_preserves_eager_fit():
+    ctx = ray.data.DataContext.get_current()
+    assert not ctx.enable_aggregation_based_preprocessors, "default must be off"
+
+    ds = _example_dataset()
+    chain, (scaler, imputer, encoder) = _example_chain()
+    chain.fit(ds)
+
+    assert scaler.has_stats()
+    assert imputer.has_stats()
+    assert encoder.has_stats()
+
+
+def test_dag_structure(deferred_fit_enabled):
+    from ray.data.preprocessors.dag import (
+        _AggregationNode,
+        _build_aggregation_dag,
+    )
+
+    ds = _example_dataset()
+    chain, (scaler, imputer, encoder) = _example_chain()
+    chain.fit(ds)
+
+    nodes = _build_aggregation_dag([scaler, imputer, encoder])
+
+    scaler_nodes = [n for n in nodes if n.preprocessor is scaler]
+    imputer_nodes = [n for n in nodes if n.preprocessor is imputer]
+    encoder_nodes = [n for n in nodes if n.preprocessor is encoder]
+
+    assert len(scaler_nodes) == 4  # mean/std x A/B
+    assert len(imputer_nodes) == 1  # mean(B)
+    assert len(encoder_nodes) == 1  # unique_values(C)
+    assert all(isinstance(n, _AggregationNode) for n in nodes)
+
+    # Scaler writes B; imputer reads B -> the imputer node depends on every
+    # scaler node (dependencies are per-preprocessor, not per-column).
+    for node in imputer_nodes:
+        assert {dep.preprocessor for dep in node.dependencies} == {scaler}
+    # The encoder only touches C -> fully independent.
+    for node in encoder_nodes:
+        assert not node.dependencies
+    for node in scaler_nodes:
+        assert not node.dependencies
+
+
 if __name__ == "__main__":
     import sys
 

--- a/python/ray/data/tests/preprocessors/test_encoder.py
+++ b/python/ray/data/tests/preprocessors/test_encoder.py
@@ -1671,6 +1671,32 @@ class TestEncoderSerialization:
         assert exc_info.value.preprocessor_type == "NonExistentEncoder"
 
 
+def test_encoders_fit_via_aggregation():
+    """Encoder fits register plan aggregators, not driver-side callable stats.
+
+    This is what allows a `Dataset.aggregate()`-based fit (one distributed
+    query per preprocessor, batchable with others) instead of the legacy
+    `compute_unique_value_indices` map_batches + driver-side counter merge.
+    """
+    df = pd.DataFrame({"A": ["a", "b", "a"], "B": [["x"], ["y"], ["x", "y"]]})
+    ds = ray.data.from_pandas(df)
+
+    encoders = [
+        OrdinalEncoder(["A"]),
+        OneHotEncoder(["A"], max_categories={"A": 1}),
+        MultiHotEncoder(["B"]),
+        LabelEncoder("A"),
+        Categorizer(["A"]),
+    ]
+    for encoder in encoders:
+        encoder.fit(ds)
+        assert not encoder._stat_computation_plan.has_custom_stat_fn(), (
+            f"{type(encoder).__name__} should fit via aggregators, "
+            "not callable stats"
+        )
+        assert encoder.has_stats(), f"{type(encoder).__name__} should have stats"
+
+
 if __name__ == "__main__":
     import sys
 

--- a/python/ray/data/tests/preprocessors/test_imputer.py
+++ b/python/ray/data/tests/preprocessors/test_imputer.py
@@ -623,6 +623,39 @@ class TestSimpleImputerSerialization:
         assert np.isnan(deserialized.stats_["mean(col)"])
 
 
+def test_most_frequent_fits_via_aggregation():
+    """most_frequent registers a plan aggregator, not a callable stat."""
+    ds = ray.data.from_items([{"A": "a"}, {"A": "a"}, {"A": "b"}])
+    imputer = SimpleImputer(["A"], strategy="most_frequent")
+    imputer.fit(ds)
+    assert not imputer._stat_computation_plan.has_custom_stat_fn()
+    assert imputer.stats_ == {"most_frequent(A)": "a"}
+
+
+def test_most_frequent_never_imputes_null():
+    """Nulls never win the frequency contest, even when most common.
+
+    An Arrow-backed column reports nulls as `value_counts` entries, so without
+    filtering, a mostly-null column would be "imputed" with null.
+    """
+    ds = ray.data.from_items(
+        [{"A": None}, {"A": None}, {"A": None}, {"A": "a"}, {"A": "a"}, {"A": "b"}]
+    )
+    imputer = SimpleImputer(["A"], strategy="most_frequent")
+    imputer.fit(ds)
+    assert imputer.stats_ == {"most_frequent(A)": "a"}
+
+
+def test_most_frequent_deterministic_tiebreak():
+    """Among equally frequent values, the smallest wins."""
+    ds = ray.data.from_items(
+        [{"A": "zebra"}, {"A": "apple"}, {"A": "zebra"}, {"A": "apple"}]
+    )
+    imputer = SimpleImputer(["A"], strategy="most_frequent")
+    imputer.fit(ds)
+    assert imputer.stats_ == {"most_frequent(A)": "apple"}
+
+
 if __name__ == "__main__":
     import sys
 

--- a/python/ray/data/tests/test_aggregations.py
+++ b/python/ray/data/tests/test_aggregations.py
@@ -8,6 +8,7 @@ from ray.data.aggregate import (
     ApproximateQuantile,
     ApproximateTopK,
     MissingValuePercentage,
+    TopKUnique,
     Unique,
     ZeroPercentage,
 )
@@ -557,6 +558,140 @@ class TestUnique:
         answer = ["a", "b", "c"]
 
         assert Counter(result["unique(id)"]) == Counter(answer)
+
+
+class TestTopKUnique:
+    """Test cases for TopKUnique aggregation."""
+
+    def test_topk_unique_basic(self, ray_start_regular_shared_2_cpus):
+        """Test basic exact top-k by global frequency."""
+        data = [
+            *[{"word": "apple"} for _ in range(5)],
+            *[{"word": "banana"} for _ in range(3)],
+            *[{"word": "cherry"} for _ in range(2)],
+        ]
+        ds = ray.data.from_items(data)
+        result = ds.aggregate(TopKUnique(on="word", k=2))
+        assert result["topk_unique(word)"] == ["apple", "banana"]
+
+    def test_topk_unique_global_ranking_across_blocks(
+        self, ray_start_regular_shared_2_cpus
+    ):
+        """A value that never wins within any single block must still win globally.
+
+        With per-block top-1 semantics, "c" (3+3+3=9 occurrences, never a block
+        winner) would be dropped in favor of per-block winners "a" (4) and
+        "b" (4+2=6). Exact global counting must return "c".
+        """
+        data = [
+            # Block 1: a wins locally.
+            *[{"v": "a"} for _ in range(4)],
+            *[{"v": "c"} for _ in range(3)],
+            # Block 2: b wins locally.
+            *[{"v": "b"} for _ in range(4)],
+            *[{"v": "c"} for _ in range(3)],
+            # Block 3: b wins locally.
+            *[{"v": "b"} for _ in range(2)],
+            *[{"v": "c"} for _ in range(3)],
+        ]
+        ds = ray.data.from_items(data, override_num_blocks=3)
+        result = ds.aggregate(TopKUnique(on="v", k=1))
+        assert result["topk_unique(v)"] == ["c"]
+
+    def test_topk_unique_deterministic_tiebreak(self, ray_start_regular_shared_2_cpus):
+        """Equal counts are broken by value order, deterministically."""
+        data = [
+            *[{"v": "zebra"} for _ in range(2)],
+            *[{"v": "apple"} for _ in range(2)],
+            *[{"v": "mango"} for _ in range(2)],
+        ]
+        ds = ray.data.from_items(data, override_num_blocks=2)
+        result = ds.aggregate(TopKUnique(on="v", k=2))
+        assert result["topk_unique(v)"] == ["apple", "mango"]
+
+    def test_topk_unique_custom_alias(self, ray_start_regular_shared_2_cpus):
+        """Test custom alias name."""
+        data = [{"item": "x"}, {"item": "x"}, {"item": "y"}]
+        ds = ray.data.from_items(data)
+        result = ds.aggregate(TopKUnique(on="item", k=1, alias_name="top_items"))
+        assert result["top_items"] == ["x"]
+
+    def test_topk_unique_groupby(self, ray_start_regular_shared_2_cpus):
+        """Test top-k per group."""
+        data = [
+            *[{"category": "A", "item": "apple"} for _ in range(5)],
+            *[{"category": "A", "item": "banana"} for _ in range(3)],
+            *[{"category": "B", "item": "cherry"} for _ in range(4)],
+            *[{"category": "B", "item": "date"} for _ in range(2)],
+        ]
+        ds = ray.data.from_items(data)
+        result = ds.groupby("category").aggregate(TopKUnique(on="item", k=1)).take_all()
+
+        result_by_category = {
+            row["category"]: row["topk_unique(item)"] for row in result
+        }
+        assert result_by_category["A"] == ["apple"]
+        assert result_by_category["B"] == ["cherry"]
+
+    def test_topk_unique_fewer_items_than_k(self, ray_start_regular_shared_2_cpus):
+        """Fewer distinct values than k returns all of them."""
+        data = [{"id": "a"}, {"id": "b"}]
+        ds = ray.data.from_items(data)
+        result = ds.aggregate(TopKUnique(on="id", k=5))
+        assert sorted(result["topk_unique(id)"]) == ["a", "b"]
+
+    def test_topk_unique_counts_nulls_by_default(self, ray_start_regular_shared_2_cpus):
+        """With ignore_nulls=False (default), nulls compete for top-k slots."""
+        data = [
+            *[{"v": None} for _ in range(5)],
+            *[{"v": "a"} for _ in range(3)],
+            *[{"v": "b"} for _ in range(1)],
+        ]
+        ds = ray.data.from_items(data, override_num_blocks=2)
+        result = ds.aggregate(TopKUnique(on="v", k=2))
+        assert result["topk_unique(v)"] == [None, "a"]
+
+    def test_topk_unique_ignore_nulls(self, ray_start_regular_shared_2_cpus):
+        """With ignore_nulls=True, nulls are excluded from counting."""
+        data = [
+            *[{"v": None} for _ in range(5)],
+            *[{"v": "a"} for _ in range(3)],
+            *[{"v": "b"} for _ in range(1)],
+        ]
+        ds = ray.data.from_items(data, override_num_blocks=2)
+        result = ds.aggregate(TopKUnique(on="v", k=2, ignore_nulls=True))
+        assert result["topk_unique(v)"] == ["a", "b"]
+
+    def test_topk_unique_encode_lists(self, ray_start_regular_shared_2_cpus):
+        """With encode_lists=True, list elements are counted individually."""
+        data = [
+            {"tokens": ["a", "b", "a"]},
+            {"tokens": ["a", "c"]},
+            {"tokens": ["b"]},
+        ]
+        ds = ray.data.from_items(data)
+        result = ds.aggregate(
+            TopKUnique(on="tokens", k=2, ignore_nulls=True, encode_lists=True)
+        )
+        assert result["topk_unique(tokens)"] == ["a", "b"]
+
+    def test_topk_unique_whole_lists_as_values(self, ray_start_regular_shared_2_cpus):
+        """With encode_lists=False, whole lists are counted as single values."""
+        data = [
+            {"tokens": ["a", "b"]},
+            {"tokens": ["a", "b"]},
+            {"tokens": ["c"]},
+        ]
+        ds = ray.data.from_items(data, override_num_blocks=2)
+        result = ds.aggregate(TopKUnique(on="tokens", k=1, ignore_nulls=True))
+        # Values are counted as tuples internally (for hashability), but the
+        # result round-trips through Arrow, which represents them as lists.
+        assert [list(v) for v in result["topk_unique(tokens)"]] == [["a", "b"]]
+
+    def test_topk_unique_invalid_k(self, ray_start_regular_shared_2_cpus):
+        """k must be positive."""
+        with pytest.raises(ValueError, match="`k` must be a positive integer"):
+            TopKUnique(on="v", k=0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Why are these changes needed?

`Chain.fit()` runs one full dataset scan per fittable member — and because Ray
Datasets are lazy, each scan also re-executes the upstream read/transform
pipeline. A `Chain(SimpleImputer, StandardScaler, OrdinalEncoder)` reads the
data three times to fit.

Every fit statistic is the answer to an aggregation query (mean/std, unique
values, value counts), and members that touch disjoint columns are
independent. This PR adds an opt-in fast path that batches those queries:

- With `DataContext.enable_aggregation_based_preprocessors` set (env:
  `RAY_DATA_ENABLE_AGGREGATION_BASED_PREPROCESSORS`, **default off**),
  `Chain.fit()` only registers each member's aggregations on its stat
  computation plan and returns.
- The first `transform()` builds a column-dependency DAG (new
  `preprocessors/dag.py`): a later member depends on an earlier one iff it
  reads a column the earlier one writes. All aggregations with satisfied
  dependencies run as **one** `Dataset.aggregate()` call; results are routed
  into each member's `stats_` by aggregator alias; each fully-fitted member
  then transforms the (lazy) fit dataset so the next level aggregates over
  transformed data. Cost: one scan per dependency level instead of one per
  member — a chain of independent members fits in a single scan.
- Statistics are computed over **the dataset passed to `fit()`** (stashed on
  the chain), never over the dataset being transformed, so the fitted values
  are identical to sequential fitting even when a different dataset is
  transformed first.

**The user-visible behavioral change** (why this is behind a default-off
flag): with the flag on, `Chain.fit()` returns with member `stats_` empty;
they materialize at the first `transform()`, `transform_batch()`, or
serialization. An RFC issue for this semantic is open at #<RFC-issue-number>.

Safety properties (all in this PR, with tests — the flag isn't safe without
them):

1. **Opt-in per class.** A new `_supports_deferred_fit` marker is set only on
   preprocessors whose `_fit` purely registers plan aggregators
   (StandardScaler, SimpleImputer, and the five encoders as of the previous
   PR). A chain containing any unmarked fittable member — third-party
   subclasses, discretizers, CountVectorizer — keeps today's sequential eager
   fit for the whole chain.
2. **Serial fallback** (with a warning) at materialization time if a member
   registered a custom callable stat.
3. **Idempotence**: repeated `transform()` never re-runs aggregations.
4. **Serialization-safe**: `serialize()` and plain pickling of a
   fitted-but-never-transformed chain materialize the stats first, in
   dependency order; the fit dataset itself is never pickled.
5. Non-fittable members (e.g. `Concatenator`) become placeholder DAG nodes
   that carry their read/write columns, so a member reading a non-fittable's
   output only aggregates after that transform is applied.
6. Nested chains defer recursively and fit on the data flowing into their
   chain position.
7. Two members needing the same aggregation alias in one level run in
   separate query batches instead of colliding on a result column.

Also extracts the aggregate-execution half of `StatComputationPlan.compute`
into a shared `execute_aggregate_specs` helper (no behavior change) and gives
`Chain` `get_input_columns`/`get_output_columns`.

With the flag off (the default), behavior is unchanged; an explicit test
asserts the eager path.

## Related issue number

RFC: # [66090](https://github.com/ray-project/ray/issues/66090). Not a duplicate: searched open PRs/issues for chain
fit / preprocessor aggregation work; no overlap found.

Depends on the [encoder-aggregation PR](https://github.com/ray-project/ray/pull/66088) (stacked; will rebase once it lands).

## Checks

- [x] I've signed off every commit (DCO).
- [x] I've run pre-commit hooks — all hooks pass.
- [x] Testing (macOS / Python 3.12, source build):
  - `pytest python/ray/data/tests/preprocessors/test_chain.py` — 20 passed
    (deferral semantics, eager-vs-deferred stats equality, one-query batching
    of independent members, one-scan-per-level, no re-aggregation on repeated
    transform, fit-dataset semantics, placeholder ordering, unmarked-member
    fallback, callable-stat serial fallback, alias collision, nested chain,
    serialization, transform_batch, flag-off eager path, DAG structure).
  - `pytest python/ray/data/tests/preprocessors/` — pass/fail set
    byte-identical to clean master on the same machine (pre-existing local
    pandas-3.0.5 failures only; verified by diffing failure lists).

AI assistance was used to draft this change (Claude Code); every line has been
reviewed by the submitter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)