### PR TITLE
[Data] DownstreamCapacity: don't count blocks the consumer already holds as output pressure

### DIFF
--- a/python/ray/data/_internal/execution/backpressure_policy/downstream_capacity_backpressure_policy.py
+++ b/python/ray/data/_internal/execution/backpressure_policy/downstream_capacity_backpressure_policy.py
@@ -185,15 +185,49 @@ class DownstreamCapacityBackpressurePolicy(BackpressurePolicy):
             # No downstream capacity to backpressure against, so no backpressure.
             return 0
 
-        output_size_bytes = self._resource_manager.get_mem_op_outputs(
-            op, include_ineligible_downstream=True
-        )
+        output_size_bytes = self._get_output_size_bytes(op)
         # output_size_bytes includes both buffered outputs and downstream
         # in-flight inputs. Subtract 1 to isolate the buffered portion:
         #   output_pressure = op_outqueue_bytes / downstream_in_flight_bytes
         #   output_size_bytes = op_outqueue_bytes + downstream_in_flight_bytes
         #   output_pressure = output_size_bytes / downstream_in_flight_bytes - 1
         return (output_size_bytes / downstream_capacity_size_bytes) - 1
+
+    def _get_output_size_bytes(self, op: "PhysicalOperator") -> int:
+        """Bytes of ``op``'s outputs that are waiting to be consumed, plus the
+        bytes the consumer is currently working on.
+
+        When another eligible operator consumes the outputs, the ref-counted
+        output usage is the right measure: downstream tasks release blocks as
+        they finish with them, so a live block is a block still waiting.
+
+        When the consumer does not release the output blocks after reading them,
+        eg: train jobs calling ``materialize()`` on their shard and holding every
+        block until training ends, the ref-counted output usage still tracks
+        those blocks as unconsumed and can wrongly end up backpressuring the
+        producer (down to a single task). So in that case we count only the
+        blocks sitting in the queues, plus what the consumer says it is holding.
+        """
+        has_eligible_downstream = any(
+            True for _ in self._resource_manager.get_downstream_eligible_ops(op)
+        )
+        if has_eligible_downstream:
+            return self._resource_manager.get_mem_op_outputs(
+                op, include_ineligible_downstream=True
+            )
+
+        # No eligible downstream op: the outputs leave the pipeline through an
+        # iterator or streaming_split, maybe via pass-through ops such as
+        # OutputSplitter. Count what is queued instead of what is alive, without
+        # relying on the block ref counter.
+        buffered_bytes = self._topology[op].output_queue_bytes() + (
+            op.metrics.obj_store_mem_internal_outqueue or 0
+        )
+        for downstream_op in self._resource_manager._get_downstream_ineligible_ops(op):
+            buffered_bytes += self._topology[downstream_op].output_queue_bytes()
+            buffered_bytes += downstream_op.metrics.obj_store_mem_internal_inqueue or 0
+            buffered_bytes += downstream_op.metrics.obj_store_mem_internal_outqueue or 0
+        return buffered_bytes + self._resource_manager.get_external_consumer_bytes()
 
     def _should_apply_backpressure(self, op: "PhysicalOperator") -> bool:
         """Check if backpressure should be applied for the operator.
@@ -221,9 +255,7 @@ class DownstreamCapacityBackpressurePolicy(BackpressurePolicy):
         prev = self._prev_should_backpressure.get(op)
         if prev != result:
             downstream_capacity_bytes = self._get_downstream_capacity_size_bytes(op)
-            output_size_bytes = self._resource_manager.get_mem_op_outputs(
-                op, include_ineligible_downstream=True
-            )
+            output_size_bytes = self._get_output_size_bytes(op)
             logger.debug(
                 f"Backpressure change {op.name}: {prev} -> {result} "
                 f"({output_pressure=}, {output_size_bytes=}, "

--- a/python/ray/data/tests/test_downstream_capacity_backpressure_policy.py
+++ b/python/ray/data/tests/test_downstream_capacity_backpressure_policy.py
@@ -74,6 +74,7 @@ class TestDownstreamCapacityBackpressurePolicy:
             obj_store_mem_pending_task_inputs
         )
         mock_operator.metrics.obj_store_mem_pending_task_outputs = 0
+        mock_operator.metrics.obj_store_mem_internal_outqueue = 0
         mock_operator.output_dependencies = []
 
         # Set up eligibility methods (used by ResourceManager.is_op_eligible)
@@ -491,7 +492,9 @@ class TestDownstreamCapacityBackpressurePolicy:
             DownstreamCapacityBackpressurePolicy.OBJECT_STORE_BUDGET_UTIL_THRESHOLD
         )
         self._set_utilized_budget_fraction(rm, threshold + 0.05)
-        rm.get_mem_op_outputs.return_value = 1000
+        # 900 bytes buffered in the op's output queue + the consumer's 100
+        # prefetched bytes = 1000 bytes of outputs in flight.
+        op_state.output_queue_bytes.return_value = 900
 
         policy = self._create_policy(
             topology, data_context=context, resource_manager=rm
@@ -500,6 +503,76 @@ class TestDownstreamCapacityBackpressurePolicy:
         # Capacity comes from the external consumer, not a downstream op.
         assert policy._get_downstream_capacity_size_bytes(op) == external_bytes
         assert policy._get_output_pressure(op) == pytest.approx(expected_pressure)
+        assert policy.can_add_input(op) is expected_can_add_input
+
+    def test_terminal_op_ignores_blocks_retained_by_consumer(self):
+        """Blocks the consumer has taken and still holds are not pressure."""
+        op, op_state = self._mock_task_pool_map_operator()
+        op.output_dependencies = []  # terminal: consumed by an iterator
+        topology = {op: op_state}
+        context = self._create_context(backpressure_ratio=2.0)
+        rm = self._mock_resource_manager(external_bytes=100)
+
+        threshold = (
+            DownstreamCapacityBackpressurePolicy.OBJECT_STORE_BUDGET_UTIL_THRESHOLD
+        )
+        self._set_utilized_budget_fraction(rm, threshold + 0.05)
+        # Ref counter still sees the whole dataset (held by the consumer)...
+        rm.get_mem_op_outputs.return_value = 10**9
+        # ...but only 50 bytes are actually buffered ahead of the consumer.
+        op_state.output_queue_bytes.return_value = 50
+
+        policy = self._create_policy(
+            topology, data_context=context, resource_manager=rm
+        )
+
+        assert policy._get_output_pressure(op) == pytest.approx(0.5)
+        assert policy.can_add_input(op) is True
+        assert policy.max_task_output_bytes_to_read(op) is None
+
+    @pytest.mark.parametrize(
+        "splitter_inqueue_bytes, expected_can_add_input",
+        [
+            # 50 (op outqueue) + 50 (splitter outqueue) + 100 (splitter buffer)
+            # = 200 buffered / 100 prefetched = 2.0, not above the threshold.
+            pytest.param(100, True, id="splitter_buffer_within_ratio"),
+            # 50 + 50 + 900 = 1000 buffered / 100 prefetched = 10 > 2.0.
+            pytest.param(900, False, id="splitter_buffer_backs_up"),
+        ],
+    )
+    def test_terminal_chain_counts_ineligible_downstream_queues(
+        self, splitter_inqueue_bytes, expected_can_add_input
+    ):
+        """read -> OutputSplitter -> streaming_split consumers.
+
+        The splitter is ineligible, so it is an extension of the read op. Its
+        internal buffer and output queue are buffered outputs of the read op
+        and do count toward pressure; blocks the consumers hold do not.
+        """
+        op, op_state = self._mock_task_pool_map_operator()
+        splitter, splitter_state = self._mock_operator(
+            throttling_disabled=True,
+            obj_store_mem_internal_inqueue=splitter_inqueue_bytes,
+        )
+        op.output_dependencies = [splitter]
+        splitter.output_dependencies = []
+        topology = {op: op_state, splitter: splitter_state}
+        context = self._create_context(backpressure_ratio=2.0)
+        rm = self._mock_resource_manager(external_bytes=100)
+
+        threshold = (
+            DownstreamCapacityBackpressurePolicy.OBJECT_STORE_BUDGET_UTIL_THRESHOLD
+        )
+        self._set_utilized_budget_fraction(rm, threshold + 0.05)
+        rm.get_mem_op_outputs.return_value = 10**9  # retained by consumers
+        op_state.output_queue_bytes.return_value = 50
+        splitter_state.output_queue_bytes.return_value = 50
+
+        policy = self._create_policy(
+            topology, data_context=context, resource_manager=rm
+        )
+
+        assert policy._get_downstream_capacity_size_bytes(op) == 100
         assert policy.can_add_input(op) is expected_can_add_input
 
     def test_max_bytes_returns_none_when_backpressure_disabled(self):


### PR DESCRIPTION
## overview

`lightgbm_train_batch_inference_benchmark_100G` fails in release test with `RuntimeError: Training is taking ... longer than expected (600 seconds)`. The training dataset read that normally takes ~40s takes 400-560s.

Root cause: since #64456 the `DownstreamCapacityBackpressurePolicy` measures an operator's output pressure with the block ref counter. When the output goes to an iterator or `streaming_split`, that number includes every block the consumer has already taken and still holds. The LightGBM/XGBoost train loops call `materialize()` on their shard, so they hold every block until training ends. The read op's "pending output" then looks like the whole dataset (51 GiB) versus ~1 GiB of consumer prefetch, the ratio never drops, and `ReadFiles` is pinned to a single task by the liveness fallback (`Tasks: 1 [backpressured:tasks(DownstreamCapacity)]`).

## Fix
For an operator with no eligible downstream operator, compute output pressure from what is actually queued (its output queues, the pass-through operators' queues such as `OutputSplitter`, plus the bytes the consumer reports holding) instead of the ref count. Operator-to-operator edges keep the current ref-count measure, where it is accurate because downstream tasks release blocks when they finish.
