### PR TITLE
[doc] Add Linux and macOS Python 3.14 nightly wheels to the install page

### DIFF
--- a/doc/source/ray-overview/installation.md
+++ b/doc/source/ray-overview/installation.md
@@ -123,6 +123,8 @@ pip install -U "ray[default] @ LINK_TO_WHEEL.whl"
   - [Linux Python 3.12 (aarch64)](https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp312-cp312-manylinux2014_aarch64.whl)
 * - [Linux Python 3.13 (x86_64)](https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp313-cp313-manylinux2014_x86_64.whl) (beta)
   - [Linux Python 3.13 (aarch64)](https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp313-cp313-manylinux2014_aarch64.whl) (beta)
+* - [Linux Python 3.14 (x86_64)](https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp314-cp314-manylinux2014_x86_64.whl) (beta)
+  - [Linux Python 3.14 (aarch64)](https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp314-cp314-manylinux2014_aarch64.whl) (beta)
 ```
 ::::
 
@@ -136,6 +138,7 @@ pip install -U "ray[default] @ LINK_TO_WHEEL.whl"
 * - [MacOS Python 3.11 (arm64)](https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp311-cp311-macosx_12_0_arm64.whl)
 * - [MacOS Python 3.12 (arm64)](https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp312-cp312-macosx_12_0_arm64.whl)
 * - [MacOS Python 3.13 (arm64)](https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp313-cp313-macosx_12_0_arm64.whl) (beta)
+* - [MacOS Python 3.14 (arm64)](https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp314-cp314-macosx_12_0_arm64.whl) (beta)
 ```
 ::::
 

--- a/doc/source/ray-overview/installation.md
+++ b/doc/source/ray-overview/installation.md
@@ -121,8 +121,8 @@ pip install -U "ray[default] @ LINK_TO_WHEEL.whl"
   - [Linux Python 3.11 (aarch64)](https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp311-cp311-manylinux2014_aarch64.whl)
 * - [Linux Python 3.12 (x86_64)](https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp312-cp312-manylinux2014_x86_64.whl)
   - [Linux Python 3.12 (aarch64)](https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp312-cp312-manylinux2014_aarch64.whl)
-* - [Linux Python 3.13 (x86_64)](https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp313-cp313-manylinux2014_x86_64.whl) (beta)
-  - [Linux Python 3.13 (aarch64)](https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp313-cp313-manylinux2014_aarch64.whl) (beta)
+* - [Linux Python 3.13 (x86_64)](https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp313-cp313-manylinux2014_x86_64.whl)
+  - [Linux Python 3.13 (aarch64)](https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp313-cp313-manylinux2014_aarch64.whl)
 * - [Linux Python 3.14 (x86_64)](https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp314-cp314-manylinux2014_x86_64.whl) (experimental)
   - [Linux Python 3.14 (aarch64)](https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp314-cp314-manylinux2014_aarch64.whl) (experimental)
 ```
@@ -137,7 +137,7 @@ pip install -U "ray[default] @ LINK_TO_WHEEL.whl"
 * - [MacOS Python 3.10 (arm64)](https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp310-cp310-macosx_12_0_arm64.whl)
 * - [MacOS Python 3.11 (arm64)](https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp311-cp311-macosx_12_0_arm64.whl)
 * - [MacOS Python 3.12 (arm64)](https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp312-cp312-macosx_12_0_arm64.whl)
-* - [MacOS Python 3.13 (arm64)](https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp313-cp313-macosx_12_0_arm64.whl) (beta)
+* - [MacOS Python 3.13 (arm64)](https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp313-cp313-macosx_12_0_arm64.whl)
 * - [MacOS Python 3.14 (arm64)](https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp314-cp314-macosx_12_0_arm64.whl) (experimental)
 ```
 ::::

--- a/doc/source/ray-overview/installation.md
+++ b/doc/source/ray-overview/installation.md
@@ -123,8 +123,8 @@ pip install -U "ray[default] @ LINK_TO_WHEEL.whl"
   - [Linux Python 3.12 (aarch64)](https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp312-cp312-manylinux2014_aarch64.whl)
 * - [Linux Python 3.13 (x86_64)](https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp313-cp313-manylinux2014_x86_64.whl) (beta)
   - [Linux Python 3.13 (aarch64)](https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp313-cp313-manylinux2014_aarch64.whl) (beta)
-* - [Linux Python 3.14 (x86_64)](https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp314-cp314-manylinux2014_x86_64.whl) (beta)
-  - [Linux Python 3.14 (aarch64)](https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp314-cp314-manylinux2014_aarch64.whl) (beta)
+* - [Linux Python 3.14 (x86_64)](https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp314-cp314-manylinux2014_x86_64.whl) (experimental)
+  - [Linux Python 3.14 (aarch64)](https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp314-cp314-manylinux2014_aarch64.whl) (experimental)
 ```
 ::::
 
@@ -138,7 +138,7 @@ pip install -U "ray[default] @ LINK_TO_WHEEL.whl"
 * - [MacOS Python 3.11 (arm64)](https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp311-cp311-macosx_12_0_arm64.whl)
 * - [MacOS Python 3.12 (arm64)](https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp312-cp312-macosx_12_0_arm64.whl)
 * - [MacOS Python 3.13 (arm64)](https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp313-cp313-macosx_12_0_arm64.whl) (beta)
-* - [MacOS Python 3.14 (arm64)](https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp314-cp314-macosx_12_0_arm64.whl) (beta)
+* - [MacOS Python 3.14 (arm64)](https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp314-cp314-macosx_12_0_arm64.whl) (experimental)
 ```
 ::::
 


### PR DESCRIPTION
## Description

The Linux and MacOS tabs on the install page stop at Python 3.13, but cp314 wheels have been built and uploaded for all three targets for a while.

Build coverage on master:

- `.buildkite/_wheel-build.rayci.yml` — `3.14` in the `ray-wheel-build` (x86_64) matrix
- `.buildkite/linux_aarch64.rayci.yml` — `3.14` in the aarch64 matrices
- `python/build-wheel-macos.sh` — `PY_MMS=("3.10" "3.11" "3.12" "3.13" "3.14")`
- `python/setup.py` already declares the `Programming Language :: Python :: 3.14` classifier

All three nightly URLs resolve:

- `ray-3.0.0.dev0-cp314-cp314-manylinux2014_x86_64.whl` → HTTP 200
- `ray-3.0.0.dev0-cp314-cp314-manylinux2014_aarch64.whl` → HTTP 200
- `ray-3.0.0.dev0-cp314-cp314-macosx_12_0_arm64.whl` → HTTP 200

This PR:

1. Adds the three missing 3.14 rows, labelled `(experimental)`.
2. Drops the stale `(beta)` suffix from the 3.13 rows. Ray has shipped 3.13 wheels for several releases and `setup.py` lists the 3.13 classifier alongside 3.10-3.12, so the marker no longer reflects reality.

Net effect: `(experimental)` on 3.14 is the only per-version marker left, consistent across all three platforms.

## Related issues

Companion to #66099, which does the same for the Windows tab and uses the same `(experimental)` label for 3.14. The two touch different hunks of the same file and merge cleanly in either order.

## Additional information

Docs-only change, no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)