### PR TITLE
[serve] Deflake test_metrics_2 - Keep queued requests alive across the metric waits

### DIFF
--- a/python/ray/serve/tests/test_metrics_2.py
+++ b/python/ray/serve/tests/test_metrics_2.py
@@ -39,6 +39,8 @@ from ray.serve.tests.test_metrics import (
 METRICS_FIRST_EXPORT_TIMEOUT_S = 90
 METRICS_WAIT_TIMEOUT_S = 45
 METRICS_RETRY_INTERVAL_MS = 1000
+# Comfortably longer than the metric waits a held-open request has to survive.
+QUEUED_REQUEST_TIMEOUT_S = 300
 
 
 def wait_for_metric(predicate, budget_s=METRICS_WAIT_TIMEOUT_S, **kwargs):
@@ -807,7 +809,9 @@ class TestHandleMetrics:
 
         @ray.remote(num_cpus=0)
         def do_request():
-            r = httpx.get("http://localhost:8000/", timeout=10)
+            # These requests are torn down by the ray.cancel below, so the client
+            # timeout only has to outlast the metric waits between here and there.
+            r = httpx.get("http://localhost:8000/", timeout=QUEUED_REQUEST_TIMEOUT_S)
             r.raise_for_status()
             return r
 


### PR DESCRIPTION
test_queued_queries_disconnected holds four requests open, asserts on the queue gauges, then disconnects them explicitly with ray.cancel(force=True). The requests have to survive every metric wait in between, but their httpx client timeout was 10s while those waits are budgeted at 45-90s each. Once the queued_queries wait takes more than about 7s, the requests time out on their own and the next assertion waits its full budget for a state that no longer exists, failing with 0.0 != 4.0.

A 100x soak under CPU contention reproduced this three times, each one the same site with the same shape: the preceding wait took 7.86s, 7.25s and 8.09s, and the following wait then burned 45s and read 0. A larger budget cannot help, since the requests are already gone; the client timeout has to outlast the waits instead.