### PR TITLE
[RLlib] `_update_add_metrics(module_to_num_episodes_added, module_to_num_steps_added)`

### DIFF
--- a/rllib/utils/replay_buffers/episode_replay_buffer.py
+++ b/rllib/utils/replay_buffers/episode_replay_buffer.py
@@ -313,8 +313,8 @@ class EpisodeReplayBuffer(ReplayBufferInterface):
             agent_to_num_steps_added=agent_to_num_steps_added,
             agent_to_num_episodes_evicted=agent_to_num_episodes_evicted,
             agent_to_num_steps_evicted=agent_to_num_steps_evicted,
-            module_to_num_episodes_added=module_to_num_steps_added,
-            module_to_num_steps_added=module_to_num_episodes_added,
+            module_to_num_episodes_added=module_to_num_episodes_added,
+            module_to_num_steps_added=module_to_num_steps_added,
             module_to_num_episodes_evicted=module_to_num_episodes_evicted,
             module_to_num_steps_evicted=module_to_num_steps_evicted,
         )

--- a/rllib/utils/replay_buffers/multi_agent_episode_buffer.py
+++ b/rllib/utils/replay_buffers/multi_agent_episode_buffer.py
@@ -343,8 +343,8 @@ class MultiAgentEpisodeReplayBuffer(EpisodeReplayBuffer):
             agent_to_num_steps_added=agent_to_num_steps_added,
             agent_to_num_episodes_evicted=agent_to_num_episodes_evicted,
             agent_to_num_steps_evicted=agent_to_num_steps_evicted,
-            module_to_num_episodes_added=module_to_num_steps_added,
-            module_to_num_steps_added=module_to_num_episodes_added,
+            module_to_num_episodes_added=module_to_num_episodes_added,
+            module_to_num_steps_added=module_to_num_steps_added,
             module_to_num_episodes_evicted=module_to_num_episodes_evicted,
             module_to_num_steps_evicted=module_to_num_steps_evicted,
         )

--- a/rllib/utils/replay_buffers/multi_agent_prioritized_episode_buffer.py
+++ b/rllib/utils/replay_buffers/multi_agent_prioritized_episode_buffer.py
@@ -447,8 +447,8 @@ class MultiAgentPrioritizedEpisodeReplayBuffer(
             agent_to_num_steps_added=agent_to_num_steps_added,
             agent_to_num_episodes_evicted=agent_to_num_episodes_evicted,
             agent_to_num_steps_evicted=agent_to_num_steps_evicted,
-            module_to_num_episodes_added=module_to_num_steps_added,
-            module_to_num_steps_added=module_to_num_episodes_added,
+            module_to_num_episodes_added=module_to_num_episodes_added,
+            module_to_num_steps_added=module_to_num_steps_added,
             module_to_num_episodes_evicted=module_to_num_episodes_evicted,
             module_to_num_steps_evicted=module_to_num_steps_evicted,
         )

--- a/rllib/utils/replay_buffers/prioritized_episode_buffer.py
+++ b/rllib/utils/replay_buffers/prioritized_episode_buffer.py
@@ -348,8 +348,8 @@ class PrioritizedEpisodeReplayBuffer(EpisodeReplayBuffer):
             agent_to_num_steps_added=agent_to_num_steps_added,
             agent_to_num_episodes_evicted=agent_to_num_episodes_evicted,
             agent_to_num_steps_evicted=agent_to_num_steps_evicted,
-            module_to_num_episodes_added=module_to_num_steps_added,
-            module_to_num_steps_added=module_to_num_episodes_added,
+            module_to_num_episodes_added=module_to_num_episodes_added,
+            module_to_num_steps_added=module_to_num_steps_added,
             module_to_num_episodes_evicted=module_to_num_episodes_evicted,
             module_to_num_steps_evicted=module_to_num_steps_evicted,
         )


### PR DESCRIPTION
## Description
In updating the docstrings for Rllib, claude noticed that `_updaste_add_metrics` across all our ReplayBuffers where using the wrong arguments for `module_to_num_episodes_added` and `module_to_num_steps_added`. This PR fixes those arguments in all cases across the repo