### PR TITLE
[serve][docs] Add New Relic mention to monitoring documentation

### DIFF
--- a/doc/source/serve/monitoring.md
+++ b/doc/source/serve/monitoring.md
@@ -907,3 +907,7 @@ Besides using Prometheus to check out Ray metrics, Ray Serve also has the flexib
 [Arize](https://docs.arize.com/arize/) is a machine learning observability platform which can help you to monitor real-time model performance, root cause model failures/performance degradation using explainability & slice analysis and surface drift, data quality, data consistency issues etc.
 
 To integrate with Arize, add Arize client code directly into your Serve deployment code.
+
+## Exporting metrics into New Relic
+
+[New Relic](https://newrelic.com/) collects the Prometheus metrics that Ray exposes: add a [remote write](https://docs.newrelic.com/docs/infrastructure/prometheus-integrations/install-configure-remote-write/set-your-prometheus-remote-write-integration/) block pointing at New Relic to the Prometheus server that scrapes your Ray cluster. Applications instrumented with OpenTelemetry can also send traces and metrics to [New Relic's native OTLP endpoint](https://docs.newrelic.com/docs/opentelemetry/best-practices/opentelemetry-otlp/).


### PR DESCRIPTION
## Description
Add New Relic to Ray Serve's monitoring documentation as a supported observability platform.

New Relic ingests OpenTelemetry Protocol (OTLP) natively, allowing Ray metrics to be exported directly through New Relic's observability platform. This change documents the integration option alongside existing platform integrations.

## Related issues
N/A

## Additional information
- Added minimal mention with link to New Relic's OTLP best practices documentation
- Follows existing style and placement in the documentation
- Link verified: https://docs.newrelic.com/docs/opentelemetry/best-practices/opentelemetry-otlp/

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KybsFC28cLtu6pCdwdwBBw