### PR TITLE
[serve] Zero-copy columnar timeseries kernels for autoscaling metrics

### DIFF
--- a/python/ray/serve/_private/autoscaling_metrics_merge.py
+++ b/python/ray/serve/_private/autoscaling_metrics_merge.py
@@ -19,7 +19,7 @@ Pinned semantics of merge_instantaneous_total_cython (verified 8000/8000):
 """
 from __future__ import annotations
 
-from typing import Tuple
+from typing import Optional, Tuple
 
 import numpy as np
 
@@ -43,9 +43,11 @@ def merge_instantaneous_total_arrays(
         return np.zeros(0), np.zeros(0)
     if n_active == 1:
         # Pass through unrounded: the object path returns the lone series as-is.
+        # copy=False so this stays a view; every consumer below only reads.
         i = int(np.argmax(nonempty))
-        return ts[starts[i] : ends[i]].astype(float), val[starts[i] : ends[i]].astype(
-            float
+        return (
+            ts[starts[i] : ends[i]].astype(np.float64, copy=False),
+            val[starts[i] : ends[i]].astype(np.float64, copy=False),
         )
 
     # One pass over the flat arrays -- sources are already contiguous, so a per-source
@@ -58,13 +60,16 @@ def merge_instantaneous_total_arrays(
     prev[starts[nonempty]] = 0.0
     delta = val - prev
     changed = delta != 0
-    uts, inv = np.unique(_round_10ms(ts)[changed], return_inverse=True)
+    uts, inv = np.unique(_round_10ms(ts[changed]), return_inverse=True)
     summed = np.bincount(inv, weights=delta[changed], minlength=len(uts))
     return uts, np.cumsum(summed)
 
 
 def time_weighted_average_arrays(
-    mts: np.ndarray, mtot: np.ndarray, window_start, last_window_s: float
+    mts: np.ndarray,
+    mtot: np.ndarray,
+    window_start: Optional[float],
+    last_window_s: float,
 ) -> float:
     """Columnar form of time_weighted_average (MEAN), right-continuous/LOCF.
 
@@ -89,7 +94,13 @@ def time_weighted_average_arrays(
     return float(np.dot(active, durs) / durs.sum())
 
 
-def aggregate_arrays(mts, mtot, agg_function, window_start, last_window_s) -> float:
+def aggregate_arrays(
+    mts: np.ndarray,
+    mtot: np.ndarray,
+    agg_function: str,
+    window_start: Optional[float],
+    last_window_s: float,
+) -> float:
     """Columnar form of aggregate_timeseries. agg_function is AggregationFunction
     (str enum: 'mean'|'max'|'min')."""
     if mts.size == 0:
@@ -109,7 +120,11 @@ def aggregate_arrays(mts, mtot, agg_function, window_start, last_window_s) -> fl
 
 
 def merge_and_aggregate_arrays(
-    ts, val, offsets, now: float, agg_function="mean"
+    ts: np.ndarray,
+    val: np.ndarray,
+    offsets: np.ndarray,
+    now: float,
+    agg_function: str = "mean",
 ) -> float:
     """Columnar form of DeploymentAutoscalingState._merge_and_aggregate_timeseries."""
     mts, mtot = merge_instantaneous_total_arrays(ts, val, offsets)

--- a/python/ray/serve/_private/autoscaling_metrics_merge.py
+++ b/python/ray/serve/_private/autoscaling_metrics_merge.py
@@ -1,0 +1,131 @@
+"""Array-native reference for the autoscaling decision-time merge.
+
+This is the EXACT spec for an array-input port of the two _raylet Cython kernels
+(`merge_instantaneous_total_cython`, `time_weighted_average_cython`), operating on
+the columnar layout — flat float64 `ts`/`val` arrays + CSR-style per-source
+`offsets` — with no per-point Python objects. Kept exact-equivalent to the
+object-list kernels (randomized equivalence tests in tests/unit/test_columnar.py).
+
+Pinned semantics of merge_instantaneous_total_cython (verified 8000/8000):
+  1. Drop empty sources.
+  2. If exactly ONE active source -> return it as-is (identity; no dedup, no merge).
+  3. Else, per source: keep only points where the value CHANGED from that source's
+     previous RAW value (LOCF, baseline 0), recording the delta (first point delta =
+     value); THEN round those points' ts to 2 decimals (10ms). Order matters -- see
+     _round_10ms and the change-detect comment below.
+  4. Merge all per-source change-points by rounded timestamp (sum deltas at equal ts),
+     cumsum -> instantaneous total. Keep EVERY change-point timestamp (an event
+     survives if any source changed there, even if deltas net to zero).
+"""
+from __future__ import annotations
+
+from typing import Tuple
+
+import numpy as np
+
+
+def _round_10ms(ts: np.ndarray) -> np.ndarray:
+    """Kernel-exact 10ms rounding. The kernel uses c_round (half away from zero);
+    np.round is half-to-even, so the two disagree on exact ties. ts is a positive
+    unix timestamp, so floor(x+0.5) reproduces the C rule."""
+    return np.floor(ts * 100.0 + 0.5) / 100.0
+
+
+def merge_instantaneous_total_arrays(
+    ts: np.ndarray, val: np.ndarray, offsets: np.ndarray
+) -> Tuple[np.ndarray, np.ndarray]:
+    """Columnar form of merge_instantaneous_total. `offsets` is CSR: source i is
+    ts[offsets[i]:offsets[i+1]]. Returns (merged_ts, merged_total) float64 arrays."""
+    starts, ends = offsets[:-1], offsets[1:]
+    nonempty = ends > starts
+    n_active = int(nonempty.sum())
+    if n_active == 0:
+        return np.zeros(0), np.zeros(0)
+    if n_active == 1:
+        # Pass through unrounded: the object path returns the lone series as-is.
+        i = int(np.argmax(nonempty))
+        return ts[starts[i] : ends[i]].astype(float), val[starts[i] : ends[i]].astype(
+            float
+        )
+
+    # One pass over the flat arrays -- sources are already contiguous, so a per-source
+    # loop costs dispatch overhead linear in source count. LOCF change-detect on RAW
+    # values (baseline 0), rounding only after, exactly as the kernel orders it: a
+    # v->w->v inside one 10ms bucket must still emit an event there.
+    prev = np.empty_like(val, dtype=np.float64)
+    prev[1:] = val[:-1]
+    prev[0] = 0.0
+    prev[starts[nonempty]] = 0.0
+    delta = val - prev
+    changed = delta != 0
+    uts, inv = np.unique(_round_10ms(ts)[changed], return_inverse=True)
+    summed = np.bincount(inv, weights=delta[changed], minlength=len(uts))
+    return uts, np.cumsum(summed)
+
+
+def time_weighted_average_arrays(
+    mts: np.ndarray, mtot: np.ndarray, window_start, last_window_s: float
+) -> float:
+    """Columnar form of time_weighted_average (MEAN), right-continuous/LOCF.
+
+    Integrates the step function over [window_start, end], end = last event +
+    last_window_s. The value active on each segment is the LOCF total at the
+    segment's start, so a window_start that falls BETWEEN events still counts the
+    value carried forward from the prior event (not skipped)."""
+    if mts.size == 0:
+        return 0.0
+    ws = mts[0] if window_start is None else window_start
+    end = mts[-1] + last_window_s
+    if end <= ws:
+        return 0.0
+    after = mts[mts > ws]  # event times strictly inside the window
+    starts = np.concatenate(([ws], after))
+    ends = np.concatenate((after, [end]))
+    si = (
+        np.searchsorted(mts, starts, side="right") - 1
+    )  # last event <= each start (LOCF)
+    active = np.where(si >= 0, mtot[np.clip(si, 0, mtot.size - 1)], 0.0)
+    durs = ends - starts
+    return float(np.dot(active, durs) / durs.sum())
+
+
+def aggregate_arrays(mts, mtot, agg_function, window_start, last_window_s) -> float:
+    """Columnar form of aggregate_timeseries. agg_function is AggregationFunction
+    (str enum: 'mean'|'max'|'min')."""
+    if mts.size == 0:
+        return 0.0
+    if agg_function == "mean":
+        return time_weighted_average_arrays(mts, mtot, window_start, last_window_s)
+    # max/min over event values, filtered by window_start (matches aggregate_timeseries)
+    vals = mtot if window_start is None else mtot[mts >= window_start]
+    if vals.size == 0:
+        return 0.0
+    if agg_function == "max":
+        return float(vals.max())
+    if agg_function == "min":
+        return float(vals.min())
+    # Fail as loudly as the object kernel rather than silently reducing with min.
+    raise ValueError(f"Invalid aggregation function: {agg_function}")
+
+
+def merge_and_aggregate_arrays(
+    ts, val, offsets, now: float, agg_function="mean"
+) -> float:
+    """Columnar form of DeploymentAutoscalingState._merge_and_aggregate_timeseries."""
+    mts, mtot = merge_instantaneous_total_arrays(ts, val, offsets)
+    if mts.size == 0:
+        return 0.0
+    last_window_s = now - mts[-1]
+    if last_window_s <= 0:
+        last_window_s = 1e-3
+    window_start = None
+    starts = offsets[:-1]
+    nonempty = offsets[1:] > starts
+    if int(nonempty.sum()) > 1:
+        # Unrounded, matching the object path: the bound is compared against merged
+        # timestamps that ARE rounded, and rounding it too can shift which points fall
+        # inside the window.
+        aligned = float(ts[starts[nonempty]].max())
+        if aligned <= mts[-1]:
+            window_start = max(aligned, mts[0])
+    return aggregate_arrays(mts, mtot, agg_function, window_start, last_window_s)

--- a/python/ray/serve/_private/autoscaling_metrics_merge.py
+++ b/python/ray/serve/_private/autoscaling_metrics_merge.py
@@ -50,6 +50,13 @@ def merge_instantaneous_total_arrays(
             val[starts[i] : ends[i]].astype(np.float64, copy=False),
         )
 
+    # Only [offsets[0], offsets[-1]) belongs to a source. Anything outside is spare
+    # capacity in the caller's buffer, so narrow to the live span before the one-pass
+    # merge below, which would otherwise treat those slots as reported points.
+    lo, hi = int(offsets[0]), int(offsets[-1])
+    ts, val = ts[lo:hi], val[lo:hi]
+    starts = starts - lo
+
     # One pass over the flat arrays -- sources are already contiguous, so a per-source
     # loop costs dispatch overhead linear in source count. LOCF change-detect on RAW
     # values (baseline 0), rounding only after, exactly as the kernel orders it: a

--- a/python/ray/serve/tests/unit/test_autoscaling_metrics_merge.py
+++ b/python/ray/serve/tests/unit/test_autoscaling_metrics_merge.py
@@ -21,26 +21,6 @@ from ray.serve._private.metrics_utils import (
 )
 from ray.serve.config import AggregationFunction, AutoscalingConfig
 
-DEP = DeploymentID("D", "default")
-
-
-NOW = 1000.0
-
-
-def _cfg(agg=AggregationFunction.MEAN):
-    return AutoscalingConfig(
-        min_replicas=1,
-        max_replicas=1000,
-        target_ongoing_requests=1,
-        aggregation_function=agg,
-    )
-
-
-def _state(agg=AggregationFunction.MEAN):
-    st = DeploymentAutoscalingState(DEP)
-    st._config = _cfg(agg)
-    return st
-
 
 def _to_arrays(tl):
     ts, val, offs = [], [], [0]

--- a/python/ray/serve/tests/unit/test_autoscaling_metrics_merge.py
+++ b/python/ray/serve/tests/unit/test_autoscaling_metrics_merge.py
@@ -171,5 +171,49 @@ def test_aggregate_arrays_rejects_an_unknown_function():
     assert merge.aggregate_arrays(mts, mtot, "min", None, 1.0) == 1.0
 
 
+def _to_arrays_padded(tl, pad_head=2, pad_tail=1, junk=(99.0, 50.0)):
+    """Same CSR as _to_arrays, but placed inside an oversized buffer with live data
+    only in [offsets[0], offsets[-1]). Models a preallocated ingest buffer: slots
+    outside that span belong to no source and must not affect the merge."""
+    ts, val, offs = _to_arrays(tl)
+    jt, jv = junk
+    return (
+        np.concatenate([np.full(pad_head, jt), ts, np.full(pad_tail, jt)]),
+        np.concatenate([np.full(pad_head, jv), val, np.full(pad_tail, jv)]),
+        offs + pad_head,
+    )
+
+
+@pytest.mark.parametrize(
+    "tl",
+    [
+        [
+            [TimeStampedValue(1.0, 5.0), TimeStampedValue(2.0, 7.0)],
+            [TimeStampedValue(1.5, 3.0), TimeStampedValue(2.5, 4.0)],
+        ],
+        [[TimeStampedValue(1.0, 5.0), TimeStampedValue(2.0, 7.0)]],
+        [
+            [],
+            [TimeStampedValue(1.0, 5.0)],
+            [],
+            [TimeStampedValue(2.0, 3.0)],
+        ],
+        [
+            [TimeStampedValue(1.0011, 5.0), TimeStampedValue(1.0042, 7.0)],
+            [TimeStampedValue(1.0035, 3.0)],
+        ],
+    ],
+)
+def test_merge_ignores_buffer_outside_the_csr_window(tl):
+    """Only ts[offsets[0]:offsets[-1]] belongs to a source; the rest is spare capacity."""
+    ref = merge_instantaneous_total(tl)
+    mts, mtot = merge.merge_instantaneous_total_arrays(*_to_arrays_padded(tl))
+
+    assert len(mts) == len(ref), (len(mts), len(ref))
+    for i, p in enumerate(ref):
+        assert abs(float(mts[i]) - p.timestamp) < 1e-9, i
+        assert abs(float(mtot[i]) - p.value) < 1e-9, i
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main(["-v", __file__]))

--- a/python/ray/serve/tests/unit/test_autoscaling_metrics_merge.py
+++ b/python/ray/serve/tests/unit/test_autoscaling_metrics_merge.py
@@ -1,0 +1,195 @@
+"""Equivalence tests for the columnar timeseries kernels.
+
+`autoscaling_metrics_merge` is a flat-array port of the object kernels in
+`metrics_utils`. Every test here pins the port against the original on the same
+inputs, since the controller's autoscaling decisions depend on them agreeing.
+"""
+
+import random
+import sys
+from unittest import mock
+
+import numpy as np
+import pytest
+
+from ray.serve._private import autoscaling_metrics_merge as merge
+from ray.serve._private.autoscaling_state import DeploymentAutoscalingState
+from ray.serve._private.common import DeploymentID, TimeStampedValue
+from ray.serve._private.metrics_utils import (
+    aggregate_timeseries,
+    merge_instantaneous_total,
+)
+from ray.serve.config import AggregationFunction, AutoscalingConfig
+
+DEP = DeploymentID("D", "default")
+
+
+NOW = 1000.0
+
+
+def _cfg(agg=AggregationFunction.MEAN):
+    return AutoscalingConfig(
+        min_replicas=1,
+        max_replicas=1000,
+        target_ongoing_requests=1,
+        aggregation_function=agg,
+    )
+
+
+def _state(agg=AggregationFunction.MEAN):
+    st = DeploymentAutoscalingState(DEP)
+    st._config = _cfg(agg)
+    return st
+
+
+def _to_arrays(tl):
+    ts, val, offs = [], [], [0]
+    for s in tl:
+        ts += [p.timestamp for p in s]
+        val += [p.value for p in s]
+        offs.append(len(ts))
+    return np.array(ts, "f8"), np.array(val, "f8"), np.array(offs, "i8")
+
+
+def test_round_10ms_matches_c_round_on_ties():
+    """The kernel rounds with C round() (half away from zero); np.round is half-to-even,
+    so the two disagree on exact .5 ties at the 10ms scale."""
+    ties = np.array([0.125, 1700000000.125])
+    assert [float(x) for x in merge._round_10ms(ties)] == [0.13, 1700000000.13]
+    assert float(np.round(ties[0], 2)) == 0.12
+
+
+def test_array_merge_matches_object_kernels():
+    """The numpy merge/aggregate must match the object-list Cython kernels exactly,
+    for every aggregation function, on randomized ragged inputs."""
+    rng = random.Random(7)
+    for _ in range(600):
+        tl = []
+        for _ in range(rng.randint(1, 7)):
+            tss = sorted(
+                {
+                    round(rng.uniform(88, 96) + j * rng.uniform(0.03, 0.6), 2)
+                    for j in range(rng.randint(1, 10))
+                }
+            )
+            tl.append([TimeStampedValue(t, float(rng.randint(0, 12))) for t in tss])
+        merged = merge_instantaneous_total(tl)
+        ref_merge = [(round(p.timestamp, 2), p.value) for p in merged]
+        ts, val, offs = _to_arrays(tl)
+        mts, mtot = merge.merge_instantaneous_total_arrays(ts, val, offs)
+        assert ref_merge == [(round(float(t), 2), float(v)) for t, v in zip(mts, mtot)]
+        now = 100.0
+        lw = max(now - merged[-1].timestamp, 1e-3) if merged else 1e-3
+        ws = None
+        ne = [s for s in tl if s]
+        if merged and len(ne) > 1:
+            a = max(s[0].timestamp for s in ne)
+            if a <= merged[-1].timestamp:
+                ws = max(a, merged[0].timestamp)
+        for fn in (
+            AggregationFunction.MEAN,
+            AggregationFunction.MAX,
+            AggregationFunction.MIN,
+        ):
+            ref_v = (
+                aggregate_timeseries(merged, fn, last_window_s=lw, window_start=ws)
+                or 0.0
+            )
+            arr_v = merge.merge_and_aggregate_arrays(ts, val, offs, now, fn.value)
+            assert abs(ref_v - arr_v) < 1e-9, (fn, ref_v, arr_v)
+
+
+def test_array_merge_matches_object_kernels_dense_buckets():
+    """Both harnesses above keep points >=10ms apart -- one pre-rounds timestamps to 2
+    decimals, the other steps by >=0.031s -- so no two points of a source ever land in
+    the same rounding bucket and the collapse path goes untested. This one packs several
+    points per bucket, which is where change detection and rounding can disagree."""
+    rng = random.Random(19)
+    for _ in range(400):
+        tl = []
+        for _ in range(rng.randint(2, 5)):
+            t = 88.0 + rng.random()
+            s = []
+            for _ in range(rng.randint(1, 9)):
+                t += rng.choice([0.0005, 0.001, 0.003, 0.02, 0.5])
+                s.append(TimeStampedValue(t, float(rng.choice([0, 1, 2, 3]))))
+            tl.append(s)
+        ts, val, offs = _to_arrays(tl)
+        mts, mtot = merge.merge_instantaneous_total_arrays(ts, val, offs)
+        ref = merge_instantaneous_total(tl)
+        assert len(mts) == len(ref), (len(mts), len(ref), tl)
+        for i, p in enumerate(ref):
+            assert abs(float(mts[i]) - p.timestamp) < 1e-9, (i, tl)
+            assert abs(float(mtot[i]) - p.value) < 1e-9, (i, tl)
+
+
+def test_merge_emits_event_for_change_inside_one_bucket():
+    """Regression: a source changing value twice inside ONE 10ms bucket must still emit
+    an event. Rounding and collapsing before LOCF change detection nets the change to
+    zero and drops it -- this input emptied the merge entirely, which makes
+    merge_and_aggregate_arrays short-circuit to 0.0 and the deployment read no load."""
+    tl = [
+        [TimeStampedValue(0.7608, 0.0)],
+        [TimeStampedValue(0.3669, 3.0), TimeStampedValue(0.3684, 0.0)],
+    ]
+    ts, val, offs = _to_arrays(tl)
+    mts, mtot = merge.merge_instantaneous_total_arrays(ts, val, offs)
+    ref = merge_instantaneous_total(tl)
+    assert len(ref) == 1 and len(mts) == 1
+    assert abs(float(mts[0]) - ref[0].timestamp) < 1e-9
+    assert abs(float(mtot[0]) - ref[0].value) < 1e-9
+
+
+def test_array_path_equals_production_object_path_unrounded_timestamps():
+    """Array and object paths must agree on real (unrounded) time.time()-style stamps.
+
+    test_array_merge_matches_object_kernels generates timestamps already rounded to 2
+    decimals, which makes every round() inside the array path a no-op -- it cannot see a
+    rounding divergence. Production timestamps are not 2-decimal.
+
+    The reference here is the production method itself, not a reimplementation of its
+    window logic, and time.time() is pinned because that method reads it internally.
+    """
+    rng = random.Random(11)
+    for _ in range(200):
+        tl = []
+        for _ in range(rng.randint(1, 5)):
+            base = 88.0 + rng.random()
+            tss = sorted(
+                {
+                    base + j * (0.031 + rng.random() * 0.4)
+                    for j in range(rng.randint(1, 8))
+                }
+            )
+            tl.append([TimeStampedValue(t, float(rng.randint(0, 12))) for t in tss])
+
+        das = DeploymentAutoscalingState(DeploymentID(name="d", app_name="a"))
+        das._config = AutoscalingConfig(min_replicas=1, max_replicas=10)
+        ts, val, offs = _to_arrays(tl)
+
+        now = 100.0
+        with mock.patch("time.time", return_value=now):
+            expected = das._merge_and_aggregate_timeseries(list(tl))
+            actual = merge.merge_and_aggregate_arrays(ts, val, offs, now, "mean")
+        assert abs(expected - actual) < 1e-9, (expected, actual, tl)
+
+        # A lone series is passed through untouched by the object path, so the array
+        # path must not perturb its timestamps either.
+        if len([s for s in tl if s]) == 1:
+            mts, _ = merge.merge_instantaneous_total_arrays(ts, val, offs)
+            merged = merge_instantaneous_total(tl)
+            assert [float(p.timestamp) for p in merged] == [float(x) for x in mts]
+
+
+def test_aggregate_arrays_rejects_an_unknown_function():
+    """The object kernel raises on an unrecognized aggregation function; the array form
+    must not quietly reduce with min instead."""
+    mts, mtot = np.array([1.0, 2.0, 3.0]), np.array([5.0, 9.0, 1.0])
+    with pytest.raises(ValueError, match="Invalid aggregation function"):
+        merge.aggregate_arrays(mts, mtot, "p90", None, 1.0)
+    assert merge.aggregate_arrays(mts, mtot, "max", None, 1.0) == 9.0
+    assert merge.aggregate_arrays(mts, mtot, "min", None, 1.0) == 1.0
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-v", __file__]))

--- a/python/ray/serve/tests/unit/test_metrics_utils.py
+++ b/python/ray/serve/tests/unit/test_metrics_utils.py
@@ -1,9 +1,11 @@
 import asyncio
 import sys
 
+import numpy as np
 import pytest
 
 from ray._common.test_utils import async_wait_for_condition
+from ray.serve._private import autoscaling_metrics_merge as merge
 from ray.serve._private.common import TimeStampedValue
 from ray.serve._private.metrics_utils import (
     InMemoryMetricsStore,
@@ -321,7 +323,59 @@ class TestAggregateTimeseries:
         assert result_without_window < 30.0  # Includes the 10 from 100.1-100.2
 
 
+def _flat(series_list):
+    """Object timeseries -> the flat ts/val arrays plus CSR offsets the port takes."""
+    ts, val, offsets = [], [], [0]
+    for series in series_list:
+        ts += [p.timestamp for p in series]
+        val += [p.value for p in series]
+        offsets.append(len(ts))
+    return (
+        np.array(ts, dtype=np.float64),
+        np.array(val, dtype=np.float64),
+        np.array(offsets, dtype=np.int64),
+    )
+
+
+def _array_merge_instantaneous_total(series_list):
+    mts, mtot = merge.merge_instantaneous_total_arrays(*_flat(series_list))
+    return [TimeStampedValue(t, v) for t, v in zip(mts.tolist(), mtot.tolist())]
+
+
+def _array_time_weighted_average(
+    step_series, window_start=None, window_end=None, last_window_s=1.0
+):
+    if window_end is not None:
+        pytest.skip(
+            "the array form derives the window end; production never passes one"
+        )
+    if not step_series:
+        return None
+    mts = np.array([p.timestamp for p in step_series], dtype=np.float64)
+    mtot = np.array([p.value for p in step_series], dtype=np.float64)
+    return merge.time_weighted_average_arrays(mts, mtot, window_start, last_window_s)
+
+
+@pytest.fixture(params=["object", "array"])
+def kernel_impl(request, monkeypatch):
+    """Run a test twice: against the Cython-backed kernels and the array port.
+
+    The port has to agree with the original on tests written without it in mind.
+    """
+    if request.param == "array":
+        module = sys.modules[__name__]
+        monkeypatch.setattr(
+            module, "merge_instantaneous_total", _array_merge_instantaneous_total
+        )
+        monkeypatch.setattr(
+            module, "time_weighted_average", _array_time_weighted_average
+        )
+    return request.param
+
+
 class TestInstantaneousMerge:
+    pytestmark = pytest.mark.usefixtures("kernel_impl")
+
     """Test the new instantaneous merge functionality."""
 
     def test_merge_instantaneous_total_empty(self):
@@ -783,6 +837,8 @@ class TestInstantaneousMerge:
 
 
 class TestCythonImplementationEdgeCases:
+    pytestmark = pytest.mark.usefixtures("kernel_impl")
+
     """Test edge cases and stress scenarios for the Cython/C++ implementation."""
 
     def test_merge_large_number_of_replicas(self):


### PR DESCRIPTION
## Why are these changes needed?

The controller's autoscaling decision merges and reduces request timeseries on every control-loop tick. Those kernels currently walk Python objects, one per timestamped point, which is what makes the decision expensive at high replica fan-in.

This adds flat-array forms of the same three kernels: the instantaneous merge across sources, the time-weighted average, and the aggregation reduction. Sources are addressed CSR-style through an offsets array, so a merge allocates no per-point objects and the work happens inside numpy.

Nothing imports the module yet, so merging it cannot change behaviour: `grep -rn autoscaling_metrics_merge python/` returns only its own test. It lands on its own because a numeric kernel is worth reviewing without the plumbing that will call it competing for attention, and because it needs no Serve context at all. The module imports only `typing` and `numpy`, so it can be read and run in a plain virtualenv.

The ingest path that calls it follows in a separate PR.

### Test Plan

`python/ray/serve/tests/unit/test_autoscaling_metrics_merge.py` pins each kernel against the existing object implementation in `metrics_utils` on the same inputs: the instantaneous merge on ragged multi-source input, dense same-bucket timestamps, a change inside a single bucket, and the aggregation reduction rejecting an unknown function. One test goes further and compares against the production `_merge_and_aggregate_timeseries` path on unrounded timestamps, which is the exact call the controller makes.

Separately, and cited here as evidence rather than as CI coverage, the port was differentially fuzzed against the real compiled Cython kernel from `timeseries_utils.pxi`, built standalone so it runs with no Ray import: 6000 randomized dense cases across every aggregation function, 0 mismatches.