### PR TITLE
[serve] Split the object aggregation out of get_total_num_requests

### DIFF
--- a/python/ray/serve/_private/autoscaling_state.py
+++ b/python/ray/serve/_private/autoscaling_state.py
@@ -585,6 +585,11 @@ class DeploymentAutoscalingState:
         Returns:
             The aggregated total of running and queued requests.
         """
+        return self._object_aggregate_total_requests()
+
+    def _object_aggregate_total_requests(self) -> float:
+        """Aggregate the object-store timeseries. Split out of get_total_num_requests
+        so the caller can pick an aggregation path without carrying its body."""
         # Collect replica-based running requests (returns List[TimeSeries])
         replica_timeseries = self._collect_replica_running_requests()
         metrics_collected_on_replicas = len(replica_timeseries) > 0


### PR DESCRIPTION
## Why are these changes needed?

Preparatory refactor with no behaviour change. `get_total_num_requests` computes the aggregate inline, so a follow-up that needs to choose between aggregation paths would have to rewrite the function that produces every autoscaling decision.

The body moves to `_object_aggregate_total_requests` and `get_total_num_requests` returns it. The entry point keeps its docstring, which documents the merge and windowing semantics and is worth leaving where callers look for it.

The moved lines are byte-identical to what ran before, comments included, so the whole diff is five added lines and no deletions.

### Test Plan

`test_autoscaling_policy` (46), `test_application_state` (122) and `test_deployment_state` (256) all pass unmodified.