### PR TITLE
[serve] Measure autoscaling-metrics ingest cost in the controller

### DIFF
--- a/python/ray/serve/_private/controller.py
+++ b/python/ray/serve/_private/controller.py
@@ -409,8 +409,13 @@ class ServeController:
     def record_autoscaling_metrics_from_replica(
         self, replica_metric_report: Union[ReplicaMetricReport, bytes]
     ):
+        ingest_start = time.time()
         if isinstance(replica_metric_report, bytes):
+            decompress_start = time.time()
             replica_metric_report = decompress_metric_report(replica_metric_report)
+            self._health_metrics_tracker.record_decompress(
+                (time.time() - decompress_start) * 1000
+            )
         # Decompression (above) always yields a ReplicaMetricReport.
         replica_metric_report = cast(ReplicaMetricReport, replica_metric_report)
         self._record_metrics_delay(
@@ -422,12 +427,20 @@ class ServeController:
         self.autoscaling_state_manager.record_request_metrics_for_replica(
             replica_metric_report
         )
+        self._health_metrics_tracker.record_replica_ingest(
+            (time.time() - ingest_start) * 1000
+        )
 
     def record_autoscaling_metrics_from_handle(
         self, handle_metric_report: Union[HandleMetricReport, bytes]
     ):
+        ingest_start = time.time()
         if isinstance(handle_metric_report, bytes):
+            decompress_start = time.time()
             handle_metric_report = decompress_metric_report(handle_metric_report)
+            self._health_metrics_tracker.record_decompress(
+                (time.time() - decompress_start) * 1000
+            )
         # Decompression (above) always yields a HandleMetricReport.
         handle_metric_report = cast(HandleMetricReport, handle_metric_report)
         self._record_metrics_delay(
@@ -438,6 +451,9 @@ class ServeController:
         )
         self.autoscaling_state_manager.record_request_metrics_for_handle(
             handle_metric_report
+        )
+        self._health_metrics_tracker.record_handle_ingest(
+            (time.time() - ingest_start) * 1000
         )
 
     def record_autoscaling_metrics_from_async_inference_task_queue(

--- a/python/ray/serve/_private/controller.py
+++ b/python/ray/serve/_private/controller.py
@@ -409,12 +409,12 @@ class ServeController:
     def record_autoscaling_metrics_from_replica(
         self, replica_metric_report: Union[ReplicaMetricReport, bytes]
     ):
-        ingest_start = time.time()
+        ingest_start = time.monotonic()
         if isinstance(replica_metric_report, bytes):
-            decompress_start = time.time()
+            decompress_start = time.monotonic()
             replica_metric_report = decompress_metric_report(replica_metric_report)
             self._health_metrics_tracker.record_decompress(
-                (time.time() - decompress_start) * 1000
+                (time.monotonic() - decompress_start) * 1000
             )
         # Decompression (above) always yields a ReplicaMetricReport.
         replica_metric_report = cast(ReplicaMetricReport, replica_metric_report)
@@ -428,18 +428,18 @@ class ServeController:
             replica_metric_report
         )
         self._health_metrics_tracker.record_replica_ingest(
-            (time.time() - ingest_start) * 1000
+            (time.monotonic() - ingest_start) * 1000
         )
 
     def record_autoscaling_metrics_from_handle(
         self, handle_metric_report: Union[HandleMetricReport, bytes]
     ):
-        ingest_start = time.time()
+        ingest_start = time.monotonic()
         if isinstance(handle_metric_report, bytes):
-            decompress_start = time.time()
+            decompress_start = time.monotonic()
             handle_metric_report = decompress_metric_report(handle_metric_report)
             self._health_metrics_tracker.record_decompress(
-                (time.time() - decompress_start) * 1000
+                (time.monotonic() - decompress_start) * 1000
             )
         # Decompression (above) always yields a HandleMetricReport.
         handle_metric_report = cast(HandleMetricReport, handle_metric_report)
@@ -453,7 +453,7 @@ class ServeController:
             handle_metric_report
         )
         self._health_metrics_tracker.record_handle_ingest(
-            (time.time() - ingest_start) * 1000
+            (time.monotonic() - ingest_start) * 1000
         )
 
     def record_autoscaling_metrics_from_async_inference_task_queue(

--- a/python/ray/serve/_private/controller_health_metrics_tracker.py
+++ b/python/ray/serve/_private/controller_health_metrics_tracker.py
@@ -22,6 +22,9 @@ class ControllerHealthMetricsTracker:
     """Tracker for collecting controller health metrics over time."""
 
     controller_start_time: float = field(default_factory=time.time)
+    # Separate monotonic anchor: controller_start_time is an absolute timestamp
+    # reported in the schema, but a rate must not be measured off the wall clock.
+    mono_start_time: float = field(default_factory=time.monotonic)
 
     # Rolling history of loop durations
     loop_durations: Deque[float] = field(
@@ -86,7 +89,7 @@ class ControllerHealthMetricsTracker:
     def record_loop_duration(self, duration: float):
         self.loop_durations.append(duration)
         # Sampled here, not on the ingest path, so the rate costs the fan-in nothing.
-        self.ingest_totals.append((time.time(), self.total_ingest_seconds))
+        self.ingest_totals.append((time.monotonic(), self.total_ingest_seconds))
 
     def record_handle_metrics_delay(self, delay_ms: float):
         self.handle_metrics_delays.append(delay_ms)
@@ -170,11 +173,14 @@ class ControllerHealthMetricsTracker:
             self.handle_reports_received + self.replica_reports_received
         )
         # Fraction of one event-loop core consumed by ingestion over the sampled
-        # window, falling back to uptime before the first loop sample lands.
-        ingest_span, ingest_seconds = uptime, self.total_ingest_seconds
+        # window, falling back to the whole run before the first loop sample lands.
+        # Monotonic end to end so an NTP step cannot distort the rate.
+        mono_now = time.monotonic()
+        ingest_span = mono_now - self.mono_start_time
+        ingest_seconds = self.total_ingest_seconds
         if self.ingest_totals:
             sampled_at, sampled_total = self.ingest_totals[0]
-            ingest_span = now - sampled_at
+            ingest_span = mono_now - sampled_at
             ingest_seconds = self.total_ingest_seconds - sampled_total
         ingest_cpu_fraction = ingest_seconds / ingest_span if ingest_span > 0 else 0.0
 

--- a/python/ray/serve/_private/controller_health_metrics_tracker.py
+++ b/python/ray/serve/_private/controller_health_metrics_tracker.py
@@ -3,13 +3,18 @@ import sys
 import time
 from collections import deque
 from dataclasses import dataclass, field
-from typing import Deque
+from typing import Deque, Tuple
 
 from ray.serve._private.constants import CONTROL_LOOP_INTERVAL_S
 from ray.serve.schema import ControllerHealthMetrics, DurationStats
 
 # Number of recent loop iterations to track for rolling averages
 _HEALTH_METRICS_HISTORY_SIZE = 100
+
+# Larger window for ingestion samples: at high fan-in there are many more
+# record_* calls than control loops, so we keep more samples to get a stable
+# picture of per-call cost.
+_INGEST_METRICS_HISTORY_SIZE = 2000
 
 
 @dataclass
@@ -45,6 +50,34 @@ class ControllerHealthMetricsTracker:
         default_factory=lambda: deque(maxlen=_HEALTH_METRICS_HISTORY_SIZE)
     )
 
+    # --- Ingestion-path instrumentation (autoscaling metrics fan-in) ---
+    # Rolling history of per-call ingestion processing time (ms): the wall time
+    # spent inside record_autoscaling_metrics_from_{handle,replica}, i.e. the
+    # decompress + deserialize + state-write work that shares the controller's
+    # single event loop with the control loop.
+    handle_ingest_durations: Deque[float] = field(
+        default_factory=lambda: deque(maxlen=_INGEST_METRICS_HISTORY_SIZE)
+    )
+    replica_ingest_durations: Deque[float] = field(
+        default_factory=lambda: deque(maxlen=_INGEST_METRICS_HISTORY_SIZE)
+    )
+    # Decompress-only time (ms), to split transport cost from state-write cost.
+    decompress_durations: Deque[float] = field(
+        default_factory=lambda: deque(maxlen=_INGEST_METRICS_HISTORY_SIZE)
+    )
+
+    # Monotonic counters since controller start.
+    handle_reports_received: int = 0
+    replica_reports_received: int = 0
+    # Cumulative wall-seconds spent on the ingestion path since start.
+    total_ingest_seconds: float = 0.0
+    # (wall clock, total_ingest_seconds) sampled once per control loop, so
+    # ingest_cpu_fraction can report a recent rate rather than a lifetime average
+    # that a long-lived controller can never move.
+    ingest_totals: Deque[Tuple[float, float]] = field(
+        default_factory=lambda: deque(maxlen=_HEALTH_METRICS_HISTORY_SIZE)
+    )
+
     # Latest values (used in collect_metrics)
     last_sleep_duration_s: float = 0.0
     num_control_loops: int = 0
@@ -52,6 +85,8 @@ class ControllerHealthMetricsTracker:
 
     def record_loop_duration(self, duration: float):
         self.loop_durations.append(duration)
+        # Sampled here, not on the ingest path, so the rate costs the fan-in nothing.
+        self.ingest_totals.append((time.time(), self.total_ingest_seconds))
 
     def record_handle_metrics_delay(self, delay_ms: float):
         self.handle_metrics_delays.append(delay_ms)
@@ -70,6 +105,19 @@ class ControllerHealthMetricsTracker:
 
     def record_node_update_duration(self, duration: float):
         self.node_update_durations.append(duration)
+
+    def record_handle_ingest(self, duration_ms: float):
+        self.handle_ingest_durations.append(duration_ms)
+        self.handle_reports_received += 1
+        self.total_ingest_seconds += duration_ms / 1000.0
+
+    def record_replica_ingest(self, duration_ms: float):
+        self.replica_ingest_durations.append(duration_ms)
+        self.replica_reports_received += 1
+        self.total_ingest_seconds += duration_ms / 1000.0
+
+    def record_decompress(self, duration_ms: float):
+        self.decompress_durations.append(duration_ms)
 
     def collect_metrics(self) -> ControllerHealthMetrics:
         """Collect and return current health metrics."""
@@ -110,6 +158,26 @@ class ControllerHealthMetricsTracker:
         )
         node_update_stats = DurationStats.from_values(list(self.node_update_durations))
 
+        # Ingestion-path statistics
+        handle_ingest_stats = DurationStats.from_values(
+            list(self.handle_ingest_durations)
+        )
+        replica_ingest_stats = DurationStats.from_values(
+            list(self.replica_ingest_durations)
+        )
+        decompress_stats = DurationStats.from_values(list(self.decompress_durations))
+        ingest_reports_received = (
+            self.handle_reports_received + self.replica_reports_received
+        )
+        # Fraction of one event-loop core consumed by ingestion over the sampled
+        # window, falling back to uptime before the first loop sample lands.
+        ingest_span, ingest_seconds = uptime, self.total_ingest_seconds
+        if self.ingest_totals:
+            sampled_at, sampled_total = self.ingest_totals[0]
+            ingest_span = now - sampled_at
+            ingest_seconds = self.total_ingest_seconds - sampled_total
+        ingest_cpu_fraction = ingest_seconds / ingest_span if ingest_span > 0 else 0.0
+
         # Get memory usage in MB
         # Note: ru_maxrss is in bytes on macOS but kilobytes on Linux
         # The resource module is Unix-only, so we handle Windows gracefully
@@ -144,5 +212,12 @@ class ControllerHealthMetricsTracker:
             node_update_duration_s=node_update_stats,
             handle_metrics_delay_ms=handle_delay_stats,
             replica_metrics_delay_ms=replica_delay_stats,
+            handle_ingest_duration_ms=handle_ingest_stats,
+            replica_ingest_duration_ms=replica_ingest_stats,
+            metrics_decompress_duration_ms=decompress_stats,
+            handle_reports_received=self.handle_reports_received,
+            replica_reports_received=self.replica_reports_received,
+            ingest_reports_received=ingest_reports_received,
+            ingest_cpu_fraction=ingest_cpu_fraction,
             process_memory_mb=process_memory_mb,
         )

--- a/python/ray/serve/schema.py
+++ b/python/ray/serve/schema.py
@@ -1753,6 +1753,47 @@ class ControllerHealthMetrics(BaseModel):
         default=0, description="Number of pending asyncio tasks."
     )
 
+    # Ingestion-path metrics (autoscaling metrics fan-in)
+    handle_ingest_duration_ms: Optional[DurationStats] = Field(
+        default=None,
+        description=(
+            "Per-call processing time inside "
+            "record_autoscaling_metrics_from_handle (rolling window, ms)."
+        ),
+    )
+    replica_ingest_duration_ms: Optional[DurationStats] = Field(
+        default=None,
+        description=(
+            "Per-call processing time inside "
+            "record_autoscaling_metrics_from_replica (rolling window, ms)."
+        ),
+    )
+    metrics_decompress_duration_ms: Optional[DurationStats] = Field(
+        default=None,
+        description=(
+            "Per-call decompress time for cloudpickle metric reports "
+            "(rolling window, ms)."
+        ),
+    )
+    handle_reports_received: int = Field(
+        default=0, description="Total handle metric reports ingested since start."
+    )
+    replica_reports_received: int = Field(
+        default=0, description="Total replica metric reports ingested since start."
+    )
+    ingest_reports_received: int = Field(
+        default=0,
+        description="Total autoscaling metric reports ingested since start.",
+    )
+    ingest_cpu_fraction: float = Field(
+        default=0.0,
+        description=(
+            "Fraction of one event-loop core consumed by the metrics ingestion "
+            "path over the recent sampling window. Approaches 1.0 as ingestion "
+            "monopolizes the single control-loop thread."
+        ),
+    )
+
     # Component update durations (rolling window stats)
     deployment_state_update_duration_s: Optional[DurationStats] = Field(
         default=None,

--- a/python/ray/serve/tests/unit/test_controller_health_metrics_tracker.py
+++ b/python/ray/serve/tests/unit/test_controller_health_metrics_tracker.py
@@ -14,15 +14,15 @@ def test_ingest_cpu_fraction_is_a_windowed_rate():
     """Cumulative-over-uptime could never show a controller that saturates late. The
     fraction is anchored on control-loop samples, so it tracks the recent window."""
     tracker = ControllerHealthMetricsTracker()
-    tracker.controller_start_time = 0.0
-    # Before any loop sample anchors a window, it falls back to cumulative over uptime.
+    tracker.mono_start_time = 0.0
+    # Before any loop sample anchors a window, it falls back to the whole run.
     tracker.record_handle_ingest(500.0)
-    with mock.patch("time.time", return_value=1000.0):
+    with mock.patch("time.monotonic", return_value=1000.0):
         assert abs(tracker.collect_metrics().ingest_cpu_fraction - 0.0005) < 1e-9
-    with mock.patch("time.time", return_value=1000.0):
+    with mock.patch("time.monotonic", return_value=1000.0):
         tracker.record_loop_duration(0.1)  # window anchor
     tracker.record_handle_ingest(500.0)  # 0.5s of ingest inside the window
-    with mock.patch("time.time", return_value=1001.0):
+    with mock.patch("time.monotonic", return_value=1001.0):
         metrics = tracker.collect_metrics()
     assert abs(metrics.ingest_cpu_fraction - 0.5) < 1e-6
     assert metrics.handle_reports_received == 2

--- a/python/ray/serve/tests/unit/test_controller_health_metrics_tracker.py
+++ b/python/ray/serve/tests/unit/test_controller_health_metrics_tracker.py
@@ -1,0 +1,32 @@
+"""Unit tests for the controller ingest health metrics."""
+
+import sys
+from unittest import mock
+
+import pytest
+
+from ray.serve._private.controller_health_metrics_tracker import (
+    ControllerHealthMetricsTracker,
+)
+
+
+def test_ingest_cpu_fraction_is_a_windowed_rate():
+    """Cumulative-over-uptime could never show a controller that saturates late. The
+    fraction is anchored on control-loop samples, so it tracks the recent window."""
+    tracker = ControllerHealthMetricsTracker()
+    tracker.controller_start_time = 0.0
+    # Before any loop sample anchors a window, it falls back to cumulative over uptime.
+    tracker.record_handle_ingest(500.0)
+    with mock.patch("time.time", return_value=1000.0):
+        assert abs(tracker.collect_metrics().ingest_cpu_fraction - 0.0005) < 1e-9
+    with mock.patch("time.time", return_value=1000.0):
+        tracker.record_loop_duration(0.1)  # window anchor
+    tracker.record_handle_ingest(500.0)  # 0.5s of ingest inside the window
+    with mock.patch("time.time", return_value=1001.0):
+        metrics = tracker.collect_metrics()
+    assert abs(metrics.ingest_cpu_fraction - 0.5) < 1e-6
+    assert metrics.handle_reports_received == 2
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-v", __file__]))


### PR DESCRIPTION
## Why are these changes needed?

The controller ingests every replica and handle metric report on its single control-loop thread. Nothing reported how long that takes, so the cost was only ever visible indirectly, as loop time it displaced.

This records per-call ingest duration for both report kinds, decompress duration on its own so transport cost is separable from the state write, report counters, and the fraction of a recent control-loop window spent ingesting. All of it is exposed on the controller health schema.

The fraction is anchored on control-loop samples rather than cumulative uptime, because a cumulative ratio can never show a controller that starts saturating late in its life.

This measures the path exactly as it runs today. No ingest behaviour changes and no report value is altered.

### Test Plan

`python/ray/serve/tests/unit/test_controller_health_metrics_tracker.py` covers the windowed rate, including its fallback to cumulative-over-uptime before any loop sample anchors a window, and the report counters.

Also ran every unit suite that touches the controller, the tracker or the schema: `test_controller` (71), `test_schema` (116), `test_config` (88), `test_application_state` (122), `test_deployment_state` (256), `test_proxy_state` (36), `test_deployment_rank_manager` (65), `test_build_app` (24), `test_task_consumer` (15), `test_cli` (9).