### PR TITLE
[Data] Add Node-aware Actor Pool Execution Logic

### DIFF
--- a/ci/lint/pyrefly-excluded-files.txt
+++ b/ci/lint/pyrefly-excluded-files.txt
@@ -250,6 +250,7 @@ python/ray/data/tests/preprocessors/test_torch.py
 python/ray/data/tests/preprocessors/test_transformer.py
 python/ray/data/tests/preprocessors/test_vectorizer.py
 python/ray/data/tests/test_actor_pool_map_operator.py
+python/ray/data/tests/test_advanced_fault_tolerance.py
 python/ray/data/tests/test_agg_e2e.py
 python/ray/data/tests/test_arrow_block.py
 python/ray/data/tests/test_arrow_serialization.py
@@ -302,6 +303,7 @@ python/ray/data/tests/test_map_operator.py
 python/ray/data/tests/test_map_transformer.py
 python/ray/data/tests/test_metadata_provider.py
 python/ray/data/tests/test_monotonically_increasing_id.py
+python/ray/data/tests/test_node_aware_actor_pool.py
 python/ray/data/tests/test_numpy_support.py
 python/ray/data/tests/test_object_gc.py
 python/ray/data/tests/test_op_runtime_metrics.py

--- a/python/ray/data/BUILD.bazel
+++ b/python/ray/data/BUILD.bazel
@@ -249,6 +249,49 @@ py_test(
 )
 
 py_test(
+    name = "test_node_aware_actor_pool",
+    size = "medium",
+    srcs = ["tests/test_node_aware_actor_pool.py"],
+    tags = [
+        "exclusive",
+        "team:data",
+    ],
+    deps = [
+        ":conftest",
+        "//:ray_lib",
+    ],
+)
+
+py_test(
+    name = "test_advanced_fault_tolerance",
+    size = "large",
+    srcs = ["tests/test_advanced_fault_tolerance.py"],
+    tags = [
+        "data_non_parallel",
+        "exclusive",
+        "team:data",
+    ],
+    deps = [
+        ":conftest",
+        "//:ray_lib",
+    ],
+)
+
+py_test(
+    name = "test_cache",
+    size = "small",
+    srcs = ["tests/test_cache.py"],
+    tags = [
+        "exclusive",
+        "team:data",
+    ],
+    deps = [
+        ":conftest",
+        "//:ray_lib",
+    ],
+)
+
+py_test(
     name = "test_arrow_serialization",
     size = "small",
     srcs = ["tests/test_arrow_serialization.py"],

--- a/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
+++ b/python/ray/data/_internal/execution/operators/actor_pool_map_operator.py
@@ -49,6 +49,7 @@ from ray.data._internal.execution.interfaces import (
     NodeIdStr,
     PhysicalOperator,
     RefBundle,
+    ReportsExtraResourceUsage,
     TaskContext,
 )
 from ray.data._internal.execution.node_trackers.actor_location import (
@@ -62,6 +63,11 @@ from ray.data._internal.execution.operators.map_operator import (
 from ray.data._internal.execution.operators.map_transformer import MapTransformer
 from ray.data._internal.execution.util import locality_string, merge_label_selector
 from ray.data._internal.remote_fn import _add_system_error_to_retry_exceptions
+from ray.data._internal.utils.cached_ray_internals import (
+    get_actor_locations,
+    get_draining_nodes,
+    get_local_ongoing_lineage_reconstruction_tasks,
+)
 from ray.data._internal.utils.heapdict import heapdict
 from ray.data.block import Block, BlockMetadata
 from ray.data.context import (
@@ -85,7 +91,7 @@ def get_map_worker_cls_name(op_name: str) -> str:
     return f"MapWorker({op_name})"
 
 
-class ActorPoolMapOperator(MapOperator):
+class ActorPoolMapOperator(MapOperator, ReportsExtraResourceUsage):
     """A MapOperator implementation that executes tasks on an actor pool.
 
     NOTE: This class is NOT thread-safe
@@ -225,7 +231,12 @@ class ActorPoolMapOperator(MapOperator):
         self, compute_strategy: ActorPoolStrategy
     ) -> "AutoscalingActorPool":
         config = self._create_actor_pool_config(compute_strategy)
-        return _ActorPool(
+        pool_cls = (
+            _NodeAwareActorPool
+            if self.data_context.enable_node_aware_actor_pool
+            else _ActorPool
+        )
+        return pool_cls(
             create_actor_fn=self._start_actor,
             config=config,
             map_worker_cls_name=self._map_worker_cls_name,
@@ -663,6 +674,43 @@ class ActorPoolMapOperator(MapOperator):
 
     def min_scheduling_resources(self) -> ExecutionResources:
         return self._actor_pool.per_actor_resource_usage()
+
+    @override
+    def extra_resource_usage(self) -> ExecutionResources:
+        """Returns resources occupied by lineage reconstruction actors.
+
+        This shouldn't include resources used by actors that haven't been reconstructed,
+        even if they're running retried tasks.
+        """
+        if not self.data_context.enable_node_aware_actor_pool:
+            return ExecutionResources.zero()
+
+        num_actors = self._num_lineage_reconstructed_actors(self._actor_pool)
+        per_actor_resources = self._actor_pool.per_actor_resource_usage()
+        return per_actor_resources.scale(num_actors)
+
+    def _num_lineage_reconstructed_actors(
+        self, actor_pool: "AutoscalingActorPool"
+    ) -> int:
+        """Actors that have been recreated to lineage reconstruct an object."""
+        assert isinstance(actor_pool, _ActorPool), actor_pool
+
+        logical_id_label_key = actor_pool.get_logical_id_label_key()
+
+        # `get_local_ongoing_lineage_reconstruction_tasks` returns every task this
+        # driver is reconstructing, so filter to this operator's actor tasks. Normal
+        # tasks carry no logical actor ID.
+        reconstructing_actors = set()
+        for task_info, _ in get_local_ongoing_lineage_reconstruction_tasks():
+            if task_info.labels.get(self._OPERATOR_ID_LABEL_KEY) != self.id:
+                continue
+            logical_actor_id = task_info.labels.get(logical_id_label_key)
+            if logical_actor_id is not None:
+                reconstructing_actors.add(logical_actor_id)
+
+        # Actors still in the pool are already counted by normal accounting, so only
+        # the released ones are extra.
+        return len(reconstructing_actors - set(actor_pool._get_logical_ids()))
 
     def refresh_state(self):
         """Updates internal state"""
@@ -1366,3 +1414,51 @@ class _ActorPool(AutoscalingActorPool):
 
     def pending_logical_usage(self) -> ExecutionResources:
         return self._pending_or_restarting_usage
+
+
+class _NodeAwareActorPool(_ActorPool):
+    """An actor pool that avoids launching tasks to Actors on draining nodes. We assume
+    actors on draining nodes are unlikely to finish their tasks before the drain
+    deadline. By prioritizing ALIVE (non-restarting) actors on ACTIVE (non-draining)
+    nodes, we prevent task retries. Furthermore, unlike the parent implementation, this
+    actor pool updates actor locations upon restart.
+    """
+
+    @override
+    def refresh_actor_state(self):
+        # Snapshots state that _update_running_actor_state() depends on.
+        # Must be called before _update_running_actor_state() (see refresh_actor_state).
+        self._actor_node_id_map_snapshot: Dict[
+            LogicalActorId, NodeIdStr
+        ] = get_actor_locations(tuple(self._get_logical_ids()))
+        self._draining_nodes_snapshot: Dict[NodeIdStr, int] = get_draining_nodes()
+
+        super().refresh_actor_state()
+
+    @override
+    def _update_rank(self, actor: ActorHandle, state: _ActorState, died: bool):
+        # 1) Update node_id location.
+        # The ActorLocationTracker may return stale information when
+        #   - Actor is recently created
+        #   - get_actor_locations() returns *cached* information
+        # NOTE:
+        #   - We fallback to previous location if information is stale
+        #   - Actor locations are not updated in the base implementation
+        logical_id = self._get_actor_logical_id(actor)
+        node_id = (
+            self._actor_node_id_map_snapshot.get(logical_id) or state.actor_location
+        )
+        state.actor_location = node_id
+
+        restarting_actor = state.is_restarting
+        draining_node = node_id in self._draining_nodes_snapshot
+
+        # 2) Build node_id -> [ActorHandle] for only ALIVE actors and ACTIVE nodes
+        if not (restarting_actor or draining_node or died):
+            rank = _ActorRank(state.num_tasks_in_flight)
+            self._alive_node_to_actor_heap[node_id][actor] = rank
+            if actor not in self._alive_actors_to_in_flight_tasks_heap:
+                assert state.num_tasks_in_flight <= self.max_tasks_in_flight_per_actor()
+                self._alive_actors_to_in_flight_tasks_heap[actor] = rank
+        elif actor in self._alive_actors_to_in_flight_tasks_heap:
+            del self._alive_actors_to_in_flight_tasks_heap[actor]

--- a/python/ray/data/_internal/execution/resource_manager.py
+++ b/python/ray/data/_internal/execution/resource_manager.py
@@ -221,7 +221,7 @@ class ResourceManager:
             )
 
             if isinstance(op, ReportsExtraResourceUsage):
-                op_usage.add(op.extra_resource_usage())
+                op_usage = op_usage.add(op.extra_resource_usage())
 
             self._op_usages[op] = op_usage
             self._op_running_usages[op] = op_running_usage

--- a/python/ray/data/_internal/utils/cache.py
+++ b/python/ray/data/_internal/utils/cache.py
@@ -1,0 +1,77 @@
+import functools
+import time
+from contextlib import contextmanager
+from typing import Any, Callable, Dict, Tuple, TypeVar
+
+from typing_extensions import ParamSpec
+
+P = ParamSpec("P")
+R = TypeVar("R")
+
+_IS_TIMED_CACHE_ENABLED = True
+
+
+def enable_timed_cache():
+    global _IS_TIMED_CACHE_ENABLED
+    _IS_TIMED_CACHE_ENABLED = True
+
+
+def disable_timed_cache():
+    global _IS_TIMED_CACHE_ENABLED
+    _IS_TIMED_CACHE_ENABLED = False
+
+
+@contextmanager
+def _disable_timed_cache_for_tests():
+    """Bypass all TTL caches, for tests that assert on up-to-date values."""
+    disable_timed_cache()
+    try:
+        yield
+    finally:
+        enable_timed_cache()
+
+
+def timed_cache(
+    ttl: float, get_time_fn: Callable[[], float] = time.time
+) -> Callable[[Callable[P, R]], Callable[P, R]]:
+    """Decorator that caches function results for a given TTL (in seconds).
+
+    Args:
+        ttl: Time-to-live in seconds for each cache entry.
+        get_time_fn: Callable returning the current time in seconds, used to
+            measure cache entry age. Defaults to ``time.time``.
+
+    Returns:
+        A decorator that wraps a function with TTL-based result caching.
+    """
+
+    def decorator(fn: Callable[P, R]) -> Callable[P, R]:
+        cache: Dict[Tuple, Tuple[float, Any]] = {}
+
+        @functools.wraps(fn)
+        def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
+            if not _IS_TIMED_CACHE_ENABLED:
+                return fn(*args, **kwargs)
+
+            key = args + tuple(sorted(kwargs.items()))
+            try:
+                hash(key)
+            except TypeError as e:
+                raise ValueError(
+                    f"`timed_cache` only supports arguments that are hashable, "
+                    f"but '{key}' isn't hashable"
+                ) from e
+
+            now = get_time_fn()
+            if key in cache:
+                cached_time, value = cache[key]
+                if now - cached_time < ttl:
+                    return value
+
+            result = fn(*args, **kwargs)
+            cache[key] = (now, result)
+            return result
+
+        return wrapper
+
+    return decorator

--- a/python/ray/data/_internal/utils/cached_ray_internals.py
+++ b/python/ray/data/_internal/utils/cached_ray_internals.py
@@ -1,0 +1,35 @@
+from typing import Dict, Tuple
+
+import ray
+import ray._private.internal_api
+import ray._private.state
+from ray.data._internal.execution.node_trackers.actor_location import (
+    get_or_create_actor_location_tracker,
+)
+from ray.data._internal.utils.cache import timed_cache
+
+
+@timed_cache(ttl=60)
+def get_local_ongoing_lineage_reconstruction_tasks():
+    # ResourceManager.update_usages() calls extra_resource_usage() on map
+    # operators. Unit tests exercise that path without ray.init(); lineage
+    # reconstruction can only exist with a live worker, so treat offline as empty.
+    if not ray.is_initialized():
+        return []
+    return ray._private.internal_api.get_local_ongoing_lineage_reconstruction_tasks()
+
+
+@timed_cache(ttl=1)
+def get_draining_nodes() -> Dict[str, int]:
+    return ray._private.state.state.get_draining_nodes()
+
+
+@timed_cache(ttl=1)
+def get_actor_locations(logical_actor_ids: Tuple[str, ...]) -> Dict[str, str]:
+    """Get the actor locations from logical actor ids.
+    NOTE: This function is not thread-safe"""
+    return ray.get(
+        get_or_create_actor_location_tracker().get_actor_locations.remote(
+            logical_actor_ids
+        )
+    )

--- a/python/ray/data/context.py
+++ b/python/ray/data/context.py
@@ -390,6 +390,11 @@ DEFAULT_ACTOR_POOL_MAX_UPSCALING_DELTA: Optional[int] = env_integer(
     1,
 )
 
+DEFAULT_ENABLE_NODE_AWARE_ACTOR_POOL: bool = env_bool(
+    "RAY_DATA_ENABLE_NODE_AWARE_ACTOR_POOL",
+    False,
+)
+
 
 # Disable dynamic output queue size backpressure by default.
 DEFAULT_ENABLE_DYNAMIC_OUTPUT_QUEUE_SIZE_BACKPRESSURE: bool = env_bool(
@@ -747,6 +752,10 @@ class DataContext:
             tasks in the queue allows us to overlap pulling of the blocks (which are
             tasks arguments) with the execution of the prior tasks maximizing
             individual Actor's utilization
+        enable_node_aware_actor_pool: If ``True``, actor pools stop dispatching
+            tasks to actors on draining nodes, refresh actor locations after a
+            restart, and report actors held by lineage reconstruction as extra
+            resource usage. Defaults to ``False``.
         retried_io_errors: A list of patterns to match against error messages that should
             trigger a retry when reading or writing files. Each pattern is first checked
             as a substring, then as a regex. This is useful for handling
@@ -1010,6 +1019,7 @@ class DataContext:
     wait_for_min_actors_s: int = DEFAULT_WAIT_FOR_MIN_ACTORS_S
     # This setting serves as a global override
     max_tasks_in_flight_per_actor: Optional[int] = None
+    enable_node_aware_actor_pool: bool = DEFAULT_ENABLE_NODE_AWARE_ACTOR_POOL
     retried_io_errors: List[str] = field(
         default_factory=lambda: list(DEFAULT_RETRIED_IO_ERRORS)
     )

--- a/python/ray/data/tests/conftest.py
+++ b/python/ray/data/tests/conftest.py
@@ -19,6 +19,7 @@ from ray.data._internal.execution.operators.base_physical_operator import (
 )
 from ray.data._internal.tensor_extensions.arrow import ArrowTensorArray
 from ray.data._internal.utils.arrow_utils import get_pyarrow_version
+from ray.data._internal.utils.cache import _disable_timed_cache_for_tests
 from ray.data.block import BlockExecStats, BlockMetadata
 from ray.data.constants import TENSOR_COLUMN_NAME
 from ray.data.context import DEFAULT_TARGET_MAX_BLOCK_SIZE, DataContext, ShuffleStrategy
@@ -844,3 +845,9 @@ def assert_blocks_expected_in_plasma(
 @pytest.fixture(autouse=True, scope="function")
 def log_internal_stack_trace(restore_data_context):
     ray.data.context.DataContext.get_current().log_internal_stack_trace = True
+
+
+@pytest.fixture
+def disable_timed_cache_fixture():
+    with _disable_timed_cache_for_tests():
+        yield

--- a/python/ray/data/tests/test_advanced_fault_tolerance.py
+++ b/python/ray/data/tests/test_advanced_fault_tolerance.py
@@ -1,0 +1,304 @@
+import asyncio
+import threading
+import time
+
+import pyarrow as pa
+import pytest
+
+import ray
+from ray._common.test_utils import wait_for_condition
+from ray._raylet import GcsClient
+from ray.core.generated import autoscaler_pb2
+from ray.data._internal.compute import ActorPoolStrategy
+from ray.data._internal.execution.interfaces import (
+    BlockEntry,
+    ExecutionResources,
+    RefBundle,
+)
+from ray.data._internal.execution.operators.input_data_buffer import InputDataBuffer
+from ray.data._internal.execution.operators.map_operator import MapOperator
+from ray.data._internal.execution.operators.map_transformer import (
+    BlockMapTransformFn,
+    MapTransformer,
+)
+from ray.data._internal.execution.streaming_executor import StreamingExecutor
+from ray.data.block import BlockAccessor
+from ray.data.context import DataContext
+from ray.data.tests.conftest import *  # noqa: F403
+from ray.tests.conftest import *  # noqa: F403
+
+
+def test_removed_nodes_not_added_back(ray_start_cluster, restore_data_context):
+    """Test that a dataset with actor pools can finish, when some
+    nodes in the cluster are removed and not added back."""
+    DataContext.get_current().enable_node_aware_actor_pool = True
+
+    cluster = ray_start_cluster
+    cluster.add_node(num_cpus=0)
+    ray.init()
+
+    @ray.remote(num_cpus=0)
+    class Signal:
+        def __init__(self):
+            self._num_alive_actors = 0
+            self._nodes_removed = False
+
+        async def notify_actor_alive(self):
+            self._num_alive_actors += 1
+
+        async def wait_for_actors_alive(self, value):
+            while self._num_alive_actors != value:
+                await asyncio.sleep(0.01)
+
+        async def notify_nodes_removed(self):
+            self._nodes_removed = True
+
+        async def wait_for_nodes_removed(self):
+            while not self._nodes_removed:
+                await asyncio.sleep(0.01)
+
+    # Create the signal actor on the head node.
+    signal_actor = Signal.remote()
+
+    num_nodes = 4
+    nodes = []
+    for _ in range(num_nodes):
+        nodes.append(cluster.add_node(num_cpus=10, num_gpus=1))
+    cluster.wait_for_nodes()
+
+    num_items = 100
+
+    class MyUDF:
+        def __init__(self, signal_actor):
+            self._signal_actor = signal_actor
+            self._signal_sent = False
+
+        def __call__(self, batch):
+            if not self._signal_sent:
+                self._signal_actor.notify_actor_alive.remote()
+                # Wait for the driver to remove nodes. This makes sure all
+                # actors are running tasks when removing nodes.
+                ray.get(self._signal_actor.wait_for_nodes_removed.remote())
+                self._signal_sent = True
+            time.sleep(0.01)
+            return batch
+
+    res = []
+
+    def run_dataset():
+        nonlocal res
+
+        ds = ray.data.range(num_items, override_num_blocks=num_items)
+        ds = ds.map_batches(
+            MyUDF,
+            fn_constructor_args=[signal_actor],
+            concurrency=num_nodes,
+            batch_size=1,
+            num_gpus=1,
+        )
+        res = ds.take_all()
+
+    thread = threading.Thread(target=run_dataset)
+    thread.start()
+
+    # Wait for all actors to start, then remove some nodes.
+    ray.get(signal_actor.wait_for_actors_alive.remote(num_nodes))
+    print("Removing nodes")
+    nodes_to_remove = nodes[-num_nodes // 2 :]
+    for node in nodes_to_remove:
+        cluster.remove_node(node)
+    ray.get(signal_actor.notify_nodes_removed.remote())
+
+    thread.join()
+    assert sorted(res, key=lambda x: x["id"]) == [{"id": i} for i in range(num_items)]
+
+
+def test_map_operator_counts_lineage_reconstruction_tasks(
+    ray_start_cluster_enabled, disable_timed_cache_fixture, restore_data_context
+):
+    # the `disable_timed_cache_fixture` is neccessary because this test relies on
+    # the most up-to-date values from `get_local_ongoing_lineage_reconstruction_tasks`
+    data_context = DataContext.get_current()
+    data_context.enable_node_aware_actor_pool = True
+
+    # Create a cluster with a head node and a single worker node.
+    cluster = ray_start_cluster_enabled
+    cluster.add_node(resources={"head": 1})
+    ray.init(address=cluster.address)
+    worker = cluster.add_node(resources={"worker": 1})
+
+    # Create an input data operator with a single block as input.
+    block = pa.Table.from_pylist([{"data": "\x00" * 128 * 1024 * 1024}])
+    block_ref = ray.put(block)
+    metadata = BlockAccessor.for_block(block).get_metadata()
+    schema = BlockAccessor.for_block(block).schema()
+    bundle = RefBundle(
+        [BlockEntry(ref=block_ref, metadata=metadata)],
+        owns_blocks=False,
+        schema=schema,
+    )
+    input_op = InputDataBuffer(data_context, [bundle])
+
+    # Create a signal actor so the map only finishes when we want it to.
+    @ray.remote(num_cpus=0, resources={"head": 1})
+    class Signal:
+        def __init__(self, is_map_blocked: bool):
+            self._is_map_blocked = is_map_blocked
+
+        def block_map(self):
+            print("Blocking map function")
+            self._is_map_blocked = True
+
+        def unblock_map(self):
+            print("Unblocking map function")
+            self._is_map_blocked = False
+
+        def is_map_blocked(self) -> bool:
+            return self._is_map_blocked
+
+    # Start with the transform function unblocked.
+    signal = Signal.remote(False)
+
+    def block_fn(block, _):
+        print("Entering block function")
+
+        while ray.get(signal.is_map_blocked.remote()):
+            print("Waiting for map to be unblocked")
+            time.sleep(0.1)
+
+        print("Exiting block function")
+        return block
+
+    transform_fns = [BlockMapTransformFn(block_fn)]
+    map_transformer = MapTransformer(transform_fns)
+    map_op = MapOperator.create(
+        map_transformer,
+        input_op,
+        data_context,
+        compute_strategy=ActorPoolStrategy(size=1),
+        ray_remote_args={"resources": {"worker": 1, "num_cpus": 0}},
+    )
+
+    output_bundles = []
+    executor = StreamingExecutor(data_context)
+    for bundle in executor.execute(map_op):
+        output_bundles.append(bundle)
+
+    assert map_op.extra_resource_usage() == ExecutionResources.zero()
+
+    # Remove the node to trigger lineage reconstruction.
+    ray.get(signal.block_map.remote())
+    cluster.remove_node(worker)
+    wait_for_condition(lambda: map_op.extra_resource_usage().cpu == 1, timeout=10)
+
+    # Re-add the node and unblock the map function.
+    ray.get(signal.unblock_map.remote())
+    cluster.add_node(resources={"worker": 1})
+    wait_for_condition(
+        lambda: map_op.extra_resource_usage() == ExecutionResources.zero(), timeout=10
+    )
+
+
+def test_map_operator_does_not_launch_actor_tasks_on_draining_nodes(
+    ray_start_cluster_enabled, disable_timed_cache_fixture, restore_data_context
+):
+    DataContext.get_current().enable_node_aware_actor_pool = True
+
+    # Create a cluster with a head node and two worker nodes.
+    cluster = ray_start_cluster_enabled
+    cluster.add_node(resources={"head": 1})
+    cluster.wait_for_nodes()
+    ray.init(address=cluster.address)
+
+    @ray.remote(num_cpus=0)
+    class DrainNodeSignal:
+        def __init__(self, waiting_for_num_actors: int):
+            self.actor_init_event = asyncio.Event()
+            self.node_drained_event = asyncio.Event()
+            self.lock = asyncio.Lock()
+            self.waiting_for_num_actors = waiting_for_num_actors
+
+        async def send_actor_started(self):
+            async with self.lock:
+                self.waiting_for_num_actors -= 1
+                if self.waiting_for_num_actors == 0:
+                    self.actor_init_event.set()
+
+        def send_node_drained(self):
+            self.node_drained_event.set()
+
+        async def wait_for_actors_to_start(self):
+            await self.actor_init_event.wait()
+
+        async def wait_for_node_drained(self):
+            await self.node_drained_event.wait()
+
+    # Make sure signal actor created on the head node
+    signal_actor = DrainNodeSignal.remote(2)
+
+    # now add worker nodes
+    worker1 = cluster.add_node(resources={"worker": 1}, num_cpus=1)
+    cluster.add_node(resources={"worker": 1}, num_cpus=1)
+    cluster.wait_for_nodes()
+
+    drained_node_id = worker1.node_id
+
+    class AssertingUDF:
+        def __init__(self, signal_actor):
+            self._node_id = ray.get_runtime_context().get_node_id()
+            self._signal_actor = signal_actor
+            ray.get(self._signal_actor.send_actor_started.remote())
+            ray.get(self._signal_actor.wait_for_node_drained.remote())
+
+        def __call__(self, batch):
+            # Check that this task isn't running on the draining node.
+            assert self._node_id != drained_node_id
+
+            return batch
+
+    exception = None
+
+    def run_dataset():
+        try:
+            ray.data.range(50, override_num_blocks=50).map_batches(
+                AssertingUDF,
+                fn_constructor_args=[signal_actor],
+                concurrency=2,
+                num_cpus=0,
+                resources={"worker": 1},
+            ).take_all()
+        except Exception as e:
+            nonlocal exception
+            exception = e
+
+    # Execute the Dataset in a separate thread
+    thread = threading.Thread(target=run_dataset)
+    thread.start()
+
+    # Wait for actors to start.
+    ray.get(signal_actor.wait_for_actors_to_start.remote())
+
+    # Drain the first worker.
+    print("Draining node", drained_node_id)
+    gcs_client = GcsClient(address=ray.get_runtime_context().gcs_address)
+    deadline_timestamp_ms = (time.time_ns() // 1e6) + (999999 * 1e3)
+    is_accepted, _ = gcs_client.drain_node(
+        drained_node_id,
+        autoscaler_pb2.DrainNodeReason.Value("DRAIN_NODE_REASON_PREEMPTION"),
+        "",
+        deadline_timestamp_ms,
+    )
+    assert is_accepted
+
+    ray.get(signal_actor.send_node_drained.remote())
+
+    # Wait for the dataset to finish.
+    thread.join()
+
+    assert exception is None, exception
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main(["-v", __file__]))

--- a/python/ray/data/tests/test_cache.py
+++ b/python/ray/data/tests/test_cache.py
@@ -1,0 +1,153 @@
+import pytest
+
+from ray.data._internal.utils.cache import (
+    _disable_timed_cache_for_tests,
+    timed_cache,
+)
+
+
+def test_cache_miss():
+    TEST_VALUE = 1
+
+    @timed_cache(ttl=10000)
+    def get_value():
+        return TEST_VALUE
+
+    # cache miss, should return TEST_VALUE
+    v = get_value()
+    assert v == TEST_VALUE, v
+
+
+def test_cache_hit():
+    TEST_VALUE = 1
+
+    time = 0
+
+    @timed_cache(ttl=10000, get_time_fn=lambda: time)
+    def get_value():
+        return TEST_VALUE
+
+    # cache miss, should return TEST_VALUE
+    v = get_value()
+    assert v == TEST_VALUE, v
+
+    # ttl not expired, should return prev_value
+    time += 9999
+    prev_value = TEST_VALUE
+    TEST_VALUE += 1
+    v = get_value()
+    assert v == prev_value, (v, prev_value)
+
+
+def test_cache_ttl_expire():
+    TEST_VALUE = 1
+
+    time = 0
+
+    @timed_cache(ttl=10000, get_time_fn=lambda: time)
+    def get_value():
+        return TEST_VALUE
+
+    # cache miss, should return TEST_VALUE
+    v = get_value()
+    assert v == TEST_VALUE, v
+
+    # ttl expired, should return new TEST_VALUE
+    time += 10001
+    TEST_VALUE += 1
+    v = get_value()
+    assert v == TEST_VALUE, (v, TEST_VALUE)
+
+
+def test_cache_keys():
+    time = 0
+
+    @timed_cache(ttl=10000, get_time_fn=lambda: time)
+    def get_value(x):
+        return x
+
+    # cache miss
+    v = get_value(0)
+    assert v == 0, v
+
+    # cache miss
+    v = get_value(1)
+    assert v == 1, v
+
+
+def test_cache_keys_expire():
+    TEST_VALUE = 100
+
+    time = 0
+
+    @timed_cache(ttl=10000, get_time_fn=lambda: time)
+    def get_value(x):
+        return x + TEST_VALUE
+
+    # cache miss
+    v = get_value(0)
+    assert v == 100, v
+
+    time += 9999
+
+    # cache miss
+    v = get_value(1)
+    assert v == 101, v
+
+    time += 2
+
+    # At this point, v=0 should expire, but not v=1
+    prev_value = TEST_VALUE
+    TEST_VALUE = 0
+    v = get_value(0)
+    assert v == 0 + TEST_VALUE, v
+
+    v = get_value(1)
+    assert v == 1 + prev_value, v
+
+
+def test_cache_unhashable_args():
+    @timed_cache(ttl=10000)
+    def get_value(x):
+        return x
+
+    with pytest.raises(ValueError, match="hashable"):
+        get_value(["not", "hashable"])
+
+
+def test_disable_timed_cache_for_tests():
+    num_calls = 0
+
+    @timed_cache(ttl=10000)
+    def get_value():
+        nonlocal num_calls
+        num_calls += 1
+        return num_calls
+
+    with _disable_timed_cache_for_tests():
+        assert get_value() == 1
+        assert get_value() == 2
+
+    # Caching resumes once the context manager exits.
+    assert get_value() == 3
+    assert get_value() == 3
+
+
+def test_disable_timed_cache_restored_on_error():
+    @timed_cache(ttl=10000)
+    def get_value():
+        return 1
+
+    with pytest.raises(RuntimeError):
+        with _disable_timed_cache_for_tests():
+            raise RuntimeError("boom")
+
+    from ray.data._internal.utils import cache
+
+    assert cache._IS_TIMED_CACHE_ENABLED
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main(["-v", __file__]))

--- a/python/ray/data/tests/test_node_aware_actor_pool.py
+++ b/python/ray/data/tests/test_node_aware_actor_pool.py
@@ -1,0 +1,362 @@
+from unittest.mock import patch
+
+import pytest
+
+# Imported under a name that doesn't start with "Test" so pytest doesn't collect the
+# base suite twice.
+import ray.data.tests.test_actor_pool_map_operator as oss_test_module
+from ray.core.generated import gcs_pb2
+from ray.data._internal.actor_autoscaler.autoscaling_actor_pool import (
+    AutoscalingActorConfig,
+)
+from ray.data._internal.execution.interfaces import ExecutionResources
+from ray.data._internal.execution.interfaces.ref_bundle import RefBundle
+from ray.data._internal.execution.operators.actor_pool_map_operator import (
+    _NodeAwareActorPool,
+)
+from ray.data.tests.conftest import *  # noqa: F403
+
+_MODULE = "ray.data._internal.execution.operators.actor_pool_map_operator"
+
+_make_bundle_queue = oss_test_module._make_bundle_queue
+_schedule_bundles = oss_test_module._schedule_bundles
+
+
+class TestNodeAwareActorPool(oss_test_module.TestActorPool):
+    """Re-runs the whole ``_ActorPool`` suite against ``_NodeAwareActorPool``, plus
+    the draining-node cases that only the node-aware pool implements."""
+
+    def _create_actor_pool(
+        self,
+        min_size=1,
+        max_size=4,
+        initial_size=1,
+        max_tasks_in_flight=4,
+        map_worker_cls_name="MapWorker",
+    ):
+        config = AutoscalingActorConfig(
+            min_size=min_size,
+            max_size=max_size,
+            initial_size=initial_size,
+            max_tasks_in_flight_per_actor=max_tasks_in_flight,
+            max_actor_concurrency=1,
+            per_actor_resource_usage=ExecutionResources(cpu=1),
+        )
+        return _NodeAwareActorPool(
+            create_actor_fn=self._create_actor_fn,
+            map_worker_cls_name=map_worker_cls_name,
+            config=config,
+        )
+
+    @patch(f"{_MODULE}.get_draining_nodes")
+    @patch(f"{_MODULE}.get_actor_locations")
+    def test_selector_excludes_actors_on_draining_nodes(
+        self, mock_get_actor_locations, mock_get_draining_nodes
+    ):
+        """Test that actors on draining nodes are excluded from scheduling.
+
+        Verifies that:
+            - can_schedule_task() returns False when all actors are on draining nodes
+            - can_schedule_task() returns True when at least one actor is on non-draining node
+            - select_actors() does not return an actor on a draining node
+        """
+        pool = self._create_actor_pool(max_tasks_in_flight=1)
+
+        actor1 = self._add_ready_actor(pool, node_id="node1")
+        actor2 = self._add_ready_actor(pool, node_id="node2")
+
+        assert pool.num_running_actors() == 2
+
+        mock_get_actor_locations.return_value = {
+            pool._get_actor_logical_id(actor1): "node1",
+            pool._get_actor_logical_id(actor2): "node2",
+        }
+
+        # Case 1: No draining nodes, both actors should be schedulable
+        mock_get_draining_nodes.return_value = set()
+        pool.refresh_actor_state()
+        assert pool.can_schedule_task()
+
+        results = _schedule_bundles(pool, _make_bundle_queue(2))
+        assert len(results) == 2
+        assert {actor1, actor2} == set(results)
+
+        # Return the actors so we can schedule again
+        for actor in results:
+            pool.on_task_completed(actor)
+
+        # Case 2: node1 is draining, only actor2 should be schedulable
+        mock_get_draining_nodes.return_value = {"node1"}
+        pool.refresh_actor_state()
+        assert pool.can_schedule_task()
+
+        results = _schedule_bundles(pool, _make_bundle_queue(1))
+        assert results == [actor2]
+
+        pool.on_task_completed(actor2)
+
+        # Case 3: Both nodes draining - no actors should be schedulable
+        mock_get_draining_nodes.return_value = {"node1", "node2"}
+        pool.refresh_actor_state()
+        assert not pool.can_schedule_task()
+
+        bundle = _make_bundle_queue(1).get_next()
+        assert pool.select_actors(bundle=bundle, actor_locality_enabled=False) is None
+
+        # Case 4: node1 stops draining (actor1 becomes schedulable again)
+        mock_get_draining_nodes.return_value = {"node2"}
+        pool.refresh_actor_state()
+        assert pool.can_schedule_task()
+
+        results = _schedule_bundles(pool, _make_bundle_queue(1))
+        assert results == [actor1]
+
+    @patch(f"{_MODULE}.get_draining_nodes")
+    @patch(f"{_MODULE}.get_actor_locations")
+    def test_three_actors_one_node_draining(
+        self, mock_get_actor_locations, mock_get_draining_nodes
+    ):
+        """With three actors on three nodes, draining one node leaves two schedulable."""
+        pool = self._create_actor_pool(max_tasks_in_flight=2)
+
+        actor1 = self._add_ready_actor(pool, node_id="node1")
+        actor2 = self._add_ready_actor(pool, node_id="node2")
+        actor3 = self._add_ready_actor(pool, node_id="node3")
+        assert pool.num_running_actors() == 3
+
+        mock_get_actor_locations.return_value = {
+            pool._get_actor_logical_id(actor1): "node1",
+            pool._get_actor_logical_id(actor2): "node2",
+            pool._get_actor_logical_id(actor3): "node3",
+        }
+        mock_get_draining_nodes.return_value = {"node2"}
+        pool.refresh_actor_state()
+
+        assert pool.can_schedule_task()
+        # Schedule 4 tasks (2 per actor max); only actor1 and actor3 should be used
+        results = _schedule_bundles(pool, _make_bundle_queue(4))
+        assert len(results) == 4
+        assert actor2 not in results
+        assert all(actor in (actor1, actor3) for actor in results)
+
+    @patch(f"{_MODULE}.get_draining_nodes", return_value={})
+    @patch(f"{_MODULE}.get_actor_locations", return_value={})
+    def test_unknown_actor_location_falls_back(
+        self, mock_get_actor_locations, mock_get_draining_nodes
+    ):
+        """An actor the location tracker hasn't recorded keeps its known location.
+
+        ``ActorLocationTracker.update_actor_location`` is fire-and-forget, so a
+        just-created actor can be missing from the snapshot. Losing its location
+        would make it invisible to locality-based selection.
+        """
+        pool = self._create_actor_pool(max_tasks_in_flight=2)
+        actor = self._add_ready_actor(pool, node_id="node1")
+
+        pool.refresh_actor_state()
+
+        assert pool.get_actor_location(actor) == "node1"
+        assert "node1" in pool._alive_node_to_actor_heap
+        assert actor in pool._alive_node_to_actor_heap["node1"]
+
+    def test_select_actors_spreads_without_locality(self):
+        """With locality disabled, select_actors spreads tasks across actors."""
+        pool = self._create_actor_pool(max_tasks_in_flight=2)
+        self._add_ready_actor(pool, node_id="node1")
+        self._add_ready_actor(pool, node_id="node2")
+        self._add_ready_actor(pool, node_id="node3")
+        assert pool.num_running_actors() == 3
+
+        results = _schedule_bundles(
+            pool, _make_bundle_queue(6), actor_locality_enabled=False
+        )
+
+        assert len(results) == 6
+
+        first_half = results[:3]
+        last_half = results[3:]
+
+        # The pool should evenly spread the load between actors, so
+        # each half should have unique actors
+        assert len(set(first_half)) == 3
+        assert len(set(last_half)) == 3
+
+    def test_can_schedule_task_false_when_all_slots_busy(self):
+        """can_schedule_task returns False when every actor is at max_tasks_in_flight."""
+        pool = self._create_actor_pool(max_tasks_in_flight=1)
+        actor1 = self._add_ready_actor(pool)
+        self._add_ready_actor(pool)
+
+        assert pool.can_schedule_task()
+        results = _schedule_bundles(pool, _make_bundle_queue(2))
+        assert len(results) == 2
+        assert not pool.can_schedule_task()
+        pool.on_task_completed(actor1)
+        assert pool.can_schedule_task()
+
+    @patch(f"{_MODULE}.get_draining_nodes", return_value=set())
+    @patch(f"{_MODULE}.get_actor_locations")
+    def test_restarting_actor_excluded_from_scheduling(
+        self, mock_get_actor_locations, mock_get_draining_nodes
+    ):
+        """Test that restarting actors are excluded from scheduling.
+
+        When one actor is RESTARTING (mocked via _get_local_state), can_schedule_task
+        and select_actors should use only the alive actor.
+        """
+        pool = self._create_actor_pool(max_tasks_in_flight=1)
+        actor1 = self._add_ready_actor(pool, node_id="node1")
+        actor2 = self._add_ready_actor(pool, node_id="node2")
+        assert pool.num_running_actors() == 2
+
+        mock_get_actor_locations.return_value = {
+            pool._get_actor_logical_id(actor1): "node1",
+            pool._get_actor_logical_id(actor2): "node2",
+        }
+        pool.refresh_actor_state()
+        assert pool.can_schedule_task()
+
+        with patch.object(
+            actor1,
+            "_get_local_state",
+            return_value=gcs_pb2.ActorTableData.ActorState.RESTARTING,
+        ):
+            pool.refresh_actor_state()
+
+        assert pool.num_restarting_actors() == 1
+        assert pool.num_alive_actors() == 1
+        assert pool.num_running_actors() == 2
+        # Should still be schedulable (actor2 is alive)
+        assert pool.can_schedule_task()
+
+        # select_actors should return actor2, not actor1
+        bundle = _make_bundle_queue(1).get_next()
+        actor = pool.select_actors(bundle=bundle, actor_locality_enabled=False)
+        assert actor == actor2
+        pool.on_task_submitted(actor)
+        # No more schedulable actors
+        assert not pool.can_schedule_task()
+        assert pool.num_idle_actors() == 1
+        assert pool.num_running_actors() == 2
+        assert pool.num_restarting_actors() == 1
+
+        with patch.object(
+            actor1,
+            "_get_local_state",
+            return_value=gcs_pb2.ActorTableData.ActorState.ALIVE,
+        ):
+            pool.refresh_actor_state()
+        assert pool.num_restarting_actors() == 0
+        assert pool.num_alive_actors() == 2
+        assert pool.num_running_actors() == 2
+        assert pool.can_schedule_task()
+        assert pool.num_idle_actors() == 1
+
+        pool.on_task_completed(actor2)
+        assert pool.num_idle_actors() == 2
+
+    @patch(f"{_MODULE}.get_draining_nodes", return_value=set())
+    @patch(f"{_MODULE}.get_actor_locations")
+    def test_all_actors_restarting_not_schedulable(
+        self, mock_get_actor_locations, mock_get_draining_nodes
+    ):
+        """When all actors are RESTARTING, can_schedule_task returns False."""
+        pool = self._create_actor_pool(max_tasks_in_flight=1)
+        actor = self._add_ready_actor(pool, node_id="node1")
+        assert pool.num_running_actors() == 1
+
+        mock_get_actor_locations.return_value = {
+            pool._get_actor_logical_id(actor): "node1",
+        }
+        pool.refresh_actor_state()
+        assert pool.can_schedule_task()
+
+        with patch.object(
+            actor,
+            "_get_local_state",
+            return_value=gcs_pb2.ActorTableData.ActorState.RESTARTING,
+        ):
+            pool.refresh_actor_state()
+
+        assert pool.num_restarting_actors() == 1
+        assert pool.num_alive_actors() == 0
+        assert not pool.can_schedule_task()
+
+        bundle = _make_bundle_queue(1).get_next()
+        assert pool.select_actors(bundle=bundle, actor_locality_enabled=False) is None
+
+    @patch(f"{_MODULE}.get_draining_nodes")
+    @patch(f"{_MODULE}.get_actor_locations")
+    def test_select_actor_none_probes_schedulability(
+        self, mock_get_actor_locations, mock_get_draining_nodes
+    ):
+        """select_actors(bundle=None) agrees with can_schedule_task."""
+        pool = self._create_actor_pool(max_tasks_in_flight=1)
+
+        # Empty pool
+        assert pool.select_actors() is None
+        assert not pool.can_schedule_task()
+
+        actor = self._add_ready_actor(pool, node_id="node1")
+        mock_get_actor_locations.return_value = {
+            pool._get_actor_logical_id(actor): "node1",
+        }
+        mock_get_draining_nodes.return_value = set()
+        pool.refresh_actor_state()
+
+        assert pool.select_actors() is not None
+        assert pool.can_schedule_task()
+
+        # Exhaust capacity
+        pool.on_task_submitted(actor)
+        assert pool.select_actors() is None
+        assert not pool.can_schedule_task()
+
+        # Free a slot
+        pool.on_task_completed(actor)
+        assert pool.select_actors() is not None
+        assert pool.can_schedule_task()
+
+        # Drain the node
+        mock_get_draining_nodes.return_value = {"node1"}
+        pool.refresh_actor_state()
+        assert pool.select_actors() is None
+        assert not pool.can_schedule_task()
+
+    @patch.object(
+        RefBundle,
+        "get_preferred_object_locations",
+        return_value={"node1": 1024, "node2": 512},
+    )
+    @patch(f"{_MODULE}.get_draining_nodes", return_value={"node1"})
+    @patch(f"{_MODULE}.get_actor_locations")
+    def test_locality_skips_draining_preferred_node(
+        self, mock_get_actor_locations, mock_get_draining_nodes, _mock_locs
+    ):
+        """Locality falls through to the next node when the best one is draining.
+
+        node1 holds the most bytes, so it wins locality, but it's draining. Every
+        task should land on actor2 instead of waiting for or retrying on actor1.
+        """
+        pool = self._create_actor_pool(max_tasks_in_flight=2)
+
+        actor1 = self._add_ready_actor(pool, node_id="node1")
+        actor2 = self._add_ready_actor(pool, node_id="node2")
+        mock_get_actor_locations.return_value = {
+            pool._get_actor_logical_id(actor1): "node1",
+            pool._get_actor_logical_id(actor2): "node2",
+        }
+        pool.refresh_actor_state()
+
+        results = _schedule_bundles(
+            pool, _make_bundle_queue(4), actor_locality_enabled=True
+        )
+
+        # Only actor2 is usable, so it fills to max_tasks_in_flight and stops.
+        assert results == [actor2, actor2]
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main(["-v", __file__]))


### PR DESCRIPTION
## Description
This PR introduces node-aware actor pools. The pool stops dispatching to actors on draining nodes, whose tasks are unlikely to finish before the drain deadline and get retried elsewhere, and it refreshes actor locations after a restart instead of reading them once when the actor starts. It also reports actors Ray Core revived for lineage reconstruction, which hold CPU/GPU but have left the pool, so accounting stops under-counting during recovery. Node-aware actor pools will replace the old actor pools as the new default.

## Additional information
Adds `_NodeAwareActorPool` and `ActorPoolMapOperator.extra_resource_usage()`, plus TTL-cached wrappers in `_internal/utils/` so the per-iteration draining-node and actor-location lookups don't cost an RPC per scheduling loop. Also fixes `ResourceManager.update_usages()` discarding the result of `op_usage.add(...)`, which made `extra_resource_usage()` a no-op.