### PR TITLE
[Data] Index block rows directly instead of materializing a one-row table

### DIFF
--- a/python/ray/data/_internal/arrow_block.py
+++ b/python/ray/data/_internal/arrow_block.py
@@ -86,65 +86,71 @@ def get_concat_and_sort_transform(context: DataContext) -> Callable:
 
 class ArrowRow(Mapping):
     """
-    Row of a tabular Dataset backed by a Arrow Table block.
+    Row of a tabular Dataset backed by a pyarrow RecordBatch or Table and a row index.
     """
 
-    def __init__(self, row: Any):
-        self._row = row
+    def __init__(
+        self, batch: Union["pyarrow.Table", "pyarrow.RecordBatch"], row_idx: int
+    ):
+        self._batch = batch
+        self._row_idx = row_idx
 
     def __getitem__(self, key: Union[str, List[str]]) -> Any:
         from ray.data.extensions import get_arrow_extension_tensor_types
 
         tensor_arrow_extension_types = get_arrow_extension_tensor_types()
+        schema = self._batch.schema
 
         def get_item(keys: List[str]) -> Any:
-            schema = self._row.schema
+            # Check for tensor extension type on first key
             if isinstance(schema.field(keys[0]).type, tensor_arrow_extension_types):
                 # Build a tensor row.
                 return tuple(
-                    [
-                        ArrowBlockAccessor._build_tensor_row(
-                            self._row, col_name=key, row_idx=0
-                        )
-                        for key in keys
-                    ]
+                    ArrowBlockAccessor._build_tensor_row(
+                        self._batch, col_name=key, row_idx=self._row_idx
+                    )
+                    for key in keys
                 )
 
-            table = self._row.select(keys)
-            if len(table) == 0:
+            # Pyarrow select internally creates a new table by slicing which is
+            # expensive. Instead, access the columns directly at row_idx.
+            items = []
+            for col_name in keys:
+                col_idx = schema.get_field_index(col_name)
+                if col_idx == -1:
+                    # key not found
+                    return None
+                col = self._batch.column(col_idx)
+                value = col[self._row_idx]
+                items.append(value)
+
+            if not items:
                 return None
 
-            items = [col[0] for col in table.columns]
             try:
                 # Try to interpret this as a pyarrow.Scalar value.
-                return tuple([item.as_py() for item in items])
-
+                return tuple(item.as_py() for item in items)
             except AttributeError:
                 # Assume that this row is an element of an extension array, and
                 # that it is bypassing pyarrow's scalar model for Arrow < 8.0.0.
-                return items
+                return tuple(items)
 
         is_single_item = isinstance(key, str)
         keys = [key] if is_single_item else key
-
         items = get_item(keys)
 
         if items is None:
             return None
-        elif is_single_item:
-            return items[0]
-        else:
-            return items
+        return items[0] if is_single_item else items
 
     def __iter__(self) -> Iterator:
-        for k in self._row.column_names:
-            yield k
+        yield from self._batch.schema.names
 
     def __len__(self):
-        return self._row.num_columns
+        return len(self._batch.schema)
 
     def as_pydict(self) -> Dict[str, Any]:
-        return dict(self.items())
+        return {k: self[k] for k in self}
 
     def __str__(self):
         return row_str(self)
@@ -217,8 +223,7 @@ class ArrowBlockAccessor(TableBlockAccessor):
         self._max_chunk_size: Optional[int] = None
 
     def _get_row(self, index: int) -> ArrowRow:
-        base_row = self.slice(index, index + 1, copy=False)
-        return ArrowRow(base_row)
+        return self.ROW_TYPE(self._table, index)
 
     def column_names(self) -> List[str]:
         return self._table.column_names

--- a/python/ray/data/_internal/pandas_block.py
+++ b/python/ray/data/_internal/pandas_block.py
@@ -203,62 +203,65 @@ class PandasRow(Mapping):
     Row of a tabular Dataset backed by a Pandas DataFrame block.
     """
 
-    def __init__(self, row: Any):
-        self._row = row
+    def __init__(self, df: "pandas.DataFrame", row_idx: int):
+        self._batch = df
+        self._row_idx = row_idx
 
     def __getitem__(self, key: Union[str, List[str]]) -> Any:
         from ray.data.extensions import TensorArrayElement
 
         def get_item(keys: List[str]) -> Any:
-            col = self._row[keys]
-            if len(col) == 0:
-                return None
+            items = []
+            for col_name in keys:
+                if col_name not in self._batch.columns:
+                    return None
+                val = self._batch[col_name].iloc[self._row_idx]
+                if isinstance(val, TensorArrayElement):
+                    # Getting an item in a Pandas tensor column may return
+                    # a TensorArrayElement, which we have to convert to an ndarray.
+                    val = val.to_numpy()
+                items.append(val)
 
-            items = col.iloc[0]
-            if isinstance(items.iloc[0], TensorArrayElement):
-                # Getting an item in a Pandas tensor column may return
-                # a TensorArrayElement, which we have to convert to an ndarray.
-                return tuple(item.to_numpy() for item in items)
-
+            # Try to interpret this as a numpy-type value.
+            # See https://stackoverflow.com/questions/9452775/converting-numpy-dtypes-to-native-python-types.  # noqa: E501
             try:
-                # Try to interpret this as a numpy-type value.
-                # See https://stackoverflow.com/questions/9452775/converting-numpy-dtypes-to-native-python-types.  # noqa: E501
-                return tuple(item for item in items)
-
+                return tuple(v.item() if hasattr(v, "item") else v for v in items)
             except (AttributeError, ValueError) as e:
-                logger.warning(f"Failed to convert {items} to a tuple", exc_info=e)
-
+                logger.warning(
+                    f"Failed to convert {items} to native Python types", exc_info=e
+                )
                 # Fallback to the original form.
-                return items
+                return tuple(items)
 
         is_single_item = isinstance(key, str)
         keys = [key] if is_single_item else key
-
         items = get_item(keys)
 
         if items is None:
             return None
-
-        elif is_single_item:
-            return items[0]
-        else:
-            return items
+        return items[0] if is_single_item else items
 
     def __iter__(self) -> Iterator:
-        for k in self._row.columns:
-            yield k
+        return iter(self._batch.columns)
 
     def __len__(self):
-        return self._row.shape[1]
+        return self._batch.shape[1]
 
     def as_pydict(self) -> Dict[str, Any]:
+        from ray.data.extensions import TensorArrayElement
+
         pydict: Dict[str, Any] = {}
-        for key, value in self.items():
+        for key in self:
+            value = self._batch[key].iloc[self._row_idx]
             # Convert NA to None for consistency across block formats. `pd.isna`
             # returns True for both NA and NaN, but since we want to preserve NaN
             # values, we check for identity instead.
             if is_scalar(value) and value is pd.NA:
                 pydict[key] = None
+            elif isinstance(value, TensorArrayElement):
+                pydict[key] = value.to_numpy()
+            elif isinstance(value, np.generic):
+                pydict[key] = value.item()
             else:
                 pydict[key] = value
 
@@ -502,8 +505,7 @@ class PandasBlockAccessor(TableBlockAccessor):
         super().__init__(table)
 
     def _get_row(self, index: int) -> PandasRow:
-        base_row = self.slice(index, index + 1, copy=False)
-        return PandasRow(base_row)
+        return self.ROW_TYPE(self._table, index)
 
     def column_names(self) -> List[str]:
         return self._table.columns.tolist()


### PR DESCRIPTION
## Description

`ArrowRow` and `PandasRow` are the objects Ray Data hands out for a single row of a block. Both are currently built by slicing the block down to one row:

```python
def _get_row(self, index):
    base_row = self.slice(index, index + 1, copy=False)
    return ArrowRow(base_row)
```

and subscripting then selects a second time:

```python
table = self._row.select(keys)
items = [col[0] for col in table.columns]
```

Reading one field therefore costs two intermediate tables plus one sliced array per column in the block, regardless of how few columns the caller asked for.

This PR makes both row types a lazy view over `(block, row_idx)`. Construction copies nothing, and subscripting indexes only the requested columns at `row_idx`.

Paths affected: `BlockAccessor.iter_rows(public_row_format=False)` (row-wise `AggregateFn`s, `write_sql`, `write_kafka`, row-oriented file sinks), `BlockAccessor._iter_groups_sorted` (one row object per group on the group-by aggregation path), `PandasBlockAccessor.iter_rows(public_row_format=True)`, and `RandomAccessDataset`.

## Related issues

N/A

## Additional information

Benchmark: 100,000 rows, 3 columns (`int64`, `float64`, `string`), iterating every row with `BlockAccessor.iter_rows()`.

| Backend | `public_row_format` | Before (rows/s) | After (rows/s) | Speedup |
|---|---|---|---|---|
| Arrow | `True` | 2,154,681 | 2,076,942 | unchanged |
| Arrow | `False` | 1,748,955 | 11,051,250 | 6.3x |
| Pandas | `True` | 6,063 | 170,909 | 28x |
| Pandas | `False` | 189,162 | 10,692,995 | 57x |

`public_row_format=True` yields plain `dict`s; `False` yields the `ArrowRow`/`PandasRow` objects this PR changes. Arrow's `True` path is unchanged because it goes through `table.to_batches()` → `batch.to_pylist()` and never constructs an `ArrowRow`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
