### PR TITLE
[Data] Size Parquet V2 read tasks by exact decoded bytes from footer SizeStatistics

### DIFF
--- a/python/ray/data/_internal/datasource_v2/chunkers/file_chunker.py
+++ b/python/ray/data/_internal/datasource_v2/chunkers/file_chunker.py
@@ -66,8 +66,9 @@ class ParquetRowGroupChunkMetadata(ChunkMetadata):
     coalescing/splitting the bin packer applied is already expanded away here.
     ``num_rows`` is the summed footer row count of those groups (for sizing /
     limit accounting). ``uncompressed_size`` is their summed, projection-scoped
-    uncompressed byte size, carried so the reader can size batches without
-    re-reading the footer ``ListFiles`` already read.
+    uncompressed byte size, and ``decoded_size`` the corresponding Arrow decoded
+    size, both carried so the reader can size batches without re-reading the
+    footer ``ListFiles`` already read.
     """
 
     row_group_ids: Tuple[int, ...]
@@ -80,6 +81,12 @@ class ParquetRowGroupChunkMetadata(ChunkMetadata):
     # for coalesced runs so a partitioner can split at exact boundaries.
     rg_sizes: Tuple[int, ...]
     rg_rows: Tuple[int, ...]
+    # Arrow decoded size of these groups, and its per-row-group breakdown.
+    # ``None`` / empty when the footer could not yield it exactly, which routes
+    # consumers back to scaling ``uncompressed_size``. See
+    # ``parquet_decoded_size.decoded_size_or_fallback``.
+    decoded_size: Optional[int]
+    rg_decoded_sizes: Tuple[int, ...]
 
 
 @DeveloperAPI

--- a/python/ray/data/_internal/datasource_v2/chunkers/parquet_decoded_size.py
+++ b/python/ray/data/_internal/datasource_v2/chunkers/parquet_decoded_size.py
@@ -1,0 +1,349 @@
+"""Estimate the Arrow decoded size of a Parquet row group from its footer.
+
+``total_uncompressed_size`` is Parquet's *encoded* size: decompressed, but still
+dictionary/RLE/bit-packed. It is a poor proxy for the Arrow block a read task
+materializes -- measured decoded/uncompressed ratios span 0.87x for plain
+``int64`` to 133x for a nullable dictionary-encoded string column. Sizing read
+tasks on it (whether raw or scaled by a fixed ratio) therefore either floods the
+scheduler with tiny tasks or overfills blocks to the point of OOM.
+
+Decoded size decomposes into three quantities per leaf. Two come from the footer
+exactly: the value count, from ``ColumnChunkMetaData.num_values``, and the
+per-value width, a pure function of the leaf's Parquet type. The third -- total
+character bytes of ``BYTE_ARRAY`` leaves -- comes from ``SizeStatistics``, which
+:mod:`.parquet_size_statistics` recovers from the footer bytes.
+
+Every function here returns ``None`` rather than guessing when the inputs cannot
+support an exact answer, which is the caller's signal to keep its existing
+uncompressed-size behavior.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from typing import Iterable, List, NamedTuple, Optional, Sequence
+
+from pyarrow.parquet import (
+    ColumnChunkMetaData,
+    ColumnSchema,
+    ParquetSchema,
+    RowGroupMetaData,
+)
+
+from ray.data._internal.datasource_v2.chunkers.parquet_size_statistics import (
+    LeafSizeStats,
+)
+
+# The V2 copy, which is what the reader's own fallback sizing uses
+# (parquet_file_reader.py); importing the same definition keeps this module's
+# fallback and the reader's from ever diverging.
+from ray.data._internal.datasource_v2.readers.in_memory_size_estimator import (
+    PARQUET_ENCODING_RATIO_ESTIMATE_DEFAULT,
+)
+
+# Arrow's offsets buffer for string/binary/list uses int32 offsets and holds one
+# more entry than there are values, so the trailing end offset is included.
+_OFFSET_WIDTH = 4
+
+_BOOLEAN = "BOOLEAN"
+_BYTE_ARRAY = "BYTE_ARRAY"
+_FIXED_LEN_BYTE_ARRAY = "FIXED_LEN_BYTE_ARRAY"
+
+# Widths of the Arrow type each Parquet physical type decodes to. INT96 is 12
+# bytes on disk but decodes to a 64-bit nanosecond timestamp.
+_PHYSICAL_WIDTHS = {
+    "INT32": 4,
+    "INT64": 8,
+    "INT96": 8,
+    "FLOAT": 4,
+    "DOUBLE": 8,
+}
+
+# Logical INT annotations narrow their physical type's Arrow width: an INT(8)
+# rides on INT32 storage but decodes to a 1-byte Arrow integer.
+_INT_LOGICAL_WIDTHS = {8: 1, 16: 2, 32: 4, 64: 8}
+_FLOAT16_WIDTH = 2
+_UUID_WIDTH = 16
+# Arrow uses decimal128 up to precision 38 and decimal256 beyond it.
+_DECIMAL128_WIDTH = 16
+_DECIMAL256_WIDTH = 32
+_MAX_DECIMAL128_PRECISION = 38
+
+
+def _logical_type_name(column: ColumnSchema) -> Optional[str]:
+    logical_type = column.logical_type
+    if logical_type is None:
+        return None
+    name = logical_type.type
+    # PyArrow reports "NONE" (and historically "UNKNOWN") for a leaf carrying no
+    # logical annotation, which must not be mistaken for a real one.
+    return None if name in ("NONE", "UNKNOWN") else name
+
+
+def _int_logical_bit_width(column: ColumnSchema) -> Optional[int]:
+    """Bit width of a leaf's logical ``INT`` annotation, if it declares one.
+
+    ``ColumnSchema.precision`` is DECIMAL-only (it reports ``-1`` here) and
+    ``ParquetLogicalType`` exposes only ``type`` and ``to_json``, so the width has
+    to come out of the JSON. Reached only for ``INT32`` leaves carrying an ``INT``
+    annotation, so the parse is not on the common path.
+    """
+    try:
+        return json.loads(column.logical_type.to_json()).get("bitWidth")
+    except (ValueError, AttributeError):
+        return None
+
+
+def _decimal_width(column: ColumnSchema) -> int:
+    precision = column.precision
+    if precision and precision > _MAX_DECIMAL128_PRECISION:
+        return _DECIMAL256_WIDTH
+    return _DECIMAL128_WIDTH
+
+
+def parquet_leaf_fixed_width(column: ColumnSchema) -> Optional[int]:
+    """Bytes per value in the Arrow data buffer for a fixed-width leaf.
+
+    Returns ``None`` for ``BOOLEAN`` (bit-packed, so not a whole number of bytes
+    per value) and ``BYTE_ARRAY`` (variable width), both of which callers size
+    separately. Derived from the Parquet type rather than by building an Arrow
+    schema, so no schema-tree walk is needed.
+
+    Args:
+        column: A ``pyarrow.parquet.ColumnSchema`` leaf.
+
+    Returns:
+        The per-value width in bytes, or ``None`` if the leaf is not fixed-width
+        or its type is unrecognized.
+    """
+    physical_type = column.physical_type
+    logical_name = _logical_type_name(column)
+
+    if logical_name == "DECIMAL":
+        return _decimal_width(column)
+
+    if physical_type == _FIXED_LEN_BYTE_ARRAY:
+        if logical_name == "FLOAT16":
+            return _FLOAT16_WIDTH
+        if logical_name == "UUID":
+            return _UUID_WIDTH
+        # Otherwise it decodes to fixed_size_binary of the declared length.
+        length = column.length
+        return length if length and length > 0 else None
+
+    if physical_type == "INT32" and logical_name == "INT":
+        bit_width = _int_logical_bit_width(column)
+        return _INT_LOGICAL_WIDTHS.get(bit_width, 4) if bit_width else 4
+
+    return _PHYSICAL_WIDTHS.get(physical_type)
+
+
+class LeafProfile(NamedTuple):
+    """The per-leaf schema facts the estimator consumes, all constant per file.
+
+    Hoisted out of the per-row-group loop because every accessor behind them --
+    ``ParquetSchema.column``, ``ColumnSchema.logical_type``, and the JSON
+    round-trip for INT bit widths -- builds a fresh object per call, and the
+    estimator runs once per row group.
+    """
+
+    physical_type: str
+    # Bytes per value in the Arrow data buffer; ``None`` for ``BOOLEAN``
+    # (bit-packed) and ``BYTE_ARRAY`` (variable width), which are sized
+    # separately, and for unrecognized types, which force the fallback.
+    fixed_width: Optional[int]
+    max_definition_level: int
+    max_repetition_level: int
+
+
+def build_leaf_profiles(parquet_schema: ParquetSchema) -> List[LeafProfile]:
+    """One :class:`LeafProfile` per leaf, in schema (== row group) column order.
+
+    Called once per file; the result feeds every row group's
+    :func:`estimate_row_group_decoded_size` call.
+    """
+    profiles: List[LeafProfile] = []
+    for leaf_idx in range(len(parquet_schema)):
+        column = parquet_schema.column(leaf_idx)
+        profiles.append(
+            LeafProfile(
+                physical_type=column.physical_type,
+                fixed_width=parquet_leaf_fixed_width(column),
+                max_definition_level=column.max_definition_level,
+                max_repetition_level=column.max_repetition_level,
+            )
+        )
+    return profiles
+
+
+def _has_nulls(
+    profile: LeafProfile, chunk: ColumnChunkMetaData, stats: LeafSizeStats
+) -> bool:
+    """Whether this leaf chunk actually contains a null.
+
+    Arrow allocates a validity bitmap only when a null is present, so keying off
+    ``max_definition_level > 0`` (i.e. "nullable") instead double-counts: a
+    nullable but null-free ``bool`` column then estimates 2.00x its real
+    ``nbytes``.
+    """
+    if profile.max_definition_level == 0:
+        return False  # required leaf: a null is impossible
+    histogram = stats.definition_level_histogram
+    if histogram:
+        # The last bucket counts values at the max definition level, i.e. the
+        # non-null ones; everything below it is a null at some level.
+        return chunk.num_values > histogram[-1]
+    # The spec permits omitting the histogram when max_definition_level <= 1, so
+    # fall back to the null count PyArrow does expose.
+    #
+    # Cold for PyArrow-written files, which emit the histogram even at
+    # max_definition_level 1 -- worth knowing because it is not cheap: building a
+    # ``Statistics`` per leaf measured at roughly two thirds of this module's
+    # total estimating cost. A writer that omits histograms would pay that on
+    # every nullable leaf, which is where to look first if sizing turns up slow.
+    statistics = chunk.statistics
+    if statistics is not None and statistics.has_null_count:
+        return statistics.null_count > 0
+    # Unknown: assume a bitmap exists. Overestimating is the safe direction,
+    # since undersizing a bin is what overfills a read task.
+    return True
+
+
+def _list_offsets_size(profile: LeafProfile, stats: LeafSizeStats) -> int:
+    """Bytes of Arrow list-offset buffers for a repeated leaf.
+
+    A leaf nested under ``R`` repeated groups decodes to ``R`` nested list
+    arrays, each with its own offsets buffer. The repetition level histogram
+    gives the count at each level, and the number of lists at level ``k`` is the
+    running sum up to ``k`` -- so level 0 alone is the number of top-level lists.
+    """
+    max_repetition_level = profile.max_repetition_level
+    if max_repetition_level == 0:
+        return 0
+    histogram = stats.repetition_level_histogram
+    if not histogram:
+        # Permitted omission only when max_repetition_level is 0, which is
+        # already handled above; without the histogram there is no list count to
+        # work from, so contribute nothing rather than invent one.
+        return 0
+    total = 0
+    running = 0
+    for level in range(min(max_repetition_level, len(histogram))):
+        running += histogram[level]
+        total += _OFFSET_WIDTH * (running + 1)
+    return total
+
+
+def _leaf_decoded_size(
+    profile: LeafProfile, chunk: ColumnChunkMetaData, stats: LeafSizeStats
+) -> Optional[int]:
+    """Decoded Arrow bytes for one leaf column chunk, or ``None`` if unknown."""
+    num_values = chunk.num_values
+    physical_type = profile.physical_type
+
+    if physical_type == _BYTE_ARRAY:
+        if stats.unencoded_byte_array_data_bytes is None:
+            # The one hard requirement: a BYTE_ARRAY leaf's character bytes exist
+            # nowhere else in the footer, so without them there is no exact
+            # answer and the caller must fall back.
+            return None
+        # The spec defines the field as exclusive of each value's length prefix,
+        # so Arrow's offsets buffer is added separately rather than assumed
+        # included.
+        total = stats.unencoded_byte_array_data_bytes + _OFFSET_WIDTH * (num_values + 1)
+    elif physical_type == _BOOLEAN:
+        total = math.ceil(num_values / 8)
+    else:
+        width = profile.fixed_width
+        if width is None:
+            return None
+        total = num_values * width
+
+    if _has_nulls(profile, chunk, stats):
+        total += math.ceil(num_values / 8)
+    total += _list_offsets_size(profile, stats)
+    return total
+
+
+def estimate_row_group_decoded_size(
+    row_group: RowGroupMetaData,
+    leaf_profiles: Optional[List[LeafProfile]],
+    leaf_indices: Optional[Sequence[int]],
+    size_stats: Optional[List[Optional[LeafSizeStats]]],
+) -> Optional[int]:
+    """Decoded Arrow size of one row group's read set, or ``None`` to fall back.
+
+    The decision is all-or-nothing per row group: mixing exact and fallback
+    sizing within one group produces a number that is hard to reason about, and
+    the mixed case only arises with writers that partially emit size statistics.
+
+    Note that ``None`` is returned only when a *``BYTE_ARRAY``* leaf lacks
+    ``unencoded_byte_array_data_bytes``. Fixed-width leaves legitimately omit
+    that sub-field -- the spec restricts it to ``BYTE_ARRAY`` -- and requiring it
+    everywhere would silently disable exact sizing for every flat numeric schema
+    while still paying the decode cost.
+
+    Args:
+        row_group: The ``RowGroupMetaData`` to size.
+        leaf_profiles: The file's per-leaf profiles from
+            :func:`build_leaf_profiles`, or ``None`` when no size statistics
+            were recovered for the file (in which case the answer is ``None``
+            regardless).
+        leaf_indices: Leaf-column indices the read task will decode, or ``None``
+            for all of them.
+        size_stats: This row group's per-leaf ``SizeStatistics``, as returned by
+            :func:`~.parquet_size_statistics.read_size_statistics`, or ``None``.
+
+    Returns:
+        The summed decoded size in bytes, or ``None`` if it cannot be determined
+        exactly.
+    """
+    if size_stats is None or leaf_profiles is None:
+        return None
+    indices = range(row_group.num_columns) if leaf_indices is None else leaf_indices
+    total = 0
+    for leaf_idx in indices:
+        if leaf_idx >= len(size_stats) or leaf_idx >= len(leaf_profiles):
+            return None
+        stats = size_stats[leaf_idx]
+        if stats is None:
+            return None
+        leaf_size = _leaf_decoded_size(
+            leaf_profiles[leaf_idx], row_group.column(leaf_idx), stats
+        )
+        if leaf_size is None:
+            return None
+        total += leaf_size
+    return total
+
+
+def sum_exact(values: Iterable[Optional[int]]) -> Optional[int]:
+    """Sum of ``values``, or ``None`` if any of them is ``None``.
+
+    The one rule for combining decoded sizes: a total is exact only when every
+    part is, and mixing exact parts with fallback estimates would produce a
+    number no consumer could interpret. Shared by every site that aggregates
+    decoded sizes (coalescing, bin sealing) so the rule has a single home.
+    """
+    total = 0
+    for value in values:
+        if value is None:
+            return None
+        total += value
+    return total
+
+
+def decoded_size_or_fallback(
+    decoded_size: Optional[int], uncompressed_size: int
+) -> int:
+    """A chunk's decoded size, or the pre-existing estimate when unavailable.
+
+    ``None`` means the footer could not yield an exact answer, so this reproduces
+    exactly what shipped before: uncompressed bytes scaled by the fixed encoding
+    ratio. Shared by the bin packer and the reader's batch sizing so the two
+    cannot drift.
+    """
+    if decoded_size is not None:
+        return decoded_size
+    return uncompressed_size * PARQUET_ENCODING_RATIO_ESTIMATE_DEFAULT

--- a/python/ray/data/_internal/datasource_v2/chunkers/parquet_footer_types.py
+++ b/python/ray/data/_internal/datasource_v2/chunkers/parquet_footer_types.py
@@ -1,24 +1,31 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Tuple
+from typing import Optional, Tuple
 
 
 @dataclass(frozen=True)
 class RowGroupInfo:
     """A chunk of one file: a contiguous run of ``rg_count`` physical row groups.
 
-    ``uncompressed_size`` / ``num_rows`` are summed over the run. For a single
-    physical row group (``rg_count == 1``) the run is its own atom and needs no
-    breakdown, so ``rg_sizes`` / ``rg_rows`` stay empty; they're populated only
-    for coalesced runs (``rg_count > 1``) so the bin packer can split them back
-    at exact byte/row boundaries.
+    ``uncompressed_size`` / ``decoded_size`` / ``num_rows`` are summed over the
+    run. For a single physical row group (``rg_count == 1``) the run is its own
+    atom and needs no breakdown, so ``rg_sizes`` / ``rg_decoded_sizes`` /
+    ``rg_rows`` stay empty; they're populated only for coalesced runs
+    (``rg_count > 1``) so the bin packer can split them back at exact byte/row
+    boundaries.
     """
 
     # Start row-group index (== the row group's index when rg_count == 1).
     rg_idx: int
     uncompressed_size: int  # summed over the run
     num_rows: int  # summed over the run
+    # Arrow decoded size, summed over the run. ``None`` when the footer could not
+    # yield it exactly (no SizeStatistics, or the Thrift walk failed its
+    # cross-check), which routes consumers back to scaling ``uncompressed_size``.
+    # Kept alongside rather than replacing it so both numbers stay visible for
+    # A/B comparison and debug logging.
+    decoded_size: Optional[int] = None
     # True when every row in the run is guaranteed to satisfy the filter (or there
     # is no filter), so ``num_rows`` is an exact survivor count and the limit can
     # be pushed down on it. False for partially-matching groups, whose ``num_rows``
@@ -30,6 +37,10 @@ class RowGroupInfo:
     # Populated only for coalesced runs (``rg_count > 1``).
     rg_sizes: Tuple[int, ...] = ()
     rg_rows: Tuple[int, ...] = ()
+    # Per-physical-row-group decoded sizes, parallel to ``rg_sizes``. Empty when
+    # decoded sizing is unavailable for the run, so a splittable run falls back to
+    # scaling ``rg_sizes``.
+    rg_decoded_sizes: Tuple[int, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -60,13 +71,24 @@ class BinItem:
     # coalesced runs (rg_count > 1); lets the packer split at row-group boundaries.
     rg_sizes: Tuple[int, ...] = ()
     rg_rows: Tuple[int, ...] = ()
+    # See RowGroupInfo.decoded_size / rg_decoded_sizes. The packer's capacity math
+    # runs on these; ``None`` / empty routes it back to scaling the uncompressed
+    # values.
+    decoded_size: Optional[int] = None
+    rg_decoded_sizes: Tuple[int, ...] = ()
 
 
 @dataclass(frozen=True)
 class Bin:
     """A sealed bin: a set of row-group chunks (across one or more files) whose
-    combined uncompressed size targets one bin budget. Becomes one
-    ``FileManifest`` block == one downstream read task."""
+    combined decoded size targets one bin budget. Becomes one ``FileManifest``
+    block == one downstream read task.
+
+    Both totals are carried: ``total_decoded_size`` is what the budget was
+    enforced against, while ``total_uncompressed_size`` stays for debug logging
+    and for comparing against the pre-existing sizing.
+    """
 
     items: Tuple[BinItem, ...]
     total_uncompressed_size: int
+    total_decoded_size: int = 0

--- a/python/ray/data/_internal/datasource_v2/chunkers/parquet_row_group_coalescing.py
+++ b/python/ray/data/_internal/datasource_v2/chunkers/parquet_row_group_coalescing.py
@@ -1,7 +1,11 @@
 """Pure row-group coalescing for the footer-based Parquet chunking path."""
 from dataclasses import replace
-from typing import List, Optional, Tuple
+from typing import List, Tuple
 
+from ray.data._internal.datasource_v2.chunkers.parquet_decoded_size import (
+    decoded_size_or_fallback,
+    sum_exact,
+)
 from ray.data._internal.datasource_v2.chunkers.parquet_footer_types import RowGroupInfo
 
 __all__ = [
@@ -20,12 +24,17 @@ def coalesce_row_groups(
     reaches ``target``. A single row group larger than ``target`` forms its own
     chunk. ``target == 0`` disables coalescing entirely (one chunk per physical
     row group). Coalesced chunks (``rg_count > 1``) carry per-row-group
-    ``rg_sizes`` / ``rg_rows`` so the packer can split them back at exact
-    boundaries.
+    ``rg_sizes`` / ``rg_decoded_sizes`` / ``rg_rows`` so the packer can split them
+    back at exact boundaries.
+
+    ``target`` is measured in decoded bytes, since that is what the downstream bin
+    budget is measured in. A run whose row groups do not all have an exact decoded
+    size falls back to the scaled uncompressed estimate for the accumulator, and
+    reports ``decoded_size=None`` so consumers keep falling back consistently.
 
     Args:
         per_rg: Single-row-group infos in ascending ``rg_idx`` order.
-        target: Target chunk size in bytes; ``0`` disables coalescing.
+        target: Target chunk size in decoded bytes; ``0`` disables coalescing.
 
     Returns:
         The coalesced row-group chunks, in the same ascending order.
@@ -33,37 +42,55 @@ def coalesce_row_groups(
     if not target:
         return tuple(per_rg)
     out: List[RowGroupInfo] = []
-    cur: Optional[RowGroupInfo] = None
-    cur_sizes: List[int] = []
-    cur_rows: List[int] = []
+    # The open run, plus its running totals in the units the fullness check
+    # needs. Everything else about a run is derived from the list at flush time.
+    run: List[RowGroupInfo] = []
+    run_uncompressed = 0
+    # ``None`` once any member lacks exact decoded sizing, so the fullness check
+    # below falls back for the whole run -- the same all-or-nothing rule the
+    # flushed chunk reports via ``sum_exact``.
+    run_decoded: "int | None" = 0
 
     def _flush() -> None:
-        if cur is None:
+        if not run:
             return
-        if len(cur_sizes) > 1:
-            out.append(replace(cur, rg_sizes=tuple(cur_sizes), rg_rows=tuple(cur_rows)))
-        else:
-            out.append(cur)
+        if len(run) == 1:
+            out.append(run[0])
+            return
+        decoded = sum_exact(rg.decoded_size for rg in run)
+        out.append(
+            replace(
+                run[0],
+                rg_count=sum(rg.rg_count for rg in run),
+                uncompressed_size=sum(rg.uncompressed_size for rg in run),
+                num_rows=sum(rg.num_rows for rg in run),
+                decoded_size=decoded,
+                rg_sizes=tuple(rg.uncompressed_size for rg in run),
+                rg_rows=tuple(rg.num_rows for rg in run),
+                rg_decoded_sizes=(
+                    tuple(rg.decoded_size for rg in run) if decoded is not None else ()
+                ),
+            )
+        )
 
     for rg in per_rg:  # ascending rg_idx; each is a single physical row group
         if (
-            cur is not None
-            and cur.fully_matched == rg.fully_matched
-            and cur.rg_idx + cur.rg_count == rg.rg_idx  # contiguous
-            and cur.uncompressed_size < target  # not full yet
+            run
+            and run[0].fully_matched == rg.fully_matched
+            and run[-1].rg_idx + run[-1].rg_count == rg.rg_idx  # contiguous
+            # Not full yet, measured the same way the bin budget is.
+            and decoded_size_or_fallback(run_decoded, run_uncompressed) < target
         ):
-            cur = replace(
-                cur,
-                rg_count=cur.rg_count + rg.rg_count,
-                uncompressed_size=cur.uncompressed_size + rg.uncompressed_size,
-                num_rows=cur.num_rows + rg.num_rows,
-            )
-            cur_sizes.append(rg.uncompressed_size)
-            cur_rows.append(rg.num_rows)
+            run.append(rg)
         else:
             _flush()
-            cur = rg
-            cur_sizes = [rg.uncompressed_size]
-            cur_rows = [rg.num_rows]
+            run = [rg]
+            run_uncompressed = 0
+            run_decoded = 0
+        run_uncompressed += rg.uncompressed_size
+        if run_decoded is not None:
+            run_decoded = (
+                None if rg.decoded_size is None else run_decoded + rg.decoded_size
+            )
     _flush()
     return tuple(out)

--- a/python/ray/data/_internal/datasource_v2/chunkers/parquet_size_statistics.py
+++ b/python/ray/data/_internal/datasource_v2/chunkers/parquet_size_statistics.py
@@ -1,0 +1,515 @@
+"""Recover Parquet ``SizeStatistics`` from the footer bytes PyArrow already holds.
+
+``SizeStatistics`` (parquet-format 2.10) carries the one quantity needed to size
+a decoded Arrow block that nothing else in the footer provides: the total
+character bytes of ``BYTE_ARRAY`` leaves. PyArrow's C++ writer emits the struct
+by default, and arrow-rs exposes it as
+``ColumnChunkMetaData::unencoded_byte_array_data_bytes``, but PyArrow's Python
+bindings declare no getter for it.
+
+The data is still reachable with zero extra I/O: ``FileMetaData.__reduce__()``
+hands back the raw Thrift-serialized footer, so a targeted TCompactProtocol walk
+can read it out of the footer ``ListFiles`` already fetched.
+
+The walk is deliberately narrow -- ``FileMetaData.4 -> RowGroup.1 ->
+ColumnChunk.3 -> ColumnMetaData.16`` -- and skips every other field generically.
+That is both far cheaper than a full parse (which would materialize every
+``SchemaElement`` and every ``Statistics`` min/max blob) and keeps the surface
+small enough to delete outright if PyArrow ever binds the accessor.
+
+The same approach is what arrow-rs adopted to make footer parsing 3-9x faster
+than its generated Thrift parser, and the reasoning transfers directly:
+
+    https://arrow.apache.org/blog/2025/10/23/rust-parquet-metadata/
+
+Two of its lessons shape the code below. First, skipped bytes must be *scanned*
+but need not be *decoded* -- Thrift's compact encoding is variable-length, so
+there is no random access, but stepping over a field is much cheaper than
+building a value from it. Second, the cost of a targeted walk is dominated by
+per-field overhead, which in a generated Rust parser means small heap
+allocations and here means Python-level calls and tuples. So the skip path
+decodes nothing it does not need for width, materializes no ``(id, type)``
+pairs, and reads the buffer through local variables rather than a method call
+per byte.
+
+On correctness: hand-decoded binary fails by returning wrong numbers, not by
+raising, because a one-byte cursor desync leaves the field-id deltas decoding
+onto plausible but wrong ids. Nothing downstream can catch that -- a decoded size
+has no independent source to be checked against -- so the guards are all up
+front: type assertions on every field this walk claims to recognize, a shape
+check on the row-group and leaf counts, and a differential test against
+``thriftpy2``'s own compact protocol over a matrix of schemas. Treat that
+differential test as the module's real contract; changes to the skip paths in
+particular should not be trusted without it.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Iterator, List, NamedTuple, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+if TYPE_CHECKING:
+    # Behind TYPE_CHECKING so this module stays importable without PyArrow, which
+    # keeps the protocol reader testable in isolation.
+    from pyarrow.parquet import FileMetaData
+
+# TCompactProtocol type ids.
+_BOOL_TRUE, _BOOL_FALSE, _BYTE, _I16, _I32, _I64 = 1, 2, 3, 4, 5, 6
+_DOUBLE, _BINARY, _LIST, _SET, _MAP, _STRUCT = 7, 8, 9, 10, 11, 12
+
+# Field ids from the parquet-format Thrift schema, the authoritative source for
+# every constant below:
+# https://github.com/apache/parquet-format/blob/master/src/main/thrift/parquet.thrift
+# (see `struct FileMetaData`, `struct RowGroup`, `struct ColumnChunk`,
+# `struct ColumnMetaData` and `struct SizeStatistics`; line numbers drift, the
+# struct names do not).
+#
+# These ids are the wire identity of a field -- the serialized bytes carry the id,
+# not the name -- so parquet-format can only ever append, never renumber. Fields
+# 14/15 were added in 2.10 and geospatial took 17 rather than displacing 16; a
+# future field 18 is handled by the generic skip.
+_FILE_META_ROW_GROUPS = 4
+_ROW_GROUP_COLUMNS = 1
+_COLUMN_CHUNK_META_DATA = 3
+_COLUMN_META_SIZE_STATISTICS = 16
+_SIZE_STATS_UNENCODED_BYTES = 1
+_SIZE_STATS_REPETITION_HISTOGRAM = 2
+_SIZE_STATS_DEFINITION_HISTOGRAM = 3
+
+
+class LeafSizeStats(NamedTuple):
+    """One leaf column chunk's ``SizeStatistics``.
+
+    ``unencoded_byte_array_data_bytes`` is ``None`` for every non-``BYTE_ARRAY``
+    leaf: the spec restricts the field to that physical type, and fixed-width
+    leaves get their width from the schema instead. Both histograms may be empty,
+    which the spec permits when ``max_repetition_level`` is 0 or
+    ``max_definition_level`` is at most 1.
+    """
+
+    unencoded_byte_array_data_bytes: Optional[int]
+    repetition_level_histogram: Tuple[int, ...]
+    definition_level_histogram: Tuple[int, ...]
+
+
+class _ThriftDesync(Exception):
+    """A decoded field's type contradicts parquet.thrift.
+
+    Raised instead of skipping, because a type mismatch on a field we claim to
+    recognize means the cursor has drifted and the *ids* are no longer
+    trustworthy, not that the file is using a newer schema.
+    """
+
+
+class _CompactReader:
+    """A minimal TCompactProtocol reader over a footer buffer.
+
+    Only the traversal path is decoded; everything else goes through
+    :meth:`_skip`. Unknown field ids and types are tolerated so a newer
+    parquet-format writer cannot break the walk.
+    """
+
+    __slots__ = ("_buf", "_pos")
+
+    def __init__(self, buf):
+        self._buf = buf
+        self._pos = 0
+
+    def _byte(self) -> int:
+        # Indexing past the end raises IndexError, which read_size_statistics
+        # turns into a clean fallback -- a truncated footer must never produce a
+        # partial answer.
+        value = self._buf[self._pos]
+        self._pos += 1
+        return value
+
+    def _varint(self) -> int:
+        """Decode an unsigned base-128 varint.
+
+        Each byte carries 7 payload bits in its low bits, with the high bit set to
+        mean "another byte follows". Payload groups are ordered least-significant
+        first, so byte *i* contributes its 7 bits at position ``7 * i`` -- hence
+        the running ``shift``. Small values therefore cost one byte, which is the
+        whole point: most Parquet footer integers are small.
+
+        Example: ``0x80 0xFA 0x01`` -> low group ``0x00``, then ``0x7A << 7``,
+        then ``0x01 << 14`` == 32000, which :meth:`_zigzag` in turn reads as
+        16000.
+
+        Deliberately does not go through :meth:`_byte`: a footer runs to hundreds
+        of thousands of bytes, and hoisting the buffer and cursor into locals for
+        the duration turns a Python call per byte into an index per byte.
+        """
+        buf, pos = self._buf, self._pos
+        result = shift = 0
+        while True:
+            byte = buf[pos]
+            pos += 1
+            result |= (byte & 0x7F) << shift
+            if not byte & 0x80:  # high bit clear: last byte of the varint
+                self._pos = pos
+                return result
+            shift += 7
+
+    def _skip_varint(self) -> None:
+        """Step over a varint without reconstructing its value.
+
+        Only the terminator matters when skipping, and it is in-band: the first
+        byte with its high bit clear ends the field. Nothing needs the integer,
+        so the shift/or work that :meth:`_varint` does is pure waste here --
+        which matters because most skipped footer fields are varints.
+        """
+        buf, pos = self._buf, self._pos
+        while buf[pos] & 0x80:
+            pos += 1
+        self._pos = pos + 1
+
+    def _zigzag(self) -> int:
+        """Decode a signed integer from its zigzag-encoded varint.
+
+        A plain varint would make every negative number maximally long, since
+        two's complement sets the high bits. Zigzag instead interleaves the signs
+        -- 0, -1, 1, -2, 2 encode as 0, 1, 2, 3, 4 -- so magnitude, not sign,
+        drives the length.
+
+        Inverting it: ``n >> 1`` recovers the magnitude, and ``-(n & 1)`` is 0 for
+        an even ``n`` (a non-negative value, leaving it unchanged) or -1 for an odd
+        one. -1 is all-ones, so XOR against it flips every bit, which is exactly
+        the two's complement negation ``~x``.
+        """
+        n = self._varint()
+        return (n >> 1) ^ -(n & 1)
+
+    def _list_header(self) -> Tuple[int, int]:
+        """Decode a list/set header into ``(element_count, element_type)``.
+
+        One byte packs both: the high nibble is the count and the low nibble the
+        element type id. A nibble only holds 0-14, so a count of 15 (``0x0F``) is
+        the escape marker meaning "the real count follows as a varint".
+        """
+        header = self._byte()
+        size, element_type = (header >> 4) & 0x0F, header & 0x0F
+        return (self._varint() if size == 0x0F else size), element_type
+
+    def _fields(self) -> Iterator[Tuple[int, int]]:
+        """Yield ``(field_id, field_type)`` for each field of a struct.
+
+        A field header is one byte: the high nibble is the field id expressed as a
+        *delta from the previous field in this struct*, and the low nibble is the
+        type id. Since writers emit fields in ascending id order, most deltas are
+        1 and fit the nibble, so a whole field header costs a single byte. An
+        all-zero byte is the STOP marker ending the struct.
+
+        Two consequences worth knowing:
+
+        - A delta of 0 does not mean "same id"; it is the escape marker saying the
+          delta did not fit the nibble, so an explicit zigzag i16 id follows.
+        - Because ids are relative, the absolute id depends on every preceding
+          field being consumed at exactly the right width. This is why a one-byte
+          desync is dangerous: the next delta still decodes, just onto the wrong
+          id, silently. Nothing downstream re-derives the answer, so the type
+          assertions on recognized fields and the differential test against an
+          independent Thrift implementation are what stand between a skip bug and
+          wrong block sizes.
+
+        The caller MUST fully consume each field's value before requesting the
+        next header -- either by decoding it or by calling :meth:`_skip` -- and
+        must never ``break`` out of the loop, or the cursor desyncs.
+        """
+        buf = self._buf
+        last_id = 0
+        while True:
+            pos = self._pos
+            header = buf[pos]
+            self._pos = pos + 1
+            if header == 0:  # STOP
+                return
+            delta, field_type = (header >> 4) & 0x0F, header & 0x0F
+            last_id = self._zigzag() if delta == 0 else last_id + delta
+            yield last_id, field_type
+
+    def _skip_element(self, element_type: int) -> None:
+        """Skip one element of a map.
+
+        Lists go through :meth:`_skip_list`, which skips whole runs at a time;
+        maps interleave two element types, so they are stepped one at a time and
+        are rare enough in a footer not to be worth the same treatment.
+        """
+        # Inside a container a bool costs one byte; inside a struct it is encoded
+        # in the type nibble itself and occupies no payload.
+        if element_type in (_BOOL_TRUE, _BOOL_FALSE):
+            self._pos += 1
+        else:
+            self._skip(element_type)
+
+    def _skip(self, field_type: int) -> None:
+        """Advance the cursor past one field's value.
+
+        Branches are ordered by how often each type appears in a real footer --
+        integers dominate, then the binary blobs in ``Statistics``, then nested
+        structs -- since this runs on the large majority of the footer's bytes.
+        """
+        if field_type in (_I16, _I32, _I64):
+            self._skip_varint()
+        elif field_type == _BINARY:
+            # Deliberately not ``self._pos += self._varint()``: Python evaluates
+            # the left operand first, so the advance _varint() performs while
+            # reading the length is discarded and every binary field consumes one
+            # byte too few. That desync is silent -- the walk then reports
+            # plausible but wrong field ids.
+            nbytes = self._varint()
+            self._pos += nbytes
+        elif field_type == _STRUCT:
+            self._skip_struct()
+        elif field_type in (_LIST, _SET):
+            self._skip_list()
+        elif field_type in (_BOOL_TRUE, _BOOL_FALSE):
+            # A bool in a struct is encoded in the type nibble and has no payload.
+            return
+        elif field_type == _BYTE:
+            self._pos += 1
+        elif field_type == _DOUBLE:
+            self._pos += 8
+        elif field_type == _MAP:
+            size = self._varint()
+            if size:
+                header = self._byte()
+                key_type, value_type = (header >> 4) & 0x0F, header & 0x0F
+                for _ in range(size):
+                    self._skip_element(key_type)
+                    self._skip_element(value_type)
+        else:
+            raise _ThriftDesync(f"unknown compact type {field_type}")
+
+    def _skip_struct(self) -> None:
+        """Skip a whole struct without materializing anything about its fields.
+
+        Separate from :meth:`_fields` because skipping needs strictly less than
+        traversing: field *ids* are irrelevant when nothing will be read, so the
+        long-form id is stepped over rather than decoded, and no ``(id, type)``
+        pair is ever built. That matters because this is where the footer's bulk
+        goes -- every ``SchemaElement``, every ``Statistics``, every
+        ``ColumnIndex`` offset -- and a tuple per field across a wide footer is
+        hundreds of thousands of allocations for data we discard.
+        """
+        buf = self._buf
+        while True:
+            pos = self._pos
+            header = buf[pos]
+            pos += 1
+            if header == 0:  # STOP
+                self._pos = pos
+                return
+            field_type = header & 0x0F
+            if not (header >> 4) & 0x0F:  # long-form id, whose value we discard
+                while buf[pos] & 0x80:
+                    pos += 1
+                pos += 1
+            if field_type in (_I16, _I32, _I64):
+                # Integers are most of what a footer skips, so this one case is
+                # unrolled rather than dispatched through _skip.
+                while buf[pos] & 0x80:
+                    pos += 1
+                self._pos = pos + 1
+            else:
+                self._pos = pos
+                self._skip(field_type)
+
+    def _skip_list(self) -> None:
+        """Skip a list or set, in one step where the element width allows it.
+
+        Fixed-width elements need no per-element walk at all, which is what makes
+        the level histograms and ``ColumnIndex`` null-page lists cheap to step
+        over. Varints have to be scanned individually since their width is in
+        the data.
+        """
+        size, element_type = self._list_header()
+        if not size:
+            return
+        if element_type in (_I16, _I32, _I64):
+            for _ in range(size):
+                self._skip_varint()
+        elif element_type in (_BOOL_TRUE, _BOOL_FALSE, _BYTE):
+            # Unlike in a struct, a bool in a container does occupy a byte.
+            self._pos += size
+        elif element_type == _DOUBLE:
+            self._pos += 8 * size
+        else:
+            for _ in range(size):
+                self._skip(element_type)
+
+    def _i64_list(self, field_id: int) -> Tuple[int, ...]:
+        size, element_type = self._list_header()
+        # An empty list's element type carries no information, so only a
+        # populated list is worth checking.
+        if size and element_type != _I64:
+            raise _ThriftDesync(
+                f"SizeStatistics field {field_id} is a list of type "
+                f"{element_type}, expected i64"
+            )
+        return tuple(self._zigzag() for _ in range(size))
+
+    def _size_statistics(self) -> LeafSizeStats:
+        unencoded: Optional[int] = None
+        repetition: Tuple[int, ...] = ()
+        definition: Tuple[int, ...] = ()
+        for field_id, field_type in self._fields():
+            # Type mismatches on 1/2/3 are the load-bearing check: field 17
+            # ``geospatial_statistics`` is also a struct, so a cursor that
+            # drifted onto it would pass the outer struct test. Its field 1 is a
+            # BoundingBox struct rather than an i64, which only this catches.
+            if field_id == _SIZE_STATS_UNENCODED_BYTES:
+                if field_type != _I64:
+                    raise _ThriftDesync(
+                        f"SizeStatistics field 1 has type {field_type}, expected i64"
+                    )
+                unencoded = self._zigzag()
+            elif field_id == _SIZE_STATS_REPETITION_HISTOGRAM:
+                if field_type != _LIST:
+                    raise _ThriftDesync(
+                        f"SizeStatistics field 2 has type {field_type}, expected list"
+                    )
+                repetition = self._i64_list(field_id)
+            elif field_id == _SIZE_STATS_DEFINITION_HISTOGRAM:
+                if field_type != _LIST:
+                    raise _ThriftDesync(
+                        f"SizeStatistics field 3 has type {field_type}, expected list"
+                    )
+                definition = self._i64_list(field_id)
+            else:
+                self._skip(field_type)
+        return LeafSizeStats(unencoded, repetition, definition)
+
+    def _column_metadata(self) -> Optional[LeafSizeStats]:
+        """Read field 16 out of one ``ColumnMetaData``, or ``None`` if absent.
+
+        Hand-inlined rather than driven by :meth:`_fields`, because this is the
+        walk's innermost loop -- once per leaf per row group -- and every field
+        but one is stepped over. Most of them are integers (offsets, counts,
+        sizes), so that case is unrolled here and only the remainder reaches
+        :meth:`_skip`. arrow-rs hand-optimized the equivalent structs, and left
+        the colder ones declarative, for the same reason.
+        """
+        size_stats: Optional[LeafSizeStats] = None
+        buf = self._buf
+        last_id = 0
+        while True:
+            pos = self._pos
+            header = buf[pos]
+            self._pos = pos + 1
+            if header == 0:  # STOP
+                break
+            field_type = header & 0x0F
+            delta = (header >> 4) & 0x0F
+            last_id = last_id + delta if delta else self._zigzag()
+
+            if last_id == _COLUMN_META_SIZE_STATISTICS:
+                if field_type != _STRUCT:
+                    raise _ThriftDesync(
+                        f"ColumnMetaData field 16 has type {field_type}, "
+                        "expected struct"
+                    )
+                size_stats = self._size_statistics()
+            elif field_type in (_I16, _I32, _I64):
+                self._skip_varint()
+            else:
+                self._skip(field_type)
+        return size_stats
+
+    def _column_chunk(self) -> Optional[LeafSizeStats]:
+        stats: Optional[LeafSizeStats] = None
+        for field_id, field_type in self._fields():
+            if field_id == _COLUMN_CHUNK_META_DATA and field_type == _STRUCT:
+                stats = self._column_metadata()
+            else:
+                self._skip(field_type)
+        return stats
+
+    def _row_group(self) -> List[Optional[LeafSizeStats]]:
+        columns: List[Optional[LeafSizeStats]] = []
+        for field_id, field_type in self._fields():
+            if field_id == _ROW_GROUP_COLUMNS and field_type == _LIST:
+                size, _ = self._list_header()
+                columns = [self._column_chunk() for _ in range(size)]
+            else:
+                self._skip(field_type)
+        return columns
+
+    def read(self) -> List[List[Optional[LeafSizeStats]]]:
+        row_groups: List[List[Optional[LeafSizeStats]]] = []
+        for field_id, field_type in self._fields():
+            if field_id == _FILE_META_ROW_GROUPS and field_type == _LIST:
+                size, _ = self._list_header()
+                row_groups = [self._row_group() for _ in range(size)]
+            else:
+                self._skip(field_type)
+        return row_groups
+
+
+def footer_bytes(metadata: "FileMetaData") -> Optional[memoryview]:
+    """The raw Thrift footer behind a ``FileMetaData``, or ``None``.
+
+    ``__reduce__`` is how PyArrow pickles ``FileMetaData``, so it returns the
+    serialized footer with no additional I/O. It is an implementation detail
+    rather than public API, hence probed defensively -- Ray supports
+    ``pyarrow >= 17.0.0``.
+    """
+    try:
+        payload = metadata.__reduce__()[1][0]
+    except Exception as exc:
+        logger.error(f"Error getting footer bytes: {exc}")
+        return None
+    try:
+        # ``memoryview(pyarrow.Buffer)`` has format 'b' -- *signed* char -- so
+        # every byte >= 0x80 reads back negative. The reader only ever consumes
+        # bytes through masks, which Python's arbitrary-precision two's complement
+        # makes sign-agnostic, so this cast is not load-bearing today; it is here
+        # so that anything later comparing a raw byte value cannot be caught out.
+        return memoryview(payload).cast("B")
+    except (TypeError, ValueError) as exc:
+        logger.error(f"Error casting footer bytes: {exc}")
+        return None
+
+
+def read_size_statistics(
+    metadata: "FileMetaData",
+) -> Optional[List[List[Optional[LeafSizeStats]]]]:
+    """``SizeStatistics`` indexed ``[row_group][leaf]``, or ``None`` if unusable.
+
+    ``None`` means the caller must fall back to its existing sizing: the footer
+    bytes were unrecoverable, or the walk could not produce a result of the shape
+    the footer says it should have.
+
+    What guards the result is structural: the type assertions on the fields this
+    walk claims to recognize (see :meth:`_CompactReader._size_statistics`), and
+    the row-group and leaf counts checked here. The counts matter beyond sanity
+    because callers pair ``[row_group][leaf]`` against ``ParquetSchema.column``
+    by position, so a wrong leaf count would silently size the wrong columns.
+
+    Note what is *not* checked: the decoded numbers themselves. A cursor desync
+    that survives the type assertions and preserves the counts would return
+    plausible but wrong sizes rather than ``None``. That is a deliberate trade --
+    per-chunk verification cost a decode of two extra fields on every leaf -- and
+    it is why the differential test against an independent Thrift implementation
+    is the load-bearing check on this module.
+    """
+    buf = footer_bytes(metadata)
+    if buf is None:
+        return None
+    try:
+        row_groups = _CompactReader(buf).read()
+    except Exception as exc:
+        logger.error(f"Error reading size statistics: {exc}")
+        # Includes _ThriftDesync and the IndexError a truncated footer produces.
+        # Never raises into the caller: sizing has a working fallback, so a
+        # footer we cannot decode must not fail the read.
+        return None
+
+    if len(row_groups) != metadata.num_row_groups:
+        return None
+    num_columns = metadata.num_columns
+    if any(len(columns) != num_columns for columns in row_groups):
+        return None
+    return row_groups

--- a/python/ray/data/_internal/datasource_v2/listing/footer_file_indexer.py
+++ b/python/ray/data/_internal/datasource_v2/listing/footer_file_indexer.py
@@ -75,6 +75,8 @@ def _file_chunks_to_manifest(file_chunks: FileChunks) -> FileManifest:
                 fully_matched=rg.fully_matched,
                 rg_sizes=rg.rg_sizes,
                 rg_rows=rg.rg_rows,
+                decoded_size=rg.decoded_size,
+                rg_decoded_sizes=rg.rg_decoded_sizes,
             )
             for rg in file_chunks.row_groups
         ],

--- a/python/ray/data/_internal/datasource_v2/listing/footer_reader.py
+++ b/python/ray/data/_internal/datasource_v2/listing/footer_reader.py
@@ -13,12 +13,21 @@ import ray
 from ray.data._internal.datasource.parquet_datasource import (
     _row_group_uncompressed_size,
 )
+from ray.data._internal.datasource_v2.chunkers.parquet_decoded_size import (
+    LeafProfile,
+    build_leaf_profiles,
+    estimate_row_group_decoded_size,
+)
 from ray.data._internal.datasource_v2.chunkers.parquet_footer_types import (
     FileChunks,
     RowGroupInfo,
 )
 from ray.data._internal.datasource_v2.chunkers.parquet_row_group_coalescing import (
     coalesce_row_groups,
+)
+from ray.data._internal.datasource_v2.chunkers.parquet_size_statistics import (
+    LeafSizeStats,
+    read_size_statistics,
 )
 from ray.data._internal.planner.plan_expression.expression_visitors import (
     get_column_references,
@@ -106,7 +115,7 @@ class FooterReader:
             else list(DEFAULT_RETRIED_IO_ERRORS)
         )
         # Coalescing target: merge contiguous row groups into chunks of
-        # ~coalesce_bytes uncompressed before returning them, so the driver packs
+        # ~coalesce_bytes decoded before returning them, so the driver packs
         # fewer items. 0 disables coalescing (one chunk per physical row group).
         self.coalesce_bytes = coalesce_bytes
         self.filesystem = filesystem
@@ -164,6 +173,8 @@ class FooterReader:
         row_group: RowGroupMetaData,
         rg_idx: int,
         leaf_indices: list[int] | None,
+        leaf_profiles: list[LeafProfile] | None,
+        size_stats: list[LeafSizeStats | None] | None,
         fully_matched: bool = False,
     ) -> RowGroupInfo:
         # Sum per-column sizes on both paths -- with a projection, only the
@@ -174,11 +185,20 @@ class FooterReader:
         # tasks, which is the failure this whole path exists to avoid. Shares
         # the V1 helper so the three call sites cannot drift.
         uncompressed = _row_group_uncompressed_size(row_group, leaf_indices)
+        # The decoded size is what a read task's Arrow block actually costs, so
+        # it is what the bin budget wants. ``None`` (the estimator's answer to
+        # ``leaf_profiles``/``size_stats`` of ``None``, i.e. a footer with no
+        # usable SizeStatistics) leaves consumers on the uncompressed value; the
+        # uncompressed number is recorded either way so both stay comparable.
+        decoded = estimate_row_group_decoded_size(
+            row_group, leaf_profiles, leaf_indices, size_stats
+        )
         return RowGroupInfo(
             rg_idx=rg_idx,
             uncompressed_size=uncompressed,
             num_rows=row_group.num_rows,
             fully_matched=fully_matched,
+            decoded_size=decoded,
         )
 
     def _locate_filter_columns(self, schema: ParquetSchema) -> _FilterLeaves:
@@ -279,9 +299,12 @@ class FooterReader:
         )
         # Both column look-ups are schema-derived, and a Parquet file has a
         # single schema, so resolve them once rather than rescanning every leaf
-        # for each group. The read-column lookup reads leaf paths off row group 0,
-        # which a file with no row groups has none of; it sizes nothing either way.
-        filter_leaves = self._locate_filter_columns(metadata.schema)
+        # for each group. (``metadata.schema`` builds a fresh wrapper per access,
+        # hence the local.) The read-column lookup reads leaf paths off row group
+        # 0, which a file with no row groups has none of; it sizes nothing either
+        # way.
+        schema = metadata.schema
+        filter_leaves = self._locate_filter_columns(schema)
         leaf_indices = (
             self._read_leaf_indices(metadata.row_group(0))
             if metadata.num_row_groups
@@ -334,11 +357,23 @@ class FooterReader:
             # falls through to its fully-matched default for every group.
             fully_by_idx = {}
 
+        # One Thrift walk per file over the footer bytes ``metadata`` already
+        # holds -- no extra IO, though ``__reduce__`` does re-serialize the
+        # footer, so skip it when the predicate pruned every row group. ``None``
+        # when the writer emitted no SizeStatistics or the walk failed its
+        # cross-check, which leaves every row group of this file on the
+        # uncompressed sizing. The leaf profiles hoist the estimator's
+        # schema-derived facts out of the per-row-group loop.
+        size_stats = read_size_statistics(metadata) if rg_indices else None
+        leaf_profiles = build_leaf_profiles(schema) if size_stats is not None else None
+
         per_rg = [
             self._row_group_info(
                 row_group=metadata.row_group(rg_idx),
                 rg_idx=rg_idx,
                 leaf_indices=leaf_indices,
+                leaf_profiles=leaf_profiles,
+                size_stats=size_stats[rg_idx] if size_stats is not None else None,
                 fully_matched=fully_by_idx.get(rg_idx, True),
             )
             for rg_idx in rg_indices

--- a/python/ray/data/_internal/datasource_v2/parquet_datasource_v2.py
+++ b/python/ray/data/_internal/datasource_v2/parquet_datasource_v2.py
@@ -10,6 +10,7 @@ Constructed from `read_api.read_parquet` when
 from __future__ import annotations
 
 import logging
+import sys
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, List, Literal, Optional, Union
 
@@ -39,7 +40,7 @@ from ray.data.checkpoint.generated_id import (
     GENERATED_ID_COLUMN_TYPE,
     get_generated_id_column_name,
 )
-from ray.data.context import DataContext
+from ray.data.context import DEFAULT_TARGET_MAX_BLOCK_SIZE, DataContext
 from ray.data.datasource.partitioning import (
     Partitioning,
     PartitionStyle,
@@ -191,9 +192,25 @@ class ParquetDatasourceV2(DataSourceV2[FileManifest]):
         from ray.data._internal.datasource_v2.partitioners.online_bin_packer import (
             OnlineBinPacker,
         )
-        from ray.data._internal.util import MiB
 
-        max_bin_bytes = env_integer("RAY_DATA_PARQUET_BIN_PACKING_BYTES", 128 * MiB)
+        # Bins are budgeted in Arrow decoded bytes, which is exactly what
+        # ``target_max_block_size`` bounds, so default the cap to it rather than
+        # to an independent constant that could drift from the block target. The
+        # env var stays as an override.
+        #
+        # ``read_api`` passes ``sys.maxsize`` when block sizing is disabled, and
+        # that as a bin cap would pack every file into a single bin, so the
+        # sentinel falls back to the default block target -- the same constant
+        # ``max_bucket_size`` is derived from when block sizing is on.
+        max_bucket_size = kwargs.get("max_bucket_size")
+        default_bin_bytes = (
+            max_bucket_size
+            if max_bucket_size and max_bucket_size < sys.maxsize
+            else DEFAULT_TARGET_MAX_BLOCK_SIZE
+        )
+        max_bin_bytes = env_integer(
+            "RAY_DATA_PARQUET_BIN_PACKING_BYTES", default_bin_bytes
+        )
         max_shared_open_bins = env_integer(
             "RAY_DATA_PARQUET_BIN_PACKING_MAX_SHARED_OPEN_BINS", 16
         )

--- a/python/ray/data/_internal/datasource_v2/partitioners/file_partitioner.py
+++ b/python/ray/data/_internal/datasource_v2/partitioners/file_partitioner.py
@@ -1,4 +1,5 @@
 from abc import ABC, abstractmethod
+from typing import Optional
 
 from ray.data._internal.datasource_v2.listing.file_manifest import FileManifest
 
@@ -23,6 +24,20 @@ class FilePartitioner(ABC):
         ``True``, and ``plan_list_files_op`` then runs listing as a single task.
         """
         return False
+
+    @property
+    def max_partition_decoded_bytes(self) -> Optional[int]:
+        """Upper bound, in Arrow decoded bytes, on the data in one partition.
+
+        ``None`` (the default) means the partitioner can't bound it, which is the
+        honest answer whenever partitions are sized from an encoding-ratio
+        estimate rather than from real decoded sizes. Callers use this to reserve
+        Ray ``memory`` per read task (see
+        :mod:`~ray.data._internal.datasource_v2.read_task_memory`), so returning
+        a number derived from a guess would turn that guess into a scheduling
+        constraint.
+        """
+        return None
 
     @abstractmethod
     def add_input(self, input_manifest: FileManifest):

--- a/python/ray/data/_internal/datasource_v2/partitioners/online_bin_packer.py
+++ b/python/ray/data/_internal/datasource_v2/partitioners/online_bin_packer.py
@@ -11,6 +11,10 @@ from ray.data._internal.datasource_v2.chunkers.file_chunker import (
     ParquetRowGroupChunkMetadata,
     create_chunk_metadata,
 )
+from ray.data._internal.datasource_v2.chunkers.parquet_decoded_size import (
+    decoded_size_or_fallback,
+    sum_exact,
+)
 from ray.data._internal.datasource_v2.chunkers.parquet_footer_types import (
     Bin,
     BinItem,
@@ -23,17 +27,37 @@ from ray.data._internal.datasource_v2.partitioners.file_partitioner import (
 logger = logging.getLogger(__name__)
 
 
+def _decoded_bytes(item: BinItem) -> int:
+    """The item's size in the units the bin budget is measured in.
+
+    Parquet's uncompressed size is still dictionary/RLE/bit-packed, so it is a
+    poor proxy for the Arrow block a read task materializes -- which is what the
+    budget is really bounding. Falls back to the pre-existing scaled estimate when
+    the footer could not produce an exact decoded size.
+    """
+    return decoded_size_or_fallback(item.decoded_size, item.uncompressed_size)
+
+
 @dataclass
 class _OpenBin:
     items: List[BinItem] = field(default_factory=list)
+    # Decoded bytes, which is what the cap is enforced against.
     used_bytes: int = 0
+    # Tracked only so a sealed bin can report both numbers; never compared to the
+    # cap.
+    uncompressed_bytes: int = 0
 
     def add(self, item: BinItem) -> None:
         self.items.append(item)
-        self.used_bytes += item.uncompressed_size
+        self.used_bytes += _decoded_bytes(item)
+        self.uncompressed_bytes += item.uncompressed_size
 
     def seal(self) -> Bin:
-        return Bin(tuple(self.items), self.used_bytes)
+        return Bin(
+            items=tuple(self.items),
+            total_uncompressed_size=self.uncompressed_bytes,
+            total_decoded_size=self.used_bytes,
+        )
 
 
 def _prefix_sums(unit_sizes: List[int]) -> List[int]:
@@ -68,6 +92,9 @@ def _slice_bin_item(item: BinItem, a: int, b: int) -> BinItem:
     # limit push-down, and rg_idx shifts by ``a`` because the run is contiguous.
     sizes = item.rg_sizes[a:b]
     rows = item.rg_rows[a:b]
+    # Empty when the run had no exact decoded sizing, in which case the slice
+    # inherits that and keeps falling back.
+    decoded_sizes = item.rg_decoded_sizes[a:b]
     count = b - a
     return BinItem(
         path=item.path,
@@ -78,6 +105,8 @@ def _slice_bin_item(item: BinItem, a: int, b: int) -> BinItem:
         rg_count=count,
         rg_sizes=sizes if count > 1 else (),
         rg_rows=rows if count > 1 else (),
+        decoded_size=sum(decoded_sizes) if decoded_sizes else None,
+        rg_decoded_sizes=decoded_sizes if count > 1 else (),
     )
 
 
@@ -150,7 +179,7 @@ class _SharedBinPool(_BinPool):
         # First Fit on the WHOLE item: place it unsplit in the first bin it fits.
         # Returns False when it fits nowhere, leaving the caller to fall back to
         # the best-fit-per-unit walk.
-        total = item.uncompressed_size
+        total = _decoded_bytes(item)
         target = next(
             (b for b in self._bins if b.used_bytes + total <= self._cap), None
         )
@@ -253,6 +282,11 @@ def _bin_items(manifest: FileManifest) -> List[BinItem]:
         manifest.paths, manifest.file_sizes, manifest.file_chunk_metadatas
     ):
         if md is None or "row_group_ids" not in md:
+            # No footer stats, so the only size available is the file's on-disk
+            # (compressed) length. Leaving ``decoded_size`` unset routes it
+            # through the same fallback as a chunk whose footer had no size
+            # statistics, which is the coherent reading now that the bin budget
+            # counts decoded bytes.
             items.append(
                 BinItem(
                     path=str(path),
@@ -263,6 +297,11 @@ def _bin_items(manifest: FileManifest) -> List[BinItem]:
             )
             continue
         ids = md["row_group_ids"]
+        # ``.get`` rather than ``[]``: a manifest produced by another partitioner,
+        # or by a chunker predating decoded sizing, need not carry these keys.
+        # Tested against None explicitly because manifest columns arrive as numpy
+        # arrays, whose truthiness is ambiguous.
+        rg_decoded_sizes = md.get("rg_decoded_sizes")
         items.append(
             BinItem(
                 path=str(path),
@@ -273,6 +312,10 @@ def _bin_items(manifest: FileManifest) -> List[BinItem]:
                 rg_count=len(ids),
                 rg_sizes=tuple(md["rg_sizes"]),
                 rg_rows=tuple(md["rg_rows"]),
+                decoded_size=md.get("decoded_size"),
+                rg_decoded_sizes=(
+                    () if rg_decoded_sizes is None else tuple(rg_decoded_sizes)
+                ),
             )
         )
     return items
@@ -316,6 +359,14 @@ class OnlineBinPacker(FilePartitioner):
     def requires_global_input(self) -> bool:
         return True
 
+    @property
+    def max_partition_decoded_bytes(self) -> Optional[int]:
+        # The cap is enforced in decoded bytes (see ``_decoded_bytes``), so it is
+        # a real bound rather than an estimate -- except for the relaxation that
+        # lets a lone row group larger than a whole bin through, which a caller
+        # sizing memory off this should treat as the known outlier it is.
+        return self._cap
+
     # === Feeding ===
 
     def add_input(self, input_manifest: FileManifest) -> None:
@@ -323,16 +374,21 @@ class OnlineBinPacker(FilePartitioner):
             self._place(item)
 
     def _units(self, item: BinItem) -> List[int]:
-        # The row-group boundaries an item may be cut between, as unit sizes. A
-        # splittable coalesced run (split_coalesced and rg_count > 1) yields one
-        # unit per physical row group; anything else yields a single indivisible
-        # unit (the whole item). Placement only ever cuts at unit boundaries.
+        # The row-group boundaries an item may be cut between, as unit sizes in
+        # decoded bytes (the units the cap is in). A splittable coalesced run
+        # (split_coalesced and rg_count > 1) yields one unit per physical row
+        # group; anything else yields a single indivisible unit (the whole item).
+        # Placement only ever cuts at unit boundaries.
         if self._split_coalesced and item.rg_count > 1:
-            return list(item.rg_sizes)
-        return [item.uncompressed_size]
+            if item.rg_decoded_sizes:
+                return list(item.rg_decoded_sizes)
+            # Apply the fallback per row group so the units still sum to the
+            # item's own decoded size.
+            return [decoded_size_or_fallback(None, size) for size in item.rg_sizes]
+        return [_decoded_bytes(item)]
 
     def _place(self, item: BinItem) -> None:
-        item_bytes = item.uncompressed_size
+        item_bytes = _decoded_bytes(item)
         seen_bytes = self._seen_bytes_by_path.get(item.path, 0)
         self._seen_bytes_by_path[item.path] = seen_bytes + item_bytes
 
@@ -340,7 +396,13 @@ class OnlineBinPacker(FilePartitioner):
             # Relaxation: an indivisible chunk bigger than a whole bin gets its own
             # bin. A splittable oversized run instead falls through and is cut into
             # bin-sized pieces by the placers.
-            self._output.append(Bin((item,), item_bytes))
+            self._output.append(
+                Bin(
+                    items=(item,),
+                    total_uncompressed_size=item.uncompressed_size,
+                    total_decoded_size=item_bytes,
+                )
+            )
         elif seen_bytes < self._cap:
             # Prefer keeping a light item whole; fall back to splitting it across
             # the shared bins. This also lets a first, splittable oversized
@@ -377,8 +439,11 @@ class OnlineBinPacker(FilePartitioner):
 
     def next_partition(self) -> FileManifest:
         bin_ = self._output.popleft()
+        # Both totals: the decoded one is what the cap bounded, and the pair makes
+        # the effective inflation ratio visible when a bin looks mis-sized.
         logger.debug(
-            "Emitting bin with %d uncompressed bytes: %s",
+            "Emitting bin with %d decoded bytes (%d uncompressed): %s",
+            bin_.total_decoded_size,
             bin_.total_uncompressed_size,
             [
                 (item.path, item.rg_idx, item.rg_idx + item.rg_count - 1)
@@ -398,35 +463,36 @@ class OnlineBinPacker(FilePartitioner):
         # One manifest row per distinct file in the bin. A file's (possibly-split)
         # items cover disjoint contiguous runs, so union their physical row-group
         # ids into the read unit for that file.
-        ids_by_path: defaultdict = defaultdict(list)
-        rows_by_path: defaultdict = defaultdict(int)
-        size_by_path: defaultdict = defaultdict(int)
-        matched_by_path: dict = {}
+        items_by_path: defaultdict = defaultdict(list)
         for item in bin_.items:
-            ids_by_path[item.path].extend(
-                range(item.rg_idx, item.rg_idx + item.rg_count)
-            )
-            rows_by_path[item.path] += item.num_rows
-            size_by_path[item.path] += item.uncompressed_size
-            matched_by_path[item.path] = (
-                matched_by_path.get(item.path, True) and item.fully_matched
-            )
+            items_by_path[item.path].append(item)
 
         paths: List[str] = []
         sizes: List[int] = []
         chunk_metadatas: List[ParquetRowGroupChunkMetadata] = []
-        for path, ids in ids_by_path.items():
+        for path, items in items_by_path.items():
+            ids = [
+                rg_id
+                for item in items
+                for rg_id in range(item.rg_idx, item.rg_idx + item.rg_count)
+            ]
+            uncompressed_size = sum(item.uncompressed_size for item in items)
             paths.append(path)
-            sizes.append(size_by_path[path])
+            sizes.append(uncompressed_size)
             chunk_metadatas.append(
                 create_chunk_metadata(
                     ParquetRowGroupChunkMetadata,
                     row_group_ids=tuple(sorted(ids)),
-                    num_rows=rows_by_path[path],
-                    uncompressed_size=size_by_path[path],
-                    fully_matched=matched_by_path[path],
+                    num_rows=sum(item.num_rows for item in items),
+                    uncompressed_size=uncompressed_size,
+                    fully_matched=all(item.fully_matched for item in items),
                     rg_sizes=(),
                     rg_rows=(),
+                    # A file's decoded size is exact only if every one of its
+                    # items was (sum_exact); one fallback item makes the whole
+                    # row fall back rather than reporting a mixed total.
+                    decoded_size=sum_exact(item.decoded_size for item in items),
+                    rg_decoded_sizes=(),
                 )
             )
         # TypedDict invariance: ``ParquetRowGroupChunkMetadata`` has extra keys

--- a/python/ray/data/_internal/datasource_v2/read_task_memory.py
+++ b/python/ray/data/_internal/datasource_v2/read_task_memory.py
@@ -1,0 +1,97 @@
+"""Logical memory reservation for V2 read tasks.
+
+A read task's heap footprint is dominated by the block it produces, and for
+Parquet the footer's ``SizeStatistics`` tell us that block's Arrow size exactly
+(see :mod:`~ray.data._internal.datasource_v2.chunkers.parquet_decoded_size`).
+That makes it worth reserving Ray ``memory`` up front rather than leaving read
+tasks to the operator-level default, which is a flat per-CPU number that has to
+assume the worst.
+"""
+
+from typing import Any, Dict
+
+from ray.data._internal.datasource_v2.partitioners.file_partitioner import (
+    FilePartitioner,
+)
+from ray.data._internal.util import MiB
+from ray.data.context import DataContext
+from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
+
+# What a read worker costs before it touches any data: interpreter, the
+# ``ray`` / ``pyarrow`` / ``numpy`` / ``pandas`` imports, and allocator warmup.
+# Measured at 168-189 MiB of peak worker RSS reading an 8 KiB file on Linux
+# (glibc 2.41), rounded up for headroom since the real figure grows with
+# whatever else a job imports into its workers.
+READ_TASK_BASE_MEMORY = 256 * MiB
+
+# How much peak RSS a read task adds per Arrow byte of the block it produces.
+# Measured against real Ray worker peak RSS on Linux, fitting peak against
+# target block size across a 16-type matrix: the slope ranges from 3.7x for flat
+# ``int64`` up to 8.1x for 50 KiB strings.
+#
+# It exceeds 1x because the transient decode state peaks *alongside* the output
+# block rather than replacing it -- encoded pages, batches in flight, and the
+# copy made when the block builder seals the block. The spread is by column
+# type, so this takes the steepest measured slope; the alternative is
+# under-reserving the very workloads (wide lists, tensors, large strings) most
+# likely to exhaust a worker.
+READ_TASK_MEMORY_PER_DECODED_BYTE = 8
+
+
+def read_task_memory(max_partition_decoded_bytes: int) -> int:
+    """Bytes of Ray ``memory`` to reserve for one read task.
+
+    Args:
+        max_partition_decoded_bytes: Upper bound on the Arrow size of the data a
+            single read task handles.
+
+    Returns:
+        The reservation, in bytes.
+    """
+    return (
+        READ_TASK_BASE_MEMORY
+        + READ_TASK_MEMORY_PER_DECODED_BYTE * max_partition_decoded_bytes
+    )
+
+
+def apply_read_task_memory(
+    ray_remote_args: Dict[str, Any],
+    partitioner: FilePartitioner,
+    ctx: DataContext,
+) -> Dict[str, Any]:
+    """Add a ``memory`` reservation to ``ray_remote_args`` when we can size one.
+
+    No-ops unless the partitioner can bound a partition's decoded size, which
+    today means the Parquet footer path -- every other partitioner sizes
+    partitions from an encoding-ratio guess that isn't worth reserving against.
+
+    Args:
+        ray_remote_args: Remote args for the read op. Not mutated.
+        partitioner: The partitioner grouping listing rows into read tasks.
+        ctx: The active data context, consulted for scheduling strategy.
+
+    Returns:
+        ``ray_remote_args``, or a copy carrying an added ``memory`` key.
+    """
+    # An explicit `memory=` from the caller wins.
+    if "memory" in ray_remote_args:
+        return ray_remote_args
+
+    max_bytes = partitioner.max_partition_decoded_bytes
+    if not max_bytes:
+        return ray_remote_args
+
+    # Reserving memory inside a placement group that reserves none would leave
+    # read tasks permanently unschedulable. ``ConfigureMapTaskMemoryRule``
+    # declines for the same reason.
+    if any(
+        isinstance(strategy, PlacementGroupSchedulingStrategy)
+        for strategy in (
+            ray_remote_args.get("scheduling_strategy"),
+            ctx.scheduling_strategy,
+            ctx.scheduling_strategy_large_args,
+        )
+    ):
+        return ray_remote_args
+
+    return {**ray_remote_args, "memory": read_task_memory(max_bytes)}

--- a/python/ray/data/_internal/datasource_v2/readers/parquet_file_reader.py
+++ b/python/ray/data/_internal/datasource_v2/readers/parquet_file_reader.py
@@ -17,6 +17,9 @@ from ray._common.utils import env_integer
 from ray.data._internal.datasource.parquet_datasource import (
     _row_group_uncompressed_size,
 )
+from ray.data._internal.datasource_v2.chunkers.parquet_decoded_size import (
+    decoded_size_or_fallback,
+)
 from ray.data._internal.datasource_v2.chunkers.parquet_file_chunking_utils import (
     _fragments_from_row_group_ids,
     _with_io_retry,
@@ -153,21 +156,26 @@ def _estimate_batch_size_from_chunk_stats(
     uncompressed_size: int,
     num_rows: int,
     target_block_size: int,
+    decoded_size: Optional[int] = None,
 ) -> Optional[int]:
     """Estimate batch size from footer-derived chunk stats, without any I/O.
 
     ``ListFiles`` already read each file's footer and recorded the
-    projection-scoped uncompressed byte size and row count of the row groups it
-    assigned to this chunk (:class:`ParquetRowGroupChunkMetadata`). Sizing from
-    those avoids the extra footer read that
-    :func:`_estimate_batch_size_from_metadata` incurs. Mirrors that function's
-    math but over the whole chunk (its row-group average) rather than the first
-    row group; the estimate is refined from real data after the first batch.
+    projection-scoped byte size and row count of the row groups it assigned to
+    this chunk (:class:`ParquetRowGroupChunkMetadata`). Sizing from those avoids
+    the extra footer read that :func:`_estimate_batch_size_from_metadata` incurs.
+    Works over the whole chunk (its row-group average) rather than the first row
+    group; the estimate is refined from real data after the first batch.
+
+    ``decoded_size`` is the Arrow size the footer's ``SizeStatistics`` yielded,
+    which is what a batch actually costs in memory. When it is absent this falls
+    back to scaling ``uncompressed_size`` by the fixed encoding ratio -- the same
+    approximation of the same quantity, just a far cruder one.
     """
     if num_rows <= 0 or uncompressed_size <= 0:
         return None
     estimated_in_mem_row_size = (
-        uncompressed_size * PARQUET_ENCODING_RATIO_ESTIMATE_DEFAULT / num_rows
+        decoded_size_or_fallback(decoded_size, uncompressed_size) / num_rows
     )
     if estimated_in_mem_row_size == 0:
         return None
@@ -319,6 +327,7 @@ class ParquetFileReader(FileReader, SupportsMetadata):
                 chunk["uncompressed_size"],
                 chunk["num_rows"],
                 self._target_block_size,
+                chunk.get("decoded_size"),
             )
             if estimated is not None:
                 return estimated

--- a/python/ray/data/read_api.py
+++ b/python/ray/data/read_api.py
@@ -529,6 +529,9 @@ def _read_datasource_v2(
         _build_pruners,
         sample_files,
     )
+    from ray.data._internal.datasource_v2.read_task_memory import (
+        apply_read_task_memory,
+    )
     from ray.data.datasource.file_based_datasource import FileShuffleConfig
 
     ctx = DataContext.get_current()
@@ -626,6 +629,12 @@ def _read_datasource_v2(
         max_bucket_size=max_bucket_size,
         num_buckets=num_buckets,
     )
+
+    # When the partitioner bounds a read task's decoded size, reserve Ray
+    # ``memory`` for it. Setting it here means ``ConfigureMapTaskMemoryRule``
+    # leaves the read op alone, so this replaces that rule's flat per-CPU
+    # default with a number derived from the footer.
+    ray_remote_args = apply_read_task_memory(ray_remote_args, partitioner, ctx)
 
     # NOTE: We're using shuffle config factory to fix the seed at the planning
     #       time, rather than at the composition time (for backward-compatibility)

--- a/python/ray/data/tests/unit/datasource_v2/test_file_chunker.py
+++ b/python/ray/data/tests/unit/datasource_v2/test_file_chunker.py
@@ -28,6 +28,8 @@ class TestCreateChunkMetadata:
                 fully_matched=True,
                 rg_sizes=(),
                 rg_rows=(),
+                decoded_size=50,
+                rg_decoded_sizes=(),
                 extra_field="boom",
             )
 
@@ -40,6 +42,8 @@ class TestCreateChunkMetadata:
             fully_matched=True,
             rg_sizes=(),
             rg_rows=(),
+            decoded_size=50,
+            rg_decoded_sizes=(),
         )
         assert md == {
             "row_group_ids": (0, 1),
@@ -48,6 +52,8 @@ class TestCreateChunkMetadata:
             "fully_matched": True,
             "rg_sizes": (),
             "rg_rows": (),
+            "decoded_size": 50,
+            "rg_decoded_sizes": (),
         }
 
 
@@ -89,6 +95,8 @@ def test_chunk_metadata_subclasses_are_typeddicts():
         fully_matched=True,
         rg_sizes=(),
         rg_rows=(),
+        decoded_size=50,
+        rg_decoded_sizes=(),
     )
     lmd: ChunkMetadata = create_chunk_metadata(
         LineDelimitedFileChunkMetadata,
@@ -102,6 +110,8 @@ def test_chunk_metadata_subclasses_are_typeddicts():
         "fully_matched",
         "rg_sizes",
         "rg_rows",
+        "decoded_size",
+        "rg_decoded_sizes",
     }
     assert set(lmd.keys()) == {"chunk_byte_start_idx", "chunk_byte_end_idx"}
 

--- a/python/ray/data/tests/unit/datasource_v2/test_online_bin_packer.py
+++ b/python/ray/data/tests/unit/datasource_v2/test_online_bin_packer.py
@@ -1,3 +1,4 @@
+from dataclasses import replace
 from typing import Any
 
 import pytest
@@ -16,13 +17,41 @@ from ray.data._internal.datasource_v2.listing.footer_file_indexer import (
 from ray.data._internal.datasource_v2.partitioners.online_bin_packer import (
     OnlineBinPacker,
 )
+from ray.data._internal.datasource_v2.readers.in_memory_size_estimator import (
+    PARQUET_ENCODING_RATIO_ESTIMATE_DEFAULT,
+)
 
 
 def _rg(
     idx: int, size: int, rows: int = 10, fully_matched: bool = True
 ) -> RowGroupInfo:
+    # ``decoded_size == uncompressed_size`` so every byte budget in these tests
+    # reads directly as decoded bytes, which is what the packer measures. The
+    # no-size-statistics fallback is exercised separately via
+    # ``_rg_without_size_stats``.
     return RowGroupInfo(
-        rg_idx=idx, uncompressed_size=size, num_rows=rows, fully_matched=fully_matched
+        rg_idx=idx,
+        uncompressed_size=size,
+        num_rows=rows,
+        fully_matched=fully_matched,
+        decoded_size=size,
+    )
+
+
+def _rg_without_size_stats(
+    idx: int, size: int, rows: int = 10, fully_matched: bool = True
+) -> RowGroupInfo:
+    """A row group whose footer carried no usable ``SizeStatistics``.
+
+    Consumers must then fall back to scaling ``uncompressed_size`` by
+    ``PARQUET_ENCODING_RATIO_ESTIMATE_DEFAULT``, i.e. the pre-existing behavior.
+    """
+    return RowGroupInfo(
+        rg_idx=idx,
+        uncompressed_size=size,
+        num_rows=rows,
+        fully_matched=fully_matched,
+        decoded_size=None,
     )
 
 
@@ -243,6 +272,8 @@ def test_split_coalesced_prefers_bin_that_fits_largest_prefix() -> None:
         rg_count=3,
         rg_sizes=(30, 30, 30),
         rg_rows=(10, 10, 10),
+        decoded_size=90,
+        rg_decoded_sizes=(30, 30, 30),
     )
     bins = _pack(
         [
@@ -272,6 +303,8 @@ def test_split_coalesced_splits_oversize_run_at_boundaries() -> None:
         rg_count=3,
         rg_sizes=(30, 30, 30),
         rg_rows=(10, 10, 10),
+        decoded_size=90,
+        rg_decoded_sizes=(30, 30, 30),
     )
     bins = _pack(
         [FileChunks(path="a", size=90, row_groups=(coalesced,))],
@@ -293,6 +326,8 @@ def test_oversize_coalesced_run_fills_shared_bin() -> None:
         rg_count=2,
         rg_sizes=(40, 80),
         rg_rows=(4, 8),
+        decoded_size=120,
+        rg_decoded_sizes=(40, 80),
     )
     bins = _pack(
         [
@@ -304,6 +339,118 @@ def test_oversize_coalesced_run_fills_shared_bin() -> None:
     )
 
     assert bins == [{"light": [0], "big": [0]}, {"big": [1]}]
+
+
+# ---------------------------------------------------------------------------
+# Decoded sizing, and falling back to the pre-existing math
+# ---------------------------------------------------------------------------
+
+
+def _manifest_decoded(manifest: FileManifest) -> dict[str, int | None]:
+    """A sealed bin's manifest as ``{path: decoded_size}``."""
+    return {
+        str(path): meta["decoded_size"]
+        for path, meta in zip(manifest.paths, manifest.file_chunk_metadatas)
+    }
+
+
+def test_capacity_is_measured_in_decoded_bytes() -> None:
+    # Two row groups of 40 uncompressed bytes each, but 60 decoded. A 100-byte
+    # cap fits one, not both -- which packing on uncompressed bytes would get
+    # wrong, since 40 + 40 <= 100.
+    inflated = RowGroupInfo(
+        rg_idx=0, uncompressed_size=40, num_rows=10, decoded_size=60
+    )
+    bins = _pack(
+        [
+            FileChunks(path="a", size=40, row_groups=(inflated,)),
+            FileChunks(path="b", size=40, row_groups=(replace(inflated, rg_idx=0),)),
+        ],
+        max_bin_bytes=100,
+    )
+    assert bins == [{"a": [0]}, {"b": [0]}]
+
+
+def test_falls_back_to_scaled_uncompressed_without_size_statistics() -> None:
+    # 20 uncompressed bytes -> 100 decoded under the fixed ratio, which exactly
+    # fills a 100-byte bin, so the second row group must open a new one.
+    size = 100 // PARQUET_ENCODING_RATIO_ESTIMATE_DEFAULT
+    bins = _pack(
+        [
+            FileChunks(
+                path="a", size=size, row_groups=(_rg_without_size_stats(0, size),)
+            ),
+            FileChunks(
+                path="b", size=size, row_groups=(_rg_without_size_stats(0, size),)
+            ),
+        ],
+        max_bin_bytes=100,
+    )
+    assert bins == [{"a": [0]}, {"b": [0]}]
+
+
+def test_manifest_carries_decoded_size_when_known() -> None:
+    packer = OnlineBinPacker(max_bin_bytes=1000)
+    packer.add_input(
+        _file_chunks_to_manifest(
+            FileChunks(
+                path="a",
+                size=30,
+                row_groups=(_rg(idx=0, size=10), _rg(idx=1, size=20)),
+            )
+        )
+    )
+    packer.finalize()
+
+    assert _manifest_decoded(packer.next_partition()) == {"a": 30}
+
+
+def test_manifest_reports_none_when_any_item_fell_back() -> None:
+    # Mixing exact and fallback sizing inside one row would produce a total no
+    # consumer could interpret, so the whole row falls back instead.
+    packer = OnlineBinPacker(max_bin_bytes=10_000)
+    packer.add_input(
+        _file_chunks_to_manifest(
+            FileChunks(
+                path="a",
+                size=30,
+                row_groups=(_rg(idx=0, size=10), _rg_without_size_stats(1, 20)),
+            )
+        )
+    )
+    packer.finalize()
+
+    assert _manifest_decoded(packer.next_partition()) == {"a": None}
+
+
+def test_coalesce_target_measures_decoded_bytes() -> None:
+    # 10 uncompressed bytes each but 30 decoded, so a 50-byte target admits two
+    # row groups and then breaks -- where sizing on uncompressed bytes would have
+    # merged all three.
+    per_rg = [
+        RowGroupInfo(rg_idx=i, uncompressed_size=10, num_rows=1, decoded_size=30)
+        for i in range(3)
+    ]
+    out = coalesce_row_groups(per_rg, 50)
+
+    assert [(c.rg_idx, c.rg_count) for c in out] == [(0, 2), (2, 1)]
+    assert out[0].decoded_size == 60
+    assert out[0].rg_decoded_sizes == (30, 30)
+
+
+def test_coalesce_drops_decoded_size_for_a_mixed_run() -> None:
+    per_rg = [
+        RowGroupInfo(rg_idx=0, uncompressed_size=10, num_rows=1, decoded_size=30),
+        RowGroupInfo(rg_idx=1, uncompressed_size=10, num_rows=1, decoded_size=None),
+    ]
+    out = coalesce_row_groups(per_rg, 1000)
+
+    assert len(out) == 1 and out[0].rg_count == 2
+    # Uncompressed stays exact and keeps its breakdown; decoded falls back.
+    assert out[0].uncompressed_size == 20
+    assert out[0].rg_sizes == (10, 10)
+    assert out[0].decoded_size is None
+    assert out[0].rg_decoded_sizes == ()
 
 
 if __name__ == "__main__":

--- a/python/ray/data/tests/unit/datasource_v2/test_parquet_decoded_size.py
+++ b/python/ray/data/tests/unit/datasource_v2/test_parquet_decoded_size.py
@@ -1,0 +1,455 @@
+"""Tests for Arrow decoded-size estimation from Parquet footer metadata.
+
+The point of the estimator is accuracy against what a read task actually
+materializes, so most of these compare against a real ``pa.Table.nbytes`` rather
+than against a hand-computed formula -- a formula test would pass just as happily
+with the wrong formula.
+"""
+
+import datetime
+import os
+from decimal import Decimal
+
+import numpy as np
+import pytest
+
+from ray.data._internal.datasource_v2.chunkers.parquet_decoded_size import (
+    build_leaf_profiles,
+    decoded_size_or_fallback,
+    estimate_row_group_decoded_size,
+    parquet_leaf_fixed_width,
+)
+from ray.data._internal.datasource_v2.chunkers.parquet_size_statistics import (
+    LeafSizeStats,
+    read_size_statistics,
+)
+from ray.data._internal.datasource_v2.readers.in_memory_size_estimator import (
+    PARQUET_ENCODING_RATIO_ESTIMATE_DEFAULT,
+)
+
+pa = pytest.importorskip("pyarrow")
+pq = pytest.importorskip("pyarrow.parquet")
+
+N = 5000
+
+# Arrow allocates a validity bitmap for some null-free optional leaves anyway, so
+# the estimate can sit a bitmap's worth (1/8 byte per value) below the real
+# nbytes. That is ~1.5% on an 8-byte type and irrelevant against a bin budget of
+# hundreds of megabytes, but it means "exact" here means "within a bitmap".
+_TOLERANCE = 0.02
+
+
+def _cases():
+    """The measured case matrix: every branch of the width table and the gate."""
+    return {
+        "int64-plain": pa.table({"a": pa.array(np.arange(N, dtype="int64"))}),
+        # Dictionary-encoded on disk, so uncompressed size badly understates it.
+        "int64-low-cardinality": pa.table({"a": pa.array(np.zeros(N, dtype="int64"))}),
+        "float64": pa.table({"a": pa.array(np.random.rand(N))}),
+        "bool": pa.table({"a": pa.array([i % 2 == 0 for i in range(N)])}),
+        "string-low-cardinality": pa.table(
+            {"a": pa.array([f"v{i % 5}" for i in range(N)])}
+        ),
+        "string-high-cardinality": pa.table(
+            {"a": pa.array([f"val_{i}_{i * 7}" for i in range(N)])}
+        ),
+        "string-nullable-dict": pa.table(
+            {"a": pa.array([None if i % 3 == 0 else f"v{i % 4}" for i in range(N)])}
+        ),
+        "string-large-values": pa.table(
+            {"a": pa.array(["x" * 50_000 for _ in range(20)])}
+        ),
+        "mixed-int-string": pa.table(
+            {
+                "i": pa.array(np.arange(N, dtype="int64")),
+                "s": pa.array([f"s{i % 101}" for i in range(N)]),
+            }
+        ),
+        "list-int64": pa.table(
+            {"a": pa.array([[1, 2, 3]] * N, type=pa.list_(pa.int64()))}
+        ),
+        "decimal128": pa.table({"a": pa.array(range(N), type=pa.decimal128(10, 2))}),
+        "timestamp": pa.table(
+            {"a": pa.array(np.arange(N, dtype="int64"), type=pa.timestamp("us"))}
+        ),
+        "int8": pa.table({"a": pa.array([i % 100 for i in range(N)], type=pa.int8())}),
+        "int16": pa.table(
+            {"a": pa.array([i % 3000 for i in range(N)], type=pa.int16())}
+        ),
+        "struct-string-list": pa.table(
+            {
+                "a": pa.array(
+                    [{"s": f"v{i % 7}", "l": [1, 2]} for i in range(N)],
+                    type=pa.struct([("s", pa.string()), ("l", pa.list_(pa.int64()))]),
+                )
+            }
+        ),
+    }
+
+
+def _estimate_whole_file(path, leaf_indices=None):
+    """Decoded-size estimate summed over every row group of a single file."""
+    metadata = pq.read_metadata(str(path))
+    size_stats = read_size_statistics(metadata)
+    assert size_stats is not None, "PyArrow-written files should carry SizeStatistics"
+    leaf_profiles = build_leaf_profiles(metadata.schema)
+    total = 0
+    for rg_idx in range(metadata.num_row_groups):
+        estimate = estimate_row_group_decoded_size(
+            metadata.row_group(rg_idx),
+            leaf_profiles,
+            leaf_indices,
+            size_stats[rg_idx],
+        )
+        assert estimate is not None
+        total += estimate
+    return total
+
+
+@pytest.mark.parametrize("label", list(_cases()))
+def test_estimate_matches_actual_nbytes(tmp_path, label):
+    table = _cases()[label]
+    path = tmp_path / f"{label}.parquet"
+    # One row group, so the estimate is compared against exactly one table.
+    pq.write_table(table, path, row_group_size=len(table))
+
+    estimate = _estimate_whole_file(path)
+    actual = pq.read_table(str(path)).nbytes
+
+    assert estimate == pytest.approx(actual, rel=_TOLERANCE), (
+        f"{label}: estimated {estimate}, actual {actual} "
+        f"(ratio {estimate / actual:.3f})"
+    )
+
+
+@pytest.mark.parametrize("label", list(_cases()))
+def test_estimate_beats_the_fixed_encoding_ratio(tmp_path, label):
+    """The whole point: decoded sizing must be closer than uncompressed x 5.
+
+    The fixed ratio spans well over two orders of magnitude across this matrix --
+    far under-sizing dictionary-encoded data and far over-sizing plain numerics --
+    which is what makes it unusable for a decision as final as bin assignment.
+    """
+    table = _cases()[label]
+    path = tmp_path / f"{label}.parquet"
+    pq.write_table(table, path, row_group_size=len(table))
+
+    metadata = pq.read_metadata(str(path))
+    actual = pq.read_table(str(path)).nbytes
+    uncompressed = sum(
+        metadata.row_group(rg).column(leaf).total_uncompressed_size
+        for rg in range(metadata.num_row_groups)
+        for leaf in range(metadata.num_columns)
+    )
+
+    new_error = abs(_estimate_whole_file(path) / actual - 1.0)
+    old_error = abs(
+        uncompressed * PARQUET_ENCODING_RATIO_ESTIMATE_DEFAULT / actual - 1.0
+    )
+    assert new_error <= old_error
+
+
+def test_estimate_is_scoped_to_projected_leaves(tmp_path):
+    """A projection must size only the leaves the read task decodes."""
+    path = tmp_path / "mixed.parquet"
+    table = _cases()["mixed-int-string"]
+    pq.write_table(table, path, row_group_size=len(table))
+
+    int_only = _estimate_whole_file(path, leaf_indices=[0])
+    string_only = _estimate_whole_file(path, leaf_indices=[1])
+    both = _estimate_whole_file(path, leaf_indices=None)
+
+    assert int_only + string_only == both
+    assert int_only == pytest.approx(
+        pq.read_table(str(path), columns=["i"]).nbytes, rel=_TOLERANCE
+    )
+
+
+def test_multiple_row_groups_sum_to_whole_file(tmp_path):
+    path = tmp_path / "multi.parquet"
+    table = _cases()["mixed-int-string"]
+    pq.write_table(table, path, row_group_size=len(table) // 4)
+
+    assert pq.read_metadata(str(path)).num_row_groups == 4
+    assert _estimate_whole_file(path) == pytest.approx(
+        pq.read_table(str(path)).nbytes, rel=_TOLERANCE
+    )
+
+
+# ---------------------------------------------------------------------------
+# Falling back
+# ---------------------------------------------------------------------------
+
+
+def test_returns_none_without_size_statistics(tmp_path):
+    path = tmp_path / "flat.parquet"
+    table = _cases()["string-high-cardinality"]
+    pq.write_table(table, path, row_group_size=len(table))
+    metadata = pq.read_metadata(str(path))
+
+    assert (
+        estimate_row_group_decoded_size(
+            metadata.row_group(0), build_leaf_profiles(metadata.schema), None, None
+        )
+        is None
+    )
+
+
+def test_returns_none_when_byte_array_leaf_lacks_unencoded_bytes(tmp_path):
+    """A BYTE_ARRAY leaf's character bytes exist nowhere else in the footer."""
+    path = tmp_path / "strings.parquet"
+    table = _cases()["string-high-cardinality"]
+    pq.write_table(table, path, row_group_size=len(table))
+    metadata = pq.read_metadata(str(path))
+    stripped = [LeafSizeStats(None, (), (0, N))]
+
+    assert (
+        estimate_row_group_decoded_size(
+            metadata.row_group(0), build_leaf_profiles(metadata.schema), None, stripped
+        )
+        is None
+    )
+
+
+def test_fixed_width_leaf_needs_no_unencoded_bytes(tmp_path):
+    """The gate must be BYTE_ARRAY-scoped, not applied to every leaf.
+
+    PyArrow legitimately omits sub-field 1 on numeric leaves, so a gate requiring
+    it everywhere would silently disable exact sizing for every flat numeric
+    schema while still paying the decode cost.
+    """
+    path = tmp_path / "ints.parquet"
+    table = _cases()["int64-plain"]
+    pq.write_table(table, path, row_group_size=len(table))
+    metadata = pq.read_metadata(str(path))
+
+    estimate = estimate_row_group_decoded_size(
+        metadata.row_group(0),
+        build_leaf_profiles(metadata.schema),
+        None,
+        [LeafSizeStats(None, (), (0, N))],
+    )
+    assert estimate == N * 8
+
+
+def test_missing_leaf_entry_returns_none(tmp_path):
+    path = tmp_path / "mixed.parquet"
+    table = _cases()["mixed-int-string"]
+    pq.write_table(table, path, row_group_size=len(table))
+    metadata = pq.read_metadata(str(path))
+
+    # Two leaves in the read set, only one entry available.
+    assert (
+        estimate_row_group_decoded_size(
+            metadata.row_group(0),
+            build_leaf_profiles(metadata.schema),
+            None,
+            [LeafSizeStats(None, (), (0, N))],
+        )
+        is None
+    )
+
+
+def test_decoded_size_or_fallback_reproduces_the_old_math():
+    assert decoded_size_or_fallback(1234, 999) == 1234
+    assert (
+        decoded_size_or_fallback(None, 999)
+        == 999 * PARQUET_ENCODING_RATIO_ESTIMATE_DEFAULT
+    )
+
+
+# ---------------------------------------------------------------------------
+# Width table
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "arrow_type, values, expected_width",
+    [
+        # INT32 storage narrowed by the logical INT annotation's bit width.
+        (pa.int8(), [1, 2], 1),
+        (pa.uint8(), [1, 2], 1),
+        (pa.int16(), [1, 2], 2),
+        (pa.uint16(), [1, 2], 2),
+        (pa.int32(), [1, 2], 4),
+        (pa.int64(), [1, 2], 8),
+        (pa.float32(), [1.0, 2.0], 4),
+        (pa.float64(), [1.0, 2.0], 8),
+        # INT64 storage, and Arrow keeps 8 bytes.
+        (pa.timestamp("us"), [1, 2], 8),
+        (pa.date32(), [datetime.date(2020, 1, 1), datetime.date(2021, 2, 3)], 4),
+        # FIXED_LEN_BYTE_ARRAY variants, all identified by logical type.
+        (pa.decimal128(10, 2), [Decimal("1.00"), Decimal("2.50")], 16),
+        (pa.decimal256(50, 2), [Decimal("1.00"), Decimal("2.50")], 32),
+        (pa.binary(7), [b"1234567", b"abcdefg"], 7),
+        (pa.float16(), np.array([1.0, 2.0], dtype=np.float16), 2),
+    ],
+)
+def test_fixed_width_table(tmp_path, arrow_type, values, expected_width):
+    path = tmp_path / "widths.parquet"
+    pq.write_table(pa.table({"a": pa.array(values, type=arrow_type)}), path)
+
+    column = pq.read_metadata(str(path)).schema.column(0)
+    assert parquet_leaf_fixed_width(column) == expected_width
+
+
+def test_variable_width_leaves_have_no_fixed_width(tmp_path):
+    path = tmp_path / "variable.parquet"
+    pq.write_table(
+        pa.table(
+            {
+                "s": pa.array(["a", "bb"]),
+                # BOOLEAN is bit-packed, so it has no whole-byte per-value width.
+                "b": pa.array([True, False]),
+            }
+        ),
+        path,
+    )
+    schema = pq.read_metadata(str(path)).schema
+
+    assert parquet_leaf_fixed_width(schema.column(0)) is None
+    assert parquet_leaf_fixed_width(schema.column(1)) is None
+
+
+def test_null_free_optional_bool_is_not_double_counted(tmp_path):
+    """Keying the validity bitmap off nullability instead of actual nulls would
+    estimate a null-free ``bool`` column at 2.00x its real size."""
+    path = tmp_path / "bools.parquet"
+    table = pa.table({"a": pa.array([i % 2 == 0 for i in range(N)])})
+    pq.write_table(table, path, row_group_size=N)
+
+    # Data buffer only: one bit per value, no bitmap.
+    assert _estimate_whole_file(path) == N // 8
+
+
+# ---------------------------------------------------------------------------
+# End to end: footer read -> decoded sizing -> bin packing
+# ---------------------------------------------------------------------------
+
+
+def _pack_through_footer_reader(paths, max_bin_bytes):
+    """Run the real listing path: footer read, then bin packing, no Ray runtime.
+
+    ``FooterReader`` is a plain class that ``FooterReaderActor`` wraps, so it can
+    be driven directly. That covers footer decode, the estimator, coalescing and
+    the packer in one go, which is where a wiring mistake between them would hide.
+    """
+    from pyarrow.fs import LocalFileSystem
+
+    from ray.data._internal.datasource_v2.listing.footer_file_indexer import (
+        _file_chunks_to_manifest,
+    )
+    from ray.data._internal.datasource_v2.listing.footer_reader import FooterReader
+    from ray.data._internal.datasource_v2.partitioners.online_bin_packer import (
+        OnlineBinPacker,
+    )
+
+    reader = FooterReader(LocalFileSystem())
+    packer = OnlineBinPacker(max_bin_bytes=max_bin_bytes)
+    manifests = []
+
+    def drain():
+        while packer.has_partition():
+            manifests.append(packer.next_partition())
+
+    for path in paths:
+        chunks = reader._read_and_chunk(str(path), os.path.getsize(path))
+        packer.add_input(_file_chunks_to_manifest(chunks))
+        drain()
+    packer.finalize()
+    drain()
+    return manifests
+
+
+def _bin_decoded_totals(manifests):
+    return [
+        sum(meta["decoded_size"] for meta in manifest.file_chunk_metadatas)
+        for manifest in manifests
+    ]
+
+
+@pytest.mark.parametrize(
+    "label",
+    # Opposite ends of the encoding-ratio range: dictionary-encoded strings,
+    # where uncompressed size badly *understates* the Arrow block, and plain
+    # numerics, where it overstates it once scaled by the fixed 5x.
+    ["string-low-cardinality", "int64-plain"],
+)
+def test_bins_land_near_target_block_size(tmp_path, label):
+    path = tmp_path / f"{label}.parquet"
+    table = _cases()[label]
+    # Several row groups, so the packer has boundaries to cut on.
+    pq.write_table(table, path, row_group_size=len(table) // 10)
+
+    actual_nbytes = pq.read_table(str(path)).nbytes
+    # A budget that must yield roughly four bins if sizing is right.
+    target = actual_nbytes // 4
+
+    totals = _bin_decoded_totals(_pack_through_footer_reader([path], target))
+
+    # Sizing is accurate in aggregate: the bins account for the real Arrow bytes.
+    assert sum(totals) == pytest.approx(actual_nbytes, rel=_TOLERANCE)
+    # And each bin lands at or under the budget. Bins may undershoot, since a bin
+    # seals as soon as no further row group fits.
+    for total in totals:
+        assert total <= target
+    assert 3 <= len(totals) <= 6, totals
+
+
+def test_dictionary_encoded_strings_would_collapse_into_one_bin_when_sized_on_disk(
+    tmp_path,
+):
+    """The regression this change exists to prevent.
+
+    Low-cardinality strings compress so well that their uncompressed footer size
+    is a small fraction of the Arrow block they decode to. Budgeting on that
+    number packs far too much into one read task -- the OOM direction -- which is
+    exactly what decoded sizing fixes.
+    """
+    path = tmp_path / "dict-strings.parquet"
+    table = _cases()["string-low-cardinality"]
+    pq.write_table(table, path, row_group_size=len(table) // 10)
+
+    metadata = pq.read_metadata(str(path))
+    uncompressed = sum(
+        metadata.row_group(rg).column(0).total_uncompressed_size
+        for rg in range(metadata.num_row_groups)
+    )
+    actual_nbytes = pq.read_table(str(path)).nbytes
+    target = actual_nbytes // 4
+
+    # Sizing on uncompressed bytes, the whole file fits in one bin many times over.
+    assert uncompressed < target
+    # Sizing on decoded bytes, it does not.
+    assert len(_bin_decoded_totals(_pack_through_footer_reader([path], target))) > 1
+
+
+def test_multiple_files_share_bins_by_decoded_size(tmp_path):
+    table = _cases()["mixed-int-string"]
+    paths = []
+    for i in range(4):
+        path = tmp_path / f"part{i}.parquet"
+        pq.write_table(table, path, row_group_size=len(table) // 4)
+        paths.append(path)
+
+    per_file_nbytes = pq.read_table(str(paths[0])).nbytes
+    manifests = _pack_through_footer_reader(paths, per_file_nbytes * 2)
+    totals = _bin_decoded_totals(manifests)
+
+    assert sum(totals) == pytest.approx(per_file_nbytes * 4, rel=_TOLERANCE)
+    for total in totals:
+        assert total <= per_file_nbytes * 2
+    # Every row group is accounted for exactly once across the bins.
+    covered = [
+        (str(path), rg_id)
+        for manifest in manifests
+        for path, meta in zip(manifest.paths, manifest.file_chunk_metadatas)
+        for rg_id in meta["row_group_ids"]
+    ]
+    assert len(covered) == len(set(covered)) == 4 * 4
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main(["-v", __file__]))

--- a/python/ray/data/tests/unit/datasource_v2/test_parquet_size_statistics.py
+++ b/python/ray/data/tests/unit/datasource_v2/test_parquet_size_statistics.py
@@ -1,0 +1,612 @@
+"""Tests for the targeted Parquet ``SizeStatistics`` Thrift reader.
+
+Hand-decoded binary fails dangerously: a one-byte cursor desync makes the
+compact-protocol field-id deltas land on plausible but wrong ids, so the walk
+returns numbers rather than raising. Nothing downstream can catch that, because a
+decoded size has no second source to be compared against -- which makes this file
+the module's actual safety mechanism rather than a regression net.
+
+It attacks correctness from three directions:
+
+- A differential oracle against ``thriftpy2``'s own compact protocol, over a
+  matrix of schemas chosen to reach every branch of the walk and the estimator.
+- Fault injection that reintroduces the two desync bugs the prototype actually
+  hit, asserting that neither can yield a decoded size.
+- Hand-built payloads for the shapes the protocol permits but PyArrow never
+  writes, which the oracle therefore cannot reach.
+"""
+
+import numpy as np
+import pytest
+
+import ray.data._internal.datasource_v2.chunkers.parquet_size_statistics as pss
+from ray.data._internal.datasource_v2.chunkers.parquet_decoded_size import (
+    build_leaf_profiles,
+    estimate_row_group_decoded_size,
+)
+from ray.data._internal.datasource_v2.chunkers.parquet_size_statistics import (
+    _CompactReader,
+    footer_bytes,
+    read_size_statistics,
+)
+
+pa = pytest.importorskip("pyarrow")
+pq = pytest.importorskip("pyarrow.parquet")
+
+
+# A minimal parquet.thrift covering only the traversal path. Everything else in
+# the footer is skipped generically by the protocol, so the oracle needs no more
+# than this -- and unlike vendoring the full 1,000-line schema, it cannot drift
+# out of sync with upstream in ways that matter here. All fields are optional so
+# a missing one is a null rather than a parse error.
+_ORACLE_THRIFT = """
+struct SizeStatistics {
+  1: optional i64 unencoded_byte_array_data_bytes;
+  2: optional list<i64> repetition_level_histogram;
+  3: optional list<i64> definition_level_histogram;
+}
+struct ColumnMetaData {
+  5: optional i64 num_values;
+  6: optional i64 total_uncompressed_size;
+  16: optional SizeStatistics size_statistics;
+}
+struct ColumnChunk {
+  3: optional ColumnMetaData meta_data;
+}
+struct RowGroup {
+  1: optional list<ColumnChunk> columns;
+}
+struct FileMetaData {
+  4: optional list<RowGroup> row_groups;
+}
+"""
+
+N = 500
+
+
+def _table_cases():
+    """Schemas spanning every branch of the decoder and the estimator."""
+    return {
+        "flat-numeric": pa.table({"a": pa.array(np.arange(N, dtype="int64"))}),
+        "strings": pa.table({"a": pa.array([f"v{i % 7}" for i in range(N)])}),
+        "nullable-strings": pa.table(
+            {"a": pa.array([None if i % 3 == 0 else f"v{i}" for i in range(N)])}
+        ),
+        "mixed": pa.table(
+            {
+                "i": pa.array(np.arange(N, dtype="int64")),
+                "s": pa.array([f"s{i}" for i in range(N)]),
+                "b": pa.array([i % 2 == 0 for i in range(N)]),
+                "f": pa.array(np.random.rand(N)),
+            }
+        ),
+        "list-int64": pa.table(
+            {"a": pa.array([[1, 2, 3]] * N, type=pa.list_(pa.int64()))}
+        ),
+        "struct-nested": pa.table(
+            {
+                "a": pa.array(
+                    [{"s": f"v{i % 5}", "l": [1, 2]} for i in range(N)],
+                    type=pa.struct([("s", pa.string()), ("l", pa.list_(pa.int64()))]),
+                )
+            }
+        ),
+        "decimal-timestamp": pa.table(
+            {
+                "d": pa.array(range(N), type=pa.decimal128(12, 3)),
+                "t": pa.array(np.arange(N, dtype="int64"), type=pa.timestamp("us")),
+            }
+        ),
+        # Many row groups and columns: the widest walk, and the case where a
+        # cursor desync has the most chances to show up.
+        "wide": pa.table(
+            {f"c{c}": pa.array([f"v{c}_{i}" for i in range(N)]) for c in range(12)}
+        ),
+    }
+
+
+@pytest.fixture(scope="module")
+def written_files(tmp_path_factory):
+    """Each case written to disk with several row groups, plus its metadata."""
+    out = {}
+    directory = tmp_path_factory.mktemp("size_stats")
+    for label, table in _table_cases().items():
+        path = directory / f"{label}.parquet"
+        pq.write_table(table, path, row_group_size=max(1, len(table) // 4))
+        out[label] = (str(path), pq.read_metadata(str(path)))
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Footer byte recovery
+# ---------------------------------------------------------------------------
+
+
+def test_footer_bytes_matches_serialized_size(written_files):
+    _, metadata = written_files["flat-numeric"]
+    buf = footer_bytes(metadata)
+    assert buf is not None
+    # __reduce__ hands back exactly the serialized footer, nothing more.
+    assert len(buf) == metadata.serialized_size
+    # Signed 'b' would make every byte >= 0x80 negative and corrupt varints.
+    assert buf.format == "B"
+    assert all(value >= 0 for value in buf)
+
+
+def test_footer_bytes_returns_none_for_unreducible_object():
+    class NoReduce:
+        def __reduce__(self):
+            raise TypeError("not picklable")
+
+    assert footer_bytes(NoReduce()) is None
+
+
+# ---------------------------------------------------------------------------
+# Differential oracle
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def oracle_module(tmp_path_factory):
+    thriftpy2 = pytest.importorskip("thriftpy2")
+    path = tmp_path_factory.mktemp("thrift") / "parquet_oracle.thrift"
+    path.write_text(_ORACLE_THRIFT)
+    return thriftpy2.load(str(path), module_name="parquet_oracle_thrift")
+
+
+def _oracle_parse(oracle_module, raw):
+    """``[row_group][leaf]`` size statistics via thriftpy2's own compact protocol."""
+    from thriftpy2.protocol.compact import TCompactProtocol
+    from thriftpy2.transport import TMemoryBuffer
+
+    file_metadata = oracle_module.FileMetaData()
+    file_metadata.read(TCompactProtocol(TMemoryBuffer(bytes(raw))))
+    return [
+        [
+            None
+            if column.meta_data is None or column.meta_data.size_statistics is None
+            else (
+                column.meta_data.size_statistics.unencoded_byte_array_data_bytes,
+                tuple(
+                    column.meta_data.size_statistics.repetition_level_histogram or ()
+                ),
+                tuple(
+                    column.meta_data.size_statistics.definition_level_histogram or ()
+                ),
+            )
+            for column in row_group.columns
+        ]
+        for row_group in file_metadata.row_groups
+    ]
+
+
+@pytest.mark.parametrize("label", list(_table_cases()))
+def test_matches_thriftpy2_oracle(written_files, oracle_module, label):
+    """Our targeted walk must agree with a full independent parse, chunk for chunk."""
+    _, metadata = written_files[label]
+    ours = read_size_statistics(metadata)
+    assert ours is not None, "expected PyArrow-written files to carry SizeStatistics"
+
+    theirs = _oracle_parse(oracle_module, footer_bytes(metadata))
+    assert len(ours) == len(theirs) == metadata.num_row_groups
+    for our_row_group, their_row_group in zip(ours, theirs):
+        assert len(our_row_group) == len(their_row_group)
+        for our_leaf, their_leaf in zip(our_row_group, their_row_group):
+            assert our_leaf is not None and their_leaf is not None
+            assert (
+                our_leaf.unencoded_byte_array_data_bytes,
+                our_leaf.repetition_level_histogram,
+                our_leaf.definition_level_histogram,
+            ) == their_leaf
+
+
+# ---------------------------------------------------------------------------
+# Decoded values against ground truth
+# ---------------------------------------------------------------------------
+
+
+def test_unencoded_bytes_matches_true_character_count(tmp_path):
+    values = ["hello", "worldworld", "x"] * 1000
+    path = tmp_path / "strings.parquet"
+    pq.write_table(pa.table({"a": pa.array(values)}), path, row_group_size=len(values))
+    stats = read_size_statistics(pq.read_metadata(str(path)))
+
+    assert stats is not None
+    # Exclusive of length prefixes, so exactly the sum of the character bytes.
+    assert stats[0][0].unencoded_byte_array_data_bytes == sum(
+        len(value) for value in values
+    )
+
+
+def test_definition_histogram_counts_nulls(tmp_path):
+    values = [None if i % 3 == 0 else "abc" for i in range(999)]
+    path = tmp_path / "nullable.parquet"
+    pq.write_table(pa.table({"a": pa.array(values)}), path, row_group_size=len(values))
+    stats = read_size_statistics(pq.read_metadata(str(path)))
+
+    assert stats is not None
+    # Last bucket is the count at max definition level, i.e. the non-nulls.
+    assert stats[0][0].definition_level_histogram == (333, 666)
+
+
+def test_repetition_histogram_counts_lists(tmp_path):
+    path = tmp_path / "lists.parquet"
+    pq.write_table(
+        pa.table({"a": pa.array([[1, 2, 3]] * 1000, type=pa.list_(pa.int64()))}),
+        path,
+        row_group_size=1000,
+    )
+    stats = read_size_statistics(pq.read_metadata(str(path)))
+
+    assert stats is not None
+    # Level 0 is the number of top-level lists; level 1 the continuations.
+    assert stats[0][0].repetition_level_histogram == (1000, 2000)
+
+
+def test_fixed_width_leaves_omit_unencoded_bytes(written_files):
+    """Sub-field 1 is BYTE_ARRAY-only per spec, so numeric leaves must lack it.
+
+    A gate requiring it on *every* leaf would silently fall back for every flat
+    numeric schema while still paying the decode cost, so this asymmetry is
+    load-bearing rather than incidental.
+    """
+    _, metadata = written_files["mixed"]
+    stats = read_size_statistics(metadata)
+    assert stats is not None
+
+    for rg_idx, leaves in enumerate(stats):
+        for leaf_idx, leaf in enumerate(leaves):
+            physical_type = metadata.row_group(rg_idx).column(leaf_idx).physical_type
+            has_unencoded = leaf.unencoded_byte_array_data_bytes is not None
+            assert has_unencoded == (physical_type == "BYTE_ARRAY")
+
+
+# ---------------------------------------------------------------------------
+# Skip paths: the cursor must land exactly on the next field
+# ---------------------------------------------------------------------------
+#
+# Skipping is where a desync originates, and it is only self-evident when the
+# cursor stops one byte off. PyArrow-written footers do not contain every
+# container shape the protocol allows -- no double or byte lists, rarely a
+# long-form field id -- so the widths for those are asserted directly here
+# rather than relying on the oracle to stumble over them.
+
+
+def _reader(*byte_values):
+    return _CompactReader(memoryview(bytes(byte_values)).cast("B"))
+
+
+def _list_header(size, element_type):
+    assert size < 0x0F, "sizes >= 15 use the varint escape, not this helper"
+    return (size << 4) | element_type
+
+
+@pytest.mark.parametrize(
+    "element_type,payload,label",
+    [
+        (pss._DOUBLE, [0xFF] * 24, "3 doubles are 8 bytes each"),
+        (pss._BYTE, [0x01, 0x02, 0x03], "3 bytes are 1 byte each"),
+        # A bool costs a byte inside a container, unlike inside a struct where
+        # it lives in the type nibble.
+        (pss._BOOL_TRUE, [0x01, 0x02, 0x01], "3 container bools are 1 byte each"),
+        # Varints are the one element type whose width is in the data.
+        (pss._I64, [0xAC, 0x02, 0x02, 0x80, 0x01], "3 zigzag varints, mixed widths"),
+    ],
+)
+def test_skip_list_consumes_exactly_the_elements(element_type, payload, label):
+    size = 3
+    reader = _reader(_list_header(size, element_type), *payload)
+
+    reader._skip_list()
+
+    # +1 for the list header itself.
+    assert reader._pos == 1 + len(payload), label
+
+
+def test_skip_list_handles_nested_binary_elements():
+    """Binary elements carry their own length prefix, so they cannot be bulk-skipped."""
+    reader = _reader(
+        _list_header(2, pss._BINARY),
+        0x03,
+        0xAA,
+        0xBB,
+        0xCC,  # 3-byte value
+        0x01,
+        0xDD,  # 1-byte value
+    )
+
+    reader._skip_list()
+
+    assert reader._pos == 7
+
+
+def test_skip_struct_steps_over_a_long_form_field_id():
+    """A field id too large for the nibble is a varint the skip path must consume.
+
+    The delta-0 escape is rare in practice, which is exactly why it is worth
+    asserting: getting it wrong shifts every subsequent field id in the struct.
+    """
+    reader = _reader(
+        0x06,  # delta 0 (long form), type I64
+        0x20,  # zigzag(16) == 32 -> field id 16
+        0x0A,  # the i64 value
+        0x00,  # STOP
+    )
+
+    reader._skip_struct()
+
+    assert reader._pos == 4
+
+
+def test_skip_struct_recurses_into_nested_structs():
+    reader = _reader(
+        0x1C,  # delta 1, type STRUCT
+        0x16,  # nested: delta 1, type I64
+        0x02,  # nested value
+        0x00,  # STOP of nested struct
+        0x00,  # STOP of outer struct
+    )
+
+    reader._skip_struct()
+
+    assert reader._pos == 5
+
+
+# ---------------------------------------------------------------------------
+# Writer quirks the compact protocol permits but PyArrow does not produce
+# ---------------------------------------------------------------------------
+#
+# arrow-rs hit both of these after shipping its own custom decoder, so they are
+# known-real rather than hypothetical, and neither is reachable through a
+# PyArrow-written file -- meaning the oracle test above cannot catch a
+# regression here.
+
+
+def test_empty_list_with_zero_element_type_is_accepted():
+    """An empty list may declare element type 0, which is not a valid type id.
+
+    A decoder that validates the element type before checking the count rejects
+    such a footer outright; that was arrow-rs #8826, filed against the release
+    that introduced their custom parser. Our guard checks the count first, so
+    this pins that ordering -- it currently holds for an unrelated reason (an
+    empty list's element type carries no information), which is exactly the kind
+    of incidental correctness that a later edit can quietly undo.
+    """
+    reader = _reader(
+        0x16,  # delta 1, I64 -> unencoded_byte_array_data_bytes
+        0x0A,  # zigzag(10) == 5
+        0x19,  # delta 1, LIST -> repetition_level_histogram
+        0x00,  # size 0, element type 0
+        0x19,  # delta 1, LIST -> definition_level_histogram
+        0x00,  # size 0, element type 0
+        0x00,  # STOP
+    )
+
+    result = reader._size_statistics()
+
+    assert result == pss.LeafSizeStats(5, (), ())
+    assert reader._pos == 7
+
+
+def test_empty_list_with_zero_element_type_is_skippable():
+    """The same shape must also be steppable when it is a field we do not read."""
+    reader = _reader(
+        0x19,  # delta 1, LIST
+        0x00,  # size 0, element type 0
+        0x00,  # STOP
+    )
+
+    reader._skip_struct()
+
+    assert reader._pos == 3
+
+
+def test_column_metadata_reads_absolute_field_ids():
+    """Field 16 given in long form, i.e. no reliance on ascending deltas.
+
+    arrow-rs took a faster path that assumes ids are always delta-encoded and in
+    order, and noted it would have to be reverted if a writer using absolute ids
+    turned up (#8190). Our inlined ``_column_metadata`` keeps the general path,
+    and this is what holds it to that -- the long-form branch is otherwise
+    unexercised by PyArrow footers.
+    """
+    reader = _reader(
+        0x06,  # delta 0 (long form), type I64 -> some field we skip
+        0x0A,  # zigzag(10) == 5
+        0x02,  # its value
+        0x0C,  # delta 0, type STRUCT
+        0x20,  # zigzag(32) == 16 -> size_statistics
+        0x16,  # delta 1, I64 -> unencoded_byte_array_data_bytes
+        0x0A,  # zigzag(10) == 5
+        0x00,  # STOP of size_statistics
+        0x00,  # STOP of ColumnMetaData
+    )
+
+    result = reader._column_metadata()
+
+    assert result == pss.LeafSizeStats(5, (), ())
+
+
+def test_column_metadata_finds_field_16_after_a_higher_id():
+    """A descending id, which only the long-form escape can express.
+
+    A delta is an unsigned nibble and can only move forward, so reaching field 16
+    after field 20 requires an absolute id -- and it must still be recognized.
+    """
+    reader = _reader(
+        0x0C,  # long form, STRUCT
+        0x28,  # zigzag(40) == 20 -> an unknown field, skipped
+        0x00,  # STOP of that struct
+        0x0C,  # long form, STRUCT
+        0x20,  # zigzag(32) == 16 -> size_statistics, going backwards
+        0x16,  # delta 1, I64 -> unencoded_byte_array_data_bytes
+        0x0A,  # zigzag(10) == 5
+        0x00,  # STOP of size_statistics
+        0x00,  # STOP of ColumnMetaData
+    )
+
+    result = reader._column_metadata()
+
+    assert result == pss.LeafSizeStats(5, (), ())
+
+
+# ---------------------------------------------------------------------------
+# Fault injection: the cross-check must convert corruption into a fallback
+# ---------------------------------------------------------------------------
+
+
+def test_decoding_is_insensitive_to_view_signedness(written_files, monkeypatch):
+    """Dropping the ``.cast("B")`` must not change the decoded values.
+
+    ``memoryview(pyarrow.Buffer)`` is format 'b', so every byte >= 0x80 reads back
+    negative. That does *not* corrupt this reader: it only ever consumes bytes
+    through masks (``& 0x7F``, ``& 0x80``, ``>> 4 & 0x0F``), and Python's
+    arbitrary-precision two's complement makes those extract identical bits from a
+    sign-extended value. The cast is defensive, so this pins the equivalence
+    rather than asserting a fallback that would never fire.
+    """
+    _, metadata = written_files["wide"]
+    unsigned = read_size_statistics(metadata)
+    assert unsigned is not None  # healthy baseline
+
+    monkeypatch.setattr(
+        pss, "footer_bytes", lambda md: memoryview(md.__reduce__()[1][0])
+    )
+    assert read_size_statistics(metadata) == unsigned
+
+
+def _buggy_binary_skip(original):
+    """``self._pos += self._varint()``, the desync this module was built around.
+
+    Python evaluates the left operand first, so the advance ``_varint`` performs
+    while reading the length is discarded and every binary field consumes one
+    byte too few.
+    """
+
+    def skip(self, field_type):
+        if field_type == pss._BINARY:
+            self._pos += self._varint()  # noqa: B909 - the bug, on purpose
+            return
+        return original(self, field_type)
+
+    return skip
+
+
+def _short_varint_skip(self):
+    """A skip that stops one byte before the varint terminator."""
+    buf, pos = self._buf, self._pos
+    while buf[pos] & 0x80:
+        pos += 1
+    self._pos = pos  # missing the +1
+
+
+@pytest.mark.parametrize("bug", ["binary-skip", "short-varint"])
+@pytest.mark.parametrize("label", list(_table_cases()))
+def test_a_desync_never_yields_a_decoded_size(written_files, monkeypatch, bug, label):
+    """No cursor desync may produce an exact size, only a fallback.
+
+    This is the whole safety argument for the module, so it is asserted through
+    the estimator rather than stopping at the walk: what must never happen is a
+    *number* derived from a drifted cursor, and there are two ways to be safe --
+    the walk declines outright, or it reports a leaf as ``None`` and the estimator
+    declines. Both end at the caller's uncompressed-size fallback.
+
+    Verifying decoded values against PyArrow used to make this trivially true.
+    That check is gone, so this pins that the structural guards which remain --
+    the type assertions and the row-group/leaf shape check -- are still sufficient
+    for the failure modes we have actually hit.
+    """
+    _, metadata = written_files[label]
+    assert read_size_statistics(metadata) is not None, "healthy baseline"
+
+    if bug == "binary-skip":
+        monkeypatch.setattr(
+            _CompactReader, "_skip", _buggy_binary_skip(_CompactReader._skip)
+        )
+    else:
+        monkeypatch.setattr(_CompactReader, "_skip_varint", _short_varint_skip)
+
+    try:
+        stats = read_size_statistics(metadata)
+    except Exception:
+        return  # raising is a fallback too: the caller catches and degrades
+
+    if stats is None:
+        return
+
+    leaf_profiles = build_leaf_profiles(metadata.schema)
+    for rg_idx, leaves in enumerate(stats):
+        assert (
+            estimate_row_group_decoded_size(
+                metadata.row_group(rg_idx), leaf_profiles, None, leaves
+            )
+            is None
+        ), f"{label}/{bug} produced a size from a desynced cursor"
+
+
+def test_truncated_footer_falls_back(written_files, monkeypatch):
+    _, metadata = written_files["mixed"]
+
+    def truncated(md):
+        return memoryview(md.__reduce__()[1][0]).cast("B")[:20]
+
+    monkeypatch.setattr(pss, "footer_bytes", truncated)
+    # An IndexError from running off the end must not escape into the caller.
+    assert read_size_statistics(metadata) is None
+
+
+def test_geospatial_struct_shape_is_rejected():
+    """Field 16 must be a SizeStatistics, not any struct that lands there.
+
+    ``ColumnMetaData`` field 17 is ``geospatial_statistics``, also a struct, so a
+    cursor that drifted by one field would pass a bare "is it a struct" test. Its
+    field 1 is a ``BoundingBox`` struct rather than an i64, which the inner type
+    assertion is what catches.
+    """
+    # field 16 (delta 16 from id 0 via long form), type STRUCT, whose field 1 is
+    # itself a STRUCT (empty) -- the geospatial shape.
+    payload = bytes(
+        [
+            0x0C,  # long-form field id, type STRUCT
+            0x20,  # zigzag(16) == 32
+            0x1C,  # delta 1, type STRUCT -> inner field 1 is a struct, not i64
+            0x00,  # STOP of the inner struct
+            0x00,  # STOP of size_statistics
+            0x00,  # STOP of ColumnMetaData
+        ]
+    )
+    reader = _CompactReader(memoryview(payload).cast("B"))
+    with pytest.raises(pss._ThriftDesync):
+        reader._column_metadata()
+
+
+def test_unknown_trailing_field_is_tolerated():
+    """A future parquet-format field must be skipped, not treated as corruption."""
+    payload = bytes(
+        [
+            0x56,  # delta 5, type I64 -> num_values, which we no longer read
+            0x02,  # zigzag(2) == 1
+            0x16,  # delta 1, type I64 -> total_uncompressed_size, also skipped
+            0x04,  # zigzag(4) == 2
+            0x0C,  # long-form id, STRUCT
+            0x20,  # zigzag(16) == 32 -> size_statistics
+            0x16,  # delta 1, I64 -> unencoded_byte_array_data_bytes
+            0x0A,  # zigzag(10) == 5
+            0x00,  # STOP of size_statistics
+            0x0C,  # long-form id, STRUCT -> a hypothetical future field
+            0x28,  # zigzag(20) == 40
+            0x00,  # STOP of that struct
+            0x00,  # STOP of ColumnMetaData
+        ]
+    )
+    reader = _CompactReader(memoryview(payload).cast("B"))
+    result = reader._column_metadata()
+
+    assert result == pss.LeafSizeStats(5, (), ())
+    assert reader._pos == len(payload)
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main(["-v", __file__]))

--- a/python/ray/data/tests/unit/datasource_v2/test_read_task_memory.py
+++ b/python/ray/data/tests/unit/datasource_v2/test_read_task_memory.py
@@ -1,0 +1,122 @@
+"""Tests for the per-read-task Ray ``memory`` reservation.
+
+The reservation only makes sense when a partition's decoded size is actually
+known, and it must decline in the cases where reserving memory would either
+override the caller or make tasks unschedulable -- so most of these are about
+when *not* to set it.
+"""
+
+import pytest
+
+from ray.data._internal.datasource_v2.partitioners.online_bin_packer import (
+    OnlineBinPacker,
+)
+from ray.data._internal.datasource_v2.partitioners.round_robin_partitioner import (
+    RoundRobinPartitioner,
+)
+from ray.data._internal.datasource_v2.read_task_memory import (
+    READ_TASK_BASE_MEMORY,
+    READ_TASK_MEMORY_PER_DECODED_BYTE,
+    apply_read_task_memory,
+    read_task_memory,
+)
+from ray.data._internal.util import MiB
+from ray.data.context import DataContext
+from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
+
+
+@pytest.fixture
+def ctx():
+    # A copy, so mutating scheduling strategy can't leak into other tests.
+    return DataContext.get_current().copy()
+
+
+def test_reservation_is_base_plus_multiple_of_decoded_size():
+    assert read_task_memory(0) == READ_TASK_BASE_MEMORY
+    assert (
+        read_task_memory(128 * MiB)
+        == READ_TASK_BASE_MEMORY + READ_TASK_MEMORY_PER_DECODED_BYTE * 128 * MiB
+    )
+    # Monotonic in the bound, or a bigger bin could reserve less than a smaller one.
+    assert read_task_memory(64 * MiB) < read_task_memory(128 * MiB)
+
+
+def test_bin_packer_exposes_its_cap_as_the_decoded_bound():
+    packer = OnlineBinPacker(max_bin_bytes=128 * MiB)
+    assert packer.max_partition_decoded_bytes == 128 * MiB
+
+
+def test_memory_is_set_from_the_packers_cap(ctx):
+    packer = OnlineBinPacker(max_bin_bytes=128 * MiB)
+
+    args = apply_read_task_memory({"num_cpus": 1}, packer, ctx)
+
+    assert args["memory"] == read_task_memory(128 * MiB)
+    # Untouched keys survive.
+    assert args["num_cpus"] == 1
+
+
+def test_input_args_are_not_mutated(ctx):
+    original = {"num_cpus": 1}
+
+    apply_read_task_memory(original, OnlineBinPacker(max_bin_bytes=128 * MiB), ctx)
+
+    assert original == {"num_cpus": 1}
+
+
+def test_explicit_caller_memory_wins(ctx):
+    packer = OnlineBinPacker(max_bin_bytes=128 * MiB)
+
+    args = apply_read_task_memory({"memory": 7}, packer, ctx)
+
+    assert args["memory"] == 7
+
+
+def test_declines_when_the_partitioner_cannot_bound_decoded_size(ctx):
+    """``RoundRobinPartitioner`` sizes buckets from an encoding-ratio estimate.
+
+    Reserving against that would promote a guess to a scheduling constraint, so
+    the bound is ``None`` and no ``memory`` is set.
+    """
+    partitioner = RoundRobinPartitioner(
+        in_memory_size_estimator=None,
+        min_bucket_size=0,
+        max_bucket_size=128 * MiB,
+        num_buckets=1,
+    )
+    assert partitioner.max_partition_decoded_bytes is None
+
+    args = apply_read_task_memory({"num_cpus": 1}, partitioner, ctx)
+
+    assert "memory" not in args
+
+
+def test_declines_when_a_zero_cap_gives_nothing_to_size_against(ctx):
+    args = apply_read_task_memory(
+        {"num_cpus": 1}, OnlineBinPacker(max_bin_bytes=0), ctx
+    )
+
+    assert "memory" not in args
+
+
+@pytest.mark.parametrize("source", ["ray_remote_args", "context"])
+def test_declines_under_a_placement_group_strategy(ctx, source):
+    """A placement group that reserves no memory would never schedule the task."""
+    strategy = PlacementGroupSchedulingStrategy(placement_group=object())
+    ray_remote_args = {"num_cpus": 1}
+    if source == "ray_remote_args":
+        ray_remote_args["scheduling_strategy"] = strategy
+    else:
+        ctx.scheduling_strategy = strategy
+
+    args = apply_read_task_memory(
+        ray_remote_args, OnlineBinPacker(max_bin_bytes=128 * MiB), ctx
+    )
+
+    assert "memory" not in args
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main(["-v", __file__]))

--- a/python/requirements/ml/data-test-requirements.txt
+++ b/python/requirements/ml/data-test-requirements.txt
@@ -61,3 +61,8 @@ lerobot>=0.5.0,<0.6; python_version >= "3.12"
 # torch 2.9.
 torchcodec<0.10; python_version >= "3.12"
 av; python_version >= "3.12"
+# Test-only differential oracle for the Parquet SizeStatistics Thrift reader
+# (``test_parquet_size_statistics.py``). An independent implementation of the
+# compact protocol is the only way to show our targeted walk decodes the same
+# bytes the same way; it must never become a runtime dependency of ray[data].
+thriftpy2


### PR DESCRIPTION
## Why are these changes needed?

Parquet's `total_uncompressed_size` is the *encoded* size — decompressed, but still dictionary/RLE/bit-packed — and is a poor proxy for the Arrow block a read task actually materializes: measured decoded/uncompressed ratios span **0.87x** for plain `int64` to **133x** for nullable dictionary-encoded strings. Sizing V2 read tasks on it (raw or scaled by the fixed 5x encoding ratio) either floods the scheduler with tiny tasks or overfills blocks to the point of OOM.

The footer already carries the missing quantity: `SizeStatistics` (parquet-format 2.10), which PyArrow's C++ writer emits by default but whose Python bindings expose no getter (pyarrow 23 binds `geo_statistics` — Thrift field 17 — but not field 16). This PR recovers it with a targeted Thrift walk over footer bytes already in memory and computes each row group's **exact decoded Arrow size**, which then drives bin packing, an upfront per-task memory reservation, and reader batch sizing. On a mixed-type 100k-row file the footer-only estimate lands within **0.6%** of `pa.Table.nbytes`, where the old heuristic overestimated by **4.6x**.

Files whose footers lack usable `SizeStatistics` fall back per row group to the pre-existing `uncompressed x ratio` estimate, bit-for-bit.

### Overarching approach

```mermaid
flowchart TD
    A["FooterReader (ListFiles op)<br/>one footer fetch per file → FileMetaData"] --> B["read_size_statistics()<br/>targeted Thrift walk over footer bytes<br/>(zero extra I/O)"]
    A --> C["estimate_row_group_decoded_size()<br/>per row group, per projected leaf"]
    B -->|"LeafSizeStats[rg][leaf]"| C
    C -->|"exact decoded bytes"| D["coalesce_row_groups()<br/>merge contiguous row groups,<br/>target measured in decoded bytes"]
    C -.->|"None (no SizeStatistics)"| F["fallback: uncompressed x 5<br/>(pre-existing behavior)"]
    F -.-> D
    D --> E["OnlineBinPacker<br/>cap = target_max_block_size, in decoded bytes<br/>1 sealed bin = 1 read task"]
    E --> G["Ray memory reservation<br/>256 MiB + 8 x cap per read task"]
    E --> H["block sizing<br/>bins land on the block target"]
    E --> I["reader batch sizing<br/>rows/batch = target / (decoded/num_rows)"]
```

### Decoded-size recovery from the footer bytes

`FileMetaData.__reduce__()` returns the raw TCompactProtocol-serialized footer. The walk decodes only the recognized path `FileMetaData.4 → RowGroup.1 → ColumnChunk.3 → ColumnMetaData.16` and generically skips every other field (scanned, never materialized) — the same targeted-parse approach arrow-rs adopted for its 3-9x footer-parsing speedup.

```mermaid
flowchart TD
    A["FileMetaData.__reduce__()<br/>raw Thrift footer bytes"] --> B["struct FileMetaData<br/>field 4: row_groups — everything else skipped"]
    B -->|"x num row groups"| C["struct RowGroup<br/>field 1: columns"]
    C -->|"x num leaves"| D["struct ColumnChunk<br/>field 3: meta_data"]
    D --> E["struct ColumnMetaData<br/>field 16: size_statistics<br/>(fields 1-15, 17+ skipped, incl. Statistics blobs)"]
    E --> F["SizeStatistics<br/>1: unencoded_byte_array_data_bytes<br/>2: repetition_level_histogram<br/>3: definition_level_histogram"]
    F --> G{"per-leaf decoded size"}
    G -->|fixed width| H["num_values x arrow_width(type)"]
    G -->|BYTE_ARRAY| I["unencoded bytes + 4·(n+1) offsets"]
    G -->|BOOLEAN| J["ceil(n / 8)"]
    G --> K["+ validity bitmap iff nulls present<br/>(definition-level histogram)<br/>+ list offsets (repetition-level histogram)"]
    H & I & J & K --> L{"every projected leaf exact?"}
    L -->|yes| M["exact decoded size for the row group"]
    L -->|"no (all-or-nothing)"| N["None → fallback sizing"]
    E -->|"type assertion fails → _ThriftDesync"| N
    A -->|"truncated footer → IndexError"| N
```

Hand-decoded binary fails by returning wrong numbers, not by raising: a one-byte cursor desync decodes later field-id deltas onto plausible but wrong ids. Guards: type assertions on every recognized field (field 17 `geospatial_statistics` is also a struct — only the assert on its field 1 catches a drifted cursor), row-group/leaf shape checks against `FileMetaData`, and a **differential test against thriftpy2's independent compact-protocol implementation** (test-only dependency) as the module's real contract. Any failure returns `None` and the file keeps the old sizing.

## Related issue number

N/A. Checked for duplicate work before opening: searched open PRs for "parquet decoded size", "SizeStatistics", "read task memory parquet", and "bin packing parquet" — no open PR or issue addresses footer-based decoded-size estimation for V2 read planning.

## Checks

- [x] I've signed off every commit (DCO).
- [x] I've run pre-commit hooks (`pre-commit run` — all hooks pass; ruff/black clean).
- [x] Tests:
  - `python -m pytest python/ray/data/tests/unit/datasource_v2/test_parquet_decoded_size.py test_parquet_size_statistics.py test_online_bin_packer.py test_file_chunker.py test_read_task_memory.py test_file_indexer.py` — **204 passed**.
  - Coverage includes a thriftpy2 differential oracle over a matrix of written files, decoded-size accuracy vs real `pa.Table.nbytes` (within a validity bitmap), desync-injection tests, and fallback behavior.
- [x] AI assistance was used for parts of this change (Claude Code); I have reviewed every changed line and run the tests above locally.
- [ ] Release tests / benchmarks on wide-footer datasets (draft — pending before marking ready).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
