### PR TITLE
[Data] Raise `NotImplementedError` in `BlockColumnAccessor.sum`

### DIFF
--- a/python/ray/data/block.py
+++ b/python/ray/data/block.py
@@ -830,7 +830,7 @@ class BlockColumnAccessor:
 
     def sum(self, *, ignore_nulls: bool, as_py: bool = True) -> Optional[U]:
         """Returns a sum of the values in the column"""
-        return NotImplementedError()
+        raise NotImplementedError()
 
     def min(self, *, ignore_nulls: bool, as_py: bool = True) -> Optional[U]:
         """Returns a min of the values in the column"""


### PR DESCRIPTION
## Description

The base `BlockColumnAccessor.sum` method currently returns a `NotImplementedError`, unlike every other abstract accessor method. So we modify to raise it.

## Related issues
closes #66123 

## Additional information
> Optional: Add implementation details, API changes, usage examples, screenshots, etc.
