### PR TITLE
[Data] Preserve anti-join rows with an empty unknown-schema side

### DIFF
--- a/python/ray/data/_internal/execution/operators/join.py
+++ b/python/ray/data/_internal/execution/operators/join.py
@@ -146,12 +146,34 @@ def _make_join_reduce_fn(
         ), f"Join reduce expects two inputs (got {len(tables_by_input)})"
         left_table = _side_table(tables_by_input[0], left_schema)
         right_table = _side_table(tables_by_input[1], right_schema)
+
+        # Synthesize the empty side's schema from the known side for anti joins
+        if (
+            join_type == JoinType.LEFT_ANTI
+            and right_table is None
+            and left_table is not None
+        ):
+            right_table = (
+                left_table.select(left_key_col_names)
+                .schema.empty_table()
+                .rename_columns(right_key_col_names)
+            )
+        elif (
+            join_type == JoinType.RIGHT_ANTI
+            and left_table is None
+            and right_table is not None
+        ):
+            left_table = (
+                right_table.select(right_key_col_names)
+                .schema.empty_table()
+                .rename_columns(left_key_col_names)
+            )
+
         if left_table is None or right_table is None:
             # TODO(you-cheng): A whole input side is empty AND its schema can't be inferred
             # (0 blocks + un-inferable schema, e.g. a map_batches side), so
             # _side_table returns None and we skip the partition. This silently
-            # drops the preserved side's rows for preserving joins, left_outer/
-            # full_outer and left_anti/right_anti.
+            # drops the preserved side's rows for preserving outer joins.
             return
         yield join_tables(
             left_table,

--- a/python/ray/data/tests/test_join.py
+++ b/python/ray/data/tests/test_join.py
@@ -425,6 +425,36 @@ def test_anti_join_no_matches(
 
 
 @pytest.mark.parametrize("join_type", ["left_anti", "right_anti"])
+def test_anti_join_preserves_rows_with_unknown_schema_empty_side(
+    ray_start_regular_shared_2_cpus,
+    hash_shuffle_version,
+    join_type,
+):
+    if hash_shuffle_version != ShuffleStrategy.SHUFFLE_V2:
+        pytest.skip("Unknown-schema empty-side handling is specific to shuffle V2")
+
+    preserved = ray.data.from_items([{"id": 1, "value": "a"}, {"id": 2, "value": "b"}])
+    unknown_schema_empty = ray.data.range(0).map_batches(lambda batch: batch)
+
+    if join_type == "left_anti":
+        left, right = preserved, unknown_schema_empty
+    else:
+        left, right = unknown_schema_empty, preserved
+
+    result = left.join(
+        right,
+        join_type=join_type,
+        on=("id",),
+        num_partitions=1,
+    ).take_all()
+
+    assert sorted(result, key=lambda row: row["id"]) == [
+        {"id": 1, "value": "a"},
+        {"id": 2, "value": "b"},
+    ]
+
+
+@pytest.mark.parametrize("join_type", ["left_anti", "right_anti"])
 def test_anti_join_all_matches(
     ray_start_regular_shared_2_cpus,
     join_type,


### PR DESCRIPTION
## Description

ShuffleV2 currently skips a join partition when one side has no blocks and its schema cannot be inferred. For left and right anti-joins, it's exception.

When the unknown side of an anti-join is empty, this change synthesizes its join-key schema from the known side. The reducer can then use the normal join path and preserve the unmatched rows as expected.

Edit: also narrow the schema type.

## Related issues

closes #66125. 