### PR TITLE
[cherry-pick][2.59.0][Java] Update httpcore5 to 5.4.3 (#66081)

### DIFF
--- a/ci/build/bundled_dependency_versions_test.py
+++ b/ci/build/bundled_dependency_versions_test.py
@@ -44,3 +44,14 @@ def test_ray_dist_jar_uses_fixed_log4j_version():
         "log4j-core": "2.25.4",
         "log4j-slf4j-impl": "2.25.4",
     }
+
+
+def test_ray_dist_jar_uses_patched_httpcore5_version():
+    java_deps = (REPO_ROOT / "java" / "dependencies.bzl").read_text()
+    match = re.search(
+        r"org\.apache\.httpcomponents\.core5:httpcore5:([0-9][^\"\s]*)",
+        java_deps,
+    )
+
+    assert match is not None
+    assert match.group(1) == "5.4.3"

--- a/java/dependencies.bzl
+++ b/java/dependencies.bzl
@@ -28,7 +28,7 @@ def gen_java_deps():
             "com.lmax:disruptor:3.3.4",
             "net.java.dev.jna:jna:5.8.0",
             "org.apache.httpcomponents.client5:httpclient5:5.0.3",
-            "org.apache.httpcomponents.core5:httpcore5:5.0.2",
+            "org.apache.httpcomponents.core5:httpcore5:5.4.3",
             "org.apache.httpcomponents.client5:httpclient5-fluent:5.0.3",
             maven.artifact(
                 group = "org.testng",


### PR DESCRIPTION
Cherry-pick of #66081 (db9546de24) onto `releases/2.59.0`. Applied cleanly with `git cherry-pick -x`.

## Why this belongs in 2.59.0

Bumps the bundled Maven dependency `org.apache.httpcomponents.core5:httpcore5` from 5.0.2 to 5.4.3 for CVE-2026-54399 (#66013). This is not a test-only dependency: `io_ray_ray_serve` declares `httpcore5` in its production `deps` (`java/BUILD.bazel:203`), the `ray_dist` fat jar bundles `api`/`runtime`/`serve` with their runtime deps, and that shaded jar ships as `ray/jars/ray_dist.jar` inside the Linux wheels (built via `bazel run //java:gen_ray_java_pkg` in `ci/build/build-manylinux-ray.sh`; included by `python/setup.py` when present) and as a compile-scope dependency in the published `io.ray:ray-serve` POM. Without this pick, 2.59.0 wheels carry the vulnerable 5.0.2.

Risk: a one-line Maven version bump plus the version-guard test from the original PR. `httpclient5` stays at 5.0.3 (built against httpcore5 5.0.2); HttpCore is API-compatible within 5.x and the original PR's CI (all checks green) exercised the serve Java tests that use `httpclient5-fluent`. No Python dependency or lock changes.

## Testing

- `python -m pytest -q ci/build/bundled_dependency_versions_test.py` on this branch → 3 passed (includes the new `test_ray_dist_jar_uses_patched_httpcore5_version`)
- `pre-commit run --files java/dependencies.bzl ci/build/bundled_dependency_versions_test.py` → clean
- Original PR #66081: 6/6 checks passed on master before merge

Original PR: #66081. Fixes #66013 on the release line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)