### PR TITLE
[core] clarify _internal_kv_put return; add put_if_absent helper

### DIFF
--- a/python/ray/experimental/internal_kv.py
+++ b/python/ray/experimental/internal_kv.py
@@ -70,20 +70,27 @@ def _internal_kv_put(
     value: Union[str, bytes],
     overwrite: bool = True,
     *,
-    namespace: Optional[Union[str, bytes]] = None
+    namespace: Optional[Union[str, bytes]] = None,
 ) -> bool:
     """Globally associates a value with a given binary key.
-
-    This only has an effect if the key does not already have a value.
 
     Args:
         key: The binary key to associate the value with.
         value: The binary value to store under the key.
-        overwrite: Whether to overwrite an existing value for the key.
+        overwrite: Whether to overwrite an existing value for the key. If
+            False and the key already exists, the existing value is left
+            unchanged.
         namespace: Optional namespace under which the key is scoped.
 
     Returns:
-        Whether the value already exists.
+        True if the key already existed prior to this call; False if this
+        call newly created the key. When ``overwrite=False``, True means
+        the value was therefore NOT written.
+
+        This polarity is historical and easy to misread as "put succeeded".
+        New compare-and-set callers should use
+        ``_internal_kv_put_if_absent``, which returns True iff this call
+        created the key.
     """
 
     if isinstance(key, str):
@@ -100,12 +107,39 @@ def _internal_kv_put(
     return global_gcs_client.internal_kv_put(key, value, overwrite, namespace) == 0
 
 
+def _internal_kv_put_if_absent(
+    key: Union[str, bytes],
+    value: Union[str, bytes],
+    *,
+    namespace: Optional[Union[str, bytes]] = None,
+) -> bool:
+    """Put ``value`` only if ``key`` does not already exist.
+
+    Compare-and-set helper for callers that want a natural "did I create
+    the key?" return value. Unlike ``_internal_kv_put(..., overwrite=False)``,
+    True means this call won the race and wrote the value.
+
+    Args:
+        key: The binary key to associate the value with.
+        value: The binary value to store under the key.
+        namespace: Optional namespace under which the key is scoped.
+
+    Returns:
+        True if this call created the key; False if the key already existed
+        and nothing was written.
+    """
+    # invert the legacy "already existed" return from `_internal_kv_put`.
+    # no @client_mode_hook here: `_internal_kv_put` already redirects under
+    # ray client, so this wrapper stays correct in both modes.
+    return not _internal_kv_put(key, value, overwrite=False, namespace=namespace)
+
+
 @client_mode_hook
 def _internal_kv_del(
     key: Union[str, bytes],
     *,
     del_by_prefix: bool = False,
-    namespace: Optional[Union[str, bytes]] = None
+    namespace: Optional[Union[str, bytes]] = None,
 ) -> int:
     if isinstance(key, str):
         key = key.encode()

--- a/python/ray/tests/test_basic_5.py
+++ b/python/ray/tests/test_basic_5.py
@@ -125,6 +125,23 @@ def test_internal_kv(ray_start_regular):
         kv._internal_kv_list("@namespace_abc", namespace="n")
 
 
+def test_internal_kv_put_if_absent(ray_start_regular):
+    # regression for #66114: overwrite=False returns True when the key
+    # already existed (value not written). put_if_absent inverts that so
+    # True means "this call created the key".
+    import ray.experimental.internal_kv as kv
+
+    k = b"demo_key_put_if_absent"
+    assert kv._internal_kv_put(k, b"a", overwrite=False) is False
+    assert kv._internal_kv_put(k, b"b", overwrite=False) is True
+    assert kv._internal_kv_get(k) == b"a"
+
+    k2 = b"demo_key_put_if_absent_2"
+    assert kv._internal_kv_put_if_absent(k2, b"a") is True
+    assert kv._internal_kv_put_if_absent(k2, b"b") is False
+    assert kv._internal_kv_get(k2) == b"a"
+
+
 def test_exit_logging():
     log = run_string_as_driver(
         """


### PR DESCRIPTION
## Description

`_internal_kv_put(..., overwrite=False)` returns `True` when the key already existed (value not written). that polarity is easy to misread as "put succeeded", which can cause silent compare-and-set bugs.

this PR:
1. rewrites the docstring so the return meaning is unambiguous
2. adds `_internal_kv_put_if_absent`, which returns `True` iff this call created the key
3. leaves the existing `_internal_kv_put` return value unchanged for compatibility

## Related issues

Fixes #66114

## Additional information

split out of ray-project/enhancements#75 at @edoakes's request.

### Test plan

- added `test_internal_kv_put_if_absent` in `python/ray/tests/test_basic_5.py` covering the issue repro polarity for `_internal_kv_put(..., overwrite=False)` and the new helper
- existing `test_internal_kv` asserts on the legacy return are unchanged

cc @edoakes