### PR TITLE
[Data] Preserve ClickHouse read failure context and query IDs

### DIFF
--- a/python/ray/data/_internal/datasource/clickhouse_datasource.py
+++ b/python/ray/data/_internal/datasource/clickhouse_datasource.py
@@ -1,5 +1,6 @@
 import logging
 import math
+import uuid
 from typing import TYPE_CHECKING, Any, Callable, Dict, Iterable, List, Optional, Tuple
 
 from ray.data._internal.object_extensions.arrow import raise_on_pickle_object_columns
@@ -242,12 +243,20 @@ class ClickHouseDatasource(Datasource):
         import pyarrow as pa
 
         client = self._init_client()
+        # Generate the ID before opening the stream so it is available even when
+        # the client cannot decode the response. Use a new ID for each execution,
+        # including samples and retries, to avoid collisions between queries.
+        query_id = str(uuid.uuid4())
         try:
-            with client.query_arrow_stream(query) as stream:
+            with client.query_arrow_stream(
+                query, settings={"query_id": query_id}
+            ) as stream:
                 record_batches = list(stream)  # Collect all record batches
             table = pa.Table.from_batches(record_batches)
         except Exception as e:
-            raise RuntimeError(f"Failed to execute block query: {e}")
+            raise RuntimeError(
+                f"Failed to execute block query (query_id={query_id}): {e}"
+            ) from e
         finally:
             client.close()
         # Unpickling untrusted data can execute arbitrary code. Reject object

--- a/python/ray/data/tests/datasource/test_clickhouse.py
+++ b/python/ray/data/tests/datasource/test_clickhouse.py
@@ -1,10 +1,12 @@
 import os
 import re
+import uuid
 from unittest import mock
 from unittest.mock import MagicMock, patch
 
 import pyarrow as pa
 import pytest
+from clickhouse_connect.driver.exceptions import DatabaseError
 from clickhouse_connect.driver.summary import QuerySummary
 
 from ray.data._internal.datasource.clickhouse_datasink import (
@@ -288,6 +290,73 @@ class TestClickHouseDatasource:
         assert len(read_tasks) == 1
         for i, read_task in enumerate(read_tasks):
             assert read_task.metadata.num_rows == 16
+
+    @pytest.mark.parametrize("failure_stage", ["open", "consume"])
+    @pytest.mark.parametrize(
+        "error",
+        [
+            pa.ArrowInvalid(
+                "Expected to read 1701080899 metadata bytes, but only read 224"
+            ),
+            ConnectionError("Connection reset while reading response"),
+            DatabaseError(
+                "Code: 395. DB::Exception: test failure (FUNCTION_THROW_IF_VALUE_IS_NON_ZERO)"
+            ),
+        ],
+    )
+    def test_execute_block_query_error_context(self, datasource, failure_stage, error):
+        client = MagicMock()
+        datasource._init_client = MagicMock(return_value=client)
+        batch = pa.record_batch([pa.array([1, 2])], names=["field1"])
+
+        def failing_stream():
+            yield batch
+            raise error
+
+        if failure_stage == "open":
+            client.query_arrow_stream.side_effect = error
+        else:
+            client.query_arrow_stream.return_value.__enter__.return_value = (
+                failing_stream()
+            )
+
+        with pytest.raises(RuntimeError) as exc_info:
+            datasource._execute_block_query(datasource._query)
+
+        query_id = client.query_arrow_stream.call_args.kwargs["settings"]["query_id"]
+        assert str(uuid.UUID(query_id)) == query_id
+        assert f"query_id={query_id}" in str(exc_info.value)
+        assert str(error) in str(exc_info.value)
+        assert exc_info.value.__cause__ is error
+        client.query_arrow_stream.assert_called_once_with(
+            datasource._query, settings={"query_id": query_id}
+        )
+        client.query.assert_not_called()
+        client.command.assert_not_called()
+        client.close.assert_called_once()
+        if failure_stage == "consume":
+            client.query_arrow_stream.return_value.__exit__.assert_called_once()
+
+    def test_execute_block_query_uses_distinct_query_ids(self, datasource):
+        client = MagicMock()
+        datasource._init_client = MagicMock(return_value=client)
+        batch = pa.record_batch([pa.array([1, 2])], names=["field1"])
+        client.query_arrow_stream.return_value.__enter__.side_effect = lambda: iter(
+            [batch]
+        )
+
+        # Reusing the same read function (as on retry) must create a fresh ID.
+        read_fn = datasource._create_read_fn(datasource._query)
+        for _ in range(2):
+            assert list(read_fn())[0].equals(pa.Table.from_batches([batch]))
+
+        query_ids = [
+            call.kwargs["settings"]["query_id"]
+            for call in client.query_arrow_stream.call_args_list
+        ]
+        assert len(set(query_ids)) == 2
+        assert datasource._client_settings == {"setting1": "value1"}
+        assert client.close.call_count == 2
 
     def test_execute_block_query_rejects_pickle_object_columns(
         self, datasource, tmp_path


### PR DESCRIPTION
Fixes #66098.

When a ClickHouse Arrow stream fails, the datasource now includes a per-execution query ID in its RuntimeError and explicitly chains the original exception. The ID is sent through clickhouse-connect request settings before opening the stream, so failures after partial consumption can be correlated with server diagnostics when available. Client-provided error details are preserved; unavailable server errors are not reconstructed.

Read planning and materialization remain unchanged. Each execution, including samples and retries, gets a fresh ID. No server-log queries, log flushing, or SQL replay are added.

Duplicate-work check: no existing PR referenced #66098 when checked on September 12. Other open ClickHouse-related PRs addressed decimal schemas or Kinetica, not read error observability. The issue author invited this contribution.

Validation on Windows with Python 3.12, Ray 2.58.0 and clickhouse-connect 1.5.0; Ray data/tests were linked to the worktree using setup-dev.py:
- `python -m pytest python/ray/data/tests/datasource/test_clickhouse.py -q`: 90 passed.
- All seven new regression cases failed against the original datasource and passed with this change. Coverage includes Arrow, transport, and server errors before opening and after partial stream consumption, plus distinct IDs on repeated successful reads.
- Ruff (including import order), Black, and their staged-file pre-commit hooks passed.
- `git diff --check`: passed.

ClickHouse is mocked in these tests; no live ClickHouse integration test or full repository CI was run locally.

AI assistance: OpenAI Codex assisted with implementation and ran the local tests. The submitter reviewed and approved the changes.