### PR TITLE
[Serve] Clear removed deployment overrides

### DIFF
--- a/python/ray/serve/_private/application_state.py
+++ b/python/ray/serve/_private/application_state.py
@@ -240,6 +240,27 @@ class ApplicationTargetState:
     external_scaler_enabled: bool
 
 
+def _deployment_override_options_removed(
+    old_config: ServeApplicationSchema, new_config: ServeApplicationSchema
+) -> bool:
+    """Return whether a deployment override option was removed from the config."""
+
+    def options_by_deployment(config: ServeApplicationSchema) -> Dict[str, set]:
+        overrides: Dict[str, set] = {}
+        for deployment in config.model_dump(exclude_unset=True).get("deployments", []):
+            overrides.setdefault(deployment["name"], set()).update(
+                set(deployment) - {"name"}
+            )
+        return overrides
+
+    old_overrides = options_by_deployment(old_config)
+    new_overrides = options_by_deployment(new_config)
+    return any(
+        old_options - new_overrides.get(deployment_name, set())
+        for deployment_name, old_options in old_overrides.items()
+    )
+
+
 class ApplicationState:
     """Manage single application states with all operations"""
 
@@ -671,7 +692,10 @@ class ApplicationState:
         self._deployment_timestamp = deployment_time
 
         config_version = get_app_code_version(config)
-        if config_version == self._target_state.code_version:
+        if config_version == self._target_state.code_version and not (
+            self._target_state.config
+            and _deployment_override_options_removed(self._target_state.config, config)
+        ):
             # `deployment_infos` is non-None whenever `code_version` is
             # non-None (they are always set together in the target state).
             assert self._target_state.deployment_infos is not None

--- a/python/ray/serve/tests/test_deploy_app.py
+++ b/python/ray/serve/tests/test_deploy_app.py
@@ -582,6 +582,42 @@ def test_update_config_user_config(serve_instance):
     wait_for_condition(check)
 
 
+def test_deploy_app_removed_user_config(serve_instance):
+    client = serve_instance
+    app_name = "removed-user-config"
+    config = {
+        "applications": [
+            {
+                "name": app_name,
+                "route_prefix": "/removed-user-config",
+                "import_path": "ray.serve.tests.test_config_files.pizza.serve_dag",
+                "deployments": [{"name": "Adder", "user_config": {"increment": 10}}],
+            }
+        ]
+    }
+
+    def app_running_with_healthy_adder():
+        status = serve.status().applications[app_name]
+        return (
+            status.status == ApplicationStatus.RUNNING
+            and status.deployments["Adder"].status == DeploymentStatus.HEALTHY
+        )
+
+    client.deploy_apps(ServeDeploySchema.model_validate(config))
+    wait_for_condition(app_running_with_healthy_adder, timeout=15)
+    url = get_application_url("HTTP", app_name=app_name)
+    wait_for_condition(
+        lambda: httpx.post(url, json=["ADD", 2]).text == "12 pizzas please!"
+    )
+
+    config["applications"][0]["deployments"] = [{"name": "Adder"}]
+    client.deploy_apps(ServeDeploySchema.model_validate(config))
+    wait_for_condition(app_running_with_healthy_adder, timeout=15)
+    wait_for_condition(
+        lambda: httpx.post(url, json=["ADD", 2]).text == "4 pizzas please!"
+    )
+
+
 def test_update_config_max_ongoing_requests(serve_instance):
     """Check that replicas stay alive when max_ongoing_requests is updated."""
     client = serve_instance

--- a/python/ray/serve/tests/unit/test_application_state.py
+++ b/python/ray/serve/tests/unit/test_application_state.py
@@ -18,6 +18,7 @@ from ray.serve._private.application_state import (
     ApplicationStatusInfo,
     BuildAppStatus,
     StatusOverview,
+    _deployment_override_options_removed,
     _get_shared_build_app_label_selector,
     build_serve_application,
     override_deployment_info,
@@ -66,6 +67,22 @@ from ray.serve.schema import (
     LoggingConfig,
     ServeApplicationSchema,
 )
+
+
+def test_deployment_override_options_removed_with_duplicate_names():
+    old_config = ServeApplicationSchema(
+        import_path="module.app",
+        deployments=[
+            {"name": "A", "user_config": {"increment": 10}},
+            {"name": "A", "num_replicas": 2},
+        ],
+    )
+    new_config = ServeApplicationSchema(
+        import_path="module.app",
+        deployments=[{"name": "A", "num_replicas": 2}],
+    )
+
+    assert _deployment_override_options_removed(old_config, new_config)
 
 
 class MockEndpointState:


### PR DESCRIPTION
## Description

When a Serve app is updated through YAML and a deployment removes `user_config`, the controller reuses deployment infos because the code version is unchanged. The app reports healthy while replicas keep stale reconfiguration state.

Detect removed deployment overrides and rebuild the app instead of reusing stale deployment infos. Fresh issue and PR searches found no matching work.

AI assistance was used. The submitting human reviewed every changed line and can defend the change. Relevant tests were run locally.

## Related issues

None.

## Tests

- `python -m pytest -q python/ray/serve/tests/unit/test_application_state.py -p no:cacheprovider` — 123 passed
- `test_deploy_app_removed_user_config` passed in the final integration run; the full module passed 21/21 before the final type-only annotation. A repeat hit four unrelated startup timeouts because the release wheel lacks current master's `InnerGcsClient.get_draining_nodes`; CI pending.
- Serve mypy hook, Ruff 0.8.4, and Black 22.10.0 — passed
