### PR TITLE
[Data] Size autoscaler_scales_up_when_compute_bound to measured throughput

### DIFF
--- a/release/nightly_tests/dataset/autoscaling/autoscaler_scales_up_when_compute_bound.py
+++ b/release/nightly_tests/dataset/autoscaling/autoscaler_scales_up_when_compute_bound.py
@@ -57,9 +57,13 @@ def parse_args() -> argparse.Namespace:
 
 
 def main(args: argparse.Namespace) -> Dict[str, Any]:
-    # With 10,000 inputs this takes ~30 minutes, long enough that node
-    # provisioning speed doesn't make the test flaky.
-    num_inputs = 10000
+    # Each consume task moves a 256 MiB batch in and out of the object store, so
+    # in practice 10 GPUs sustain ~3 consume batches/s rather than the 10
+    # batches/s the sleep arithmetic below implies, and both worker groups take
+    # ~11 minutes to reach their max size. With 2,500 inputs (5,000 consume
+    # batches) the run takes ~35 minutes: long enough that node provisioning
+    # speed doesn't make the test flaky, and well inside the 1 hour timeout.
+    num_inputs = 2500
     num_output_batches = 4
     produce_sleep_s = 5
     consume_sleep_s = 1


### PR DESCRIPTION
## Description
`autoscaler_scales_up_when_compute_bound` has times out on release test runs since #65772. The consume stage sustains ~3 batches/s on 10 GPUs, not the 10 batches/s the sleep arithmetic assumes, so 10,000 inputs need ~105 min against a 60 min timeout. Size `num_inputs` to the measured rate: 2,500 inputs finish in ~35 min, and both worker groups are already at max size by ~11 min.

## Additional information
three passing runs with this change: https://buildkite.com/ray-project/release/builds/106952 

