### PR TITLE
[Data] Fix batching of Arrow IPC byte blocks

### DIFF
--- a/python/ray/data/_internal/batcher.py
+++ b/python/ray/data/_internal/batcher.py
@@ -143,7 +143,7 @@ class Batcher(BatcherInterface):
                 if isinstance(accessor, ArrowBlockAccessor):
                     accessor = BlockAccessor.for_block(
                         transform_pyarrow.try_combine_chunked_columns(
-                            block, min_chunks_to_combine=1
+                            accessor.to_block(), min_chunks_to_combine=1
                         )
                     )
 

--- a/python/ray/data/tests/datasource/test_arrow.py
+++ b/python/ray/data/tests/datasource/test_arrow.py
@@ -118,6 +118,27 @@ def test_from_arrow_refs(ray_start_regular_shared, sample_dataframes):
     assert "FromArrow" in ds.stats()
 
 
+@pytest.mark.parametrize("use_refs", [False, True])
+@pytest.mark.parametrize("batch_size", [2, 5, 7])
+def test_from_arrow_ipc_bytes(ray_start_regular_shared, use_refs, batch_size):
+    table = pa.table({"value": [0, None, 2, 3, 4], "label": list("abcde")})
+    sink = pa.BufferOutputStream()
+    with pa.ipc.new_stream(sink, table.schema) as writer:
+        writer.write_table(table, max_chunksize=2)
+    data = sink.getvalue().to_pybytes()
+
+    if use_refs:
+        ds = ray.data.from_arrow_refs(ray.put(data))
+    else:
+        ds = ray.data.from_arrow(data)
+
+    batches = list(ds.iter_batches(batch_size=batch_size, batch_format="pyarrow"))
+    assert [batch.num_rows for batch in batches] == (
+        [2, 2, 1] if batch_size == 2 else [5]
+    )
+    assert pa.concat_tables(batches).equals(table)
+
+
 def test_to_arrow_refs(ray_start_regular_shared):
     n = 5
     df = pd.DataFrame({"id": list(range(n))})

--- a/python/ray/data/tests/test_batcher.py
+++ b/python/ray/data/tests/test_batcher.py
@@ -19,6 +19,32 @@ def gen_block(num_rows):
     return pa.table({"foo": [1] * num_rows})
 
 
+@pytest.mark.parametrize("ensure_copy", [False, True])
+@pytest.mark.parametrize("max_chunksize", [None, 2])
+@pytest.mark.parametrize("prefix_rows", [0, 1])
+def test_batching_arrow_ipc_bytes(ensure_copy, max_chunksize, prefix_rows):
+    table = pa.table({"value": [0, None, 2, 3, 4], "label": list("abcde")})
+    sink = pa.BufferOutputStream()
+    with pa.ipc.new_stream(sink, table.schema) as writer:
+        writer.write_table(table, max_chunksize=max_chunksize)
+
+    batcher = Batcher(batch_size=2, ensure_copy=ensure_copy)
+    if prefix_rows:
+        batcher.add(table.slice(0, prefix_rows))
+    batcher.add(sink.getvalue().to_pybytes())
+    batcher.done_adding()
+
+    batches = []
+    while batcher.has_any():
+        batches.append(batcher.next_batch())
+
+    expected = pa.concat_tables([table.slice(0, prefix_rows), table])
+    assert [batch.num_rows for batch in batches] == (
+        [2, 2, 1] if prefix_rows == 0 else [2, 2, 2]
+    )
+    assert pa.concat_tables(batches).equals(expected)
+
+
 def test_shuffling_batcher():
     batch_size = 5
     buffer_size = 20


### PR DESCRIPTION
Fixes #38485.

Use the decoded Arrow table when combining chunks so splitting IPC byte blocks into batches doesn't crash. Adds regression coverage for byte inputs, mixed blocks, and batch-size boundaries.

### Tests

- `python -m pytest --import-mode=importlib -q python/ray/data/tests/test_batcher.py python/ray/data/tests/block_batching/test_block_batching.py -k 'not many_chunks and not shuffling_batcher_grid and not local_shuffle_determinism and not warns_if_too_large'` with 23 passed, 12 not selected
- `python -m pytest --import-mode=importlib -q python/ray/data/tests/datasource/test_arrow.py` with 17 passed
- `pre-commit run --files python/ray/data/_internal/batcher.py python/ray/data/tests/test_batcher.py python/ray/data/tests/datasource/test_arrow.py` which passed

Ten unrelated regressions failed this, they were failing before as well.

AI helped in the development of this