### PR TITLE
[serve] Do not kill the controller when gang PG leak detection cannot reach the state API

### DIFF
--- a/python/ray/serve/_private/deployment_state.py
+++ b/python/ray/serve/_private/deployment_state.py
@@ -6088,7 +6088,16 @@ class DeploymentStateManager:
                 if name.startswith(GANG_PG_NAME_PREFIX):
                     gang_pg_name_to_id[name] = pg_id_hex
 
-            occupied_pg_ids = get_active_placement_group_ids()
+            try:
+                occupied_pg_ids = get_active_placement_group_ids()
+            except Exception:
+                # The state API is optional infrastructure the controller otherwise
+                # does not need, so keep every gang PG rather than die on recovery.
+                logger.exception(
+                    "Failed to list active actors; skipping gang placement group "
+                    "leak detection for this recovery."
+                )
+                occupied_pg_ids = set(gang_pg_name_to_id.values())
             for gang_pg_name in gang_pg_names_in_cluster:
                 pg_id = gang_pg_name_to_id.get(gang_pg_name)
                 if pg_id is not None and pg_id not in occupied_pg_ids:


### PR DESCRIPTION
A hard failure was seen in test_gang_scheduling.  The failure was traced to Controller functionality.

`ServeController.__init__` dies outright if the Ray state API is unreachable while
recovering gang placement groups. `DeploymentStateManager.__init__` ->
`_recover_from_checkpoint` -> `_detect_and_remove_leaked_placement_groups`, and when any
gang placement group exists, that last call reaches `get_active_placement_group_ids()`,
whose `list_actors()` is an HTTP call to the dashboard. It is the only `ray.util.state`
dependency in `serve/_private`, it is unguarded, and a failure raises out of the
constructor, so the actor dies in its creation task. The PG-removal loop just below it is
already wrapped in try/except.

The dashboard is optional infrastructure the controller does not otherwise need, so on
failure treat every gang PG as still occupied and flag none as leaked. Keeping a leaked PG
is recoverable on the next controller recovery; releasing a live gang reservation is not.
Replica-level leak detection is unaffected.

Validated on `TestGangControllerRecovery::test_gang_context_recovery` with an injected
state API failure:

| arm | controller creation-task deaths | result |
|---|---|---|
| before | 6 | FAILED (86.7s) |
| after | 0 | passed (32.2s) |
| after, no injection | 0 | passed (38.5s) |

`linux://python/ray/serve/tests:test_gang_scheduling` is 35/35 green under the HAProxy
shard env, and every unit suite touching `deployment_state.py` matches an upstream/master
baseline in the same rig.

This is a fault-tolerance fix motivated by flakiness on the HAProxy shard, not a
demonstrated deflake: postmerge logs are not public, so the failing test there is unknown.