### PR TITLE
[serve][llm] Docs and tests for Anthropic Messages API via direct streaming

### DIFF
--- a/doc/source/serve/llm/user-guides/direct-streaming.md
+++ b/doc/source/serve/llm/user-guides/direct-streaming.md
@@ -50,7 +50,7 @@ serve run config.yaml
 :::
 ::::
 
-The deployed application is OpenAI-compatible and exposes the engine's native routes, including `/v1/chat/completions`, `/v1/completions`, and `/v1/models`.
+The deployed application exposes the engine's native routes. For vLLM those include the OpenAI-compatible `/v1/chat/completions`, `/v1/completions`, and `/v1/models`. They also include the Anthropic `/v1/messages` and `/v1/messages/count_tokens`. See {ref}`direct-streaming-anthropic`.
 
 To confirm direct streaming is active, check that the application runs two deployments: your model deployment (`LLMServer:<model_id>`) and an `LLMRouter` deployment. `LLMRouter` is the ingress request router. It replaces the standalone `OpenAiIngress` deployment that fronts a non-direct-streaming app.
 
@@ -120,6 +120,41 @@ Direct streaming works with the single-model builders for the OpenAI, data paral
 - **Standard serving** (`build_openai_app`): the `LLMServer` deployment serves the engine app directly.
 - **Data parallel attention** (`build_dp_openai_app`): the `DPServer` deployment serves the engine app directly. Use this for wide expert parallelism. See {doc}`data-parallel-attention`.
 - **Prefill/decode disaggregation** (`build_pd_openai_app`): the decode server serves the engine app directly. See {doc}`prefill-decode`.
+
+(direct-streaming-anthropic)=
+## Use Anthropic clients
+
+When you enable direct streaming, the replica serves the engine's own FastAPI app. For vLLM that app includes the Anthropic Messages API, so clients such as Claude Code can call `POST /v1/messages` and `POST /v1/messages/count_tokens` on the same application. The default `OpenAiIngress` path does not expose those routes.
+
+Set both `RAY_SERVE_ENABLE_HA_PROXY=1` and `RAY_SERVE_LLM_ENABLE_DIRECT_STREAMING=1` in the Ray controller environment before you start Serve. Direct streaming attaches an ingress request router, and Serve rejects that topology unless HAProxy is enabled.
+
+### Configure tool calling
+
+Anthropic tool calling needs three `engine_kwargs` that match the model you serve. The following values work with Qwen3-8B. Pick the `tool_call_parser` that vLLM documents for your model. See the [vLLM tool calling guide](https://docs.vllm.ai/en/stable/features/tool_calling/).
+
+```python
+engine_kwargs = {
+    "enable_auto_tool_choice": True,
+    "tool_call_parser": "hermes",
+    "reasoning_parser": "qwen3",
+}
+```
+
+The Qwen3.5 examples earlier on this page use `tool_call_parser: qwen3_coder` because that parser matches `Qwen/Qwen3.5-0.8B`.
+
+### Point Claude Code at the application
+
+Claude Code sends the model name on each request. That name must equal `model_loading_config.model_id`. It must not be `model_source`. For the YAML example on this page, pass `qwen3.5-0.8b`, not `Qwen/Qwen3.5-0.8B`.
+
+```bash
+export ANTHROPIC_BASE_URL=http://<serve-host>:8000
+export ANTHROPIC_API_KEY=not-needed
+claude --model qwen3.5-0.8b
+```
+
+Claude Code requires a credential even when the local endpoint does not enforce authentication. Any non-empty `ANTHROPIC_API_KEY` works.
+
+Direct streaming serves one model per application and does not offer LoRA-aware routing. See {ref}`direct-streaming-limitations`. There is no Anthropic ingress you can fall back to for adapter affinity.
 
 (direct-streaming-customize)=
 ## Customize replica selection

--- a/python/ray/llm/tests/BUILD.bazel
+++ b/python/ray/llm/tests/BUILD.bazel
@@ -106,6 +106,7 @@ py_test_module_list(
     files = [
         "serve/cpu/deployments/data_parallel/test_dp_direct_streaming.py",
         "serve/cpu/deployments/prefill_decode_disagg/test_pd_direct_streaming.py",
+        "serve/cpu/deployments/routers/test_anthropic_direct_streaming.py",
         "serve/cpu/deployments/routers/test_router_direct_streaming.py",
     ],
     tags = [

--- a/python/ray/llm/tests/serve/cpu/deployments/llm/test_llm_server.py
+++ b/python/ray/llm/tests/serve/cpu/deployments/llm/test_llm_server.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock, patch
 
 import numpy as np
 import pytest
+from fastapi.routing import APIRoute
 from fastapi.testclient import TestClient
 from vllm.entrypoints.openai.cli_args import make_arg_parser
 from vllm.utils.argparse_utils import FlexibleArgumentParser
@@ -868,6 +869,40 @@ class TestBuildAsgiApp:
         response = TestClient(app, raise_server_exceptions=False).get("/bad_request")
 
         assert response.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_anthropic_routes_are_registered(self):
+        """vLLM's native ASGI app must mount Anthropic Messages routes.
+
+        Direct streaming serves this app from LLMServer, so a vLLM upgrade
+        that drops ``POST /v1/messages`` or ``POST /v1/messages/count_tokens``
+        would break Anthropic clients such as Claude Code.
+        """
+        from vllm.platforms import current_platform
+
+        if not current_platform.device_type:
+            current_platform.device_type = "cpu"
+
+        vllm_args = make_arg_parser(FlexibleArgumentParser()).parse_args([])
+        engine = VLLMEngine.__new__(VLLMEngine)
+        engine._vllm_args = vllm_args
+        engine._engine_client = SimpleNamespace(model_config=None)
+        engine._token_receiver = None
+
+        with patch(
+            "vllm.entrypoints.openai.api_server.init_app_state",
+            new_callable=AsyncMock,
+        ):
+            app = await engine.build_asgi_app()
+
+        routes = {
+            (route.path, method)
+            for route in app.routes
+            if isinstance(route, APIRoute)
+            for method in route.methods
+        }
+        assert ("/v1/messages", "POST") in routes
+        assert ("/v1/messages/count_tokens", "POST") in routes
 
 
 if __name__ == "__main__":

--- a/python/ray/llm/tests/serve/cpu/deployments/routers/test_anthropic_direct_streaming.py
+++ b/python/ray/llm/tests/serve/cpu/deployments/routers/test_anthropic_direct_streaming.py
@@ -1,0 +1,111 @@
+import sys
+
+import httpx
+import pytest
+
+from ray.llm._internal.serve.core.configs.llm_config import (
+    LLMConfig,
+    ModelLoadingConfig,
+)
+from ray.llm._internal.serve.core.ingress.builder import (
+    LLMServingArgs,
+    build_openai_app,
+)
+from ray.llm.tests.serve.cpu.deployments.utils.direct_streaming_utils import (
+    requires_direct_streaming,
+    run_app_through_haproxy,
+)
+from ray.llm.tests.serve.mocks.mock_vllm_engine import (
+    MOCK_ANTHROPIC_INPUT_TOKENS,
+    MOCK_ANTHROPIC_TEXT,
+)
+
+MODEL_ID = "test-model"
+
+
+def _messages_body(*, stream: bool) -> dict:
+    return {
+        "model": MODEL_ID,
+        "max_tokens": 32,
+        "messages": [{"role": "user", "content": "hi"}],
+        "stream": stream,
+    }
+
+
+def _sse_event_types(body: str) -> list[str]:
+    return [
+        line[len("event: ") :]
+        for line in body.splitlines()
+        if line.startswith("event: ")
+    ]
+
+
+@requires_direct_streaming
+class TestAnthropicDirectStreaming:
+    """Anthropic Messages API over the full direct-streaming path.
+
+    A request flows through HAProxy and the LLMRouter ``/internal/route``
+    decision to a backend replica that serves the engine-native ASGI app.
+    """
+
+    @pytest.fixture(name="llm_config")
+    def _llm_config(self):
+        return LLMConfig(model_loading_config=ModelLoadingConfig(model_id=MODEL_ID))
+
+    @pytest.fixture(name="base_url")
+    def run_direct_streaming_app(
+        self,
+        llm_config_with_mock_engine,
+        shutdown_ray_and_serve,
+        disable_placement_bundles,
+    ):
+        llm_config = llm_config_with_mock_engine
+        llm_config.deployment_config = {
+            "num_replicas": 1,
+            "ray_actor_options": {"num_cpus": 0.1},
+        }
+        yield run_app_through_haproxy(
+            build_openai_app(LLMServingArgs(llm_configs=[llm_config]))
+        )
+
+    def test_messages_non_streaming(self, base_url):
+        resp = httpx.post(
+            f"{base_url}/v1/messages",
+            json=_messages_body(stream=False),
+            timeout=30,
+        )
+        assert resp.status_code == 200, resp.text
+        payload = resp.json()
+        assert payload["type"] == "message"
+        assert payload["role"] == "assistant"
+        assert payload["model"] == MODEL_ID
+        assert payload["content"][0]["text"] == MOCK_ANTHROPIC_TEXT
+
+    def test_messages_streaming(self, base_url):
+        resp = httpx.post(
+            f"{base_url}/v1/messages",
+            json=_messages_body(stream=True),
+            timeout=30,
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.headers["content-type"].startswith("text/event-stream")
+        events = _sse_event_types(resp.text)
+        assert events.index("message_start") < events.index("content_block_delta")
+        assert events.index("content_block_delta") < events.index("message_stop")
+        assert MOCK_ANTHROPIC_TEXT in resp.text
+
+    def test_count_tokens(self, base_url):
+        resp = httpx.post(
+            f"{base_url}/v1/messages/count_tokens",
+            json={
+                "model": MODEL_ID,
+                "messages": [{"role": "user", "content": "hi"}],
+            },
+            timeout=30,
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["input_tokens"] == MOCK_ANTHROPIC_INPUT_TOKENS
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-v", __file__]))

--- a/python/ray/llm/tests/serve/mocks/mock_vllm_engine.py
+++ b/python/ray/llm/tests/serve/mocks/mock_vllm_engine.py
@@ -40,6 +40,13 @@ from ray.serve.context import (
     _get_serve_request_context,
 )
 
+MOCK_ANTHROPIC_TEXT = "Hello from mock Anthropic."
+MOCK_ANTHROPIC_INPUT_TOKENS = 8
+
+
+def _anthropic_sse_event(event: str, data: dict) -> str:
+    return f"event: {event}\ndata: {json.dumps(data)}\n\n"
+
 
 class MockVLLMEngine(LLMEngine):
     """Mock vLLM Engine that generates fake text responses.
@@ -235,6 +242,77 @@ class MockVLLMEngine(LLMEngine):
             body = CompletionRequest.model_validate(await request.json())
             check_model(body.model)
             return await to_response(self.completions(body))
+
+        @app.post("/v1/messages")
+        async def messages(request: Request):
+            body = await request.json()
+            check_model(body.get("model"))
+            payload = {
+                "id": "msg_mock",
+                "type": "message",
+                "role": "assistant",
+                "model": self.llm_config.model_id,
+                "content": [{"type": "text", "text": MOCK_ANTHROPIC_TEXT}],
+                "stop_reason": "end_turn",
+                "usage": {
+                    "input_tokens": MOCK_ANTHROPIC_INPUT_TOKENS,
+                    "output_tokens": 6,
+                },
+            }
+            if not body.get("stream"):
+                return JSONResponse(content=payload)
+
+            async def stream():
+                yield _anthropic_sse_event(
+                    "message_start",
+                    {
+                        "type": "message_start",
+                        "message": {**payload, "content": []},
+                    },
+                )
+                yield _anthropic_sse_event(
+                    "content_block_start",
+                    {
+                        "type": "content_block_start",
+                        "index": 0,
+                        "content_block": {"type": "text", "text": ""},
+                    },
+                )
+                yield _anthropic_sse_event(
+                    "content_block_delta",
+                    {
+                        "type": "content_block_delta",
+                        "index": 0,
+                        "delta": {
+                            "type": "text_delta",
+                            "text": MOCK_ANTHROPIC_TEXT,
+                        },
+                    },
+                )
+                yield _anthropic_sse_event(
+                    "content_block_stop",
+                    {"type": "content_block_stop", "index": 0},
+                )
+                yield _anthropic_sse_event(
+                    "message_delta",
+                    {
+                        "type": "message_delta",
+                        "delta": {"stop_reason": "end_turn"},
+                        "usage": {"output_tokens": 6},
+                    },
+                )
+                yield _anthropic_sse_event(
+                    "message_stop",
+                    {"type": "message_stop"},
+                )
+
+            return StreamingResponse(stream(), media_type="text/event-stream")
+
+        @app.post("/v1/messages/count_tokens")
+        async def count_tokens(request: Request):
+            body = await request.json()
+            check_model(body.get("model"))
+            return JSONResponse(content={"input_tokens": MOCK_ANTHROPIC_INPUT_TOKENS})
 
         return app
 


### PR DESCRIPTION
## Description

This PR contributes:
- Document Anthropic / Claude Code use of direct streaming: both `RAY_SERVE_ENABLE_HA_PROXY=1` and `RAY_SERVE_LLM_ENABLE_DIRECT_STREAMING=1` are required, tool-parser kwargs are model-specific, and `--model` must equal `model_loading_config.model_id`.
- CPU test that `VLLMEngine.build_asgi_app()` registers both Anthropic POST routes (no engine start).
- Mock Anthropic responses plus HAProxy tests for non-streaming messages, SSE streaming (`message_start` -> `content_block_delta` -> `message_stop`), and `count_tokens`.

## Related issues
- Related to: https://github.com/ray-project/ray/issues/64965
- Is a rescope of #65486 (will close this one pending confirmation from maintainer)

## Additional information

### Local Tests

```bash
RAY_SERVE_ENABLE_HA_PROXY=1 RAY_SERVE_LLM_ENABLE_DIRECT_STREAMING=1 \
  pytest -v python/ray/llm/tests/serve/cpu/deployments/routers/test_anthropic_direct_streaming.py
pytest -v python/ray/llm/tests/serve/cpu/deployments/llm/test_llm_server.py -k test_anthropic_routes_are_registered
```

### Ray Setup & Configs

**Environment**

- **Driver Version:** 580.126.09
- **CUDA Version:** 13.0
- **GPU:** NVIDIA H100 80GB HBM3
- **Ray branch/commit**: master/49cc4c54dc954c2ef9dea8bfdbebe87a008b40cd
- `ray-haproxy==2.8.25` & `vllm==0.26.0`
- **Model used:** Qwen/Qwen3-8B

**Claude Setup**

```bash
export ANTHROPIC_BASE_URL=$BASE_URL
export ANTHROPIC_AUTH_TOKEN=dummy
export ANTHROPIC_MODEL=claude-sonnet-4-5-20250929
claude
```

**Ray Serve LLM commands**

```bash
export RAY_SERVE_LLM_ENABLE_DIRECT_STREAMING=1
export RAY_SERVE_ENABLE_HA_PROXY=1
ray start --head --disable-usage-stats
serve run config.yaml
```

**Ray Serve LLM configs**

  <details>
  <summary><code>config.yaml</code></summary>
  
  ```yaml
  applications:
  - name: anthropic-direct
    route_prefix: /
    import_path: ray.serve.llm:build_openai_app
    args:
      llm_configs:
      - model_loading_config:
          model_id: claude-sonnet-4-5-20250929
          model_source: Qwen/Qwen3-8B
  
        deployment_config:
          autoscaling_config:
            min_replicas: 1
            max_replicas: 1
  
        engine_kwargs:
          enable_auto_tool_choice: true
          tool_call_parser: hermes
          reasoning_parser: qwen3
          hf_overrides:
              rope_scaling:
                rope_type: yarn
                factor: 4.0
                original_max_position_embeddings: 32768
          max_model_len: 131072
          gpu_memory_utilization: 0.90
          tensor_parallel_size: 1
          enable_prefix_caching: true
  
        runtime_env:
          env_vars:
            HF_TOKEN: ""
            VLLM_DISABLE_COMPILE_CACHE: "1"
  ```

  </details>

### Limitations of using direct streaming for Anthropic Messages API support

- No **multi-model applications and LoRA / multiplex-aware routing** (direct streaming has no Anthropic ingress fallback).
- Three vLLM adapter fidelity gaps (these are problems with upstream vLLM):
  1. Unknown paths return FastAPI `{"detail":"Not Found"}` instead of an Anthropic error envelope.
  2. `thinking` blocks use `signature=uuid.uuid4().hex` in `vllm/entrypoints/anthropic/serving.py`.
  3. Context overflow returns HTTP 500 `internal_error` instead of HTTP 400 `invalid_request_error`.

```bash
 500 {"type":"error","error":{"type":"internal_error","message":"This model's maximum context length 
     is 32768 tokens. However, you requested 32000 output tokens and your prompt contains at least 769   
     input tokens, for a total of at least 32769 tokens. Please reduce the length of the input prompt or 
     the number of requested output tokens. (parameter=input_tokens, value=769)"}}                       
     Retrying in 7 seconds… (attempt 6/10) 
```
